### PR TITLE
feat(dashboard): add project/repo filter to task list

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -91,6 +91,33 @@ describe('GET /api/tasks', () => {
     const res = await request(app).get('/api/tasks');
     expect(res.body[0].agents).toEqual([]);
   });
+
+  it('filters tasks by repo_path query param', async () => {
+    insertTask(db, { id: 'task-a', repo_path: '/repo/alpha' });
+    insertTask(db, { id: 'task-b', repo_path: '/repo/beta' });
+    insertTask(db, { id: 'task-c', repo_path: '/repo/alpha' });
+
+    const res = await request(app).get('/api/tasks?repo_path=/repo/alpha');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.every((t: Task) => t.repo_path === '/repo/alpha')).toBe(true);
+  });
+
+  it('returns all tasks when repo_path is not provided', async () => {
+    insertTask(db, { id: 'task-a', repo_path: '/repo/alpha' });
+    insertTask(db, { id: 'task-b', repo_path: '/repo/beta' });
+
+    const res = await request(app).get('/api/tasks');
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('returns empty array when repo_path matches no tasks', async () => {
+    insertTask(db, { id: 'task-a', repo_path: '/repo/alpha' });
+
+    const res = await request(app).get('/api/tasks?repo_path=/repo/nonexistent');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
 });
 
 // ─── GET /api/tasks/:id ──────────────────────────────────────────────────────

--- a/server/api.ts
+++ b/server/api.ts
@@ -99,9 +99,19 @@ export function setupRoutes(app: Express): void {
   });
 
   // List all tasks with agents
-  app.get('/api/tasks', (_req: Request, res: Response) => {
+  app.get('/api/tasks', (req: Request, res: Response) => {
     const db = getDb();
-    const tasks = db.prepare('SELECT * FROM tasks ORDER BY created_at DESC').all() as Task[];
+    const repoPath = req.query.repo_path as string | undefined;
+
+    let tasks: Task[];
+    if (repoPath) {
+      tasks = db
+        .prepare('SELECT * FROM tasks WHERE repo_path = ? ORDER BY created_at DESC')
+        .all(repoPath) as Task[];
+    } else {
+      tasks = db.prepare('SELECT * FROM tasks ORDER BY created_at DESC').all() as Task[];
+    }
+
     const agentStmt = db.prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index');
 
     const result = tasks.map((task) => ({

--- a/src/components/TaskFilterBar.test.tsx
+++ b/src/components/TaskFilterBar.test.tsx
@@ -4,30 +4,55 @@ import userEvent from '@testing-library/user-event';
 import { TaskFilterBar } from './TaskFilterBar';
 import { renderWithRouter } from '../test-helpers';
 
+const defaultProps = {
+  activeStatus: 'open' as const,
+  counts: { open: 3, closed: 1 },
+  onStatusChange: () => {},
+  repos: ['/path/to/alpha', '/path/to/beta'],
+  activeRepo: '',
+  onRepoChange: () => {},
+};
+
 describe('TaskFilterBar', () => {
   it('renders Open and Closed tabs with counts', () => {
-    renderWithRouter(
-      <TaskFilterBar activeStatus="open" counts={{ open: 3, closed: 1 }} onStatusChange={() => {}} />,
-    );
+    renderWithRouter(<TaskFilterBar {...defaultProps} />);
     expect(screen.getByText('Open (3)')).toBeInTheDocument();
     expect(screen.getByText('Closed (1)')).toBeInTheDocument();
   });
 
   it('highlights active tab', () => {
-    renderWithRouter(
-      <TaskFilterBar activeStatus="open" counts={{ open: 2, closed: 0 }} onStatusChange={() => {}} />,
-    );
-    const openBtn = screen.getByText('Open (2)');
+    renderWithRouter(<TaskFilterBar {...defaultProps} />);
+    const openBtn = screen.getByText('Open (3)');
     expect(openBtn.className).toContain('border-b-2');
   });
 
   it('calls onStatusChange when clicking tab', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    renderWithRouter(
-      <TaskFilterBar activeStatus="open" counts={{ open: 2, closed: 1 }} onStatusChange={onChange} />,
-    );
+    renderWithRouter(<TaskFilterBar {...defaultProps} onStatusChange={onChange} />);
     await user.click(screen.getByText('Closed (1)'));
     expect(onChange).toHaveBeenCalledWith('closed');
+  });
+
+  it('renders repo dropdown when multiple repos exist', () => {
+    renderWithRouter(<TaskFilterBar {...defaultProps} />);
+    const select = screen.getByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText('All projects')).toBeInTheDocument();
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+  });
+
+  it('hides repo dropdown when only one repo exists', () => {
+    renderWithRouter(<TaskFilterBar {...defaultProps} repos={['/path/to/only-one']} />);
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('calls onRepoChange when selecting a repo', async () => {
+    const user = userEvent.setup();
+    const onRepoChange = vi.fn();
+    renderWithRouter(<TaskFilterBar {...defaultProps} onRepoChange={onRepoChange} />);
+    await user.selectOptions(screen.getByRole('combobox'), '/path/to/beta');
+    expect(onRepoChange).toHaveBeenCalledWith('/path/to/beta');
   });
 });

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -2,29 +2,60 @@ interface TaskFilterBarProps {
   activeStatus: 'open' | 'closed';
   counts: { open: number; closed: number };
   onStatusChange: (status: 'open' | 'closed') => void;
+  repos: string[];
+  activeRepo: string;
+  onRepoChange: (repo: string) => void;
 }
 
-export function TaskFilterBar({ activeStatus, counts, onStatusChange }: TaskFilterBarProps) {
+function repoName(repoPath: string): string {
+  return repoPath.split('/').pop() || repoPath;
+}
+
+export function TaskFilterBar({
+  activeStatus,
+  counts,
+  onStatusChange,
+  repos,
+  activeRepo,
+  onRepoChange,
+}: TaskFilterBarProps) {
   const tabs = [
     { key: 'open' as const, label: `Open (${counts.open})` },
     { key: 'closed' as const, label: `Closed (${counts.closed})` },
   ];
 
   return (
-    <div className="mb-4 flex gap-1 border-b border-border">
-      {tabs.map((tab) => (
-        <button
-          key={tab.key}
-          className={`px-3 py-2 text-sm font-medium ${
-            activeStatus === tab.key
-              ? 'border-b-2 border-primary text-foreground'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-          onClick={() => onStatusChange(tab.key)}
+    <div className="mb-4 flex items-center justify-between border-b border-border">
+      <div className="flex gap-1">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            className={`px-3 py-2 text-sm font-medium ${
+              activeStatus === tab.key
+                ? 'border-b-2 border-primary text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            onClick={() => onStatusChange(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {repos.length > 1 && (
+        <select
+          value={activeRepo}
+          onChange={(e) => onRepoChange(e.target.value)}
+          title={activeRepo || 'All projects'}
+          className="mb-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
         >
-          {tab.label}
-        </button>
-      ))}
+          <option value="">All projects</option>
+          {repos.map((repo) => (
+            <option key={repo} value={repo}>
+              {repoName(repo)}
+            </option>
+          ))}
+        </select>
+      )}
     </div>
   );
 }

--- a/src/lib/use-task-filters.test.tsx
+++ b/src/lib/use-task-filters.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTaskFilters } from './use-task-filters';
 import type { Task } from '../../server/types';
@@ -22,6 +22,10 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 describe('useTaskFilters', () => {
   const tasks: Task[] = [
@@ -49,5 +53,55 @@ describe('useTaskFilters', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
     expect(result.current.counts.open).toBe(3);
     expect(result.current.counts.closed).toBe(1);
+  });
+
+  // ─── Repo filtering ─────────────────────────────────────────────────────
+
+  it('returns sorted unique repos', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    expect(result.current.repos).toEqual(['/tmp/alpha', '/tmp/beta']);
+  });
+
+  it('defaults to all repos (empty string)', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    expect(result.current.filters.repo).toBe('');
+  });
+
+  it('filters tasks by repo', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('repo', '/tmp/alpha'));
+    const ids = result.current.filtered.map((t) => t.id);
+    // open filter + alpha repo = only t1 (running in alpha)
+    expect(ids).toEqual(['t1']);
+  });
+
+  it('updates counts when repo filter is active', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('repo', '/tmp/alpha'));
+    expect(result.current.counts.open).toBe(1);
+    expect(result.current.counts.closed).toBe(1);
+  });
+
+  it('shows all tasks for selected repo when switching status tabs', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('repo', '/tmp/alpha'));
+    act(() => result.current.setFilter('status', 'closed'));
+    const ids = result.current.filtered.map((t) => t.id);
+    expect(ids).toEqual(['t3']);
+  });
+
+  it('persists repo filter to localStorage', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('repo', '/tmp/beta'));
+    expect(localStorage.getItem('octomux-repo-filter')).toBe('/tmp/beta');
+  });
+
+  it('restores repo filter from localStorage', () => {
+    localStorage.setItem('octomux-repo-filter', '/tmp/beta');
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    expect(result.current.filters.repo).toBe('/tmp/beta');
+    // Should filter immediately
+    const ids = result.current.filtered.map((t) => t.id);
+    expect(ids).toEqual(['t2', 't4']); // open tasks in beta
   });
 });

--- a/src/lib/use-task-filters.ts
+++ b/src/lib/use-task-filters.ts
@@ -1,32 +1,55 @@
 import { useState, useMemo } from 'react';
 import type { Task } from '../../server/types';
 
+const REPO_FILTER_KEY = 'octomux-repo-filter';
+
 export interface TaskFilters {
   status: 'open' | 'closed';
+  repo: string; // full repo_path or '' for all
 }
 
 const OPEN_STATUSES = ['draft', 'setting_up', 'running', 'error'];
 
 export function useTaskFilters(tasks: Task[]) {
-  const [filters, setFilters] = useState<TaskFilters>({ status: 'open' });
+  const [filters, setFilters] = useState<TaskFilters>({
+    status: 'open',
+    repo: localStorage.getItem(REPO_FILTER_KEY) ?? '',
+  });
 
-  const counts = useMemo(
-    () => ({
-      open: tasks.filter((t) => OPEN_STATUSES.includes(t.status)).length,
-      closed: tasks.filter((t) => t.status === 'closed').length,
-    }),
-    [tasks],
-  );
+  const repos = useMemo(() => {
+    const paths = new Set(tasks.map((t) => t.repo_path));
+    return [...paths].sort((a, b) => {
+      const nameA = a.split('/').pop() || a;
+      const nameB = b.split('/').pop() || b;
+      return nameA.localeCompare(nameB);
+    });
+  }, [tasks]);
+
+  const counts = useMemo(() => {
+    const repoFiltered = filters.repo
+      ? tasks.filter((t) => t.repo_path === filters.repo)
+      : tasks;
+    return {
+      open: repoFiltered.filter((t) => OPEN_STATUSES.includes(t.status)).length,
+      closed: repoFiltered.filter((t) => t.status === 'closed').length,
+    };
+  }, [tasks, filters.repo]);
 
   const filtered = useMemo(() => {
-    return tasks.filter((t) =>
-      filters.status === 'open' ? OPEN_STATUSES.includes(t.status) : t.status === 'closed',
-    );
+    return tasks.filter((t) => {
+      const statusMatch =
+        filters.status === 'open' ? OPEN_STATUSES.includes(t.status) : t.status === 'closed';
+      const repoMatch = !filters.repo || t.repo_path === filters.repo;
+      return statusMatch && repoMatch;
+    });
   }, [tasks, filters]);
 
   function setFilter<K extends keyof TaskFilters>(key: K, value: TaskFilters[K]) {
+    if (key === 'repo') {
+      localStorage.setItem(REPO_FILTER_KEY, value as string);
+    }
     setFilters((prev) => ({ ...prev, [key]: value }));
   }
 
-  return { filters, setFilter, filtered, counts };
+  return { filters, setFilter, filtered, counts, repos };
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,7 +8,7 @@ import { api } from '@/lib/api';
 
 export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
-  const { filters, setFilter, filtered, counts } = useTaskFilters(tasks);
+  const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
 
   async function handleDelete(id: string) {
     try {
@@ -56,6 +56,9 @@ export default function Dashboard() {
                 activeStatus={filters.status}
                 counts={counts}
                 onStatusChange={(s) => setFilter('status', s)}
+                repos={repos}
+                activeRepo={filters.repo}
+                onRepoChange={(r) => setFilter('repo', r)}
               />
               <TaskList tasks={filtered} onDelete={handleDelete} onResume={handleResume} />
             </>


### PR DESCRIPTION
## What
- Add a project dropdown filter to the task list that lets users filter tasks by repo
- Backend: `GET /api/tasks` accepts optional `?repo_path=` query param
- Frontend: dropdown in `TaskFilterBar` shows repo names (last path segment), persists selection in localStorage
- Counts update to reflect the active repo filter

## Why
When working across multiple repos, the task list gets noisy. This lets users focus on one project at a time.

## Testing
- 3 new backend tests for `GET /api/tasks?repo_path=` filtering
- 7 new hook tests for repo filtering, count updates, and localStorage persistence
- 3 updated component tests for new `TaskFilterBar` props + 3 new (dropdown rendering, hide with single repo, selection callback)
- All 343 tests pass