### PR TITLE
fix(task-runner): send Enter key after pasting prompt into tmux window

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -451,6 +451,14 @@ describe('dispatchToWindow', () => {
     expect(call![1]).toContain('my-session:2');
   });
 
+  it('sends Enter key after pasting buffer', async () => {
+    await dispatchToWindow('my-session', 2, 'text');
+    const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['send-keys'] });
+    expect(call).toBeTruthy();
+    expect(call![1]).toContain('my-session:2');
+    expect(call![1]).toContain('Enter');
+  });
+
   it('rejects when load-buffer exits non-zero', async () => {
     vi.mocked(spawn).mockReturnValueOnce({
       stdin: { write: vi.fn(), end: vi.fn() },

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -287,4 +287,7 @@ export async function dispatchToWindow(
 
   // Paste into the target window
   await execFile('tmux', ['paste-buffer', '-t', target]);
+
+  // Press Enter to submit the prompt
+  await execFile('tmux', ['send-keys', '-t', target, 'Enter']);
 }


### PR DESCRIPTION
## What
- Add `tmux send-keys Enter` after `paste-buffer` in `dispatchToWindow` so pasted prompts are actually submitted
- Add test verifying Enter is sent to the correct tmux target window

## Why
When a task had an `initial_prompt`, `dispatchToWindow` loaded the text into the tmux paste buffer and pasted it, but never pressed Enter. The Claude agent sat idle with the prompt in its input buffer.

## Testing
- Added unit test for the new `send-keys Enter` call
- All 362 tests pass (`bun run test`)