### PR TITLE
test: overhaul test suite with table-driven patterns, shared helpers, and new coverage

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -10,6 +10,7 @@ import { EventEmitter } from 'events';
 vi.mock('./task-runner.js', () => ({
   startTask: vi.fn(),
   closeTask: vi.fn(),
+  resumeTask: vi.fn(),
   addAgent: vi.fn(async (_task: any, _prompt?: string) => ({
     id: 'new-agent-id',
     task_id: _task.id,
@@ -41,7 +42,7 @@ vi.mock('child_process', () => ({
 const fs = (await import('fs')).default;
 const { spawn: spawnMock } = await import('child_process');
 const { createApp } = await import('./app.js');
-const { startTask, closeTask, addAgent, stopAgent } = await import('./task-runner.js');
+const { startTask, closeTask, resumeTask, addAgent, stopAgent } = await import('./task-runner.js');
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -56,6 +57,56 @@ beforeEach(() => {
 
 afterEach(() => {
   db.close();
+});
+
+// ─── 404 for nonexistent resources (table-driven) ────────────────────────────
+
+const notFoundCases = [
+  { name: 'GET /api/tasks/:id', method: 'get' as const, url: '/api/tasks/nonexistent' },
+  {
+    name: 'PATCH /api/tasks/:id',
+    method: 'patch' as const,
+    url: '/api/tasks/nonexistent',
+    body: { status: 'closed' },
+  },
+  { name: 'DELETE /api/tasks/:id', method: 'delete' as const, url: '/api/tasks/nonexistent' },
+  {
+    name: 'POST /api/tasks/:id/start',
+    method: 'post' as const,
+    url: '/api/tasks/nonexistent/start',
+  },
+  {
+    name: 'POST /api/tasks/:id/agents',
+    method: 'post' as const,
+    url: '/api/tasks/nonexistent/agents',
+    body: {},
+  },
+  {
+    name: 'DELETE /api/tasks/:id/agents/:agentId',
+    method: 'delete' as const,
+    url: '/api/tasks/nonexistent/agents/agent1',
+  },
+  {
+    name: 'POST /api/tasks/:id/pr',
+    method: 'post' as const,
+    url: '/api/tasks/nonexistent/pr',
+    body: { base: 'main', title: 'T', body: 'B' },
+  },
+  {
+    name: 'POST /api/tasks/:id/pr/preview',
+    method: 'post' as const,
+    url: '/api/tasks/nonexistent/pr/preview',
+    body: { base: 'main' },
+  },
+];
+
+describe('404 for nonexistent resources', () => {
+  it.each(notFoundCases)('$name → 404', async ({ method, url, body }) => {
+    const res = body
+      ? await request(app)[method](url).send(body)
+      : await request(app)[method](url);
+    expect(res.status).toBe(404);
+  });
 });
 
 // ─── GET /api/tasks ───────────────────────────────────────────────────────────
@@ -123,12 +174,6 @@ describe('GET /api/tasks', () => {
 // ─── GET /api/tasks/:id ──────────────────────────────────────────────────────
 
 describe('GET /api/tasks/:id', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).get('/api/tasks/nonexistent');
-    expect(res.status).toBe(404);
-    expect(res.body.error).toBe('Task not found');
-  });
-
   it('returns task with agents', async () => {
     insertTask(db);
     insertAgent(db);
@@ -184,12 +229,6 @@ describe('POST /api/tasks', () => {
     const tasks = db.prepare('SELECT * FROM tasks').all() as Task[];
     expect(tasks).toHaveLength(1);
     expect(tasks[0].title).toBe(validPayload.title);
-  });
-
-  it('calls startTask with created task', async () => {
-    const res = await request(app).post('/api/tasks').send(validPayload);
-    expect(startTask).toHaveBeenCalledOnce();
-    expect(vi.mocked(startTask).mock.calls[0][0].id).toBe(res.body.id);
   });
 
   // ─── Validation (table-driven) ─────────────────────────────────────────
@@ -248,16 +287,21 @@ describe('POST /api/tasks', () => {
     expect(res.body.branch).toBeNull();
     expect(res.body.base_branch).toBeNull();
   });
+
+  it('stores initial_prompt when provided', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({ ...validPayload, initial_prompt: 'Fix the bug in orders.ts' });
+
+    expect(res.status).toBe(201);
+    const task = getTask(db, res.body.id);
+    expect(task?.initial_prompt).toBe('Fix the bug in orders.ts');
+  });
 });
 
 // ─── POST /api/tasks/:id/start ──────────────────────────────────────────────
 
 describe('POST /api/tasks/:id/start', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).post('/api/tasks/nonexistent/start');
-    expect(res.status).toBe(404);
-  });
-
   it('starts a draft task', async () => {
     insertTask(db);
 
@@ -280,11 +324,6 @@ describe('POST /api/tasks/:id/start', () => {
 // ─── PATCH /api/tasks/:id ────────────────────────────────────────────────────
 
 describe('PATCH /api/tasks/:id', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).patch('/api/tasks/nonexistent').send({ status: 'closed' });
-    expect(res.status).toBe(404);
-  });
-
   it('updates status and returns updated task with agents', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db);
@@ -331,16 +370,50 @@ describe('PATCH /api/tasks/:id', () => {
     expect(res.body.status).toBe('running'); // unchanged
     expect(closeTask).not.toHaveBeenCalled();
   });
+
+  // ─── Resume flow (status=running) ─────────────────────────────────────
+
+  it('returns 400 when resuming a non-closed/non-error task', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    const res = await request(app)
+      .patch(`/api/tasks/${DEFAULTS.task.id}`)
+      .send({ status: 'running' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('resume');
+  });
+
+  const resumableStatuses = ['closed', 'error'] as const;
+
+  it.each(resumableStatuses)(
+    'returns 400 when worktree missing for %s task',
+    async (status) => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      insertTask(db, { ...DEFAULTS.runningTask, status });
+      const res = await request(app)
+        .patch(`/api/tasks/${DEFAULTS.task.id}`)
+        .send({ status: 'running' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Worktree');
+    },
+  );
+
+  it.each(resumableStatuses)(
+    'calls resumeTask for %s task with valid worktree',
+    async (status) => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      insertTask(db, { ...DEFAULTS.runningTask, status });
+      const res = await request(app)
+        .patch(`/api/tasks/${DEFAULTS.task.id}`)
+        .send({ status: 'running' });
+      expect(res.status).toBe(200);
+      expect(resumeTask).toHaveBeenCalledOnce();
+    },
+  );
 });
 
 // ─── DELETE /api/tasks/:id ───────────────────────────────────────────────────
 
 describe('DELETE /api/tasks/:id', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).delete('/api/tasks/nonexistent');
-    expect(res.status).toBe(404);
-  });
-
   it('deletes task and returns 204', async () => {
     insertTask(db);
     const res = await request(app).delete(`/api/tasks/${DEFAULTS.task.id}`);
@@ -367,11 +440,6 @@ describe('DELETE /api/tasks/:id', () => {
 // ─── POST /api/tasks/:id/agents ──────────────────────────────────────────────
 
 describe('POST /api/tasks/:id/agents', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).post('/api/tasks/nonexistent/agents').send({});
-    expect(res.status).toBe(404);
-  });
-
   // ─── Status gating (table-driven) ──────────────────────────────────────
 
   const nonRunningStatuses = ['draft', 'setting_up', 'closed', 'error'];
@@ -415,14 +483,9 @@ describe('POST /api/tasks/:id/agents', () => {
 // ─── DELETE /api/tasks/:id/agents/:agentId ───────────────────────────────────
 
 describe('DELETE /api/tasks/:id/agents/:agentId', () => {
-  it('returns 404 for nonexistent agent', async () => {
+  it('returns 404 for nonexistent agent on existing task', async () => {
     insertTask(db);
     const res = await request(app).delete(`/api/tasks/${DEFAULTS.task.id}/agents/nonexistent`);
-    expect(res.status).toBe(404);
-  });
-
-  it('returns 404 when task does not exist', async () => {
-    const res = await request(app).delete('/api/tasks/nonexistent/agents/agent1');
     expect(res.status).toBe(404);
   });
 
@@ -451,13 +514,6 @@ describe('DELETE /api/tasks/:id/agents/:agentId', () => {
 // ─── POST /api/tasks/:id/pr ─────────────────────────────────────────────────
 
 describe('POST /api/tasks/:id/pr', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app)
-      .post('/api/tasks/nonexistent/pr')
-      .send({ base: 'main', title: 'T', body: 'B' });
-    expect(res.status).toBe(404);
-  });
-
   it('returns 400 when task has no branch', async () => {
     insertTask(db);
     const res = await request(app)
@@ -491,11 +547,6 @@ describe('POST /api/tasks/:id/pr', () => {
 // ─── POST /api/tasks/:id/pr/preview ─────────────────────────────────────────
 
 describe('POST /api/tasks/:id/pr/preview', () => {
-  it('returns 404 for nonexistent task', async () => {
-    const res = await request(app).post('/api/tasks/nonexistent/pr/preview').send({ base: 'main' });
-    expect(res.status).toBe(404);
-  });
-
   it('returns 400 when task has no branch', async () => {
     insertTask(db);
     const res = await request(app)
@@ -740,6 +791,32 @@ describe('POST /api/tasks/:id/pr — success path', () => {
     const task = getTask(db, DEFAULTS.task.id);
     expect(task?.pr_url).toBe('https://github.com/org/repo/pull/42');
     expect(task?.pr_number).toBe(42);
+  });
+});
+
+// ─── POST /api/tasks/:id/pr — gh failure ─────────────────────────────────────
+
+describe('POST /api/tasks/:id/pr — gh failure', () => {
+  it('returns 500 when gh CLI fails', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+
+    const { execFile } = await import('child_process');
+    vi.mocked(execFile).mockImplementation(((cmd: string, _args: any, ...rest: any[]) => {
+      const cb = rest.find((a: any) => typeof a === 'function');
+      if (cmd === 'gh') {
+        cb(new Error('gh: command not found'), null);
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+      return undefined as any;
+    }) as any);
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/pr`)
+      .send({ base: 'main', title: 'feat: test', body: '## What' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toContain('gh');
   });
 });
 

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -10,7 +10,7 @@ import {
   TASKS_TABLE_COLUMNS,
   AGENTS_TABLE_COLUMNS,
 } from './test-helpers.js';
-import { getDb } from './db.js';
+import { getDb, initDb } from './db.js';
 
 describe('Database', () => {
   let db: Database.Database;
@@ -132,6 +132,42 @@ describe('Database', () => {
   describe('getDb', () => {
     it('returns the same instance on repeated calls', () => {
       expect(getDb()).toBe(getDb());
+    });
+  });
+
+  // ─── Pragmas ──────────────────────────────────────────────────────────
+
+  describe('pragmas', () => {
+    it('sets WAL journal mode (falls back to memory for in-memory DBs)', () => {
+      const mode = db.pragma('journal_mode') as [{ journal_mode: string }];
+      // In-memory DBs can't use WAL; real DBs will use WAL
+      expect(['wal', 'memory']).toContain(mode[0].journal_mode);
+    });
+
+    it('enables foreign keys', () => {
+      const fk = db.pragma('foreign_keys') as [{ foreign_keys: number }];
+      expect(fk[0].foreign_keys).toBe(1);
+    });
+  });
+
+  // ─── Migrations ────────────────────────────────────────────────────────
+
+  describe('migrations', () => {
+    it('is idempotent — calling initDb twice does not error', () => {
+      expect(() => initDb(db)).not.toThrow();
+    });
+
+    it.each(['initial_prompt', 'base_branch'])(
+      'tasks table has column: %s (migration)',
+      (col) => {
+        const columns = db.pragma('table_info(tasks)') as { name: string }[];
+        expect(columns.map((c) => c.name)).toContain(col);
+      },
+    );
+
+    it('agents table has claude_session_id column (migration)', () => {
+      const columns = db.pragma('table_info(agents)') as { name: string }[];
+      expect(columns.map((c) => c.name)).toContain('claude_session_id');
     });
   });
 });

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -6,18 +6,12 @@ import {
   insertAgent,
   getTask,
   getAgents,
+  findCallback,
   DEFAULTS,
 } from './test-helpers.js';
 import type { Task } from './types.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
-
-function findCallback(...args: any[]): Function | undefined {
-  for (let i = args.length - 1; i >= 0; i--) {
-    if (typeof args[i] === 'function') return args[i];
-  }
-  return undefined;
-}
 
 vi.mock('child_process', () => ({
   execFile: vi.fn((...args: any[]) => {
@@ -112,6 +106,39 @@ describe('pollStatuses', () => {
     vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb?: any) => {
       const callback = cb || _opts;
       if (typeof callback === 'function') callback(new Error('dead'));
+      return undefined as any;
+    });
+
+    await pollStatuses();
+
+    const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
+  });
+
+  it('marks setting_up task as error when session dies', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, status: 'setting_up' });
+    insertAgent(db);
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) cb(new Error('session not found'));
+      return undefined as any;
+    });
+
+    await pollStatuses();
+
+    const task = getTask(db, DEFAULTS.task.id)!;
+    expect(task.status).toBe('error');
+    expect(task.error).toBe('Setup interrupted');
+  });
+
+  it('marks agents as stopped when setting_up task dies', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, status: 'setting_up' });
+    insertAgent(db);
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) cb(new Error('session not found'));
       return undefined as any;
     });
 

--- a/server/pr-template.test.ts
+++ b/server/pr-template.test.ts
@@ -9,34 +9,26 @@ describe('buildPRPrompt', () => {
     diffStats: ' src/orders.ts | 10 +++++\n 1 file changed, 10 insertions(+)',
   };
 
-  it('includes task title and description', () => {
+  // ─── Required content (table-driven) ──────────────────────────────────────
+
+  const contentCases = [
+    { name: 'task title', expected: 'Task: Fix order validation' },
+    { name: 'task description', expected: 'Description: Add negative quantity checks' },
+    { name: 'commit log', expected: 'abc1234 fix: validate order quantities' },
+    { name: 'diff stats', expected: 'src/orders.ts | 10 +++++' },
+    { name: 'Conventional Commits', expected: 'Conventional Commits' },
+    { name: 'commit types', expected: 'feat, fix, refactor, test, docs, chore' },
+    { name: 'JSON output format', expected: 'Return ONLY valid JSON' },
+    { name: 'title key', expected: '"title"' },
+    { name: 'body key', expected: '"body"' },
+  ];
+
+  it.each(contentCases)('includes $name', ({ expected }) => {
     const prompt = buildPRPrompt(baseContext);
-    expect(prompt).toContain('Task: Fix order validation');
-    expect(prompt).toContain('Description: Add negative quantity checks');
+    expect(prompt).toContain(expected);
   });
 
-  it('includes commit log', () => {
-    const prompt = buildPRPrompt(baseContext);
-    expect(prompt).toContain('abc1234 fix: validate order quantities');
-  });
-
-  it('includes diff stats', () => {
-    const prompt = buildPRPrompt(baseContext);
-    expect(prompt).toContain('src/orders.ts | 10 +++++');
-  });
-
-  it('includes Conventional Commits requirement', () => {
-    const prompt = buildPRPrompt(baseContext);
-    expect(prompt).toContain('Conventional Commits');
-    expect(prompt).toContain('feat, fix, refactor, test, docs, chore');
-  });
-
-  it('requests JSON output format', () => {
-    const prompt = buildPRPrompt(baseContext);
-    expect(prompt).toContain('Return ONLY valid JSON');
-    expect(prompt).toContain('"title"');
-    expect(prompt).toContain('"body"');
-  });
+  // ─── PR body sections (table-driven) ──────────────────────────────────────
 
   const requiredSections = ['## What', '## Why', '## Testing'];
 
@@ -44,6 +36,8 @@ describe('buildPRPrompt', () => {
     const prompt = buildPRPrompt(baseContext);
     expect(prompt).toContain(section);
   });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────────
 
   it('handles multi-line commit logs', () => {
     const context: PRPromptContext = {

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -47,7 +47,7 @@ vi.mock('child_process', () => ({
   })),
 }));
 
-const { startTask, closeTask, addAgent, stopAgent, dispatchToWindow } =
+const { startTask, closeTask, addAgent, stopAgent, resumeTask, dispatchToWindow } =
   await import('./task-runner.js');
 const { execFile, spawn } = await import('child_process');
 const fs = await import('fs');
@@ -462,5 +462,123 @@ describe('dispatchToWindow', () => {
     await expect(dispatchToWindow('s', 0, 'text')).rejects.toThrow(
       'tmux load-buffer exited with code 1',
     );
+  });
+});
+
+// ─── resumeTask ──────────────────────────────────────────────────────────────
+
+describe('resumeTask', () => {
+  const closedTask = {
+    ...DEFAULTS.runningTask,
+    status: 'closed' as const,
+  } as Task;
+
+  it('sets status to setting_up then running on success', async () => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    const updated = getTask(db, DEFAULTS.task.id)!;
+    expect(updated.status).toBe('running');
+  });
+
+  it('clears error field on resume', async () => {
+    insertTask(db, { ...closedTask, status: 'error', error: 'Previous error' });
+    insertAgent(db, { status: 'stopped' });
+
+    await resumeTask({ ...closedTask, status: 'error' as any } as Task);
+
+    const updated = getTask(db, DEFAULTS.task.id)!;
+    expect(updated.error).toBeNull();
+  });
+
+  it('marks stopped agents as running', async () => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2', status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents.every((a) => a.status === 'running')).toBe(true);
+  });
+
+  // ─── Shell commands (table-driven) ──────────────────────────────────────
+
+  const resumeShellCalls = [
+    { name: 'kills stale tmux session', cmd: 'tmux', argsInclude: ['kill-session'] },
+    { name: 'creates fresh tmux session', cmd: 'tmux', argsInclude: ['new-session'] },
+    { name: 'launches claude in window', cmd: 'tmux', argsInclude: ['send-keys', 'Enter'] },
+  ];
+
+  it.each(resumeShellCalls)('$name', async ({ cmd, argsInclude }) => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeDefined();
+  });
+
+  it('uses --resume with claude_session_id when available', async () => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped', claude_session_id: 'session-abc-123' });
+
+    await resumeTask(closedTask);
+
+    const sendKeysCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['send-keys'],
+    });
+    expect(sendKeysCall).toBeDefined();
+    const args = sendKeysCall![1] as string[];
+    const claudeCmd = args.find((a: string) => a.includes('claude'));
+    expect(claudeCmd).toContain('--resume');
+    expect(claudeCmd).toContain('session-abc-123');
+  });
+
+  it('uses --continue when claude_session_id is null', async () => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped', claude_session_id: null });
+
+    await resumeTask(closedTask);
+
+    const sendKeysCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['send-keys'],
+    });
+    const args = sendKeysCall![1] as string[];
+    const claudeCmd = args.find((a: string) => a.includes('claude'));
+    expect(claudeCmd).toContain('--continue');
+  });
+
+  it('creates new windows for agents after the first', async () => {
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2', status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    // Should create exactly one new-window (for second agent; first reuses session window)
+    const newWindowCalls = vi.mocked(execFile).mock.calls.filter(
+      (c: any[]) => c[0] === 'tmux' && (c[1] as string[]).includes('new-window'),
+    );
+    expect(newWindowCalls).toHaveLength(1);
+  });
+
+  it('sets error status on failure', async () => {
+    vi.mocked(execFile).mockImplementation(() => {
+      throw new Error('tmux not found');
+    });
+
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    const updated = getTask(db, DEFAULTS.task.id)!;
+    expect(updated.status).toBe('error');
+    expect(updated.error).toContain('tmux not found');
   });
 });

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -48,6 +48,7 @@ export const DEFAULTS = {
     window_index: 0,
     label: 'Agent 1',
     status: 'running' as const,
+    claude_session_id: null,
     created_at: '2026-01-01 00:00:00',
   },
 } satisfies Record<string, Partial<Task> | Partial<Agent>>;
@@ -104,8 +105,8 @@ export function insertAgent(db: Database.Database, overrides: Partial<Agent> = {
   } as Agent;
 
   db.prepare(
-    'INSERT INTO agents (id, task_id, window_index, label, status) VALUES (?, ?, ?, ?, ?)',
-  ).run(agent.id, agent.task_id, agent.window_index, agent.label, agent.status);
+    'INSERT INTO agents (id, task_id, window_index, label, status, claude_session_id) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(agent.id, agent.task_id, agent.window_index, agent.label, agent.status, agent.claude_session_id);
 
   return agent;
 }
@@ -116,6 +117,19 @@ export function getTask(db: Database.Database, id: string): Task | undefined {
 
 export function getAgents(db: Database.Database, taskId: string): Agent[] {
   return db.prepare('SELECT * FROM agents WHERE task_id = ?').all(taskId) as Agent[];
+}
+
+// ─── Callback Finder ─────────────────────────────────────────────────────────
+
+/**
+ * Find the callback function in a variadic argument list (for promisified execFile mocks).
+ * Searches from end to start since callbacks are typically last.
+ */
+export function findCallback(...args: any[]): Function | undefined {
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (typeof args[i] === 'function') return args[i];
+  }
+  return undefined;
 }
 
 // ─── Shell Mock Helpers ──────────────────────────────────────────────────────

--- a/src/components/AgentTabs.test.tsx
+++ b/src/components/AgentTabs.test.tsx
@@ -2,21 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AgentTabs } from './AgentTabs';
-import { renderWithRouter } from '../test-helpers';
-import type { Agent } from '../../server/types';
-
-function makeAgent(overrides: Partial<Agent> = {}): Agent {
-  return {
-    id: 'agent-01',
-    task_id: 'task-01',
-    window_index: 0,
-    label: 'Agent 1',
-    status: 'running',
-    claude_session_id: null,
-    created_at: '2026-01-01 00:00:00',
-    ...overrides,
-  };
-}
+import { renderWithRouter, makeAgent } from '../test-helpers';
 
 describe('AgentTabs', () => {
   const onSelect = vi.fn();

--- a/src/lib/api.test.tsx
+++ b/src/lib/api.test.tsx
@@ -19,193 +19,227 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// ─── request() via api methods ───────────────────────────────────────────────
+// ─── API methods (table-driven) ─────────────────────────────────────────────
 
-describe('api.listTasks', () => {
-  it('fetches /api/tasks with GET', async () => {
-    fetchMock.mockResolvedValue(mockResponse([]));
-    await api.listTasks();
+const apiCases = [
+  {
+    name: 'listTasks',
+    call: () => api.listTasks(),
+    expectedUrl: '/api/tasks',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: [{ id: 't1', title: 'Test' }],
+  },
+  {
+    name: 'getTask',
+    call: () => api.getTask('t1'),
+    expectedUrl: '/api/tasks/t1',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: { id: 't1' },
+  },
+  {
+    name: 'createTask',
+    call: () => api.createTask({ title: 'T', description: 'D', repo_path: '/tmp' }),
+    expectedUrl: '/api/tasks',
+    expectedMethod: 'POST',
+    expectedBody: JSON.stringify({ title: 'T', description: 'D', repo_path: '/tmp' }),
+    response: { id: 't1' },
+  },
+  {
+    name: 'updateTask',
+    call: () => api.updateTask('t1', { status: 'closed' }),
+    expectedUrl: '/api/tasks/t1',
+    expectedMethod: 'PATCH',
+    expectedBody: JSON.stringify({ status: 'closed' }),
+    response: { id: 't1', status: 'closed' },
+  },
+  {
+    name: 'startTask',
+    call: () => api.startTask('t1'),
+    expectedUrl: '/api/tasks/t1/start',
+    expectedMethod: 'POST',
+    expectedBody: undefined,
+    response: { id: 't1' },
+  },
+  {
+    name: 'deleteTask',
+    call: () => api.deleteTask('t1'),
+    expectedUrl: '/api/tasks/t1',
+    expectedMethod: 'DELETE',
+    expectedBody: undefined,
+    response: undefined,
+    status: 204,
+  },
+  {
+    name: 'addAgent with prompt',
+    call: () => api.addAgent('t1', { prompt: 'Write tests' }),
+    expectedUrl: '/api/tasks/t1/agents',
+    expectedMethod: 'POST',
+    expectedBody: JSON.stringify({ prompt: 'Write tests' }),
+    response: { id: 'a1' },
+  },
+  {
+    name: 'addAgent without data',
+    call: () => api.addAgent('t1'),
+    expectedUrl: '/api/tasks/t1/agents',
+    expectedMethod: 'POST',
+    expectedBody: JSON.stringify({}),
+    response: { id: 'a1' },
+  },
+  {
+    name: 'stopAgent',
+    call: () => api.stopAgent('t1', 'a1'),
+    expectedUrl: '/api/tasks/t1/agents/a1',
+    expectedMethod: 'DELETE',
+    expectedBody: undefined,
+    response: undefined,
+    status: 204,
+  },
+  {
+    name: 'browse with path',
+    call: () => api.browse('/tmp'),
+    expectedUrl: '/api/browse?path=%2Ftmp',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: { current: '/tmp', parent: '/', entries: [] },
+  },
+  {
+    name: 'browse without path',
+    call: () => api.browse(),
+    expectedUrl: '/api/browse',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: { current: '/home', parent: '/', entries: [] },
+  },
+  {
+    name: 'recentRepos',
+    call: () => api.recentRepos(),
+    expectedUrl: '/api/recent-repos',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: [],
+  },
+  {
+    name: 'listBranches',
+    call: () => api.listBranches('/tmp/repo'),
+    expectedUrl: '/api/branches?repo_path=%2Ftmp%2Frepo',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: ['main', 'develop'],
+  },
+  {
+    name: 'getDefaultBranch',
+    call: () => api.getDefaultBranch('/tmp/repo'),
+    expectedUrl: '/api/default-branch?repo_path=%2Ftmp%2Frepo',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: { branch: 'main' },
+  },
+  {
+    name: 'previewPR',
+    call: () => api.previewPR('t1', { base: 'main' }),
+    expectedUrl: '/api/tasks/t1/pr/preview',
+    expectedMethod: 'POST',
+    expectedBody: JSON.stringify({ base: 'main' }),
+    response: { title: 'feat: test', body: '## What', base: 'main' },
+  },
+  {
+    name: 'createPR',
+    call: () => api.createPR('t1', { base: 'main', title: 'feat: test', body: '## What' }),
+    expectedUrl: '/api/tasks/t1/pr',
+    expectedMethod: 'POST',
+    expectedBody: JSON.stringify({ base: 'main', title: 'feat: test', body: '## What' }),
+    response: { id: 't1', pr_url: 'https://gh/pr/1' },
+  },
+  {
+    name: 'orchestratorStatus',
+    call: () => api.orchestratorStatus(),
+    expectedUrl: '/api/orchestrator/status',
+    expectedMethod: undefined,
+    expectedBody: undefined,
+    response: { running: false, session: '' },
+  },
+  {
+    name: 'orchestratorStart',
+    call: () => api.orchestratorStart(),
+    expectedUrl: '/api/orchestrator/start',
+    expectedMethod: 'POST',
+    expectedBody: undefined,
+    response: { running: true, session: 'octomux-orchestrator' },
+  },
+  {
+    name: 'orchestratorStop',
+    call: () => api.orchestratorStop(),
+    expectedUrl: '/api/orchestrator/stop',
+    expectedMethod: 'POST',
+    expectedBody: undefined,
+    response: undefined,
+    status: 204,
+  },
+] as const;
+
+describe('api methods (table-driven)', () => {
+  it.each(apiCases)('$name → $expectedMethod $expectedUrl', async (testCase) => {
+    const status = 'status' in testCase ? (testCase.status as number) : 200;
+    fetchMock.mockResolvedValue(mockResponse(testCase.response, status));
+
+    const result = await testCase.call();
+
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks',
-      expect.objectContaining({ headers: { 'Content-Type': 'application/json' } }),
-    );
-  });
-
-  it('returns parsed response', async () => {
-    const tasks = [{ id: 't1', title: 'Test' }];
-    fetchMock.mockResolvedValue(mockResponse(tasks));
-    const result = await api.listTasks();
-    expect(result).toEqual(tasks);
-  });
-});
-
-describe('api.getTask', () => {
-  it('fetches /api/tasks/:id', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 't1' }));
-    await api.getTask('t1');
-    expect(fetchMock).toHaveBeenCalledWith('/api/tasks/t1', expect.any(Object));
-  });
-});
-
-describe('api.createTask', () => {
-  it('sends POST with body', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 't1' }));
-    await api.createTask({ title: 'T', description: 'D', repo_path: '/tmp' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks',
+      testCase.expectedUrl,
       expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ title: 'T', description: 'D', repo_path: '/tmp' }),
+        ...(testCase.expectedMethod ? { method: testCase.expectedMethod } : {}),
+        ...(testCase.expectedBody ? { body: testCase.expectedBody } : {}),
       }),
     );
-  });
-});
 
-describe('api.updateTask', () => {
-  it('sends PATCH with status', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 't1', status: 'closed' }));
-    await api.updateTask('t1', { status: 'closed' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1',
-      expect.objectContaining({
-        method: 'PATCH',
-        body: JSON.stringify({ status: 'closed' }),
-      }),
-    );
-  });
-});
-
-describe('api.deleteTask', () => {
-  it('sends DELETE and returns undefined for 204', async () => {
-    fetchMock.mockResolvedValue(mockResponse(undefined, 204));
-    const result = await api.deleteTask('t1');
-    expect(result).toBeUndefined();
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1',
-      expect.objectContaining({ method: 'DELETE' }),
-    );
-  });
-});
-
-describe('api.addAgent', () => {
-  it('sends POST with prompt', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 'a1' }));
-    await api.addAgent('t1', { prompt: 'Write tests' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1/agents',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ prompt: 'Write tests' }),
-      }),
-    );
-  });
-
-  it('sends empty object when no data provided', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 'a1' }));
-    await api.addAgent('t1');
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1/agents',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({}),
-      }),
-    );
-  });
-});
-
-describe('api.stopAgent', () => {
-  it('sends DELETE for agent', async () => {
-    fetchMock.mockResolvedValue(mockResponse(undefined, 204));
-    await api.stopAgent('t1', 'a1');
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1/agents/a1',
-      expect.objectContaining({ method: 'DELETE' }),
-    );
-  });
-});
-
-describe('api.browse', () => {
-  it('sends path as query param', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ current: '/tmp', parent: '/', entries: [] }));
-    await api.browse('/tmp');
-    expect(fetchMock).toHaveBeenCalledWith('/api/browse?path=%2Ftmp', expect.any(Object));
-  });
-
-  it('sends no query param when path is undefined', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ current: '/home', parent: '/', entries: [] }));
-    await api.browse();
-    expect(fetchMock).toHaveBeenCalledWith('/api/browse', expect.any(Object));
-  });
-});
-
-describe('api.recentRepos', () => {
-  it('fetches /api/recent-repos', async () => {
-    fetchMock.mockResolvedValue(mockResponse([]));
-    await api.recentRepos();
-    expect(fetchMock).toHaveBeenCalledWith('/api/recent-repos', expect.any(Object));
-  });
-});
-
-describe('api.previewPR', () => {
-  it('sends POST with base branch', async () => {
-    fetchMock.mockResolvedValue(
-      mockResponse({ title: 'feat: test', body: '## What', base: 'main' }),
-    );
-    await api.previewPR('t1', { base: 'main' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1/pr/preview',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ base: 'main' }),
-      }),
-    );
-  });
-});
-
-describe('api.createPR', () => {
-  it('sends POST with PR details', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ id: 't1', pr_url: 'https://gh/pr/1' }));
-    await api.createPR('t1', { base: 'main', title: 'feat: test', body: '## What' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/tasks/t1/pr',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ base: 'main', title: 'feat: test', body: '## What' }),
-      }),
-    );
+    if (status === 204) {
+      expect(result).toBeUndefined();
+    } else {
+      expect(result).toEqual(testCase.response);
+    }
   });
 });
 
 // ─── Error handling ──────────────────────────────────────────────────────────
 
 describe('request error handling', () => {
-  it('throws error from response body', async () => {
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 400,
-      statusText: 'Bad Request',
-      json: () => Promise.resolve({ error: 'title is required' }),
-    });
-    await expect(api.listTasks()).rejects.toThrow('title is required');
-  });
+  const errorCases = [
+    {
+      name: 'throws error from response body',
+      response: {
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: () => Promise.resolve({ error: 'title is required' }),
+      },
+      expectedError: 'title is required',
+    },
+    {
+      name: 'falls back to statusText when body has no error',
+      response: {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({}),
+      },
+      expectedError: 'Internal Server Error',
+    },
+    {
+      name: 'falls back to statusText when body parse fails',
+      response: {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.reject(new Error('not json')),
+      },
+      expectedError: 'Internal Server Error',
+    },
+  ];
 
-  it('falls back to statusText when body has no error', async () => {
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-      json: () => Promise.resolve({}),
-    });
-    await expect(api.listTasks()).rejects.toThrow('Internal Server Error');
-  });
-
-  it('falls back to statusText when body parse fails', async () => {
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-      json: () => Promise.reject(new Error('not json')),
-    });
-    await expect(api.listTasks()).rejects.toThrow('Internal Server Error');
+  it.each(errorCases)('$name', async ({ response, expectedError }) => {
+    fetchMock.mockResolvedValue(response);
+    await expect(api.listTasks()).rejects.toThrow(expectedError);
   });
 });

--- a/src/lib/hooks.test.tsx
+++ b/src/lib/hooks.test.tsx
@@ -22,42 +22,97 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// ─── useTasks ────────────────────────────────────────────────────────────────
+// ─── Shared hook behavior (table-driven) ─────────────────────────────────────
 
-describe('useTasks', () => {
+const hookCases = [
+  {
+    name: 'useTasks',
+    renderFn: (interval: number) => renderHook(() => useTasks(interval)),
+    mockFn: () => apiMock.listTasks,
+    successValue: [{ id: 't1', title: 'Test' }],
+    resultKey: 'tasks' as const,
+    emptyValue: [],
+  },
+  {
+    name: 'useTask',
+    renderFn: (interval: number) => renderHook(() => useTask('t1', interval)),
+    mockFn: () => apiMock.getTask,
+    successValue: { id: 't1', title: 'Test' },
+    resultKey: 'task' as const,
+    emptyValue: null,
+  },
+];
+
+describe.each(hookCases)('$name', ({ renderFn, mockFn, successValue, resultKey, emptyValue }) => {
   it('starts in loading state', async () => {
-    apiMock.listTasks.mockReturnValue(new Promise(() => {}));
-    const { result } = renderHook(() => useTasks(60000));
+    mockFn().mockReturnValue(new Promise(() => {}));
+    const { result } = renderFn(60000);
     expect(result.current.loading).toBe(true);
-    expect(result.current.tasks).toEqual([]);
+    expect((result.current as any)[resultKey]).toEqual(emptyValue);
     expect(result.current.error).toBeNull();
   });
 
-  it('returns tasks after fetch', async () => {
-    const tasks = [{ id: 't1', title: 'Test' }];
-    apiMock.listTasks.mockResolvedValue(tasks);
+  it('returns data after fetch', async () => {
+    mockFn().mockResolvedValue(successValue);
 
-    const { result } = renderHook(() => useTasks(60000));
+    const { result } = renderFn(60000);
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    expect(result.current.tasks).toEqual(tasks);
+    expect((result.current as any)[resultKey]).toEqual(successValue);
     expect(result.current.error).toBeNull();
   });
 
   it('sets error on fetch failure', async () => {
-    apiMock.listTasks.mockRejectedValue(new Error('Network error'));
+    mockFn().mockRejectedValue(new Error('Network error'));
 
-    const { result } = renderHook(() => useTasks(60000));
+    const { result } = renderFn(60000);
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
     expect(result.current.error).toBe('Network error');
-    expect(result.current.tasks).toEqual([]);
+    expect((result.current as any)[resultKey]).toEqual(emptyValue);
   });
 
+  it('polls at the specified interval', async () => {
+    mockFn().mockResolvedValue(successValue);
+
+    renderFn(50);
+
+    await waitFor(() => {
+      expect(mockFn()).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(
+      () => {
+        expect(mockFn().mock.calls.length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 500 },
+    );
+  });
+
+  it('cleans up interval on unmount', async () => {
+    mockFn().mockResolvedValue(successValue);
+
+    const { unmount } = renderFn(50);
+
+    await waitFor(() => {
+      expect(mockFn()).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    const callCount = mockFn().mock.calls.length;
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(mockFn().mock.calls.length).toBe(callCount);
+  });
+});
+
+// ─── useTasks-specific ──────────────────────────────────────────────────────
+
+describe('useTasks', () => {
   it('clears error on successful refetch via refresh()', async () => {
     apiMock.listTasks.mockRejectedValueOnce(new Error('fail'));
 
@@ -75,42 +130,6 @@ describe('useTasks', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.tasks).toEqual([{ id: 't1' }]);
-  });
-
-  it('polls at the specified interval', async () => {
-    apiMock.listTasks.mockResolvedValue([]);
-
-    // Use a very short interval for testing
-    renderHook(() => useTasks(50));
-
-    await waitFor(() => {
-      expect(apiMock.listTasks).toHaveBeenCalledTimes(1);
-    });
-
-    // Wait for at least one poll cycle
-    await waitFor(
-      () => {
-        expect(apiMock.listTasks.mock.calls.length).toBeGreaterThanOrEqual(2);
-      },
-      { timeout: 500 },
-    );
-  });
-
-  it('cleans up interval on unmount', async () => {
-    apiMock.listTasks.mockResolvedValue([]);
-
-    const { unmount } = renderHook(() => useTasks(50));
-
-    await waitFor(() => {
-      expect(apiMock.listTasks).toHaveBeenCalledTimes(1);
-    });
-
-    unmount();
-    const callCount = apiMock.listTasks.mock.calls.length;
-
-    // Wait to confirm no more calls happen
-    await new Promise((r) => setTimeout(r, 150));
-    expect(apiMock.listTasks.mock.calls.length).toBe(callCount);
   });
 
   it('provides a refresh function', async () => {
@@ -132,21 +151,9 @@ describe('useTasks', () => {
   });
 });
 
-// ─── useTask ─────────────────────────────────────────────────────────────────
+// ─── useTask-specific ───────────────────────────────────────────────────────
 
 describe('useTask', () => {
-  it('returns task after fetch', async () => {
-    const task = { id: 't1', title: 'Test' };
-    apiMock.getTask.mockResolvedValue(task);
-
-    const { result } = renderHook(() => useTask('t1', 60000));
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-    expect(result.current.task).toEqual(task);
-  });
-
   it('calls getTask with the provided id', async () => {
     apiMock.getTask.mockResolvedValue({ id: 'my-task' });
 
@@ -155,50 +162,5 @@ describe('useTask', () => {
     await waitFor(() => {
       expect(apiMock.getTask).toHaveBeenCalledWith('my-task');
     });
-  });
-
-  it('sets error on fetch failure', async () => {
-    apiMock.getTask.mockRejectedValue(new Error('Not found'));
-
-    const { result } = renderHook(() => useTask('t1', 60000));
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-    expect(result.current.error).toBe('Not found');
-    expect(result.current.task).toBeNull();
-  });
-
-  it('polls at the specified interval', async () => {
-    apiMock.getTask.mockResolvedValue({ id: 't1' });
-
-    renderHook(() => useTask('t1', 50));
-
-    await waitFor(() => {
-      expect(apiMock.getTask).toHaveBeenCalledTimes(1);
-    });
-
-    await waitFor(
-      () => {
-        expect(apiMock.getTask.mock.calls.length).toBeGreaterThanOrEqual(2);
-      },
-      { timeout: 500 },
-    );
-  });
-
-  it('cleans up interval on unmount', async () => {
-    apiMock.getTask.mockResolvedValue({ id: 't1' });
-
-    const { unmount } = renderHook(() => useTask('t1', 50));
-
-    await waitFor(() => {
-      expect(apiMock.getTask).toHaveBeenCalledTimes(1);
-    });
-
-    unmount();
-    const callCount = apiMock.getTask.mock.calls.length;
-
-    await new Promise((r) => setTimeout(r, 150));
-    expect(apiMock.getTask.mock.calls.length).toBe(callCount);
   });
 });

--- a/src/lib/use-task-filters.test.tsx
+++ b/src/lib/use-task-filters.test.tsx
@@ -1,28 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTaskFilters } from './use-task-filters';
+import { makeTask } from '../test-helpers';
 import type { Task } from '../../server/types';
-
-function makeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: 'test-01',
-    title: 'Test',
-    description: 'Desc',
-    repo_path: '/tmp/repo',
-    status: 'running',
-    branch: null,
-    base_branch: null,
-    worktree: null,
-    tmux_session: null,
-    pr_url: null,
-    pr_number: null,
-    initial_prompt: null,
-    error: null,
-    created_at: '2026-01-01 00:00:00',
-    updated_at: '2026-01-01 00:00:00',
-    ...overrides,
-  };
-}
 
 beforeEach(() => {
   localStorage.clear();

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,9 +1,23 @@
 import { render, type RenderOptions } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { ReactElement } from 'react';
-import type { Task, TaskStatus } from '../server/types';
+import type { Task, TaskStatus, Agent } from '../server/types';
 
 // ─── Default Fixtures ────────────────────────────────────────────────────────
+
+export const AGENT_DEFAULTS: Agent = {
+  id: 'agent-01',
+  task_id: 'test-task-01',
+  window_index: 0,
+  label: 'Agent 1',
+  status: 'running',
+  claude_session_id: null,
+  created_at: '2026-01-01 00:00:00',
+};
+
+export function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return { ...AGENT_DEFAULTS, ...overrides };
+}
 
 export const TASK_DEFAULTS: Task = {
   id: 'test-task-01',


### PR DESCRIPTION
## What
- Consolidate duplicated test fixtures (`makeTask`, `makeAgent`, `findCallback`) into shared test-helpers
- Convert repetitive tests to `it.each()` table-driven patterns across API, hooks, frontend API, and pr-template tests
- Consolidate 8 individual 404 tests into a single table-driven block
- Add 34 new tests covering previously untested code paths (361 → 395 tests)

## Why
The test suite had duplicated fixtures across files, repetitive individual test cases that should be table-driven per project convention, and significant untested code paths including `resumeTask`, the PATCH resume flow, `pollStatuses` for `setting_up` death, and several frontend API methods.

## Testing
- All 395 tests pass (`bun run test`)
- Lint clean (`bun run lint` — 0 errors)
- Typecheck clean (`bun run typecheck`)