### PR TITLE
fix(terminal): prevent editor/agent pane from reloading

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -83,11 +83,19 @@ export function useTask(id: string, pollInterval = 5000) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastJsonRef = useRef<string>('');
 
   const refresh = useCallback(async () => {
     try {
       const data = await api.getTask(id);
-      setTask(data);
+      // Only trigger a re-render when the task data actually changed.
+      // Without this, every poll creates a new object reference and causes
+      // the entire TaskDetail tree to re-render, risking terminal remounts.
+      const json = JSON.stringify(data);
+      if (json !== lastJsonRef.current) {
+        lastJsonRef.current = json;
+        setTask(data);
+      }
       setError(null);
     } catch (err) {
       setError((err as Error).message);

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -17,20 +17,24 @@ export default function TaskDetail() {
   const [prDialogOpen, setPrDialogOpen] = useState(false);
   const [resuming, setResuming] = useState(false);
   const [mode, setMode] = useState<'agents' | 'editor'>('agents');
-  const [userWindowIndex, setUserWindowIndex] = useState<number | null>(null);
+  const [creatingEditor, setCreatingEditor] = useState(false);
+
+  // Derive userWindowIndex from server-persisted data so it survives page
+  // refreshes and doesn't rely on ephemeral local state.
+  const userWindowIndex = task?.user_window_index ?? null;
 
   // Initialize activeWindow from first agent's window_index
+  const firstAgentWindow = task?.agents?.[0]?.window_index ?? null;
   useEffect(() => {
-    if (activeWindow === null && task?.agents?.length) {
-      setActiveWindow(task.agents[0].window_index);
+    if (activeWindow === null && firstAgentWindow !== null) {
+      setActiveWindow(firstAgentWindow);
     }
-  }, [task, activeWindow]);
+  }, [firstAgentWindow, activeWindow]);
 
-  // Auto-switch back to agents and reset editor state when task enters non-running state
+  // Auto-switch back to agents when task enters non-running state
   useEffect(() => {
     if (task && task.status !== 'running') {
       setMode('agents');
-      setUserWindowIndex(null);
     }
   }, [task?.status]);
 
@@ -107,16 +111,22 @@ export default function TaskDetail() {
       return;
     }
     if (userWindowIndex === null) {
+      if (creatingEditor) return; // Prevent duplicate requests
+      setCreatingEditor(true);
       try {
-        const result = await api.createUserTerminal(taskId);
-        setUserWindowIndex(result.user_window_index);
+        await api.createUserTerminal(taskId);
+        // The server persists user_window_index — the next poll refresh will
+        // pick it up via task.user_window_index, so no local state to set.
+        refresh();
       } catch (err) {
         console.error('Failed to create user terminal:', err);
         return;
+      } finally {
+        setCreatingEditor(false);
       }
     }
     setMode('editor');
-  }, [mode, userWindowIndex, taskId]);
+  }, [mode, userWindowIndex, taskId, creatingEditor, refresh]);
 
   if (loading) {
     return (
@@ -126,7 +136,7 @@ export default function TaskDetail() {
     );
   }
 
-  if (error || !task) {
+  if (!task) {
     return (
       <div className="flex h-screen flex-col items-center justify-center gap-4">
         <p className="text-destructive">{error || 'Task not found'}</p>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
         ws: true,
       },
     },
+    watch: {
+      // Ignore git worktrees so agent file changes don't trigger HMR/reloads
+      ignored: ['**/.worktrees/**'],
+    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- **Root cause**: Vite's file watcher detected changes in `.worktrees/` made by agents, triggering HMR/full-page reloads that killed all terminal connections
- Excluded `.worktrees/**` from Vite's watch config to prevent reload triggers
- Fixed `useTask` hook to skip re-renders when polled data is unchanged (JSON comparison)
- Derived `userWindowIndex` from server-persisted `task.user_window_index` instead of ephemeral local state — prevents duplicate editor windows and survives page refreshes
- Added `creatingEditor` guard to prevent race condition creating multiple nvim windows
- Polling errors no longer unmount the terminal (`error || !task` → `!task`)
- Stabilized `useEffect` deps to use primitive values instead of full task object

## Test plan
- [x] All 440 unit/component tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean (0 errors)
- [x] Prettier formatting passes
- [ ] Manual: start a task, open editor pane — terminal stays stable while agents work in worktrees
- [ ] Manual: click Editor button rapidly — only one nvim window created
- [ ] Manual: refresh page while editor is open — editor reconnects to existing terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)