### PR TITLE
feat: track agent permission prompts for user review

### DIFF
--- a/docs/superpowers/plans/2026-03-11-agent-permission-tracking.md
+++ b/docs/superpowers/plans/2026-03-11-agent-permission-tracking.md
@@ -1,0 +1,1414 @@
+# Agent Permission Prompt Tracking — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track Claude Code agent permission prompts via HTTP hooks and display them inline on task cards with real-time agent activity status.
+
+**Architecture:** Three HTTP hook endpoints receive events from Claude Code agents running in tmux. Events are stored in SQLite and served via the existing `/api/tasks` response. Frontend task cards show pending prompts and agent activity indicators. A derived task status (working/needs_attention/done) replaces the generic "running" badge.
+
+**Tech Stack:** Express 5, better-sqlite3, React 19, Tailwind CSS 4, shadcn/ui, vitest, supertest
+
+**Spec:** `docs/superpowers/specs/2026-03-11-agent-permission-tracking-design.md`
+
+---
+
+## File Structure
+
+### New files
+- `server/hooks.ts` — Hook route handlers (permission-request, post-tool-use, stop)
+- `server/hooks.test.ts` — Hook endpoint tests
+- `server/hook-settings.ts` — Generate/merge `.claude/settings.local.json` for worktrees
+- `server/hook-settings.test.ts` — Hook settings generation tests
+- `src/components/PermissionPromptRow.tsx` — Single permission prompt display row
+- `src/components/AgentActivityDot.tsx` — Colored dot for agent hook_activity state
+
+### Modified files
+- `server/types.ts` — Add HookActivity, PermissionPrompt, DerivedTaskStatus types
+- `server/db.ts` — Add permission_prompts table, hook_activity column, startup cleanup
+- `server/api.ts` — Mount hook routes, update GET /api/tasks to include prompts + derived_status
+- `server/task-runner.ts` — Install hooks in startTask(), resolve prompts in closeTask()/stopAgent(), fix resumeTask() session ID
+- `server/test-helpers.ts` — Add DEFAULTS.permissionPrompt, insertPermissionPrompt(), PERMISSION_PROMPTS_TABLE_COLUMNS
+- `src/components/TaskCard.tsx` — Show pending prompts, agent activity, derived status
+- `src/components/StatusBadge.tsx` — Support derived_status values
+- `src/components/AgentTabs.tsx` — Show hook_activity dot on agent tabs
+
+---
+
+## Chunk 1: Data Model + Types
+
+### Task 1: Types
+
+**Files:**
+- Modify: `server/types.ts`
+
+- [ ] **Step 1: Add HookActivity, PermissionPrompt, and DerivedTaskStatus types**
+
+Add after the existing `AgentStatus` type (line 2):
+
+```typescript
+export type HookActivity = 'active' | 'idle' | 'waiting';
+export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
+```
+
+Add after the `Agent` interface (after line 32):
+
+```typescript
+export interface PermissionPrompt {
+  id: string;
+  task_id: string;
+  agent_id: string | null;
+  agent_label: string;
+  session_id: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  status: 'pending' | 'resolved';
+  created_at: string;
+  resolved_at: string | null;
+}
+```
+
+Add `hook_activity` and `hook_activity_updated_at` to the `Agent` interface:
+
+```typescript
+hook_activity: HookActivity;
+hook_activity_updated_at: string | null;
+```
+
+Add `pending_prompts` and `derived_status` to the `Task` interface:
+
+```typescript
+pending_prompts?: PermissionPrompt[];
+derived_status?: DerivedTaskStatus | null;
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: Errors in files that construct Agent/Task objects without the new fields (this is expected — we'll fix in later tasks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/types.ts
+git commit -m "feat(types): add HookActivity, PermissionPrompt, DerivedTaskStatus types"
+```
+
+### Task 2: Database Schema + Migrations
+
+**Files:**
+- Modify: `server/db.ts`
+
+- [ ] **Step 1: Add permission_prompts table to SCHEMA constant**
+
+After the agents table definition (around line 37), add:
+
+```sql
+CREATE TABLE IF NOT EXISTS permission_prompts (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  agent_id TEXT,
+  session_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  tool_input TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_task_id ON permission_prompts(task_id);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_status ON permission_prompts(status);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_agent_status ON permission_prompts(agent_id, status);
+```
+
+- [ ] **Step 2: Add hook_activity migration in initDb()**
+
+After the existing agent column migrations (around line 77), add:
+
+```typescript
+const agentCols2 = instance.pragma('table_info(agents)') as Array<{ name: string }>;
+const agentColNames2 = agentCols2.map((c) => c.name);
+if (!agentColNames2.includes('hook_activity')) {
+  instance.exec("ALTER TABLE agents ADD COLUMN hook_activity TEXT NOT NULL DEFAULT 'active'");
+  instance.exec('ALTER TABLE agents ADD COLUMN hook_activity_updated_at TEXT');
+}
+```
+
+- [ ] **Step 3: Add startup cleanup for stale prompts**
+
+After the migrations, add:
+
+```typescript
+instance.exec(
+  `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now') WHERE status = 'pending'`
+);
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS (or same errors from Task 1 — no new errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/db.ts
+git commit -m "feat(db): add permission_prompts table and hook_activity column"
+```
+
+### Task 3: Test Helpers
+
+**Files:**
+- Modify: `server/test-helpers.ts`
+
+- [ ] **Step 1: Add DEFAULTS.permissionPrompt fixture**
+
+After `DEFAULTS.agent` (around line 56), add:
+
+```typescript
+permissionPrompt: {
+  id: 'pp_test123456',
+  task_id: 'task_test1234',
+  agent_id: 'agent_test123',
+  session_id: 'session-uuid-test',
+  tool_name: 'Bash',
+  tool_input: '{"command":"npm test"}',
+  status: 'pending' as const,
+  created_at: new Date().toISOString(),
+  resolved_at: null,
+},
+```
+
+- [ ] **Step 2: Update insertAgent() to include hook_activity column**
+
+The existing `insertAgent()` INSERT statement (line 111) does not include `hook_activity`. Update it to:
+
+```typescript
+db.prepare(
+  'INSERT INTO agents (id, task_id, window_index, label, status, claude_session_id, hook_activity) VALUES (?, ?, ?, ?, ?, ?, ?)',
+).run(
+  agent.id,
+  agent.task_id,
+  agent.window_index,
+  agent.label,
+  agent.status,
+  agent.claude_session_id,
+  agent.hook_activity || 'active',
+);
+```
+
+- [ ] **Step 3: Add insertPermissionPrompt() helper**
+
+After `insertAgent()` (around line 122), add. Note: follows existing pattern of `db` as first param:
+
+```typescript
+export function insertPermissionPrompt(
+  db: Database.Database,
+  overrides: Partial<typeof DEFAULTS.permissionPrompt> = {},
+) {
+  const pp = { ...DEFAULTS.permissionPrompt, ...overrides };
+  db.prepare(
+    `INSERT INTO permission_prompts (id, task_id, agent_id, session_id, tool_name, tool_input, status, created_at, resolved_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    pp.id,
+    pp.task_id,
+    pp.agent_id,
+    pp.session_id,
+    pp.tool_name,
+    pp.tool_input,
+    pp.status,
+    pp.created_at,
+    pp.resolved_at,
+  );
+  return pp;
+}
+```
+
+- [ ] **Step 4: Add getPermissionPrompts() helper**
+
+```typescript
+export function getPermissionPrompts(db: Database.Database, taskId: string) {
+  return db
+    .prepare('SELECT * FROM permission_prompts WHERE task_id = ? ORDER BY created_at ASC')
+    .all(taskId) as Array<Record<string, unknown>>;
+}
+```
+
+- [ ] **Step 5: Add PERMISSION_PROMPTS_TABLE_COLUMNS constant**
+
+After `AGENTS_TABLE_COLUMNS` (around line 211), add:
+
+```typescript
+export const PERMISSION_PROMPTS_TABLE_COLUMNS = [
+  'id',
+  'task_id',
+  'agent_id',
+  'session_id',
+  'tool_name',
+  'tool_input',
+  'status',
+  'created_at',
+  'resolved_at',
+];
+```
+
+- [ ] **Step 6: Update AGENTS_TABLE_COLUMNS**
+
+Add `'hook_activity'` and `'hook_activity_updated_at'` to the existing `AGENTS_TABLE_COLUMNS` array.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/test-helpers.ts
+git commit -m "feat(test): add permission prompt fixtures and helpers"
+```
+
+### Task 4: DB Migration Tests
+
+**Files:**
+- Modify: `server/db.test.ts`
+
+- [ ] **Step 1: Add tests for new table and columns**
+
+Add test cases to the existing db test file:
+
+```typescript
+describe('permission_prompts table', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('creates permission_prompts table with correct columns', () => {
+    const cols = db
+      .pragma('table_info(permission_prompts)')
+      .map((c: { name: string }) => c.name);
+    expect(cols).toEqual(PERMISSION_PROMPTS_TABLE_COLUMNS);
+  });
+
+  it('adds hook_activity column to agents table', () => {
+    const cols = db
+      .pragma('table_info(agents)')
+      .map((c: { name: string }) => c.name);
+    expect(cols).toContain('hook_activity');
+    expect(cols).toContain('hook_activity_updated_at');
+  });
+
+  it('resolves stale pending prompts on startup', () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1' });
+    insertPermissionPrompt(db, { id: 'pp1', task_id: 't1', agent_id: 'a1', status: 'pending' });
+
+    // Re-init simulates restart
+    initDb(db);
+
+    const prompts = getPermissionPrompts(db, 't1');
+    expect(prompts[0].status).toBe('resolved');
+    expect(prompts[0].resolved_at).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun run test server/db.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/db.test.ts
+git commit -m "test(db): add permission_prompts table and hook_activity migration tests"
+```
+
+---
+
+## Chunk 2: Hook Endpoints
+
+### Task 5: Hook Route Handlers
+
+**Files:**
+- Create: `server/hooks.ts`
+
+- [ ] **Step 1: Write the hook handlers module**
+
+```typescript
+import { Router } from 'express';
+import { nanoid } from 'nanoid';
+import { getDb } from './db.js';
+
+const router = Router();
+
+function findAgentBySessionId(sessionId: string) {
+  return getDb()
+    .prepare(
+      `SELECT a.id, a.task_id FROM agents a
+       WHERE a.claude_session_id = ? AND a.status != 'stopped'
+       LIMIT 1`,
+    )
+    .get(sessionId) as { id: string; task_id: string } | undefined;
+}
+
+// POST /api/hooks/permission-request
+router.post('/permission-request', (req, res) => {
+  const { session_id, tool_name, tool_input } = req.body;
+  if (!session_id || !tool_name) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    getDb()
+      .prepare(
+        `INSERT INTO permission_prompts (id, task_id, agent_id, session_id, tool_name, tool_input, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', datetime('now'))`,
+      )
+      .run(nanoid(12), agent.task_id, agent.id, session_id, tool_name, JSON.stringify(tool_input || {}));
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'waiting', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+// POST /api/hooks/post-tool-use
+router.post('/post-tool-use', (req, res) => {
+  const { session_id } = req.body;
+  if (!session_id) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    // Resolve oldest pending prompt (FIFO)
+    getDb()
+      .prepare(
+        `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+         WHERE id = (
+           SELECT id FROM permission_prompts
+           WHERE agent_id = ? AND status = 'pending'
+           ORDER BY created_at ASC LIMIT 1
+         )`,
+      )
+      .run(agent.id);
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+// POST /api/hooks/stop
+router.post('/stop', (req, res) => {
+  const { session_id } = req.body;
+  if (!session_id) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    // Resolve ALL pending prompts for this agent
+    getDb()
+      .prepare(
+        `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+         WHERE agent_id = ? AND status = 'pending'`,
+      )
+      .run(agent.id);
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'idle', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+export { router as hookRoutes };
+```
+
+- [ ] **Step 2: Mount hooks router in api.ts**
+
+In `server/api.ts`, import and mount the router. After the existing route setup (around line 65), add:
+
+```typescript
+import { hookRoutes } from './hooks.js';
+```
+
+Inside `setupRoutes()`, add:
+
+```typescript
+app.use('/api/hooks', hookRoutes);
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/hooks.ts server/api.ts
+git commit -m "feat(hooks): add permission-request, post-tool-use, and stop HTTP hook endpoints"
+```
+
+### Task 6: Hook Endpoint Tests
+
+**Files:**
+- Create: `server/hooks.test.ts`
+
+- [ ] **Step 1: Write hook endpoint tests**
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import { createTestDb, insertTask, insertAgent, insertPermissionPrompt, getPermissionPrompts, DEFAULTS } from './test-helpers.js';
+import { createApp } from './app.js';
+
+describe('Hook endpoints', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1', claude_session_id: 'sess-123' });
+  });
+
+  describe('POST /api/hooks/permission-request', () => {
+    it('creates pending permission prompt and sets agent to waiting', async () => {
+      await request(app)
+        .post('/api/hooks/permission-request')
+        .send({
+          session_id: 'sess-123',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'rm -rf dist' },
+        })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].tool_name).toBe('Bash');
+      expect(prompts[0].status).toBe('pending');
+      expect(prompts[0].agent_id).toBe('a1');
+
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('waiting');
+    });
+
+    it('ignores unknown session_id', async () => {
+      await request(app)
+        .post('/api/hooks/permission-request')
+        .send({ session_id: 'unknown', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts).toHaveLength(0);
+    });
+
+    it('ignores request with missing fields', async () => {
+      await request(app)
+        .post('/api/hooks/permission-request')
+        .send({})
+        .expect(200);
+    });
+  });
+
+  describe('POST /api/hooks/post-tool-use', () => {
+    it('resolves oldest pending prompt and sets agent to active', async () => {
+      insertPermissionPrompt(db, { id: 'pp1', task_id: 't1', agent_id: 'a1', session_id: 'sess-123', created_at: '2026-01-01T00:00:00Z' });
+      insertPermissionPrompt(db, { id: 'pp2', task_id: 't1', agent_id: 'a1', session_id: 'sess-123', created_at: '2026-01-01T00:01:00Z' });
+
+      await request(app)
+        .post('/api/hooks/post-tool-use')
+        .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      const pp1 = prompts.find((p) => p.id === 'pp1');
+      const pp2 = prompts.find((p) => p.id === 'pp2');
+      expect(pp1?.status).toBe('resolved');
+      expect(pp2?.status).toBe('pending');
+
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('active');
+    });
+
+    it('no-ops when no pending prompts exist', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use')
+        .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('active');
+    });
+  });
+
+  describe('POST /api/hooks/stop', () => {
+    it('resolves all pending prompts and sets agent to idle', async () => {
+      insertPermissionPrompt(db, { id: 'pp1', task_id: 't1', agent_id: 'a1', session_id: 'sess-123' });
+      insertPermissionPrompt(db, { id: 'pp2', task_id: 't1', agent_id: 'a1', session_id: 'sess-123' });
+
+      await request(app)
+        .post('/api/hooks/stop')
+        .send({ session_id: 'sess-123', stop_hook_active: false })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
+
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('idle');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun run test server/hooks.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/hooks.test.ts
+git commit -m "test(hooks): add hook endpoint tests for permission tracking"
+```
+
+---
+
+## Chunk 3: Hook Installation + Task Runner Integration
+
+### Task 7: Hook Settings Generator
+
+**Files:**
+- Create: `server/hook-settings.ts`
+
+- [ ] **Step 1: Write the hook settings module**
+
+```typescript
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const OCTOMUX_HOOKS = {
+  PermissionRequest: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/permission-request',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+  PostToolUse: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/post-tool-use',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+  Stop: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/stop',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+};
+
+export function installHookSettings(worktreePath: string): void {
+  const claudeDir = join(worktreePath, '.claude');
+  const settingsPath = join(claudeDir, 'settings.local.json');
+
+  let existing: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      existing = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    } catch {
+      // Corrupted file — overwrite
+    }
+  }
+
+  // Merge hooks: append our matcher groups to each event array
+  const existingHooks = (existing.hooks || {}) as Record<string, unknown[]>;
+  const mergedHooks = { ...existingHooks };
+
+  for (const [event, matcherGroups] of Object.entries(OCTOMUX_HOOKS)) {
+    const existingGroups = mergedHooks[event] || [];
+    mergedHooks[event] = [...existingGroups, ...matcherGroups];
+  }
+
+  const merged = { ...existing, hooks: mergedHooks };
+
+  if (!existsSync(claudeDir)) {
+    mkdirSync(claudeDir, { recursive: true });
+  }
+  writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/hook-settings.ts
+git commit -m "feat(hooks): add hook settings generator for worktrees"
+```
+
+### Task 8: Hook Settings Tests
+
+**Files:**
+- Create: `server/hook-settings.test.ts`
+
+- [ ] **Step 1: Write tests**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { installHookSettings } from './hook-settings.js';
+
+describe('installHookSettings', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'octomux-hooks-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates .claude/settings.local.json with hook config', () => {
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(readFileSync(join(tmpDir, '.claude', 'settings.local.json'), 'utf-8'));
+    expect(settings.hooks.PermissionRequest).toHaveLength(1);
+    expect(settings.hooks.PostToolUse).toHaveLength(1);
+    expect(settings.hooks.Stop).toHaveLength(1);
+    expect(settings.hooks.PermissionRequest[0].hooks[0].type).toBe('http');
+  });
+
+  it('merges with existing settings', () => {
+    const claudeDir = join(tmpDir, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, 'settings.local.json'),
+      JSON.stringify({ existingKey: true, hooks: { PreToolUse: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] } }),
+    );
+
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.local.json'), 'utf-8'));
+    expect(settings.existingKey).toBe(true);
+    expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(settings.hooks.PermissionRequest).toHaveLength(1);
+  });
+
+  it('handles corrupted existing file', () => {
+    const claudeDir = join(tmpDir, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.local.json'), 'not json');
+
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.local.json'), 'utf-8'));
+    expect(settings.hooks.PermissionRequest).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun run test server/hook-settings.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/hook-settings.test.ts
+git commit -m "test(hooks): add hook settings generator tests"
+```
+
+### Task 9: Integrate Hooks into Task Runner
+
+**Files:**
+- Modify: `server/task-runner.ts`
+
+- [ ] **Step 1: Install hooks in startTask()**
+
+Import at top:
+
+```typescript
+import { installHookSettings } from './hook-settings.js';
+```
+
+In `startTask()`, after the existing `.claude/settings.local.json` copy (around line 96), add:
+
+```typescript
+installHookSettings(worktreePath);
+```
+
+This runs after the copy so it merges with any existing settings from the source repo.
+
+- [ ] **Step 2: Resolve prompts in closeTask()**
+
+In `closeTask()` (around line 187), BEFORE the existing agent status update, add:
+
+```typescript
+getDb()
+  .prepare(
+    `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+     WHERE task_id = ? AND status = 'pending'`,
+  )
+  .run(task.id);
+```
+
+- [ ] **Step 3: Resolve prompts in stopAgent()**
+
+In `stopAgent()` (around line 226), BEFORE the agent status update, add:
+
+```typescript
+getDb()
+  .prepare(
+    `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+     WHERE agent_id = ? AND status = 'pending'`,
+  )
+  .run(agent.id);
+```
+
+- [ ] **Step 4: Fix resumeTask() session ID for --continue agents**
+
+In `resumeTask()`, replace the `--continue` else branch (lines 302-304):
+
+Before:
+```typescript
+const claudeCmd = agent.claude_session_id
+  ? `claude --resume ${agent.claude_session_id}`
+  : 'claude --continue';
+```
+
+After:
+```typescript
+let claudeCmd: string;
+if (agent.claude_session_id) {
+  claudeCmd = `claude --resume ${agent.claude_session_id}`;
+} else {
+  const newSessionId = crypto.randomUUID();
+  claudeCmd = `claude --continue --session-id ${newSessionId}`;
+  db.prepare('UPDATE agents SET claude_session_id = ? WHERE id = ?').run(newSessionId, agent.id);
+}
+```
+
+Add `import crypto from 'crypto';` at the top if not already present (or use `crypto.randomUUID()` which is available in Node 19+).
+
+- [ ] **Step 5: Install hooks in resumeTask()**
+
+In `resumeTask()`, after verifying the worktree exists (around line 269), add:
+
+```typescript
+installHookSettings(task.worktree!);
+```
+
+This ensures worktrees created before this feature was deployed get hook settings on resume.
+
+- [ ] **Step 6: Update addAgent() return to include hook_activity**
+
+In `addAgent()` (around line 175), update the returned Agent object to include:
+
+```typescript
+hook_activity: 'active' as const,
+hook_activity_updated_at: null,
+```
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/task-runner.ts
+git commit -m "feat(task-runner): install hooks in worktrees, resolve prompts on close/stop"
+```
+
+### Task 10: Task Runner Integration Tests
+
+**Files:**
+- Modify: `server/task-runner.test.ts`
+
+- [ ] **Step 1: Add tests for hook installation and prompt resolution**
+
+Add to existing test suite:
+
+Note: task-runner tests already have a `db` variable from `createTestDb()` in `beforeEach`.
+Use the existing test setup pattern (mock execFile, fs, etc.) from the test file.
+
+```typescript
+describe('hook integration', () => {
+  it('startTask installs hook settings in worktree', async () => {
+    // ... existing startTask test setup with mocked fs
+    await startTask(task);
+    // Verify writeFileSync was called with path containing '.claude/settings.local.json'
+    // and content containing 'permission-request'
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (call) => String(call[0]).includes('settings.local.json'),
+    );
+    expect(writeCall).toBeDefined();
+    expect(String(writeCall![1])).toContain('permission-request');
+  });
+
+  it('closeTask resolves all pending permission prompts', async () => {
+    insertPermissionPrompt(db, { id: 'pp1', task_id: task.id, agent_id: 'a1', status: 'pending' });
+    insertPermissionPrompt(db, { id: 'pp2', task_id: task.id, agent_id: 'a1', status: 'pending' });
+
+    await closeTask(task);
+
+    const prompts = getPermissionPrompts(db, task.id);
+    expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
+  });
+
+  it('stopAgent resolves pending prompts for that agent only', async () => {
+    insertAgent(db, { id: 'a2', task_id: task.id, window_index: 1 });
+    insertPermissionPrompt(db, { id: 'pp1', task_id: task.id, agent_id: 'a1', status: 'pending' });
+    insertPermissionPrompt(db, { id: 'pp2', task_id: task.id, agent_id: 'a2', status: 'pending' });
+
+    await stopAgent(task, { id: 'a1', window_index: 0 } as Agent);
+
+    const prompts = getPermissionPrompts(db, task.id);
+    const pp1 = prompts.find((p) => p.id === 'pp1');
+    const pp2 = prompts.find((p) => p.id === 'pp2');
+    expect(pp1?.status).toBe('resolved');
+    expect(pp2?.status).toBe('pending');
+  });
+
+  it('resumeTask generates session ID for --continue agents', async () => {
+    // Insert agent without claude_session_id to trigger --continue path
+    insertAgent(db, { id: 'a_noclaude', task_id: task.id, claude_session_id: null });
+
+    await resumeTask({ ...task, status: 'closed' });
+
+    const agent = db.prepare('SELECT claude_session_id FROM agents WHERE id = ?').get('a_noclaude') as { claude_session_id: string };
+    expect(agent.claude_session_id).toBeTruthy();
+    expect(agent.claude_session_id).toMatch(/^[0-9a-f-]{36}$/); // UUID format
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun run test server/task-runner.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/task-runner.test.ts
+git commit -m "test(task-runner): add hook installation and prompt resolution tests"
+```
+
+---
+
+## Chunk 4: API Response Updates
+
+### Task 11: Update GET /api/tasks to Include Prompts + Derived Status
+
+**Files:**
+- Modify: `server/api.ts`
+
+- [ ] **Step 1: Add derivedStatus helper function**
+
+At the top of `api.ts` (after imports), add:
+
+```typescript
+import type { DerivedTaskStatus, HookActivity, PermissionPrompt, Task } from './types.js';
+
+function derivedStatus(task: { status: string; agents: Array<{ status: string; hook_activity: string }> }): DerivedTaskStatus | null {
+  if (task.status !== 'running') return null;
+  const activities = task.agents
+    .filter((a) => a.status !== 'stopped')
+    .map((a) => a.hook_activity);
+  if (activities.length === 0) return 'done';
+  if (activities.includes('active')) return 'working';
+  if (activities.includes('waiting')) return 'needs_attention';
+  return 'done';
+}
+```
+
+- [ ] **Step 2: Update GET /api/tasks handler**
+
+In the tasks list handler (around line 175), after fetching agents per task, add:
+
+```typescript
+const pendingPrompts = getDb()
+  .prepare(
+    `SELECT pp.id, pp.agent_id, a.label as agent_label, pp.tool_name, pp.tool_input, pp.created_at
+     FROM permission_prompts pp
+     LEFT JOIN agents a ON pp.agent_id = a.id
+     WHERE pp.task_id = ? AND pp.status = 'pending'
+     ORDER BY pp.created_at ASC`,
+  )
+  .all(task.id) as Array<Record<string, unknown>>;
+```
+
+Parse `tool_input` from JSON string and add both `pending_prompts` and `derived_status` to the response:
+
+```typescript
+const parsedPrompts = pendingPrompts.map((pp) => ({
+  ...pp,
+  tool_input: JSON.parse((pp.tool_input as string) || '{}'),
+}));
+
+return {
+  ...task,
+  agents,
+  pending_prompts: parsedPrompts,
+  derived_status: derivedStatus({ status: task.status, agents }),
+};
+```
+
+- [ ] **Step 3: Apply same changes to GET /api/tasks/:id handler**
+
+Same pattern for the single task endpoint (around line 199).
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/api.ts
+git commit -m "feat(api): add pending_prompts and derived_status to task responses"
+```
+
+### Task 12: API Response Tests
+
+**Files:**
+- Modify: `server/api.test.ts`
+
+- [ ] **Step 1: Add tests for pending_prompts in task responses**
+
+Note: api.test.ts already has a `db` variable from `createTestDb()` in `beforeEach`.
+
+```typescript
+describe('GET /api/tasks with permission prompts', () => {
+  it('includes pending_prompts in task response', async () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1', claude_session_id: 'sess-1' });
+    insertPermissionPrompt(db, {
+      id: 'pp1',
+      task_id: 't1',
+      agent_id: 'a1',
+      tool_name: 'Bash',
+      tool_input: '{"command":"npm test"}',
+    });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    const task = res.body[0];
+    expect(task.pending_prompts).toHaveLength(1);
+    expect(task.pending_prompts[0].tool_name).toBe('Bash');
+    expect(task.pending_prompts[0].tool_input).toEqual({ command: 'npm test' });
+    expect(task.pending_prompts[0].agent_label).toBe(DEFAULTS.agent.label);
+  });
+
+  it('does not include resolved prompts', async () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1' });
+    insertPermissionPrompt(db, { id: 'pp1', task_id: 't1', agent_id: 'a1', status: 'resolved' });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    expect(res.body[0].pending_prompts).toHaveLength(0);
+  });
+
+  it.each([
+    { activities: ['active'], expected: 'working' },
+    { activities: ['waiting'], expected: 'needs_attention' },
+    { activities: ['idle'], expected: 'done' },
+    { activities: ['active', 'waiting'], expected: 'working' },
+    { activities: ['idle', 'idle'], expected: 'done' },
+  ])('derived_status is $expected when activities are $activities', async ({ activities, expected }) => {
+    insertTask(db, { id: 't1', status: 'running' });
+    activities.forEach((activity, i) => {
+      insertAgent(db, {
+        id: `a${i}`,
+        task_id: 't1',
+        window_index: i,
+        hook_activity: activity,
+      });
+    });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    expect(res.body[0].derived_status).toBe(expected);
+  });
+
+  it('derived_status is null for non-running tasks', async () => {
+    insertTask(db, { id: 't1', status: 'closed' });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    expect(res.body[0].derived_status).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun run test server/api.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/api.test.ts
+git commit -m "test(api): add permission prompt and derived status response tests"
+```
+
+---
+
+## Chunk 5: Frontend
+
+### Task 13: AgentActivityDot Component
+
+**Files:**
+- Create: `src/components/AgentActivityDot.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import type { HookActivity } from '../../server/types';
+
+const ACTIVITY_STYLES: Record<HookActivity, { dot: string; label: string }> = {
+  active: { dot: 'bg-green-500', label: 'active' },
+  idle: { dot: 'bg-zinc-400', label: 'idle' },
+  waiting: { dot: 'bg-amber-500', label: 'waiting' },
+};
+
+export function AgentActivityDot({ activity }: { activity: HookActivity }) {
+  const style = ACTIVITY_STYLES[activity] || ACTIVITY_STYLES.active;
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-zinc-400">
+      <span
+        className={`inline-block h-2 w-2 rounded-full ${style.dot} ${activity === 'active' ? 'animate-pulse' : ''}`}
+      />
+      {style.label}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/AgentActivityDot.tsx
+git commit -m "feat(ui): add AgentActivityDot component"
+```
+
+### Task 14: PermissionPromptRow Component
+
+**Files:**
+- Create: `src/components/PermissionPromptRow.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useNavigate } from 'react-router';
+import type { PermissionPrompt } from '../../server/types';
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function abbreviateInput(toolInput: Record<string, unknown>): string {
+  const command = toolInput.command || toolInput.file_path || toolInput.pattern || '';
+  const str = String(command);
+  return str.length > 40 ? str.slice(0, 37) + '...' : str;
+}
+
+export function PermissionPromptRow({
+  prompt,
+  taskId,
+}: {
+  prompt: PermissionPrompt;
+  taskId: string;
+}) {
+  const navigate = useNavigate();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigate(`/tasks/${taskId}?agent=${prompt.agent_id}`);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-amber-400 hover:bg-amber-500/10"
+    >
+      <span className="text-amber-500">⚠</span>
+      <span className="text-zinc-400">{prompt.agent_label}</span>
+      <span className="font-medium">
+        {prompt.tool_name} {abbreviateInput(prompt.tool_input)}
+      </span>
+      <span className="ml-auto text-zinc-500">{timeAgo(prompt.created_at)}</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/PermissionPromptRow.tsx
+git commit -m "feat(ui): add PermissionPromptRow component"
+```
+
+### Task 15: Update StatusBadge for Derived Status
+
+**Files:**
+- Modify: `src/components/StatusBadge.tsx`
+
+- [ ] **Step 1: Add derived status styles**
+
+Update the styles map to include `DerivedTaskStatus` values. The component should accept either a `TaskStatus` or `DerivedTaskStatus`:
+
+Add new entries to the styles object:
+
+```typescript
+working: { bg: 'bg-green-500/20 text-green-400', dot: true },
+needs_attention: { bg: 'bg-amber-500/20 text-amber-400', dot: true },
+done: { bg: 'bg-blue-500/20 text-blue-400', dot: false },
+```
+
+Update the component props to accept `status: string` and display `needs_attention` as "needs attention" (replace underscore with space).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/StatusBadge.tsx
+git commit -m "feat(ui): add derived status styles to StatusBadge"
+```
+
+### Task 16: Update TaskCard with Prompts + Activity + Derived Status
+
+**Files:**
+- Modify: `src/components/TaskCard.tsx`
+
+- [ ] **Step 1: Import new components**
+
+```typescript
+import { AgentActivityDot } from './AgentActivityDot';
+import { PermissionPromptRow } from './PermissionPromptRow';
+```
+
+- [ ] **Step 2: Show derived status in badge**
+
+Replace the status badge logic: when `task.derived_status` is not null, show it instead of `task.status`:
+
+```tsx
+<StatusBadge status={task.derived_status || task.status} />
+```
+
+- [ ] **Step 3: Add agent activity row**
+
+After the existing task metadata (repo, branch), add an agent activity summary when the task has agents:
+
+```tsx
+{task.agents && task.agents.length > 0 && task.status === 'running' && (
+  <div className="flex flex-wrap gap-3 text-xs">
+    {task.agents
+      .filter((a) => a.status !== 'stopped')
+      .map((a) => (
+        <span key={a.id} className="inline-flex items-center gap-1">
+          <AgentActivityDot activity={a.hook_activity} />
+          <span className="text-zinc-500">{a.label}</span>
+        </span>
+      ))}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Add pending prompts section**
+
+After the agent activity row, show pending prompts:
+
+```tsx
+{task.pending_prompts && task.pending_prompts.length > 0 && (
+  <div className="mt-1 space-y-0.5">
+    {task.pending_prompts.map((pp) => (
+      <PermissionPromptRow key={pp.id} prompt={pp} taskId={task.id} />
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TaskCard.tsx
+git commit -m "feat(ui): show agent activity, permission prompts, and derived status on task cards"
+```
+
+### Task 17: Update AgentTabs with Activity Dots
+
+**Files:**
+- Modify: `src/components/AgentTabs.tsx`
+
+- [ ] **Step 1: Add activity indicator to agent tabs**
+
+Import `AgentActivityDot` and add it next to each agent label in the tab:
+
+```tsx
+<AgentActivityDot activity={agent.hook_activity} />
+```
+
+Replace the existing green pulse dot (which was hardcoded for "running" status) with the `AgentActivityDot` which reflects the actual hook_activity state.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/AgentTabs.tsx
+git commit -m "feat(ui): show hook_activity on agent tabs"
+```
+
+### Task 18: Handle ?agent= Query Param in TaskDetail
+
+**Files:**
+- Modify: `src/pages/TaskDetail.tsx`
+
+- [ ] **Step 1: Read agent query param and auto-select tab**
+
+Add `useSearchParams` from react-router:
+
+```typescript
+import { useParams, useNavigate, useSearchParams } from 'react-router';
+```
+
+In the component, read the `agent` param and use it to set the active window:
+
+```typescript
+const [searchParams] = useSearchParams();
+const agentParam = searchParams.get('agent');
+```
+
+In the useEffect that initializes activeWindow (around line 23), if `agentParam` is set, find the matching agent and set its window_index as active:
+
+```typescript
+useEffect(() => {
+  if (agentParam && task?.agents) {
+    const agent = task.agents.find((a) => a.id === agentParam);
+    if (agent) {
+      setActiveWindow(agent.window_index);
+      return;
+    }
+  }
+  // ... existing fallback logic
+}, [task?.agents, agentParam]);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/pages/TaskDetail.tsx
+git commit -m "feat(ui): auto-select agent tab from ?agent= query param"
+```
+
+---
+
+## Chunk 6: Final Verification
+
+### Task 19: Lint, Format, Typecheck
+
+- [ ] **Step 1: Run lint**
+
+Run: `bun run lint:fix`
+
+- [ ] **Step 2: Run format**
+
+Run: `bun run format`
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS with no errors
+
+- [ ] **Step 4: Fix any issues and commit**
+
+```bash
+git add -A
+git commit -m "style: fix lint and formatting"
+```
+
+### Task 20: Run Full Test Suite
+
+- [ ] **Step 1: Run all tests**
+
+Run: `bun run test`
+Expected: All tests PASS
+
+- [ ] **Step 2: Fix any failures and commit**
+
+If there are failures in existing tests due to the new `hook_activity` column or `pending_prompts` field, update the affected test assertions.
+
+- [ ] **Step 3: Final commit if fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: update existing tests for permission tracking changes"
+```

--- a/docs/superpowers/specs/2026-03-11-agent-permission-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-11-agent-permission-tracking-design.md
@@ -1,0 +1,383 @@
+# Agent Permission Prompt Tracking
+
+Track when Claude Code agents hit permission prompts, display them globally on the tasks list,
+and provide real-time agent status (active/idle/waiting) via Claude Code HTTP hooks.
+
+## Problem
+
+Agents running in octomux get blocked by permission prompts (e.g., "Allow Bash?") and the user
+has no way to know without clicking into each task's terminal. An agent can sit blocked for
+20+ minutes unnoticed, killing the fire-and-forget workflow.
+
+## Solution
+
+Use Claude Code's HTTP hook system to receive real-time events from agents. Three hooks:
+
+1. **`PermissionRequest`** — fires when a permission dialog appears. Stores the event and
+   marks the agent as `waiting`. Returns empty 200 (no decision), so Claude Code shows the
+   native permission dialog to the user as normal.
+2. **`PostToolUse`** — fires after a tool completes. Resolves the oldest pending permission
+   for that agent and marks the agent as `active`.
+3. **`Stop`** — fires when the agent finishes responding. Marks the agent as `idle`
+   and resolves all pending permissions for that session.
+
+Pending permission prompts are displayed inline on task cards in the global tasks list.
+Resolved prompts disappear immediately. Clicking a prompt navigates to the task detail page
+with the correct agent terminal selected.
+
+## Hook Installation
+
+When `startTask()` creates a worktree, generate `.claude/settings.local.json` in the worktree
+with HTTP hooks pointing to the Express server.
+
+The hook JSON follows Claude Code's matcher-group structure: each event maps to an array of
+matcher groups, each containing a `hooks` array of handlers. Since we match all tool names,
+the `matcher` field is omitted.
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:7777/api/hooks/permission-request",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:7777/api/hooks/post-tool-use",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:7777/api/hooks/stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Note on sync vs async: All three hooks use HTTP type. HTTP hooks in Claude Code are
+non-blocking for errors (non-2xx, connection failures, timeouts all allow execution to
+continue). `PermissionRequest` returning an empty 200 body means "no decision" — Claude Code
+shows the native permission dialog as normal. The 5s timeout prevents blocking the agent if
+the octomux server is slow.
+
+The existing `startTask()` already copies `.claude/settings.local.json` if it exists in the
+source repo. The new behavior: always generate/merge hook config into the worktree's
+`.claude/settings.local.json`, preserving any existing settings from the source repo.
+
+## Data Model
+
+### New table: `permission_prompts`
+
+```sql
+CREATE TABLE IF NOT EXISTS permission_prompts (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  agent_id TEXT,
+  session_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  tool_input TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_task_id ON permission_prompts(task_id);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_status ON permission_prompts(status);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_agent_status ON permission_prompts(agent_id, status);
+```
+
+`tool_input` is stored as a JSON string (`JSON.stringify()` on insert, `JSON.parse()` on read).
+
+### Modified table: `agents`
+
+Add `hook_activity` column to track real-time agent state from hooks. Named `hook_activity`
+(not `activity`) to avoid confusion with the existing `status` column which tracks lifecycle
+state managed by task-runner.
+
+Migration (follows existing pattern in `initDb()` using `pragma('table_info(agents)')`):
+
+```typescript
+const agentCols = instance.pragma('table_info(agents)') as Array<{ name: string }>;
+const agentColNames = agentCols.map((c) => c.name);
+if (!agentColNames.includes('hook_activity')) {
+  instance.exec("ALTER TABLE agents ADD COLUMN hook_activity TEXT NOT NULL DEFAULT 'active'");
+  instance.exec('ALTER TABLE agents ADD COLUMN hook_activity_updated_at TEXT');
+}
+```
+
+Note: SQLite does not support CHECK constraints in ALTER TABLE ADD COLUMN. Validation of
+`hook_activity` values (`active` | `idle` | `waiting`) is enforced at the application level.
+
+### Startup cleanup
+
+In `initDb()`, after migrations, resolve all stale pending prompts:
+
+```typescript
+instance.exec(
+  `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+   WHERE status = 'pending'`
+);
+```
+
+## TypeScript Types
+
+```typescript
+// In server/types.ts
+
+export type HookActivity = 'active' | 'idle' | 'waiting';
+
+export interface Agent {
+  // ... existing fields
+  hook_activity: HookActivity;
+  hook_activity_updated_at: string | null;
+}
+
+export interface PermissionPrompt {
+  id: string;
+  task_id: string;
+  agent_id: string | null;
+  agent_label: string; // joined from agents table
+  session_id: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  status: 'pending' | 'resolved';
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export interface Task {
+  // ... existing fields
+  pending_prompts: PermissionPrompt[];
+}
+```
+
+## API Routes
+
+### Hook endpoints (called by Claude Code)
+
+All hook endpoints receive JSON from Claude Code on the request body. They correlate
+`session_id` from the hook payload to an agent via `agents.claude_session_id`.
+
+All hook handlers use a SQLite transaction (`.transaction()`) to ensure atomicity of the
+lookup + insert/update sequence, preventing race conditions from near-simultaneous hook events.
+
+**`POST /api/hooks/permission-request`**
+
+Input (from Claude Code):
+```json
+{
+  "session_id": "abc123",
+  "hook_event_name": "PermissionRequest",
+  "tool_name": "Bash",
+  "tool_input": { "command": "rm -rf dist" },
+  "permission_suggestions": [...]
+}
+```
+
+Behavior:
+1. Look up agent by `session_id` → `agents.claude_session_id`
+2. If not found, return 200 and do nothing (agent may have been stopped/deleted)
+3. Insert row into `permission_prompts` (status: pending, tool_input: JSON.stringify)
+4. Update `agents.hook_activity = 'waiting'`, `hook_activity_updated_at = now()`
+5. Return 200 with empty body (no decision — Claude Code shows native dialog)
+
+**`POST /api/hooks/post-tool-use`**
+
+Input (from Claude Code):
+```json
+{
+  "session_id": "abc123",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Bash",
+  "tool_input": { "command": "rm -rf dist" }
+}
+```
+
+Behavior:
+1. Look up agent by `session_id`
+2. Resolve the **oldest** pending `permission_prompt` for this agent (FIFO order by
+   `created_at ASC LIMIT 1`). Uses agent_id, not tool_name, to avoid mismatches when
+   the same tool fires PostToolUse without a preceding permission.
+3. Update `agents.hook_activity = 'active'`, `hook_activity_updated_at = now()`
+4. Return 200
+
+Note: FIFO resolution is used because Claude Code can only execute a tool after its
+permission is granted, so the oldest pending prompt is always the one being resolved.
+PostToolUse fires on every tool completion, not just after permission grants — if there are
+no pending prompts, step 2 is a no-op and only the activity update in step 3 runs.
+
+**`POST /api/hooks/stop`**
+
+Input (from Claude Code):
+```json
+{
+  "session_id": "abc123",
+  "hook_event_name": "Stop",
+  "stop_hook_active": false
+}
+```
+
+Behavior:
+1. Look up agent by `session_id`
+2. Resolve ALL pending `permission_prompts` for this agent
+3. Update `agents.hook_activity = 'idle'`, `hook_activity_updated_at = now()`
+4. Return 200
+
+### Query endpoints (called by frontend)
+
+**`GET /api/tasks`** — existing endpoint, response now includes:
+- `agents[].hook_activity` field on each agent object
+- `pending_prompts[]` array per task (only status='pending', not resolved)
+
+The query joins `permission_prompts` on `task_id` where `status = 'pending'` and joins
+`agents` to get `agent.label` for display.
+
+Each prompt object in the response:
+```json
+{
+  "id": "abc123",
+  "agent_id": "def456",
+  "agent_label": "Agent 1",
+  "tool_name": "Bash",
+  "tool_input": { "command": "rm -rf dist" },
+  "created_at": "2026-03-11T10:30:00Z"
+}
+```
+
+**`GET /api/tasks/:id`** — same additions as above for single task view.
+
+## Frontend
+
+### Tasks list page — task cards
+
+When a task has pending permission prompts, show them inline below the task metadata:
+
+```
+┌─ Add auth ────── [running] ──── PR #12 ──────────────┐
+│                                                       │
+│  Agent 1  ● active     Agent 2  ○ idle                │
+│                                                       │
+│  ⚠ Agent 1 · Bash "rm -rf dist"           2m ago     │
+│  ⚠ Agent 1 · Edit server/api.ts           30s ago    │
+│    click to open terminal →                           │
+└───────────────────────────────────────────────────────┘
+
+┌─ Fix bug ─────── [running] ──────────────────────────┐
+│                                                       │
+│  Agent 1  ● active                                    │
+│                                                       │
+└───────────────────────────────────────────────────────┘
+```
+
+- Warning icon + amber color for pending prompts
+- Show agent label, tool name, abbreviated tool input, relative timestamp
+- Clicking a prompt row navigates to `/tasks/:id?agent=:agentId`
+- When there are no pending prompts, the section is hidden (not an empty state)
+- Agent activity indicators: green dot = active, gray dot = idle, amber dot = waiting
+
+### Task detail page
+
+- Agent tabs show activity indicator (colored dot) matching the hook_activity state
+- No separate permissions panel — prompts are on the global view, terminal is here
+
+### Polling
+
+The existing `useTasks()` hook polls every 5 seconds. The pending prompts and agent activity
+data rides on the same `/api/tasks` response. No new polling mechanism needed.
+
+## Hook-to-Agent Correlation
+
+Claude Code hooks include `session_id` which is the Claude session identifier. We already
+store `claude_session_id` on each agent record (set at spawn time in `startTask` and
+`addAgent`). Correlation:
+
+```
+hook.session_id → agents.claude_session_id → agent.id → agent.task_id
+```
+
+If no agent matches (e.g., agent was deleted), the hook endpoint returns 200 and does nothing.
+
+### Session ID on resume
+
+When a task is resumed via `resumeTask()`, agents launched with `--resume <session_id>` reuse
+the same Claude session ID, so hooks from the resumed session correlate correctly. Agents
+launched with `--continue` (fallback, when `claude_session_id` is null) currently do NOT get a
+tracked session ID. Fix: generate a new UUID, pass `--session-id <uuid>` alongside
+`--continue`, and update `claude_session_id` in the DB. This ensures hooks from `--continue`
+agents are also tracked.
+
+## Edge Cases
+
+1. **Agent stopped while permission pending** — `stopAgent()` in task-runner should resolve
+   all pending prompts for that agent (in addition to existing cleanup).
+
+2. **Task deleted** — CASCADE delete handles this. The manual `DELETE FROM agents` in api.ts
+   triggers cascade on `permission_prompts.agent_id`, and the subsequent task deletion
+   triggers cascade on `permission_prompts.task_id`.
+
+3. **Task closed** — `closeTask()` should resolve all pending prompts for all agents in the
+   task. Run the resolution query BEFORE updating agents to `stopped` status.
+
+4. **Server restart** — On startup in `initDb()`, mark all `pending` prompts as `resolved`.
+   Hooks will re-fire if agents are still waiting after task recovery.
+
+5. **Hook arrives before agent record exists** — Possible during `startTask()` if Claude
+   starts fast. The 3s `CLAUDE_INIT_DELAY` provides buffer. If still no match, return 200
+   and ignore.
+
+6. **Existing `.claude/settings.local.json` in source repo** — Read existing file,
+   deep-merge hooks object: for each event key, append our matcher group object to the
+   event's array (don't modify existing matcher groups), write back.
+
+7. **Multiple pending prompts per agent** — Possible if agent hits multiple permission
+   prompts in quick succession. Show all of them. FIFO resolution ensures correct ordering.
+
+8. **Concurrent hook requests** — Near-simultaneous PermissionRequest and PostToolUse for the
+   same agent. SQLite transactions ensure atomicity. better-sqlite3 is synchronous so writes
+   are serialized, but Express handlers are async — the transaction boundary prevents
+   interleaved read-modify-write.
+
+9. **Orphaned prompts with null agent_id** — If a PermissionRequest arrives before the agent
+   record exists (edge case 5), it's stored with `agent_id = NULL`. These won't be resolved
+   by PostToolUse (which queries by agent_id), but will be cleaned up by Stop hook or on
+   server restart.
+
+## Testing
+
+- **Hook endpoint tests** — supertest against `createApp()`, POST to each hook endpoint with
+  mock payloads, verify DB state after each call
+- **DB migration tests** — verify `permission_prompts` table and `hook_activity` column exist
+  after `initDb()` with `createTestDb()`
+- **Task-runner integration** — `closeTask()` and `stopAgent()` resolve pending prompts
+- **Frontend component tests** — TaskCard renders pending prompts, activity dots, click
+  navigation
+- **Test helpers** — add `DEFAULTS.permissionPrompt` fixture and `insertPermissionPrompt()`
+  to `server/test-helpers.ts`
+
+## Out of Scope (Phase 2)
+
+- Remote approve/deny from the dashboard (PermissionRequest hook can return decisions)
+- Permission analytics (which tools get prompted most, per-repo patterns)
+- Allow-list suggestions based on prompt patterns
+- Sound/desktop notifications for permission prompts

--- a/docs/superpowers/specs/2026-03-11-agent-permission-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-11-agent-permission-tracking-design.md
@@ -166,11 +166,46 @@ export interface PermissionPrompt {
   resolved_at: string | null;
 }
 
+export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
+
 export interface Task {
   // ... existing fields
   pending_prompts: PermissionPrompt[];
+  derived_status: DerivedTaskStatus | null; // null when task is not 'running'
 }
 ```
+
+## Derived Task Status
+
+When a task's lifecycle `status` is `running`, compute a more informative display status from
+the `hook_activity` of its non-stopped agents:
+
+| Agent hook_activity states           | `derived_status` | Display        |
+| :----------------------------------- | :--------------- | :------------- |
+| Any agent `active`                   | `working`        | Green, working |
+| Any agent `waiting`, none `active`   | `needs_attention` | Amber, blocked |
+| All agents `idle`                    | `done`           | Blue, done     |
+
+Logic (computed in the API response, not stored in DB):
+
+```typescript
+function derivedStatus(task: Task): DerivedTaskStatus | null {
+  if (task.status !== 'running') return null;
+  const activities = task.agents
+    .filter((a) => a.status !== 'stopped')
+    .map((a) => a.hook_activity);
+  if (activities.length === 0) return 'done';
+  if (activities.includes('active')) return 'working';
+  if (activities.includes('waiting')) return 'needs_attention';
+  return 'done'; // all idle
+}
+```
+
+This replaces the generic "running" badge on task cards with a meaningful signal. The existing
+lifecycle `status` is unchanged — `derived_status` is a display-only field for the frontend.
+
+For non-running tasks (`draft`, `setting_up`, `closed`, `error`), `derived_status` is `null`
+and the frontend shows the lifecycle status as before.
 
 ## API Routes
 
@@ -274,18 +309,24 @@ Each prompt object in the response:
 When a task has pending permission prompts, show them inline below the task metadata:
 
 ```
-┌─ Add auth ────── [running] ──── PR #12 ──────────────┐
+┌─ Add auth ────── [⚠ needs attention] ── PR #12 ──────┐
 │                                                       │
-│  Agent 1  ● active     Agent 2  ○ idle                │
+│  Agent 1  ● active     Agent 2  ◉ waiting             │
 │                                                       │
-│  ⚠ Agent 1 · Bash "rm -rf dist"           2m ago     │
-│  ⚠ Agent 1 · Edit server/api.ts           30s ago    │
+│  ⚠ Agent 2 · Bash "rm -rf dist"           2m ago     │
+│  ⚠ Agent 2 · Edit server/api.ts           30s ago    │
 │    click to open terminal →                           │
 └───────────────────────────────────────────────────────┘
 
-┌─ Fix bug ─────── [running] ──────────────────────────┐
+┌─ Fix bug ─────── [● working] ────────────────────────┐
 │                                                       │
 │  Agent 1  ● active                                    │
+│                                                       │
+└───────────────────────────────────────────────────────┘
+
+┌─ Refactor ────── [✓ done] ───────────────────────────┐
+│                                                       │
+│  Agent 1  ○ idle                                      │
 │                                                       │
 └───────────────────────────────────────────────────────┘
 ```

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import Database from 'better-sqlite3';
-import { createTestDb, insertTask, insertAgent, getTask, DEFAULTS } from './test-helpers.js';
-import type { Task } from './types.js';
+import {
+  createTestDb,
+  insertTask,
+  insertAgent,
+  insertPermissionPrompt,
+  getTask,
+  DEFAULTS,
+} from './test-helpers.js';
+import type { Task, Agent } from './types.js';
 import { EventEmitter } from 'events';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -932,5 +939,89 @@ describe('POST /api/tasks/:id/pr/preview — success path', () => {
     expect(res.body.title).toBe('feat(orders): add validation');
     expect(res.body.body).toBe('## What\n- test');
     expect(res.body.base).toBe('main');
+  });
+});
+
+// ─── GET /api/tasks with permission prompts ─────────────────────────────────
+
+describe('GET /api/tasks with permission prompts', () => {
+  it('includes pending_prompts in task response', async () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1', claude_session_id: 'sess-1' });
+    insertPermissionPrompt(db, {
+      id: 'pp1',
+      task_id: 't1',
+      agent_id: 'a1',
+      tool_name: 'Bash',
+      tool_input: '{"command":"npm test"}',
+    });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    const task = res.body[0];
+    expect(task.pending_prompts).toHaveLength(1);
+    expect(task.pending_prompts[0].tool_name).toBe('Bash');
+    expect(task.pending_prompts[0].tool_input).toEqual({ command: 'npm test' });
+    expect(task.pending_prompts[0].agent_label).toBe('Agent 1');
+  });
+
+  it('does not include resolved prompts', async () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1' });
+    insertPermissionPrompt(db, {
+      id: 'pp1',
+      task_id: 't1',
+      agent_id: 'a1',
+      status: 'resolved' as any,
+    });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    expect(res.body[0].pending_prompts).toHaveLength(0);
+  });
+
+  it.each([
+    { activities: ['active'], expected: 'working' },
+    { activities: ['waiting'], expected: 'needs_attention' },
+    { activities: ['idle'], expected: 'done' },
+    { activities: ['active', 'waiting'], expected: 'working' },
+    { activities: ['idle', 'idle'], expected: 'done' },
+  ])(
+    'derived_status is $expected when activities are $activities',
+    async ({ activities, expected }) => {
+      insertTask(db, { id: 't1', status: 'running' });
+      activities.forEach((activity, i) => {
+        insertAgent(db, {
+          id: `a${i}`,
+          task_id: 't1',
+          window_index: i,
+          hook_activity: activity as Agent['hook_activity'],
+        });
+      });
+
+      const res = await request(app).get('/api/tasks').expect(200);
+      expect(res.body[0].derived_status).toBe(expected);
+    },
+  );
+
+  it('derived_status is null for non-running tasks', async () => {
+    insertTask(db, { id: 't1', status: 'closed' });
+
+    const res = await request(app).get('/api/tasks').expect(200);
+    expect(res.body[0].derived_status).toBeNull();
+  });
+
+  it('includes pending_prompts in single task response', async () => {
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1' });
+    insertPermissionPrompt(db, {
+      id: 'pp1',
+      task_id: 't1',
+      agent_id: 'a1',
+      tool_name: 'Edit',
+      tool_input: '{"file_path":"server/api.ts"}',
+    });
+
+    const res = await request(app).get('/api/tasks/t1').expect(200);
+    expect(res.body.pending_prompts).toHaveLength(1);
+    expect(res.body.derived_status).toBe('working');
   });
 });

--- a/server/api.ts
+++ b/server/api.ts
@@ -64,6 +64,14 @@ function runClaude(prompt: string, env: NodeJS.ProcessEnv): Promise<string> {
   });
 }
 
+function safeParseJson(s: string): Record<string, unknown> {
+  try {
+    return JSON.parse(s || '{}');
+  } catch {
+    return {};
+  }
+}
+
 function derivedStatus(task: {
   status: string;
   agents: Array<{ status: string; hook_activity: string }>;
@@ -205,7 +213,7 @@ export function setupRoutes(app: Express): void {
 
     const agentStmt = db.prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index');
     const promptStmt = db.prepare(
-      `SELECT pp.id, pp.agent_id, a.label as agent_label, pp.tool_name, pp.tool_input, pp.created_at
+      `SELECT pp.*, a.label as agent_label
        FROM permission_prompts pp
        LEFT JOIN agents a ON pp.agent_id = a.id
        WHERE pp.task_id = ? AND pp.status = 'pending'
@@ -217,7 +225,7 @@ export function setupRoutes(app: Express): void {
       const pendingPrompts = promptStmt.all(task.id) as Array<Record<string, unknown>>;
       const parsedPrompts = pendingPrompts.map((pp) => ({
         ...pp,
-        tool_input: JSON.parse((pp.tool_input as string) || '{}'),
+        tool_input: safeParseJson(pp.tool_input as string),
       }));
       return {
         ...task,
@@ -245,7 +253,7 @@ export function setupRoutes(app: Express): void {
       .all(task.id) as Agent[];
     const pendingPrompts = db
       .prepare(
-        `SELECT pp.id, pp.agent_id, a.label as agent_label, pp.tool_name, pp.tool_input, pp.created_at
+        `SELECT pp.*, a.label as agent_label
        FROM permission_prompts pp
        LEFT JOIN agents a ON pp.agent_id = a.id
        WHERE pp.task_id = ? AND pp.status = 'pending'
@@ -254,7 +262,7 @@ export function setupRoutes(app: Express): void {
       .all(task.id) as Array<Record<string, unknown>>;
     const parsedPrompts = pendingPrompts.map((pp) => ({
       ...pp,
-      tool_input: JSON.parse((pp.tool_input as string) || '{}'),
+      tool_input: safeParseJson(pp.tool_input as string),
     }));
     res.json({
       ...task,

--- a/server/api.ts
+++ b/server/api.ts
@@ -29,6 +29,7 @@ import type {
   AddAgentRequest,
   Task,
   Agent,
+  DerivedTaskStatus,
 } from './types.js';
 
 const execFile = promisify(execFileCb);
@@ -61,6 +62,20 @@ function runClaude(prompt: string, env: NodeJS.ProcessEnv): Promise<string> {
     proc.stdin.write(prompt);
     proc.stdin.end();
   });
+}
+
+function derivedStatus(task: {
+  status: string;
+  agents: Array<{ status: string; hook_activity: string }>;
+}): DerivedTaskStatus | null {
+  if (task.status !== 'running') return null;
+  const activities = task.agents
+    .filter((a) => a.status !== 'stopped')
+    .map((a) => a.hook_activity);
+  if (activities.length === 0) return 'done';
+  if (activities.includes('active')) return 'working';
+  if (activities.includes('waiting')) return 'needs_attention';
+  return 'done';
 }
 
 export function setupRoutes(app: Express): void {
@@ -189,11 +204,28 @@ export function setupRoutes(app: Express): void {
     }
 
     const agentStmt = db.prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index');
+    const promptStmt = db.prepare(
+      `SELECT pp.id, pp.agent_id, a.label as agent_label, pp.tool_name, pp.tool_input, pp.created_at
+       FROM permission_prompts pp
+       LEFT JOIN agents a ON pp.agent_id = a.id
+       WHERE pp.task_id = ? AND pp.status = 'pending'
+       ORDER BY pp.created_at ASC`,
+    );
 
-    const result = tasks.map((task) => ({
-      ...task,
-      agents: agentStmt.all(task.id) as Agent[],
-    }));
+    const result = tasks.map((task) => {
+      const agents = agentStmt.all(task.id) as Agent[];
+      const pendingPrompts = promptStmt.all(task.id) as Array<Record<string, unknown>>;
+      const parsedPrompts = pendingPrompts.map((pp) => ({
+        ...pp,
+        tool_input: JSON.parse((pp.tool_input as string) || '{}'),
+      }));
+      return {
+        ...task,
+        agents,
+        pending_prompts: parsedPrompts,
+        derived_status: derivedStatus({ status: task.status, agents }),
+      };
+    });
 
     res.json(result);
   });
@@ -208,10 +240,28 @@ export function setupRoutes(app: Express): void {
       res.status(404).json({ error: 'Task not found' });
       return;
     }
-    task.agents = db
+    const agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(task.id) as Agent[];
-    res.json(task);
+    const pendingPrompts = db
+      .prepare(
+        `SELECT pp.id, pp.agent_id, a.label as agent_label, pp.tool_name, pp.tool_input, pp.created_at
+       FROM permission_prompts pp
+       LEFT JOIN agents a ON pp.agent_id = a.id
+       WHERE pp.task_id = ? AND pp.status = 'pending'
+       ORDER BY pp.created_at ASC`,
+      )
+      .all(task.id) as Array<Record<string, unknown>>;
+    const parsedPrompts = pendingPrompts.map((pp) => ({
+      ...pp,
+      tool_input: JSON.parse((pp.tool_input as string) || '{}'),
+    }));
+    res.json({
+      ...task,
+      agents,
+      pending_prompts: parsedPrompts,
+      derived_status: derivedStatus({ status: task.status, agents }),
+    });
   });
 
   // Create task

--- a/server/api.ts
+++ b/server/api.ts
@@ -77,9 +77,7 @@ function derivedStatus(task: {
   agents: Array<{ status: string; hook_activity: string }>;
 }): DerivedTaskStatus | null {
   if (task.status !== 'running') return null;
-  const activities = task.agents
-    .filter((a) => a.status !== 'stopped')
-    .map((a) => a.hook_activity);
+  const activities = task.agents.filter((a) => a.status !== 'stopped').map((a) => a.hook_activity);
   if (activities.length === 0) return 'done';
   if (activities.includes('active')) return 'working';
   if (activities.includes('waiting')) return 'needs_attention';

--- a/server/api.ts
+++ b/server/api.ts
@@ -22,6 +22,7 @@ import {
   stopOrchestrator,
   getOrchestratorSession,
 } from './orchestrator.js';
+import { hookRoutes } from './hooks.js';
 import type {
   CreateTaskRequest,
   UpdateTaskRequest,
@@ -63,6 +64,8 @@ function runClaude(prompt: string, env: NodeJS.ProcessEnv): Promise<string> {
 }
 
 export function setupRoutes(app: Express): void {
+  app.use('/api/hooks', hookRoutes);
+
   // Browse directories for folder picker
   app.get('/api/browse', (req: Request, res: Response) => {
     const dirPath = (req.query.path as string) || os.homedir();

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -175,16 +175,14 @@ describe('Database', () => {
 
   describe('permission_prompts table', () => {
     it('creates permission_prompts table with correct columns', () => {
-      const cols = db
-        .pragma('table_info(permission_prompts)')
-        .map((c: { name: string }) => c.name);
+      const cols = (db.pragma('table_info(permission_prompts)') as { name: string }[]).map(
+        (c) => c.name,
+      );
       expect(cols).toEqual(PERMISSION_PROMPTS_TABLE_COLUMNS);
     });
 
     it('adds hook_activity column to agents table', () => {
-      const cols = db
-        .pragma('table_info(agents)')
-        .map((c: { name: string }) => c.name);
+      const cols = (db.pragma('table_info(agents)') as { name: string }[]).map((c) => c.name);
       expect(cols).toContain('hook_activity');
       expect(cols).toContain('hook_activity_updated_at');
     });

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -4,11 +4,14 @@ import {
   createTestDb,
   insertTask,
   insertAgent,
+  insertPermissionPrompt,
   getTask,
   getAgents,
+  getPermissionPrompts,
   DEFAULTS,
   TASKS_TABLE_COLUMNS,
   AGENTS_TABLE_COLUMNS,
+  PERMISSION_PROMPTS_TABLE_COLUMNS,
 } from './test-helpers.js';
 import { getDb, initDb } from './db.js';
 
@@ -165,6 +168,38 @@ describe('Database', () => {
     it('agents table has claude_session_id column (migration)', () => {
       const columns = db.pragma('table_info(agents)') as { name: string }[];
       expect(columns.map((c) => c.name)).toContain('claude_session_id');
+    });
+  });
+
+  // ─── Permission Prompts ──────────────────────────────────────────────
+
+  describe('permission_prompts table', () => {
+    it('creates permission_prompts table with correct columns', () => {
+      const cols = db
+        .pragma('table_info(permission_prompts)')
+        .map((c: { name: string }) => c.name);
+      expect(cols).toEqual(PERMISSION_PROMPTS_TABLE_COLUMNS);
+    });
+
+    it('adds hook_activity column to agents table', () => {
+      const cols = db
+        .pragma('table_info(agents)')
+        .map((c: { name: string }) => c.name);
+      expect(cols).toContain('hook_activity');
+      expect(cols).toContain('hook_activity_updated_at');
+    });
+
+    it('resolves stale pending prompts on startup', () => {
+      insertTask(db, { id: 't1', status: 'running' });
+      insertAgent(db, { id: 'a1', task_id: 't1' });
+      insertPermissionPrompt(db, { id: 'pp1', task_id: 't1', agent_id: 'a1', status: 'pending' });
+
+      // Re-init simulates restart
+      initDb(db);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts[0].status).toBe('resolved');
+      expect(prompts[0].resolved_at).not.toBeNull();
     });
   });
 });

--- a/server/db.ts
+++ b/server/db.ts
@@ -36,8 +36,25 @@ CREATE TABLE IF NOT EXISTS agents (
     created_at        TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS permission_prompts (
+    id         TEXT PRIMARY KEY,
+    task_id    TEXT NOT NULL,
+    agent_id   TEXT,
+    session_id TEXT NOT NULL,
+    tool_name  TEXT NOT NULL,
+    tool_input TEXT NOT NULL DEFAULT '{}',
+    status     TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_agents_task ON agents(task_id);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_task_id ON permission_prompts(task_id);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_status ON permission_prompts(status);
+CREATE INDEX IF NOT EXISTS idx_permission_prompts_agent_status ON permission_prompts(agent_id, status);
 `;
 
 let db: Database.Database;
@@ -81,4 +98,17 @@ export function initDb(instance: Database.Database): void {
   if (!colNames.includes('user_window_index')) {
     instance.exec('ALTER TABLE tasks ADD COLUMN user_window_index INTEGER');
   }
+
+  // Add hook_activity columns to agents table (for existing DBs)
+  const agentCols2 = instance.pragma('table_info(agents)') as Array<{ name: string }>;
+  const agentColNames2 = agentCols2.map((c) => c.name);
+  if (!agentColNames2.includes('hook_activity')) {
+    instance.exec("ALTER TABLE agents ADD COLUMN hook_activity TEXT NOT NULL DEFAULT 'active'");
+    instance.exec('ALTER TABLE agents ADD COLUMN hook_activity_updated_at TEXT');
+  }
+
+  // Resolve any stale pending permission prompts from previous run
+  instance.exec(
+    `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now') WHERE status = 'pending'`,
+  );
 }

--- a/server/hook-settings.test.ts
+++ b/server/hook-settings.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { installHookSettings } from './hook-settings.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-settings-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('installHookSettings', () => {
+  it('creates .claude/settings.local.json with all 3 hook events', () => {
+    installHookSettings(tmpDir);
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+
+    expect(settings.hooks.PermissionRequest).toEqual([
+      {
+        hooks: [
+          { type: 'http', url: 'http://localhost:7777/api/hooks/permission-request', timeout: 5 },
+        ],
+      },
+    ]);
+    expect(settings.hooks.PostToolUse).toEqual([
+      {
+        hooks: [
+          { type: 'http', url: 'http://localhost:7777/api/hooks/post-tool-use', timeout: 5 },
+        ],
+      },
+    ]);
+    expect(settings.hooks.Stop).toEqual([
+      {
+        hooks: [{ type: 'http', url: 'http://localhost:7777/api/hooks/stop', timeout: 5 }],
+      },
+    ]);
+  });
+
+  it('merges with existing settings preserving non-hook keys', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(claudeDir, 'settings.local.json'),
+      JSON.stringify({ allowedTools: ['Bash'], customKey: 42 }),
+    );
+
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(claudeDir, 'settings.local.json'), 'utf-8'),
+    );
+    expect(settings.allowedTools).toEqual(['Bash']);
+    expect(settings.customKey).toBe(42);
+    expect(settings.hooks.PermissionRequest).toBeDefined();
+  });
+
+  it('preserves existing hook events like PreToolUse', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const existingHooks = {
+      hooks: {
+        PreToolUse: [{ hooks: [{ type: 'http', url: 'http://example.com', timeout: 3 }] }],
+      },
+    };
+    fs.writeFileSync(
+      path.join(claudeDir, 'settings.local.json'),
+      JSON.stringify(existingHooks),
+    );
+
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(claudeDir, 'settings.local.json'), 'utf-8'),
+    );
+    expect(settings.hooks.PreToolUse).toEqual(existingHooks.hooks.PreToolUse);
+    expect(settings.hooks.PermissionRequest).toBeDefined();
+    expect(settings.hooks.PostToolUse).toBeDefined();
+    expect(settings.hooks.Stop).toBeDefined();
+  });
+
+  it('handles corrupted existing file gracefully', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.local.json'), '{not valid json!!!');
+
+    installHookSettings(tmpDir);
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(claudeDir, 'settings.local.json'), 'utf-8'),
+    );
+    expect(settings.hooks.PermissionRequest).toBeDefined();
+  });
+
+  it('creates .claude directory if it does not exist', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    expect(fs.existsSync(claudeDir)).toBe(false);
+
+    installHookSettings(tmpDir);
+
+    expect(fs.existsSync(claudeDir)).toBe(true);
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(claudeDir, 'settings.local.json'), 'utf-8'),
+    );
+    expect(settings.hooks).toBeDefined();
+  });
+});

--- a/server/hook-settings.test.ts
+++ b/server/hook-settings.test.ts
@@ -30,9 +30,7 @@ describe('installHookSettings', () => {
     ]);
     expect(settings.hooks.PostToolUse).toEqual([
       {
-        hooks: [
-          { type: 'http', url: 'http://localhost:7777/api/hooks/post-tool-use', timeout: 5 },
-        ],
+        hooks: [{ type: 'http', url: 'http://localhost:7777/api/hooks/post-tool-use', timeout: 5 }],
       },
     ]);
     expect(settings.hooks.Stop).toEqual([
@@ -68,10 +66,7 @@ describe('installHookSettings', () => {
         PreToolUse: [{ hooks: [{ type: 'http', url: 'http://example.com', timeout: 3 }] }],
       },
     };
-    fs.writeFileSync(
-      path.join(claudeDir, 'settings.local.json'),
-      JSON.stringify(existingHooks),
-    );
+    fs.writeFileSync(path.join(claudeDir, 'settings.local.json'), JSON.stringify(existingHooks));
 
     installHookSettings(tmpDir);
 

--- a/server/hook-settings.ts
+++ b/server/hook-settings.ts
@@ -1,0 +1,75 @@
+import path from 'path';
+import fs from 'fs';
+
+const HOOK_EVENTS = {
+  PermissionRequest: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/permission-request',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+  PostToolUse: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/post-tool-use',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+  Stop: [
+    {
+      hooks: [
+        {
+          type: 'http',
+          url: 'http://localhost:7777/api/hooks/stop',
+          timeout: 5,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Install Claude Code hook settings into a worktree's `.claude/settings.local.json`.
+ * Merges with any existing settings, preserving non-hook keys and non-overlapping hook events.
+ */
+export function installHookSettings(worktreePath: string): void {
+  const claudeDir = path.join(worktreePath, '.claude');
+  const settingsPath = path.join(claudeDir, 'settings.local.json');
+
+  // Ensure .claude/ directory exists
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  // Read existing settings (if any)
+  let existing: Record<string, unknown> = {};
+  try {
+    const raw = fs.readFileSync(settingsPath, 'utf-8');
+    existing = JSON.parse(raw);
+    if (typeof existing !== 'object' || existing === null || Array.isArray(existing)) {
+      existing = {};
+    }
+  } catch {
+    // File doesn't exist or is corrupted — start fresh
+    existing = {};
+  }
+
+  // Merge hooks: our events override, but preserve other hook events
+  const existingHooks =
+    typeof existing.hooks === 'object' && existing.hooks !== null && !Array.isArray(existing.hooks)
+      ? (existing.hooks as Record<string, unknown>)
+      : {};
+
+  const mergedHooks = { ...existingHooks, ...HOOK_EVENTS };
+
+  const merged = { ...existing, hooks: mergedHooks };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+}

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -39,9 +39,9 @@ describe('Hook endpoints', () => {
       expect(prompts[0].status).toBe('pending');
       expect(prompts[0].agent_id).toBe('a1');
 
-      const agent = db
-        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
-        .get('a1') as { hook_activity: string };
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+        hook_activity: string;
+      };
       expect(agent.hook_activity).toBe('waiting');
     });
 
@@ -88,9 +88,9 @@ describe('Hook endpoints', () => {
       expect(pp1?.status).toBe('resolved');
       expect(pp2?.status).toBe('pending');
 
-      const agent = db
-        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
-        .get('a1') as { hook_activity: string };
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+        hook_activity: string;
+      };
       expect(agent.hook_activity).toBe('active');
     });
 
@@ -100,9 +100,9 @@ describe('Hook endpoints', () => {
         .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
         .expect(200);
 
-      const agent = db
-        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
-        .get('a1') as { hook_activity: string };
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+        hook_activity: string;
+      };
       expect(agent.hook_activity).toBe('active');
     });
   });
@@ -130,9 +130,9 @@ describe('Hook endpoints', () => {
       const prompts = getPermissionPrompts(db, 't1');
       expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
 
-      const agent = db
-        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
-        .get('a1') as { hook_activity: string };
+      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+        hook_activity: string;
+      };
       expect(agent.hook_activity).toBe('idle');
     });
   });

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import {
+  createTestDb,
+  insertTask,
+  insertAgent,
+  insertPermissionPrompt,
+  getPermissionPrompts,
+} from './test-helpers.js';
+import { createApp } from './app.js';
+
+describe('Hook endpoints', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    insertTask(db, { id: 't1', status: 'running' });
+    insertAgent(db, { id: 'a1', task_id: 't1', claude_session_id: 'sess-123' });
+  });
+
+  describe('POST /api/hooks/permission-request', () => {
+    it('creates pending permission prompt and sets agent to waiting', async () => {
+      await request(app)
+        .post('/api/hooks/permission-request')
+        .send({
+          session_id: 'sess-123',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'rm -rf dist' },
+        })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].tool_name).toBe('Bash');
+      expect(prompts[0].status).toBe('pending');
+      expect(prompts[0].agent_id).toBe('a1');
+
+      const agent = db
+        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
+        .get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('waiting');
+    });
+
+    it('ignores unknown session_id', async () => {
+      await request(app)
+        .post('/api/hooks/permission-request')
+        .send({ session_id: 'unknown', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts).toHaveLength(0);
+    });
+
+    it('ignores request with missing fields', async () => {
+      await request(app).post('/api/hooks/permission-request').send({}).expect(200);
+    });
+  });
+
+  describe('POST /api/hooks/post-tool-use', () => {
+    it('resolves oldest pending prompt and sets agent to active', async () => {
+      insertPermissionPrompt(db, {
+        id: 'pp1',
+        task_id: 't1',
+        agent_id: 'a1',
+        session_id: 'sess-123',
+        created_at: '2026-01-01T00:00:00Z',
+      });
+      insertPermissionPrompt(db, {
+        id: 'pp2',
+        task_id: 't1',
+        agent_id: 'a1',
+        session_id: 'sess-123',
+        created_at: '2026-01-01T00:01:00Z',
+      });
+
+      await request(app)
+        .post('/api/hooks/post-tool-use')
+        .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      const pp1 = prompts.find((p) => p.id === 'pp1');
+      const pp2 = prompts.find((p) => p.id === 'pp2');
+      expect(pp1?.status).toBe('resolved');
+      expect(pp2?.status).toBe('pending');
+
+      const agent = db
+        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
+        .get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('active');
+    });
+
+    it('no-ops when no pending prompts exist', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use')
+        .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
+        .expect(200);
+
+      const agent = db
+        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
+        .get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('active');
+    });
+  });
+
+  describe('POST /api/hooks/stop', () => {
+    it('resolves all pending prompts and sets agent to idle', async () => {
+      insertPermissionPrompt(db, {
+        id: 'pp1',
+        task_id: 't1',
+        agent_id: 'a1',
+        session_id: 'sess-123',
+      });
+      insertPermissionPrompt(db, {
+        id: 'pp2',
+        task_id: 't1',
+        agent_id: 'a1',
+        session_id: 'sess-123',
+      });
+
+      await request(app)
+        .post('/api/hooks/stop')
+        .send({ session_id: 'sess-123', stop_hook_active: false })
+        .expect(200);
+
+      const prompts = getPermissionPrompts(db, 't1');
+      expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
+
+      const agent = db
+        .prepare('SELECT hook_activity FROM agents WHERE id = ?')
+        .get('a1') as { hook_activity: string };
+      expect(agent.hook_activity).toBe('idle');
+    });
+  });
+});

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -1,0 +1,132 @@
+import { Router } from 'express';
+import { nanoid } from 'nanoid';
+import { getDb } from './db.js';
+
+const router = Router();
+
+function findAgentBySessionId(sessionId: string) {
+  return getDb()
+    .prepare(
+      `SELECT a.id, a.task_id FROM agents a
+       WHERE a.claude_session_id = ? AND a.status != 'stopped'
+       LIMIT 1`,
+    )
+    .get(sessionId) as { id: string; task_id: string } | undefined;
+}
+
+// POST /api/hooks/permission-request
+router.post('/permission-request', (req, res) => {
+  const { session_id, tool_name, tool_input } = req.body;
+  if (!session_id || !tool_name) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    getDb()
+      .prepare(
+        `INSERT INTO permission_prompts (id, task_id, agent_id, session_id, tool_name, tool_input, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending', datetime('now'))`,
+      )
+      .run(
+        nanoid(12),
+        agent.task_id,
+        agent.id,
+        session_id,
+        tool_name,
+        JSON.stringify(tool_input || {}),
+      );
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'waiting', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+// POST /api/hooks/post-tool-use
+router.post('/post-tool-use', (req, res) => {
+  const { session_id } = req.body;
+  if (!session_id) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    // Resolve oldest pending prompt (FIFO)
+    getDb()
+      .prepare(
+        `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+         WHERE id = (
+           SELECT id FROM permission_prompts
+           WHERE agent_id = ? AND status = 'pending'
+           ORDER BY created_at ASC LIMIT 1
+         )`,
+      )
+      .run(agent.id);
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+// POST /api/hooks/stop
+router.post('/stop', (req, res) => {
+  const { session_id } = req.body;
+  if (!session_id) {
+    res.status(200).send();
+    return;
+  }
+
+  const agent = findAgentBySessionId(session_id);
+  if (!agent) {
+    res.status(200).send();
+    return;
+  }
+
+  const txn = getDb().transaction(() => {
+    // Resolve ALL pending prompts for this agent
+    getDb()
+      .prepare(
+        `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+         WHERE agent_id = ? AND status = 'pending'`,
+      )
+      .run(agent.id);
+
+    getDb()
+      .prepare(
+        `UPDATE agents SET hook_activity = 'idle', hook_activity_updated_at = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(agent.id);
+  });
+  txn();
+
+  res.status(200).send();
+});
+
+export { router as hookRoutes };

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -4,8 +4,10 @@ import {
   createTestDb,
   insertTask,
   insertAgent,
+  insertPermissionPrompt,
   getTask,
   getAgents,
+  getPermissionPrompts,
   findExecCall,
   DEFAULTS,
 } from './test-helpers.js';
@@ -25,6 +27,10 @@ vi.mock('fs', async (importOriginal) => {
 });
 
 let nextWindowIndex = 0;
+
+vi.mock('./hook-settings.js', () => ({
+  installHookSettings: vi.fn(),
+}));
 
 vi.mock('child_process', () => ({
   execFile: vi.fn((_cmd: string, args: string[], cb: Function) => {
@@ -60,6 +66,7 @@ const {
 } = await import('./task-runner.js');
 const { execFile, spawn } = await import('child_process');
 const fs = await import('fs');
+const { installHookSettings } = await import('./hook-settings.js');
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -736,5 +743,105 @@ describe('createUserTerminal', () => {
     expect(
       findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['new-window'] }),
     ).toBeUndefined();
+  });
+});
+
+// ─── hook integration ─────────────────────────────────────────────────────────
+
+describe('hook integration', () => {
+  it('startTask installs hook settings in worktree', async () => {
+    insertTask(db);
+    await startTask({ ...DEFAULTS.task } as Task);
+
+    expect(vi.mocked(installHookSettings)).toHaveBeenCalledWith(
+      expect.stringContaining('.worktrees/'),
+    );
+  });
+
+  it('closeTask resolves all pending permission prompts', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+    insertPermissionPrompt(db, {
+      id: 'pp_001',
+      task_id: DEFAULTS.task.id,
+      agent_id: DEFAULTS.agent.id,
+      status: 'pending',
+    });
+    insertPermissionPrompt(db, {
+      id: 'pp_002',
+      task_id: DEFAULTS.task.id,
+      agent_id: DEFAULTS.agent.id,
+      status: 'pending',
+    });
+
+    await closeTask({ ...DEFAULTS.runningTask } as Task);
+
+    const prompts = getPermissionPrompts(db, DEFAULTS.task.id);
+    expect(prompts).toHaveLength(2);
+    expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
+    expect(prompts.every((p) => p.resolved_at !== null)).toBe(true);
+  });
+
+  it('stopAgent resolves pending prompts for that agent only', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
+
+    insertPermissionPrompt(db, {
+      id: 'pp_001',
+      task_id: DEFAULTS.task.id,
+      agent_id: DEFAULTS.agent.id,
+      status: 'pending',
+    });
+    insertPermissionPrompt(db, {
+      id: 'pp_002',
+      task_id: DEFAULTS.task.id,
+      agent_id: 'agent-02',
+      status: 'pending',
+    });
+
+    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
+
+    const prompts = getPermissionPrompts(db, DEFAULTS.task.id);
+    const agent1Prompt = prompts.find((p) => p.agent_id === DEFAULTS.agent.id)!;
+    const agent2Prompt = prompts.find((p) => p.agent_id === 'agent-02')!;
+
+    expect(agent1Prompt.status).toBe('resolved');
+    expect(agent1Prompt.resolved_at).not.toBeNull();
+    expect(agent2Prompt.status).toBe('pending');
+    expect(agent2Prompt.resolved_at).toBeNull();
+  });
+
+  it('resumeTask generates session ID for --continue agents', async () => {
+    const closedTask = { ...DEFAULTS.runningTask, status: 'closed' as const } as Task;
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped', claude_session_id: null });
+
+    await resumeTask(closedTask);
+
+    const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents[0].claude_session_id).toBeTruthy();
+    // UUID format check
+    expect(agents[0].claude_session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('resumeTask installs hook settings', async () => {
+    const closedTask = { ...DEFAULTS.runningTask, status: 'closed' as const } as Task;
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped' });
+
+    await resumeTask(closedTask);
+
+    expect(vi.mocked(installHookSettings)).toHaveBeenCalledWith(DEFAULTS.runningTask.worktree);
+  });
+
+  it('addAgent returns hook_activity fields', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    const agent = await addAgent({ ...DEFAULTS.runningTask } as Task);
+
+    expect(agent.hook_activity).toBe('active');
+    expect(agent.hook_activity_updated_at).toBeNull();
   });
 });

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
+import { installHookSettings } from './hook-settings.js';
 import type { Task, Agent } from './types.js';
 
 const execFile = promisify(execFileCb);
@@ -91,6 +92,9 @@ export async function startTask(task: Task): Promise<void> {
       fs.mkdirSync(path.dirname(settingsDst), { recursive: true });
       fs.copyFileSync(settingsSrc, settingsDst);
     }
+
+    // 5b. Install hook settings for permission tracking
+    installHookSettings(worktreePath);
 
     // 6. Create tmux session
     await execFile('tmux', ['new-session', '-d', '-s', session, '-c', worktreePath]);
@@ -180,12 +184,20 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
     label,
     status: 'running',
     claude_session_id: claudeSessionId,
+    hook_activity: 'active' as const,
+    hook_activity_updated_at: null,
     created_at: new Date().toISOString(),
   };
 }
 
 export async function closeTask(task: Task): Promise<void> {
   const db = getDb();
+
+  // Resolve all pending permission prompts for this task
+  db.prepare(
+    `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+     WHERE task_id = ? AND status = 'pending'`,
+  ).run(task.id);
 
   // Mark task as closed and all agents as stopped
   db.prepare(`UPDATE tasks SET status = 'closed', updated_at = datetime('now') WHERE id = ?`).run(
@@ -225,6 +237,12 @@ export async function deleteTask(task: Task): Promise<void> {
 
 export async function stopAgent(task: Task, agent: Agent): Promise<void> {
   const db = getDb();
+
+  // Resolve pending permission prompts for this agent
+  db.prepare(
+    `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now')
+     WHERE agent_id = ? AND status = 'pending'`,
+  ).run(agent.id);
 
   // Kill the specific tmux window
   await execFile('tmux', ['kill-window', '-t', `${task.tmux_session}:${agent.window_index}`]).catch(
@@ -278,6 +296,9 @@ export async function resumeTask(task: Task): Promise<void> {
     await execFile('tmux', ['new-session', '-d', '-s', session, '-c', task.worktree!]);
     await execFile('tmux', ['set-option', '-t', session, 'aggressive-resize', 'on']);
 
+    // 3b. Install hook settings for permission tracking
+    installHookSettings(task.worktree!);
+
     // 4. Get stopped agents
     const agents = db
       .prepare(
@@ -299,9 +320,17 @@ export async function resumeTask(task: Task): Promise<void> {
       }
 
       // Launch claude with resume or continue
-      const claudeCmd = agent.claude_session_id
-        ? `claude --resume ${agent.claude_session_id}`
-        : 'claude --continue';
+      let claudeCmd: string;
+      if (agent.claude_session_id) {
+        claudeCmd = `claude --resume ${agent.claude_session_id}`;
+      } else {
+        const newSessionId = crypto.randomUUID();
+        claudeCmd = `claude --continue --session-id ${newSessionId}`;
+        db.prepare('UPDATE agents SET claude_session_id = ? WHERE id = ?').run(
+          newSessionId,
+          agent.id,
+        );
+      }
       await execFile('tmux', ['send-keys', '-t', `${session}:${windowIndex}`, claudeCmd, 'Enter']);
 
       // Update agent record

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { vi } from 'vitest';
 import { initDb, setDb } from './db.js';
-import type { Task, Agent, PermissionPrompt } from './types.js';
+import type { Task, Agent } from './types.js';
 
 // ─── Default Fixtures ────────────────────────────────────────────────────────
 

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { vi } from 'vitest';
 import { initDb, setDb } from './db.js';
-import type { Task, Agent } from './types.js';
+import type { Task, Agent, PermissionPrompt } from './types.js';
 
 // ─── Default Fixtures ────────────────────────────────────────────────────────
 
@@ -53,7 +53,19 @@ export const DEFAULTS = {
     claude_session_id: 'test-session-uuid-01',
     created_at: '2026-01-01 00:00:00',
   },
-} satisfies Record<string, Partial<Task> | Partial<Agent>>;
+
+  permissionPrompt: {
+    id: 'pp_test123456',
+    task_id: 'task_test1234',
+    agent_id: 'agent_test123',
+    session_id: 'session-uuid-test',
+    tool_name: 'Bash',
+    tool_input: '{"command":"npm test"}',
+    status: 'pending' as const,
+    created_at: new Date().toISOString(),
+    resolved_at: null,
+  },
+} satisfies Record<string, Partial<Task> | Partial<Agent> | Record<string, unknown>>;
 
 // Derived constants from defaults
 export const SESSION_PREFIX = 'octomux-agent-';
@@ -108,7 +120,7 @@ export function insertAgent(db: Database.Database, overrides: Partial<Agent> = {
   } as Agent;
 
   db.prepare(
-    'INSERT INTO agents (id, task_id, window_index, label, status, claude_session_id) VALUES (?, ?, ?, ?, ?, ?)',
+    'INSERT INTO agents (id, task_id, window_index, label, status, claude_session_id, hook_activity) VALUES (?, ?, ?, ?, ?, ?, ?)',
   ).run(
     agent.id,
     agent.task_id,
@@ -116,6 +128,7 @@ export function insertAgent(db: Database.Database, overrides: Partial<Agent> = {
     agent.label,
     agent.status,
     agent.claude_session_id,
+    (agent as any).hook_activity || 'active',
   );
 
   return agent;
@@ -127,6 +140,34 @@ export function getTask(db: Database.Database, id: string): Task | undefined {
 
 export function getAgents(db: Database.Database, taskId: string): Agent[] {
   return db.prepare('SELECT * FROM agents WHERE task_id = ?').all(taskId) as Agent[];
+}
+
+export function insertPermissionPrompt(
+  db: Database.Database,
+  overrides: Partial<typeof DEFAULTS.permissionPrompt> = {},
+) {
+  const pp = { ...DEFAULTS.permissionPrompt, ...overrides };
+  db.prepare(
+    `INSERT INTO permission_prompts (id, task_id, agent_id, session_id, tool_name, tool_input, status, created_at, resolved_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    pp.id,
+    pp.task_id,
+    pp.agent_id,
+    pp.session_id,
+    pp.tool_name,
+    pp.tool_input,
+    pp.status,
+    pp.created_at,
+    pp.resolved_at,
+  );
+  return pp;
+}
+
+export function getPermissionPrompts(db: Database.Database, taskId: string) {
+  return db
+    .prepare('SELECT * FROM permission_prompts WHERE task_id = ? ORDER BY created_at ASC')
+    .all(taskId) as Array<Record<string, unknown>>;
 }
 
 // ─── Callback Finder ─────────────────────────────────────────────────────────
@@ -207,5 +248,19 @@ export const AGENTS_TABLE_COLUMNS = [
   'label',
   'status',
   'claude_session_id',
+  'hook_activity',
+  'hook_activity_updated_at',
   'created_at',
+];
+
+export const PERMISSION_PROMPTS_TABLE_COLUMNS = [
+  'id',
+  'task_id',
+  'agent_id',
+  'session_id',
+  'tool_name',
+  'tool_input',
+  'status',
+  'created_at',
+  'resolved_at',
 ];

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,5 +1,7 @@
 export type TaskStatus = 'draft' | 'setting_up' | 'running' | 'closed' | 'error';
 export type AgentStatus = 'running' | 'idle' | 'waiting' | 'stopped';
+export type HookActivity = 'active' | 'idle' | 'waiting';
+export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
 
 export interface Task {
   id: string;
@@ -19,6 +21,8 @@ export interface Task {
   created_at: string;
   updated_at: string;
   agents?: Agent[];
+  pending_prompts?: PermissionPrompt[];
+  derived_status?: DerivedTaskStatus | null;
 }
 
 export interface Agent {
@@ -28,7 +32,22 @@ export interface Agent {
   label: string;
   status: AgentStatus;
   claude_session_id: string | null;
+  hook_activity: HookActivity;
+  hook_activity_updated_at: string | null;
   created_at: string;
+}
+
+export interface PermissionPrompt {
+  id: string;
+  task_id: string;
+  agent_id: string | null;
+  agent_label: string;
+  session_id: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  status: 'pending' | 'resolved';
+  created_at: string;
+  resolved_at: string | null;
 }
 
 export interface CreateTaskRequest {

--- a/src/components/AgentActivityDot.tsx
+++ b/src/components/AgentActivityDot.tsx
@@ -1,0 +1,19 @@
+import type { HookActivity } from '../../server/types';
+
+const ACTIVITY_STYLES: Record<HookActivity, { dot: string; label: string }> = {
+  active: { dot: 'bg-green-500', label: 'active' },
+  idle: { dot: 'bg-zinc-400', label: 'idle' },
+  waiting: { dot: 'bg-amber-500', label: 'waiting' },
+};
+
+export function AgentActivityDot({ activity }: { activity: HookActivity }) {
+  const style = ACTIVITY_STYLES[activity] || ACTIVITY_STYLES.active;
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-zinc-400">
+      <span
+        className={`inline-block h-2 w-2 rounded-full ${style.dot} ${activity === 'active' ? 'animate-pulse' : ''}`}
+      />
+      {style.label}
+    </span>
+  );
+}

--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -46,7 +46,15 @@ export function AgentTabs({
             >
               {agent.label}
               {agent.status === 'running' && (
-                <span className="ml-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-400" />
+                <span
+                  className={`ml-1.5 inline-block h-1.5 w-1.5 rounded-full ${
+                    agent.hook_activity === 'waiting'
+                      ? 'bg-amber-500'
+                      : agent.hook_activity === 'idle'
+                        ? 'bg-zinc-400'
+                        : 'animate-pulse bg-green-400'
+                  }`}
+                />
               )}
             </button>
             {agent.status === 'running' && (

--- a/src/components/PermissionPromptRow.tsx
+++ b/src/components/PermissionPromptRow.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import type { PermissionPrompt } from '../../server/types';
 
 function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  const seconds = Math.floor((Date.now() - new Date(dateStr + 'Z').getTime()) / 1000);
   if (seconds < 60) return 'just now';
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ago`;

--- a/src/components/PermissionPromptRow.tsx
+++ b/src/components/PermissionPromptRow.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom';
+import type { PermissionPrompt } from '../../server/types';
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function abbreviateInput(toolInput: Record<string, unknown>): string {
+  const command = toolInput.command || toolInput.file_path || toolInput.pattern || '';
+  const str = String(command);
+  return str.length > 40 ? str.slice(0, 37) + '...' : str;
+}
+
+export function PermissionPromptRow({
+  prompt,
+  taskId,
+}: {
+  prompt: PermissionPrompt;
+  taskId: string;
+}) {
+  const navigate = useNavigate();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigate(`/tasks/${taskId}?agent=${prompt.agent_id}`);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-amber-400 hover:bg-amber-500/10"
+    >
+      <span className="text-amber-500">&#x26A0;</span>
+      <span className="text-zinc-400">{prompt.agent_label}</span>
+      <span className="font-medium">
+        {prompt.tool_name} {abbreviateInput(prompt.tool_input)}
+      </span>
+      <span className="ml-auto text-zinc-500">{timeAgo(prompt.created_at)}</span>
+    </button>
+  );
+}

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,7 +1,6 @@
 import { Badge } from '@/components/ui/badge';
-import type { TaskStatus } from '../../server/types';
 
-const statusConfig: Record<TaskStatus, { label: string; className: string }> = {
+const statusConfig: Record<string, { label: string; className: string }> = {
   draft: { label: 'Draft', className: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30' },
   setting_up: {
     label: 'Setting up',
@@ -10,13 +9,24 @@ const statusConfig: Record<TaskStatus, { label: string; className: string }> = {
   running: { label: 'Running', className: 'bg-green-500/20 text-green-400 border-green-500/30' },
   closed: { label: 'Closed', className: 'bg-blue-500/20 text-blue-400 border-blue-500/30' },
   error: { label: 'Error', className: 'bg-red-500/20 text-red-400 border-red-500/30' },
+  working: { label: 'Working', className: 'bg-green-500/20 text-green-400 border-green-500/30' },
+  needs_attention: {
+    label: 'Needs attention',
+    className: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+  },
+  done: { label: 'Done', className: 'bg-blue-500/20 text-blue-400 border-blue-500/30' },
 };
 
-export function StatusBadge({ status }: { status: TaskStatus }) {
-  const config = statusConfig[status];
+const fallbackConfig = {
+  label: 'Unknown',
+  className: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30',
+};
+
+export function StatusBadge({ status }: { status: string }) {
+  const config = statusConfig[status] || fallbackConfig;
   return (
     <Badge variant="outline" className={config.className}>
-      {status === 'running' && (
+      {(status === 'running' || status === 'working') && (
         <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-400" />
       )}
       {config.label}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -4,6 +4,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { Task } from '../../server/types';
 import { StatusBadge } from './StatusBadge';
+import { AgentActivityDot } from './AgentActivityDot';
+import { PermissionPromptRow } from './PermissionPromptRow';
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr + 'Z').getTime();
@@ -41,7 +43,7 @@ export function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
             {task.title}
           </CardTitle>
           <div className="flex shrink-0 items-center gap-2">
-            <StatusBadge status={task.status} />
+            <StatusBadge status={task.derived_status || task.status} />
             <span className="text-xs whitespace-nowrap text-muted-foreground">
               {timeAgo(task.created_at)}
             </span>
@@ -124,6 +126,25 @@ export function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
             </Button>
           </div>
         </div>
+        {task.agents && task.agents.length > 0 && task.status === 'running' && (
+          <div className="mt-2 flex flex-wrap gap-3 text-xs">
+            {task.agents
+              .filter((a) => a.status !== 'stopped')
+              .map((a) => (
+                <span key={a.id} className="inline-flex items-center gap-1">
+                  <AgentActivityDot activity={a.hook_activity} />
+                  <span className="text-zinc-500">{a.label}</span>
+                </span>
+              ))}
+          </div>
+        )}
+        {task.pending_prompts && task.pending_prompts.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {task.pending_prompts.map((pp) => (
+              <PermissionPromptRow key={pp.id} prompt={pp} taskId={task.id} />
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -57,6 +57,8 @@ const runningTask: Task = makeTask({
       label: 'Agent 1',
       status: 'running',
       claude_session_id: null,
+      hook_activity: 'active' as const,
+      hook_activity_updated_at: null,
       created_at: '2026-01-01 00:00:00',
     },
   ],

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/StatusBadge';
 import { TerminalView } from '@/components/TerminalView';
@@ -18,13 +18,22 @@ export default function TaskDetail() {
   const [resuming, setResuming] = useState(false);
   const [mode, setMode] = useState<'agents' | 'editor'>('agents');
   const [userWindowIndex, setUserWindowIndex] = useState<number | null>(null);
+  const [searchParams] = useSearchParams();
+  const agentParam = searchParams.get('agent');
 
-  // Initialize activeWindow from first agent's window_index
+  // Initialize activeWindow from first agent's window_index or URL param
   useEffect(() => {
+    if (agentParam && task?.agents) {
+      const agent = task.agents.find((a) => a.id === agentParam);
+      if (agent) {
+        setActiveWindow(agent.window_index);
+        return;
+      }
+    }
     if (activeWindow === null && task?.agents?.length) {
       setActiveWindow(task.agents[0].window_index);
     }
-  }, [task, activeWindow]);
+  }, [task, activeWindow, agentParam]);
 
   // Auto-switch back to agents and reset editor state when task enters non-running state
   useEffect(() => {
@@ -172,7 +181,7 @@ export default function TaskDetail() {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-lg font-semibold">{task.title}</h1>
-              <StatusBadge status={task.status} />
+              <StatusBadge status={task.derived_status || task.status} />
             </div>
             <p className="max-w-xl truncate text-xs text-muted-foreground">{task.description}</p>
           </div>

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -12,6 +12,8 @@ export const AGENT_DEFAULTS: Agent = {
   label: 'Agent 1',
   status: 'running',
   claude_session_id: null,
+  hook_activity: 'active',
+  hook_activity_updated_at: null,
   created_at: '2026-01-01 00:00:00',
 };
 


### PR DESCRIPTION
## Summary

- **Hook system**: 3 HTTP hook endpoints (PermissionRequest, PostToolUse, Stop) receive real-time events from Claude Code agents via `.claude/settings.local.json` installed in worktrees. Hooks track when agents hit permission prompts and their running/idle/waiting state.
- **Backend**: New `permission_prompts` table, `hook_activity` column on agents, derived task status (working/needs_attention/done) computed from agent states. Prompts auto-resolve on tool completion (FIFO), agent stop, task close, and server restart.
- **Frontend**: Task cards show derived status badges, inline pending permission prompts with click-to-navigate, and per-agent activity dots. Agent tabs reflect hook_activity state. Deep-linking via `?agent=` query param.

## Test plan
- [ ] 471 tests passing (unit + component)
- [ ] Typecheck clean, lint clean
- [ ] Start a task, verify `.claude/settings.local.json` is created in worktree with hook config
- [ ] Trigger a permission prompt in an agent, verify it appears on the task card
- [ ] Grant the permission, verify the prompt disappears
- [ ] Verify derived status changes: working (active) → needs_attention (waiting) → done (idle)
- [ ] Click a permission prompt row, verify it navigates to the correct agent terminal
- [ ] Close a task, verify all pending prompts are resolved
- [ ] Resume a task, verify hooks are reinstalled and --continue agents get session IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)