### PR TITLE
feat(server): auto-close tasks when their PR is merged

### DIFF
--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -21,9 +21,21 @@ vi.mock('child_process', () => ({
   }),
 }));
 
-const { checkTaskStatus, pollStatuses, detectPR, pollPRs, startPolling, stopPolling } =
-  await import('./poller.js');
+vi.mock('./task-runner.js', () => ({
+  closeTask: vi.fn(),
+}));
+
+const {
+  checkTaskStatus,
+  pollStatuses,
+  detectPR,
+  pollPRs,
+  checkMergedPRs,
+  startPolling,
+  stopPolling,
+} = await import('./poller.js');
 const { execFile } = await import('child_process');
+const { closeTask } = await import('./task-runner.js');
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -324,6 +336,108 @@ describe('pollPRs', () => {
       }
     },
   );
+});
+
+// ─── checkMergedPRs ─────────────────────────────────────────────────────────
+
+describe('checkMergedPRs', () => {
+  it('closes task when PR is merged', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, pr_number: 42, pr_url: 'https://github.com/org/repo/pull/42' });
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) {
+        const cmdArgs = args[1] as string[];
+        if (cmdArgs && cmdArgs[0] === 'pr' && cmdArgs[1] === 'view') {
+          cb(null, { stdout: JSON.stringify({ state: 'MERGED' }), stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+      }
+      return undefined as any;
+    });
+
+    await checkMergedPRs();
+
+    expect(closeTask).toHaveBeenCalledWith(expect.objectContaining({ id: DEFAULTS.task.id }));
+  });
+
+  it('does not close task when PR is open', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, pr_number: 42, pr_url: 'https://github.com/org/repo/pull/42' });
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) {
+        const cmdArgs = args[1] as string[];
+        if (cmdArgs && cmdArgs[0] === 'pr' && cmdArgs[1] === 'view') {
+          cb(null, { stdout: JSON.stringify({ state: 'OPEN' }), stderr: '' });
+        } else {
+          cb(null, { stdout: '', stderr: '' });
+        }
+      }
+      return undefined as any;
+    });
+
+    await checkMergedPRs();
+
+    expect(closeTask).not.toHaveBeenCalled();
+  });
+
+  it('skips tasks without pr_number', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+
+    await checkMergedPRs();
+
+    expect(execFile).not.toHaveBeenCalled();
+    expect(closeTask).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when gh command fails', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, pr_number: 42, pr_url: 'https://github.com/org/repo/pull/42' });
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) cb(new Error('gh not found'));
+      return undefined as any;
+    });
+
+    await expect(checkMergedPRs()).resolves.not.toThrow();
+    expect(closeTask).not.toHaveBeenCalled();
+  });
+
+  it('runs gh pr view with correct args in repo directory', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, pr_number: 42, pr_url: 'https://github.com/org/repo/pull/42' });
+
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = findCallback(...args);
+      if (cb) cb(null, { stdout: JSON.stringify({ state: 'OPEN' }), stderr: '' });
+      return undefined as any;
+    });
+
+    await checkMergedPRs();
+
+    expect(execFile).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'view', '42', '--json', 'state'],
+      expect.objectContaining({ cwd: DEFAULTS.runningTask.repo_path }),
+      expect.any(Function),
+    );
+  });
+
+  const nonRunningStatuses = ['draft', 'closed', 'error', 'setting_up'] as const;
+
+  it.each(nonRunningStatuses)('skips tasks with status "%s"', async (status) => {
+    insertTask(db, {
+      ...DEFAULTS.runningTask,
+      status,
+      pr_number: 42,
+      pr_url: 'https://github.com/org/repo/pull/42',
+    });
+
+    await checkMergedPRs();
+
+    expect(execFile).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Lifecycle ───────────────────────────────────────────────────────────────

--- a/server/poller.ts
+++ b/server/poller.ts
@@ -1,15 +1,18 @@
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { getDb } from './db.js';
+import { closeTask } from './task-runner.js';
 import type { Task } from './types.js';
 
 const execFile = promisify(execFileCb);
 
 const STATUS_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 5000;
 const PR_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 30000;
+const MERGED_PR_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 30000;
 
 let statusTimer: ReturnType<typeof setInterval> | null = null;
 let prTimer: ReturnType<typeof setInterval> | null = null;
+let mergedPrTimer: ReturnType<typeof setInterval> | null = null;
 
 // ─── Session Status Polling ──────────────────────────────────────────────────
 
@@ -106,6 +109,45 @@ export async function pollPRs(): Promise<void> {
   }
 }
 
+// ─── Merged PR Detection ────────────────────────────────────────────────────
+
+export async function checkMergedPRs(): Promise<void> {
+  const db = getDb();
+  const tasks = db
+    .prepare("SELECT * FROM tasks WHERE status = 'running' AND pr_number IS NOT NULL")
+    .all() as Task[];
+
+  const results = await Promise.allSettled(
+    tasks.map(async (task) => {
+      const { stdout } = await execFile('gh', ['pr', 'view', String(task.pr_number), '--json', 'state'], {
+        cwd: task.repo_path,
+      });
+      const { state } = JSON.parse(stdout.trim());
+      return { task, state };
+    }),
+  );
+
+  for (const result of results) {
+    if (result.status !== 'fulfilled') continue;
+    const { task, state } = result.value;
+    if (state === 'MERGED') {
+      try {
+        await closeTask(task);
+      } catch {
+        // closeTask failure shouldn't stop processing other tasks
+      }
+    }
+  }
+}
+
+export async function pollMergedPRs(): Promise<void> {
+  try {
+    await checkMergedPRs();
+  } catch (err) {
+    console.error('pollMergedPRs error:', err);
+  }
+}
+
 // ─── Lifecycle ───────────────────────────────────────────────────────────────
 
 export function startPolling(): void {
@@ -114,6 +156,9 @@ export function startPolling(): void {
   }
   if (PR_INTERVAL > 0) {
     prTimer = setInterval(pollPRs, PR_INTERVAL);
+  }
+  if (MERGED_PR_INTERVAL > 0) {
+    mergedPrTimer = setInterval(pollMergedPRs, MERGED_PR_INTERVAL);
   }
 }
 
@@ -125,5 +170,9 @@ export function stopPolling(): void {
   if (prTimer) {
     clearInterval(prTimer);
     prTimer = null;
+  }
+  if (mergedPrTimer) {
+    clearInterval(mergedPrTimer);
+    mergedPrTimer = null;
   }
 }


### PR DESCRIPTION
## What
- Add merged-PR detection to the existing poller that checks GitHub PRs every 30s
- Auto-close tasks via `closeTask()` when their associated PR is detected as merged
- Add comprehensive tests for the new auto-close behavior

## Why
Tasks with merged PRs no longer need active agents running. Auto-closing them frees up resources and keeps the dashboard accurate without manual intervention.

## Testing
- [ ] Run `bun run test` — verify new poller tests pass
- [ ] Create a task with a PR, merge the PR on GitHub, and confirm the task auto-closes within 30s
- [ ] Verify tasks without PRs or with open PRs are unaffected