### PR TITLE
fix(api): remove --repo flag from gh pr create command

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -543,8 +543,6 @@ export function setupRoutes(app: Express): void {
         [
           'pr',
           'create',
-          '--repo',
-          task.repo_path,
           '--head',
           task.branch,
           '--base',


### PR DESCRIPTION
## Summary
- Removed `--repo` and `task.repo_path` args from the `gh pr create` call in `POST /api/tasks/:id/pr`
- The `--repo` flag was incorrectly receiving a local filesystem path (e.g. `/Users/.../repo`) instead of a GitHub `owner/repo` identifier
- Since `cwd` is already set to `task.repo_path`, `gh` infers the correct repo from the git remote automatically

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (442/442)

🤖 Generated with [Claude Code](https://claude.com/claude-code)