### PR TITLE
fix(tests): replace clearAllMocks with restoreAllMocks to prevent mock leaks

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -82,9 +82,9 @@ let db: Database.Database;
 let app: ReturnType<typeof createApp>;
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   db = createTestDb();
   app = createApp();
-  vi.clearAllMocks();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- Replace `vi.clearAllMocks()` with `vi.restoreAllMocks()` in `server/api.test.ts` to fix flaky test timeouts
- `clearAllMocks` only clears call history but does NOT reset mock implementations set by `mockReturnValue`/`mockImplementation`, causing stale mocks to leak between tests
- `restoreAllMocks` properly resets all mocks to their `vi.mock()` factory-defined implementations

## Test plan
- [x] Ran server tests 20 consecutive times with zero failures (previously ~2/15 failure rate)
- [x] Full test suite passes (442 tests)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)