### PR TITLE
Replace frontend polling with WebSocket events

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -23,6 +23,7 @@ import {
   getOrchestratorSession,
 } from './orchestrator.js';
 import { hookRoutes } from './hooks.js';
+import { broadcast } from './events.js';
 import type {
   CreateTaskRequest,
   UpdateTaskRequest,
@@ -315,6 +316,7 @@ export function setupRoutes(app: Express): void {
     created.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(id) as Agent[];
+    broadcast({ type: 'task:created', payload: { taskId: id } });
     res.status(201).json(created);
   });
 
@@ -350,6 +352,7 @@ export function setupRoutes(app: Express): void {
     updated.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(task.id) as Agent[];
+    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.json(updated);
   });
 
@@ -376,6 +379,7 @@ export function setupRoutes(app: Express): void {
     updated.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(task.id) as Agent[];
+    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.json(updated);
   });
 
@@ -391,9 +395,11 @@ export function setupRoutes(app: Express): void {
       return;
     }
 
+    const taskId = task.id;
     await deleteTask(task);
-    db.prepare('DELETE FROM agents WHERE task_id = ?').run(task.id);
-    db.prepare('DELETE FROM tasks WHERE id = ?').run(task.id);
+    db.prepare('DELETE FROM agents WHERE task_id = ?').run(taskId);
+    db.prepare('DELETE FROM tasks WHERE id = ?').run(taskId);
+    broadcast({ type: 'task:deleted', payload: { taskId } });
     res.status(204).send();
   });
 
@@ -416,6 +422,7 @@ export function setupRoutes(app: Express): void {
 
     const body = req.body as AddAgentRequest;
     const agent = await addAgent(task, body.prompt);
+    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.status(201).json(agent);
   });
 
@@ -435,6 +442,7 @@ export function setupRoutes(app: Express): void {
     }
 
     await stopAgent(task, agent);
+    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.json({ success: true });
   });
 
@@ -462,6 +470,7 @@ export function setupRoutes(app: Express): void {
 
     try {
       const userWindowIndex = await createUserTerminal(task);
+      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
       res.json({ user_window_index: userWindowIndex });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
@@ -618,6 +627,7 @@ export function setupRoutes(app: Express): void {
         .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
         .all(task.id) as Agent[];
 
+      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
       res.json(updated);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });

--- a/server/events.test.ts
+++ b/server/events.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setupEventWebSocket,
+  broadcast,
+  getEventClientCount,
+  cleanupEventClients,
+  handleEventUpgrade,
+} from './events.js';
+import type { IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
+
+describe('events', () => {
+  beforeEach(() => {
+    cleanupEventClients();
+    setupEventWebSocket();
+  });
+
+  it('handleEventUpgrade returns false for non-event URLs', () => {
+    const req = { url: '/ws/terminal/foo/0' } as IncomingMessage;
+    const result = handleEventUpgrade(req, {} as Duplex, Buffer.alloc(0));
+    expect(result).toBe(false);
+  });
+
+  it('starts with zero clients', () => {
+    expect(getEventClientCount()).toBe(0);
+  });
+
+  it('broadcast is a no-op with no clients', () => {
+    // Should not throw
+    broadcast({ type: 'task:updated', payload: { taskId: 't1' } });
+    expect(getEventClientCount()).toBe(0);
+  });
+
+  it('cleanupEventClients resets to zero', () => {
+    cleanupEventClients();
+    expect(getEventClientCount()).toBe(0);
+  });
+});

--- a/server/events.ts
+++ b/server/events.ts
@@ -1,0 +1,48 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import type { IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
+
+export interface ServerEvent {
+  type: 'task:updated' | 'task:created' | 'task:deleted';
+  payload: { taskId: string };
+}
+
+const clients = new Set<WebSocket>();
+let wss: WebSocketServer;
+
+export function setupEventWebSocket(): void {
+  wss = new WebSocketServer({ noServer: true });
+}
+
+export function handleEventUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {
+  if (req.url !== '/ws/events') return false;
+
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    clients.add(ws);
+    ws.on('close', () => clients.delete(ws));
+    ws.on('error', () => clients.delete(ws));
+  });
+  return true;
+}
+
+export function broadcast(event: ServerEvent): void {
+  const message = JSON.stringify(event);
+  for (const client of clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  }
+}
+
+export function getEventClientCount(): number {
+  return clients.size;
+}
+
+export function cleanupEventClients(): void {
+  for (const client of clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.close(1001, 'Server shutting down');
+    }
+  }
+  clients.clear();
+}

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
+import { broadcast } from './events.js';
 
 const router = Router();
 
@@ -36,6 +37,7 @@ router.post('/user-prompt-submit', (req, res) => {
     )
     .run(agent.id);
 
+  broadcast({ type: 'task:updated', payload: { taskId: agent.task_id } });
   res.status(200).send();
 });
 
@@ -77,6 +79,7 @@ router.post('/permission-request', (req, res) => {
   });
   txn();
 
+  broadcast({ type: 'task:updated', payload: { taskId: agent.task_id } });
   res.status(200).send();
 });
 
@@ -117,6 +120,7 @@ router.post('/post-tool-use', (req, res) => {
   });
   txn();
 
+  broadcast({ type: 'task:updated', payload: { taskId: agent.task_id } });
   res.status(200).send();
 });
 
@@ -152,6 +156,7 @@ router.post('/stop', (req, res) => {
   });
   txn();
 
+  broadcast({ type: 'task:updated', payload: { taskId: agent.task_id } });
   res.status(200).send();
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,16 @@
-import { createServer } from 'http';
+import { createServer, type IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
 import path from 'path';
 import fs from 'fs';
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { createApp } from './app.js';
-import { setupTerminalWebSocket, cleanupAllConnections } from './terminal.js';
+import {
+  setupTerminalWebSocket,
+  handleTerminalUpgrade,
+  cleanupAllConnections,
+} from './terminal.js';
+import { setupEventWebSocket, handleEventUpgrade, cleanupEventClients } from './events.js';
 import { startPolling, stopPolling } from './poller.js';
 import { checkTaskStatus } from './poller.js';
 import { resumeTask } from './task-runner.js';
@@ -16,8 +22,15 @@ const app = createApp();
 const server = createServer(app);
 const PORT = process.env.PORT || 7777;
 
-// WebSocket for terminal streaming
-setupTerminalWebSocket(server);
+// WebSocket setup
+setupTerminalWebSocket();
+setupEventWebSocket();
+
+server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+  if (handleTerminalUpgrade(req, socket, head)) return;
+  if (handleEventUpgrade(req, socket, head)) return;
+  socket.destroy();
+});
 
 // ─── Startup Recovery ──────────────────────────────────────────────────────
 async function recoverTasks(): Promise<void> {
@@ -70,8 +83,9 @@ server.listen(PORT, () => {
 function shutdown() {
   console.warn('[shutdown] Stopping pollers...');
   stopPolling();
-  console.warn('[shutdown] Cleaning up terminal connections...');
+  console.warn('[shutdown] Cleaning up connections...');
   cleanupAllConnections();
+  cleanupEventClients();
   console.warn('[shutdown] Closing HTTP server...');
   server.close(() => {
     console.warn('[shutdown] Done.');

--- a/server/poller.ts
+++ b/server/poller.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { getDb } from './db.js';
 import { closeTask } from './task-runner.js';
 import { installHookSettings } from './hook-settings.js';
+import { broadcast } from './events.js';
 import type { Task } from './types.js';
 
 const execFile = promisify(execFileCb);
@@ -51,6 +52,7 @@ export async function pollStatuses(): Promise<void> {
       db.prepare(
         `UPDATE agents SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ? AND status = 'running'`,
       ).run(task.id);
+      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     } else if (status === 'dead' && task.status === 'setting_up') {
       db.prepare(
         `UPDATE tasks SET status = 'error', error = 'Setup interrupted', updated_at = datetime('now') WHERE id = ?`,
@@ -58,6 +60,7 @@ export async function pollStatuses(): Promise<void> {
       db.prepare(
         `UPDATE agents SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ? AND status = 'running'`,
       ).run(task.id);
+      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     }
   }
 }
@@ -129,6 +132,7 @@ export async function pollPRs(): Promise<void> {
       db.prepare(
         `UPDATE tasks SET pr_url = ?, pr_number = ?, updated_at = datetime('now') WHERE id = ?`,
       ).run(pr.url, pr.number, task.id);
+      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     }
   }
 }
@@ -161,6 +165,7 @@ export async function checkMergedPRs(): Promise<void> {
     if (state === 'MERGED') {
       try {
         await closeTask(task);
+        broadcast({ type: 'task:updated', payload: { taskId: task.id } });
       } catch {
         // closeTask failure shouldn't stop processing other tasks
       }

--- a/server/terminal.test.ts
+++ b/server/terminal.test.ts
@@ -42,7 +42,7 @@ vi.mock('child_process', () => ({
   execFile: (...args: any[]) => mockExecFile(args[0], args[1], args[2]),
 }));
 
-const { setupTerminalWebSocket } = await import('./terminal.js');
+const { setupTerminalWebSocket, handleTerminalUpgrade } = await import('./terminal.js');
 const nodePty = await import('node-pty');
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
@@ -78,7 +78,12 @@ beforeEach(async () => {
   mockPty.onExit.mockReset();
 
   server = createServer();
-  setupTerminalWebSocket(server);
+  setupTerminalWebSocket();
+  server.on('upgrade', (req, socket, head) => {
+    if (!handleTerminalUpgrade(req, socket, head)) {
+      socket.destroy();
+    }
+  });
 
   await new Promise<void>((resolve) => {
     server.listen(0, () => {

--- a/server/terminal.ts
+++ b/server/terminal.ts
@@ -1,9 +1,9 @@
-import type { Server } from 'http';
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { WebSocketServer, WebSocket } from 'ws';
 import { spawn, type IPty } from 'node-pty';
 import type { IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
 import type { Task } from './types.js';
@@ -17,33 +17,32 @@ interface TerminalConnection {
 }
 
 const connections = new Map<string, TerminalConnection[]>();
+let wss: WebSocketServer;
 
-export function setupTerminalWebSocket(server: Server): void {
-  const wss = new WebSocketServer({ noServer: true });
+export function setupTerminalWebSocket(): void {
+  wss = new WebSocketServer({ noServer: true });
+}
 
-  server.on('upgrade', (req: IncomingMessage, socket, head) => {
-    // Match /ws/terminal/orchestrator
-    const orchMatch = req.url?.match(/^\/ws\/terminal\/orchestrator$/);
-    if (orchMatch) {
-      wss.handleUpgrade(req, socket, head, (ws) => {
-        handleOrchestratorConnection(ws);
-      });
-      return;
-    }
-
-    // Match /ws/terminal/:taskId/:windowIndex
-    const match = req.url?.match(/^\/ws\/terminal\/([^/]+)\/(\d+)$/);
-    if (!match) {
-      socket.destroy();
-      return;
-    }
-
+export function handleTerminalUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {
+  // Match /ws/terminal/orchestrator
+  const orchMatch = req.url?.match(/^\/ws\/terminal\/orchestrator$/);
+  if (orchMatch) {
     wss.handleUpgrade(req, socket, head, (ws) => {
-      const taskId = match[1];
-      const windowIndex = parseInt(match[2], 10);
-      handleConnection(ws, taskId, windowIndex);
+      handleOrchestratorConnection(ws);
     });
+    return true;
+  }
+
+  // Match /ws/terminal/:taskId/:windowIndex
+  const match = req.url?.match(/^\/ws\/terminal\/([^/]+)\/(\d+)$/);
+  if (!match) return false;
+
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    const taskId = match[1];
+    const windowIndex = parseInt(match[2], 10);
+    handleConnection(ws, taskId, windowIndex);
   });
+  return true;
 }
 
 function attachToTmuxSession(

--- a/src/lib/event-source.test.ts
+++ b/src/lib/event-source.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribe } from './event-source';
+
+// ─── Mock WebSocket ─────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    // Simulate async open
+    setTimeout(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  close(code = 1000) {
+    this.closed = true;
+    this.readyState = 3; // CLOSED
+    this.onclose?.({ code });
+  }
+
+  send(_data: string) {}
+
+  simulateMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+
+  simulateClose(code: number) {
+    this.readyState = 3;
+    this.onclose?.({ code });
+  }
+
+  static instances: MockWebSocket[] = [];
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  vi.stubGlobal('WebSocket', MockWebSocket);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('event-source', () => {
+  it('connects on first subscriber', async () => {
+    const cb = vi.fn();
+    const unsub = subscribe(cb);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toContain('/ws/events');
+
+    unsub();
+  });
+
+  it('calls subscriber on message', async () => {
+    const cb = vi.fn();
+    const unsub = subscribe(cb);
+
+    await vi.waitFor(() => expect(MockWebSocket.instances[0].readyState).toBe(MockWebSocket.OPEN));
+
+    MockWebSocket.instances[0].simulateMessage('{"type":"task:updated"}');
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unsub();
+  });
+
+  it('disconnects when last subscriber unsubscribes', async () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const unsub1 = subscribe(cb1);
+    const unsub2 = subscribe(cb2);
+
+    // Should reuse the same connection
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    unsub1();
+    expect(MockWebSocket.instances[0].closed).toBe(false);
+
+    unsub2();
+    expect(MockWebSocket.instances[0].closed).toBe(true);
+  });
+
+  it('reconnects on unexpected close', async () => {
+    vi.useFakeTimers();
+    const cb = vi.fn();
+    const unsub = subscribe(cb);
+
+    await vi.advanceTimersByTimeAsync(0); // let onopen fire
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // Simulate unexpected disconnect
+    MockWebSocket.instances[0].simulateClose(1006);
+
+    // After reconnect delay
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    unsub();
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/event-source.ts
+++ b/src/lib/event-source.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared WebSocket connection to /ws/events for real-time server events.
+ * Lazily connects on first subscriber, disconnects when all unsubscribe.
+ * Reconnects with exponential backoff on unexpected disconnects.
+ */
+
+const MAX_RECONNECT_DELAY = 10_000;
+const INITIAL_RECONNECT_DELAY = 1_000;
+
+let ws: WebSocket | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectDelay = INITIAL_RECONNECT_DELAY;
+const subscribers = new Set<() => void>();
+
+function getWsUrl(): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/ws/events`;
+}
+
+function connect(): void {
+  if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) return;
+
+  ws = new WebSocket(getWsUrl());
+
+  ws.onopen = () => {
+    reconnectDelay = INITIAL_RECONNECT_DELAY;
+  };
+
+  ws.onmessage = () => {
+    for (const cb of subscribers) cb();
+  };
+
+  ws.onclose = (event) => {
+    ws = null;
+    if (event.code !== 1000 && subscribers.size > 0) {
+      reconnectTimer = setTimeout(() => {
+        reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
+        connect();
+      }, reconnectDelay);
+    }
+  };
+
+  ws.onerror = () => {
+    // onclose handles reconnection
+  };
+}
+
+export function subscribe(callback: () => void): () => void {
+  subscribers.add(callback);
+  connect();
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0) {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      ws?.close(1000);
+      ws = null;
+      reconnectDelay = INITIAL_RECONNECT_DELAY;
+    }
+  };
+}

--- a/src/lib/hooks.test.tsx
+++ b/src/lib/hooks.test.tsx
@@ -18,8 +18,21 @@ vi.mock('./api', () => ({
   ),
 }));
 
+// ─── Mock event-source ──────────────────────────────────────────────────────
+
+let eventCallback: (() => void) | null = null;
+const unsubscribe = vi.fn();
+
+vi.mock('./event-source', () => ({
+  subscribe: vi.fn((cb: () => void) => {
+    eventCallback = cb;
+    return unsubscribe;
+  }),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
+  eventCallback = null;
 });
 
 // ─── Shared hook behavior (table-driven) ─────────────────────────────────────
@@ -27,7 +40,7 @@ beforeEach(() => {
 const hookCases = [
   {
     name: 'useTasks',
-    renderFn: (interval: number) => renderHook(() => useTasks(interval)),
+    renderFn: () => renderHook(() => useTasks()),
     mockFn: () => apiMock.listTasks,
     successValue: [{ id: 't1', title: 'Test' }],
     resultKey: 'tasks' as const,
@@ -35,7 +48,7 @@ const hookCases = [
   },
   {
     name: 'useTask',
-    renderFn: (interval: number) => renderHook(() => useTask('t1', interval)),
+    renderFn: () => renderHook(() => useTask('t1')),
     mockFn: () => apiMock.getTask,
     successValue: { id: 't1', title: 'Test' },
     resultKey: 'task' as const,
@@ -46,7 +59,7 @@ const hookCases = [
 describe.each(hookCases)('$name', ({ renderFn, mockFn, successValue, resultKey, emptyValue }) => {
   it('starts in loading state', async () => {
     mockFn().mockReturnValue(new Promise(() => {}));
-    const { result } = renderFn(60000);
+    const { result } = renderFn();
     expect(result.current.loading).toBe(true);
     expect((result.current as any)[resultKey]).toEqual(emptyValue);
     expect(result.current.error).toBeNull();
@@ -55,7 +68,7 @@ describe.each(hookCases)('$name', ({ renderFn, mockFn, successValue, resultKey, 
   it('returns data after fetch', async () => {
     mockFn().mockResolvedValue(successValue);
 
-    const { result } = renderFn(60000);
+    const { result } = renderFn();
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -67,7 +80,7 @@ describe.each(hookCases)('$name', ({ renderFn, mockFn, successValue, resultKey, 
   it('sets error on fetch failure', async () => {
     mockFn().mockRejectedValue(new Error('Network error'));
 
-    const { result } = renderFn(60000);
+    const { result } = renderFn();
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -76,37 +89,35 @@ describe.each(hookCases)('$name', ({ renderFn, mockFn, successValue, resultKey, 
     expect((result.current as any)[resultKey]).toEqual(emptyValue);
   });
 
-  it('polls at the specified interval', async () => {
+  it('re-fetches when event-source fires', async () => {
     mockFn().mockResolvedValue(successValue);
 
-    renderFn(50);
+    const { result } = renderFn();
 
     await waitFor(() => {
-      expect(mockFn()).toHaveBeenCalledTimes(1);
+      expect(result.current.loading).toBe(false);
+    });
+    expect(mockFn()).toHaveBeenCalledTimes(1);
+
+    // Simulate a server event
+    await act(async () => {
+      eventCallback?.();
     });
 
-    await waitFor(
-      () => {
-        expect(mockFn().mock.calls.length).toBeGreaterThanOrEqual(2);
-      },
-      { timeout: 500 },
-    );
+    expect(mockFn()).toHaveBeenCalledTimes(2);
   });
 
-  it('cleans up interval on unmount', async () => {
+  it('unsubscribes on unmount', async () => {
     mockFn().mockResolvedValue(successValue);
 
-    const { unmount } = renderFn(50);
+    const { unmount } = renderFn();
 
     await waitFor(() => {
       expect(mockFn()).toHaveBeenCalledTimes(1);
     });
 
     unmount();
-    const callCount = mockFn().mock.calls.length;
-
-    await new Promise((r) => setTimeout(r, 150));
-    expect(mockFn().mock.calls.length).toBe(callCount);
+    expect(unsubscribe).toHaveBeenCalled();
   });
 });
 
@@ -116,7 +127,7 @@ describe('useTasks', () => {
   it('clears error on successful refetch via refresh()', async () => {
     apiMock.listTasks.mockRejectedValueOnce(new Error('fail'));
 
-    const { result } = renderHook(() => useTasks(60000));
+    const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
       expect(result.current.error).toBe('fail');
@@ -135,7 +146,7 @@ describe('useTasks', () => {
   it('provides a refresh function', async () => {
     apiMock.listTasks.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useTasks(60000));
+    const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -157,7 +168,7 @@ describe('useTask', () => {
   it('calls getTask with the provided id', async () => {
     apiMock.getTask.mockResolvedValue({ id: 'my-task' });
 
-    renderHook(() => useTask('my-task', 60000));
+    renderHook(() => useTask('my-task'));
 
     await waitFor(() => {
       expect(apiMock.getTask).toHaveBeenCalledWith('my-task');

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Task } from '../../server/types';
 import { api } from './api';
+import { subscribe } from './event-source';
 
-export function useOrchestrator(pollInterval = 5000) {
+export function useOrchestrator() {
   const [running, setRunning] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -22,11 +22,8 @@ export function useOrchestrator(pollInterval = 5000) {
 
   useEffect(() => {
     refresh();
-    intervalRef.current = setInterval(refresh, pollInterval);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [refresh, pollInterval]);
+    return subscribe(refresh);
+  }, [refresh]);
 
   const start = useCallback(async () => {
     try {
@@ -49,11 +46,10 @@ export function useOrchestrator(pollInterval = 5000) {
   return { running, loading, error, start, stop, refresh };
 }
 
-export function useTasks(pollInterval = 5000) {
+export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -69,27 +65,23 @@ export function useTasks(pollInterval = 5000) {
 
   useEffect(() => {
     refresh();
-    intervalRef.current = setInterval(refresh, pollInterval);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [refresh, pollInterval]);
+    return subscribe(refresh);
+  }, [refresh]);
 
   return { tasks, loading, error, refresh };
 }
 
-export function useTask(id: string, pollInterval = 5000) {
+export function useTask(id: string) {
   const [task, setTask] = useState<Task | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastJsonRef = useRef<string>('');
 
   const refresh = useCallback(async () => {
     try {
       const data = await api.getTask(id);
       // Only trigger a re-render when the task data actually changed.
-      // Without this, every poll creates a new object reference and causes
+      // Without this, every event creates a new object reference and causes
       // the entire TaskDetail tree to re-render, risking terminal remounts.
       const json = JSON.stringify(data);
       if (json !== lastJsonRef.current) {
@@ -106,11 +98,8 @@ export function useTask(id: string, pollInterval = 5000) {
 
   useEffect(() => {
     refresh();
-    intervalRef.current = setInterval(refresh, pollInterval);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [refresh, pollInterval]);
+    return subscribe(refresh);
+  }, [refresh]);
 
   return { task, loading, error, refresh };
 }

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -7,6 +7,18 @@ import type { Task } from '../../server/types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+let eventCallbacks: Set<() => void>;
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn((cb: () => void) => {
+    eventCallbacks.add(cb);
+    return () => eventCallbacks.delete(cb);
+  }),
+}));
+
+function simulateEvent() {
+  for (const cb of eventCallbacks) cb();
+}
+
 const apiMock = mockApi();
 
 vi.mock('@/lib/api', () => ({
@@ -67,6 +79,7 @@ const runningTask: Task = makeTask({
 describe('TaskDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    eventCallbacks = new Set();
     apiMock.getTask.mockResolvedValue(runningTask);
     apiMock.updateTask.mockResolvedValue(runningTask);
     apiMock.startTask.mockResolvedValue(runningTask);
@@ -336,26 +349,22 @@ describe('TaskDetail', () => {
       });
 
       apiMock.getTask.mockResolvedValue(makeTask({ status: 'setting_up', agents: [] }));
-      await waitFor(
-        () => {
-          expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
-        },
-        { timeout: 6000 },
-      );
+      simulateEvent();
+      await waitFor(() => {
+        expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
+      });
 
       apiMock.getTask.mockResolvedValue(runningTask);
-      await waitFor(
-        () => {
-          expect(screen.getByRole('button', { name: /editor/i })).toBeInTheDocument();
-        },
-        { timeout: 6000 },
-      );
+      simulateEvent();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /editor/i })).toBeInTheDocument();
+      });
 
       await user.click(screen.getByRole('button', { name: /editor/i }));
       await waitFor(() => {
         expect(apiMock.createUserTerminal).toHaveBeenCalledTimes(2);
       });
-    }, 20000);
+    });
 
     it('auto-switches to agents when task enters setting_up state', async () => {
       const user = userEvent.setup();
@@ -370,13 +379,10 @@ describe('TaskDetail', () => {
       });
 
       apiMock.getTask.mockResolvedValue(makeTask({ status: 'setting_up', agents: [] }));
-
-      await waitFor(
-        () => {
-          expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
-        },
-        { timeout: 6000 },
-      );
-    }, 10000);
+      simulateEvent();
+      await waitFor(() => {
+        expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds a `/ws/events` WebSocket endpoint that broadcasts `task:updated`, `task:created`, and `task:deleted` events whenever task/agent state changes
- Frontend hooks (`useTasks`, `useTask`, `useOrchestrator`) now subscribe to real-time WebSocket events instead of polling every 5 seconds
- Shared WebSocket connection with lazy connect and exponential backoff reconnection (1s → 10s max)

## Changes
- **New:** `server/events.ts` — WebSocket broadcast system with client management
- **New:** `src/lib/event-source.ts` — Shared frontend WS connection singleton
- **Modified:** `server/index.ts` — Central upgrade routing for terminal + events WebSockets
- **Modified:** `server/terminal.ts` — Refactored to export upgrade handler (no longer registers internally)
- **Modified:** `server/api.ts`, `server/hooks.ts`, `server/poller.ts` — Added `broadcast()` calls after all mutations
- **Modified:** `src/lib/hooks.ts` — Replaced `setInterval` polling with `subscribe()` to event stream

## Test plan
- [x] All 507 tests pass (`bun run test`)
- [x] TypeScript compiles cleanly (`bun run typecheck`)
- [x] Lint passes with 0 errors (`bun run lint`)
- [x] Formatting clean (`bun run format:check`)
- [ ] Manual: verify task status updates appear instantly in the dashboard
- [ ] Manual: verify reconnection after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)