### PR TITLE
refactor(tests): table-driven tests and reusable harnesses

### DIFF
--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -38,18 +38,16 @@ describe('Database', () => {
       expect(columns.map((c) => c.name)).toContain(col);
     });
 
-    it('creates idx_tasks_status index', () => {
-      const indexes = db
-        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tasks'")
-        .all() as { name: string }[];
-      expect(indexes.map((i) => i.name)).toContain('idx_tasks_status');
-    });
+    const indexCases = [
+      { table: 'tasks', index: 'idx_tasks_status' },
+      { table: 'agents', index: 'idx_agents_task' },
+    ];
 
-    it('creates idx_agents_task index', () => {
+    it.each(indexCases)('creates $index on $table', ({ table, index }) => {
       const indexes = db
-        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='agents'")
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='${table}'`)
         .all() as { name: string }[];
-      expect(indexes.map((i) => i.name)).toContain('idx_agents_task');
+      expect(indexes.map((i) => i.name)).toContain(index);
     });
   });
 
@@ -160,14 +158,15 @@ describe('Database', () => {
       expect(() => initDb(db)).not.toThrow();
     });
 
-    it.each(['initial_prompt', 'base_branch'])('tasks table has column: %s (migration)', (col) => {
-      const columns = db.pragma('table_info(tasks)') as { name: string }[];
-      expect(columns.map((c) => c.name)).toContain(col);
-    });
+    const migrationColumns = [
+      { table: 'tasks', column: 'initial_prompt' },
+      { table: 'tasks', column: 'base_branch' },
+      { table: 'agents', column: 'claude_session_id' },
+    ];
 
-    it('agents table has claude_session_id column (migration)', () => {
-      const columns = db.pragma('table_info(agents)') as { name: string }[];
-      expect(columns.map((c) => c.name)).toContain('claude_session_id');
+    it.each(migrationColumns)('$table has $column column (migration)', ({ table, column }) => {
+      const columns = db.pragma(`table_info(${table})`) as { name: string }[];
+      expect(columns.map((c) => c.name)).toContain(column);
     });
   });
 
@@ -200,29 +199,24 @@ describe('Database', () => {
       expect(prompts[0].resolved_at).not.toBeNull();
     });
 
-    it('resets waiting agents to active on startup', () => {
-      insertTask(db, { id: 't1', status: 'running' });
-      insertAgent(db, { id: 'a1', task_id: 't1', hook_activity: 'waiting' });
+    const startupActivityCases = [
+      { initial: 'waiting' as const, status: 'running' as const, expected: 'active', desc: 'resets waiting to active' },
+      { initial: 'idle' as const, status: 'stopped' as const, expected: 'idle', desc: 'does not reset idle/stopped' },
+    ];
 
-      // Re-init simulates restart
-      initDb(db);
+    it.each(startupActivityCases)(
+      '$desc on startup',
+      ({ initial, status, expected }) => {
+        insertTask(db, { id: 't1', status: 'running' });
+        insertAgent(db, { id: 'a1', task_id: 't1', hook_activity: initial, status });
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('active');
-    });
+        initDb(db);
 
-    it('does not reset idle or stopped agents on startup', () => {
-      insertTask(db, { id: 't1', status: 'running' });
-      insertAgent(db, { id: 'a1', task_id: 't1', hook_activity: 'idle', status: 'stopped' });
-
-      initDb(db);
-
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('idle');
-    });
+        const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+          hook_activity: string;
+        };
+        expect(agent.hook_activity).toBe(expected);
+      },
+    );
   });
 });

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -7,6 +7,7 @@ import {
   insertAgent,
   insertPermissionPrompt,
   getPermissionPrompts,
+  getAgentActivity,
 } from './test-helpers.js';
 import { createApp } from './app.js';
 
@@ -22,43 +23,32 @@ describe('Hook endpoints', () => {
   });
 
   describe('POST /api/hooks/user-prompt-submit', () => {
-    it('sets idle agent to active when user submits a prompt', async () => {
-      db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
+    const activatableCases = [
+      { from: 'idle', description: 'idle agent' },
+      { from: 'waiting', description: 'waiting agent' },
+    ];
 
-      await request(app)
-        .post('/api/hooks/user-prompt-submit')
-        .send({ session_id: 'sess-123' })
-        .expect(200);
+    it.each(activatableCases)(
+      'sets $description to active when user submits a prompt',
+      async ({ from }) => {
+        db.prepare(`UPDATE agents SET hook_activity = ? WHERE id = ?`).run(from, 'a1');
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('active');
-    });
+        await request(app)
+          .post('/api/hooks/user-prompt-submit')
+          .send({ session_id: 'sess-123' })
+          .expect(200);
 
-    it('sets waiting agent to active when user submits a prompt', async () => {
-      db.prepare(`UPDATE agents SET hook_activity = 'waiting' WHERE id = ?`).run('a1');
+        expect(getAgentActivity(db, 'a1').hook_activity).toBe('active');
+      },
+    );
 
-      await request(app)
-        .post('/api/hooks/user-prompt-submit')
-        .send({ session_id: 'sess-123' })
-        .expect(200);
+    const ignoreCases = [
+      { name: 'unknown session_id', body: { session_id: 'unknown' } },
+      { name: 'missing session_id', body: {} },
+    ];
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('active');
-    });
-
-    it('ignores unknown session_id', async () => {
-      await request(app)
-        .post('/api/hooks/user-prompt-submit')
-        .send({ session_id: 'unknown' })
-        .expect(200);
-    });
-
-    it('ignores request with missing session_id', async () => {
-      await request(app).post('/api/hooks/user-prompt-submit').send({}).expect(200);
+    it.each(ignoreCases)('ignores request with $name', async ({ body }) => {
+      await request(app).post('/api/hooks/user-prompt-submit').send(body).expect(200);
     });
   });
 
@@ -80,24 +70,19 @@ describe('Hook endpoints', () => {
       expect(prompts[0].status).toBe('pending');
       expect(prompts[0].agent_id).toBe('a1');
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('waiting');
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('waiting');
     });
 
-    it('ignores unknown session_id', async () => {
-      await request(app)
-        .post('/api/hooks/permission-request')
-        .send({ session_id: 'unknown', tool_name: 'Bash', tool_input: {} })
-        .expect(200);
+    const ignoreCases = [
+      { name: 'unknown session_id', body: { session_id: 'unknown', tool_name: 'Bash', tool_input: {} } },
+      { name: 'missing fields', body: {} },
+    ];
+
+    it.each(ignoreCases)('ignores request with $name', async ({ body }) => {
+      await request(app).post('/api/hooks/permission-request').send(body).expect(200);
 
       const prompts = getPermissionPrompts(db, 't1');
       expect(prompts).toHaveLength(0);
-    });
-
-    it('ignores request with missing fields', async () => {
-      await request(app).post('/api/hooks/permission-request').send({}).expect(200);
     });
   });
 
@@ -129,10 +114,7 @@ describe('Hook endpoints', () => {
       expect(pp1?.status).toBe('resolved');
       expect(pp2?.status).toBe('pending');
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('active');
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('active');
     });
 
     it('no-ops when no pending prompts exist', async () => {
@@ -141,14 +123,10 @@ describe('Hook endpoints', () => {
         .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
         .expect(200);
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('active');
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('active');
     });
 
     it('does not override idle state (Stop hook may have fired first)', async () => {
-      // Simulate Stop hook having already fired
       db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
 
       await request(app)
@@ -156,10 +134,7 @@ describe('Hook endpoints', () => {
         .send({ session_id: 'sess-123', tool_name: 'Bash', tool_input: {} })
         .expect(200);
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('idle');
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('idle');
     });
   });
 
@@ -186,10 +161,7 @@ describe('Hook endpoints', () => {
       const prompts = getPermissionPrompts(db, 't1');
       expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
-        hook_activity: string;
-      };
-      expect(agent.hook_activity).toBe('idle');
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('idle');
     });
   });
 });

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -7,6 +7,7 @@ import {
   getTask,
   getAgents,
   findCallback,
+  deadSessionMock,
   DEFAULTS,
 } from './test-helpers.js';
 import type { Task } from './types.js';
@@ -99,110 +100,59 @@ describe('checkTaskStatus', () => {
 // ─── pollStatuses ────────────────────────────────────────────────────────────
 
 describe('pollStatuses', () => {
-  it('marks running task as closed when session dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
+  // ─── Session death scenarios (table-driven) ────────────────────────────────
 
-    // Make has-session fail (session dead)
-    vi.mocked(execFile).mockImplementation((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('session not found'));
-      return undefined as any;
-    });
+  const sessionDeathCases = [
+    { taskStatus: 'running' as const, expectedStatus: 'closed', expectedError: undefined },
+    { taskStatus: 'setting_up' as const, expectedStatus: 'error', expectedError: 'Setup interrupted' },
+  ];
 
-    await pollStatuses();
+  describe.each(sessionDeathCases)(
+    'when $taskStatus task session dies',
+    ({ taskStatus, expectedStatus, expectedError }) => {
+      beforeEach(() => {
+        vi.mocked(execFile).mockImplementation(deadSessionMock as any);
+      });
 
-    const task = getTask(db, DEFAULTS.task.id)!;
-    expect(task.status).toBe('closed');
-  });
+      it(`sets task status to ${expectedStatus}`, async () => {
+        insertTask(db, { ...DEFAULTS.runningTask, status: taskStatus });
+        insertAgent(db);
 
-  it('marks running agents as stopped when session dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
-    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
+        await pollStatuses();
 
-    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb?: any) => {
-      const callback = cb || _opts;
-      if (typeof callback === 'function') callback(new Error('dead'));
-      return undefined as any;
-    });
+        const task = getTask(db, DEFAULTS.task.id)!;
+        expect(task.status).toBe(expectedStatus);
+        if (expectedError) expect(task.error).toBe(expectedError);
+      });
 
-    await pollStatuses();
+      it('marks all agents as stopped', async () => {
+        insertTask(db, { ...DEFAULTS.runningTask, status: taskStatus });
+        insertAgent(db);
+        insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
 
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
-  });
+        await pollStatuses();
 
-  it('sets hook_activity to idle when session dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db, { hook_activity: 'active' });
-    insertAgent(db, {
-      id: 'agent-02',
-      window_index: 1,
-      label: 'Agent 2',
-      hook_activity: 'waiting',
-    });
+        const agents = getAgents(db, DEFAULTS.task.id);
+        expect(agents.every((a) => a.status === 'stopped')).toBe(true);
+      });
 
-    vi.mocked(execFile).mockImplementation((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('session not found'));
-      return undefined as any;
-    });
+      it('sets hook_activity to idle for all agents', async () => {
+        insertTask(db, { ...DEFAULTS.runningTask, status: taskStatus });
+        insertAgent(db, { hook_activity: 'active' });
+        insertAgent(db, {
+          id: 'agent-02',
+          window_index: 1,
+          label: 'Agent 2',
+          hook_activity: 'waiting',
+        });
 
-    await pollStatuses();
+        await pollStatuses();
 
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents.every((a) => a.hook_activity === 'idle')).toBe(true);
-  });
-
-  it('marks setting_up task as error when session dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask, status: 'setting_up' });
-    insertAgent(db);
-
-    vi.mocked(execFile).mockImplementation((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('session not found'));
-      return undefined as any;
-    });
-
-    await pollStatuses();
-
-    const task = getTask(db, DEFAULTS.task.id)!;
-    expect(task.status).toBe('error');
-    expect(task.error).toBe('Setup interrupted');
-  });
-
-  it('marks agents as stopped when setting_up task dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask, status: 'setting_up' });
-    insertAgent(db);
-
-    vi.mocked(execFile).mockImplementation((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('session not found'));
-      return undefined as any;
-    });
-
-    await pollStatuses();
-
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
-  });
-
-  it('sets hook_activity to idle when setting_up task dies', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask, status: 'setting_up' });
-    insertAgent(db, { hook_activity: 'active' });
-
-    vi.mocked(execFile).mockImplementation((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('session not found'));
-      return undefined as any;
-    });
-
-    await pollStatuses();
-
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents.every((a) => a.hook_activity === 'idle')).toBe(true);
-  });
+        const agents = getAgents(db, DEFAULTS.task.id);
+        expect(agents.every((a) => a.hook_activity === 'idle')).toBe(true);
+      });
+    },
+  );
 
   it('does not modify task when session is alive', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
@@ -220,11 +170,7 @@ describe('pollStatuses', () => {
   it.each(ignoredStatuses)('ignores tasks with status "%s"', async (status) => {
     insertTask(db, { ...DEFAULTS.runningTask, status });
 
-    vi.mocked(execFile).mockImplementation((_cmd: any, _args: any, _opts: any, cb?: any) => {
-      const callback = cb || _opts;
-      if (typeof callback === 'function') callback(new Error('dead'));
-      return undefined as any;
-    });
+    vi.mocked(execFile).mockImplementation(deadSessionMock as any);
 
     await pollStatuses();
 
@@ -274,16 +220,13 @@ describe('ensureHooksInstalled', () => {
     expect(installHookSettings).toHaveBeenCalledTimes(2);
   });
 
-  it('skips non-running tasks', () => {
-    insertTask(db, { ...DEFAULTS.runningTask, status: 'closed' });
+  const skipCases = [
+    { name: 'non-running tasks', overrides: { status: 'closed' as const } },
+    { name: 'tasks without worktree', overrides: { worktree: null } },
+  ];
 
-    ensureHooksInstalled();
-
-    expect(installHookSettings).not.toHaveBeenCalled();
-  });
-
-  it('skips tasks without worktree', () => {
-    insertTask(db, { ...DEFAULTS.runningTask, worktree: null });
+  it.each(skipCases)('skips $name', ({ overrides }) => {
+    insertTask(db, { ...DEFAULTS.runningTask, ...overrides });
 
     ensureHooksInstalled();
 
@@ -319,28 +262,24 @@ describe('detectPR', () => {
     expect(result).toEqual({ url: 'https://github.com/org/repo/pull/42', number: 42 });
   });
 
-  it('returns null when no PR found', async () => {
-    const result = await detectPR({ ...DEFAULTS.runningTask } as Task);
-    expect(result).toBeNull();
-  });
-
-  it('returns null when gh command fails', async () => {
-    vi.mocked(execFile).mockImplementationOnce((...args: any[]) => {
-      const cb = findCallback(...args);
-      if (cb) cb(new Error('gh not found'));
-      return undefined as any;
-    });
-
-    const result = await detectPR({ ...DEFAULTS.runningTask } as Task);
-    expect(result).toBeNull();
-  });
-
-  const nullFieldCases = [
-    { name: 'branch is null', overrides: { branch: null } },
-    { name: 'repo_path is null', overrides: { repo_path: '' } },
+  const nullReturnCases = [
+    { name: 'no PR found', setup: () => {} },
+    {
+      name: 'gh command fails',
+      setup: () => {
+        vi.mocked(execFile).mockImplementationOnce((...args: any[]) => {
+          const cb = findCallback(...args);
+          if (cb) cb(new Error('gh not found'));
+          return undefined as any;
+        });
+      },
+    },
+    { name: 'branch is null', setup: () => {}, overrides: { branch: null } },
+    { name: 'repo_path is empty', setup: () => {}, overrides: { repo_path: '' } },
   ];
 
-  it.each(nullFieldCases)('returns null when $name', async ({ overrides }) => {
+  it.each(nullReturnCases)('returns null when $name', async ({ setup, overrides }) => {
+    setup?.();
     const result = await detectPR({ ...DEFAULTS.runningTask, ...overrides } as Task);
     expect(result).toBeNull();
   });
@@ -385,21 +324,13 @@ describe('pollPRs', () => {
     expect(task.pr_number).toBe(99);
   });
 
-  it('skips tasks that already have a PR', async () => {
-    insertTask(db, {
-      ...DEFAULTS.runningTask,
-      pr_url: 'https://github.com/org/repo/pull/1',
-      pr_number: 1,
-    });
+  const pollPRSkipCases = [
+    { name: 'already has a PR', overrides: { pr_url: 'https://github.com/org/repo/pull/1', pr_number: 1 } },
+    { name: 'has no branch', overrides: { branch: null } },
+  ];
 
-    await pollPRs();
-
-    // execFile should not be called for gh (task already has PR)
-    expect(execFile).not.toHaveBeenCalled();
-  });
-
-  it('skips tasks without a branch', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask, branch: null });
+  it.each(pollPRSkipCases)('skips tasks that $name', async ({ overrides }) => {
+    insertTask(db, { ...DEFAULTS.runningTask, ...overrides });
 
     await pollPRs();
 

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -8,6 +8,7 @@ import {
   getTask,
   getAgents,
   getPermissionPrompts,
+  getAgentActivity,
   findExecCall,
   DEFAULTS,
 } from './test-helpers.js';
@@ -285,36 +286,29 @@ describe('startTask', () => {
 describe('addAgent', () => {
   const runningTask = { ...DEFAULTS.runningTask } as Task;
 
-  it('creates first agent when none exist', async () => {
+  const agentLabelCases = [
+    { name: 'first agent (none exist)', existingAgents: [], expectedLabel: 'Agent 1' },
+    {
+      name: 'second agent',
+      existingAgents: [{}],
+      expectedLabel: 'Agent 2',
+    },
+    {
+      name: 'third agent',
+      existingAgents: [{}, { id: 'agent-02', window_index: 1, label: 'Agent 2' }],
+      expectedLabel: 'Agent 3',
+    },
+  ];
+
+  it.each(agentLabelCases)('creates $name with label "$expectedLabel"', async ({ existingAgents, expectedLabel }) => {
     insertTask(db, { ...DEFAULTS.runningTask });
+    existingAgents.forEach((overrides) => insertAgent(db, overrides));
+
     const agent = await addAgent(runningTask);
 
-    // Window index comes from tmux list-windows after new-window
     expect(agent.window_index).toBe(1);
-    expect(agent.label).toBe('Agent 1');
+    expect(agent.label).toBe(expectedLabel);
     expect(agent.status).toBe('running');
-  });
-
-  it('creates second agent with correct label', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
-
-    const agent = await addAgent(runningTask);
-
-    // Window index comes from tmux, label increments based on DB count
-    expect(agent.window_index).toBe(1);
-    expect(agent.label).toBe('Agent 2');
-  });
-
-  it('creates third agent with correct label', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
-    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
-
-    const agent = await addAgent(runningTask);
-
-    expect(agent.window_index).toBe(1);
-    expect(agent.label).toBe('Agent 3');
   });
 
   it('reuses window index after agent is stopped', async () => {
@@ -343,20 +337,20 @@ describe('addAgent', () => {
     expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeDefined();
   });
 
-  it('dispatches prompt when provided', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    await addAgent(runningTask, 'Write tests');
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] }),
-    ).toBeDefined();
-  });
+  const promptDispatchCases = [
+    { name: 'dispatches prompt when provided', prompt: 'Write tests', expectPaste: true },
+    { name: 'does not dispatch when no prompt', prompt: undefined, expectPaste: false },
+  ];
 
-  it('does not dispatch when no prompt provided', async () => {
+  it.each(promptDispatchCases)('$name', async ({ prompt, expectPaste }) => {
     insertTask(db, { ...DEFAULTS.runningTask });
-    await addAgent(runningTask);
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] }),
-    ).toBeUndefined();
+    await addAgent(runningTask, prompt);
+    const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] });
+    if (expectPaste) {
+      expect(call).toBeDefined();
+    } else {
+      expect(call).toBeUndefined();
+    }
   });
 
   it('persists agent to database', async () => {
@@ -372,19 +366,7 @@ describe('addAgent', () => {
 // ─── closeTask ───────────────────────────────────────────────────────────────
 
 describe('closeTask', () => {
-  it('marks all agents as stopped', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
-    insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
-
-    await closeTask({ ...DEFAULTS.runningTask } as Task);
-
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents).toHaveLength(2);
-    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
-  });
-
-  it('sets hook_activity to idle for all agents', async () => {
+  it('marks all agents as stopped and sets hook_activity to idle', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db, { hook_activity: 'active' });
     insertAgent(db, {
@@ -397,6 +379,8 @@ describe('closeTask', () => {
     await closeTask({ ...DEFAULTS.runningTask } as Task);
 
     const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents).toHaveLength(2);
+    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
     expect(agents.every((a) => a.hook_activity === 'idle')).toBe(true);
   });
 
@@ -410,20 +394,15 @@ describe('closeTask', () => {
     ).toBeDefined();
   });
 
-  it('does NOT remove worktree (preserved for resume)', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    await closeTask({ ...DEFAULTS.runningTask } as Task);
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'remove'] }),
-    ).toBeUndefined();
-  });
+  const closePreservedResources = [
+    { name: 'worktree', cmd: 'git', argsInclude: ['worktree', 'remove'] },
+    { name: 'branch', cmd: 'git', argsInclude: ['branch', '-D'] },
+  ];
 
-  it('does NOT delete the branch', async () => {
+  it.each(closePreservedResources)('does NOT remove $name (preserved for resume)', async ({ cmd, argsInclude }) => {
     insertTask(db, { ...DEFAULTS.runningTask });
     await closeTask({ ...DEFAULTS.runningTask } as Task);
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['branch', '-D'] }),
-    ).toBeUndefined();
+    expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeUndefined();
   });
 
   it('skips tmux kill when tmux_session is null', async () => {
@@ -498,23 +477,14 @@ describe('stopAgent', () => {
     );
   });
 
-  it('marks agent as stopped in database', async () => {
-    insertTask(db, { ...DEFAULTS.runningTask });
-    insertAgent(db);
-
-    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
-
-    const agents = getAgents(db, DEFAULTS.task.id);
-    expect(agents[0].status).toBe('stopped');
-  });
-
-  it('sets hook_activity to idle', async () => {
+  it('marks agent as stopped and sets hook_activity to idle', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db, { hook_activity: 'active' });
 
     await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
 
     const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents[0].status).toBe('stopped');
     expect(agents[0].hook_activity).toBe('idle');
   });
 
@@ -634,9 +604,14 @@ describe('resumeTask', () => {
     expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeDefined();
   });
 
-  it('uses --resume with claude_session_id when available', async () => {
+  const resumeFlagCases = [
+    { name: 'session_id available', sessionId: 'session-abc-123', expectedFlag: '--resume', expectedId: 'session-abc-123' },
+    { name: 'session_id null', sessionId: null, expectedFlag: '--continue', expectedId: undefined },
+  ];
+
+  it.each(resumeFlagCases)('uses $expectedFlag when $name', async ({ sessionId, expectedFlag, expectedId }) => {
     insertTask(db, { ...closedTask });
-    insertAgent(db, { status: 'stopped', claude_session_id: 'session-abc-123' });
+    insertAgent(db, { status: 'stopped', claude_session_id: sessionId });
 
     await resumeTask(closedTask);
 
@@ -647,23 +622,8 @@ describe('resumeTask', () => {
     expect(sendKeysCall).toBeDefined();
     const args = sendKeysCall![1] as string[];
     const claudeCmd = args.find((a: string) => a.includes('claude'));
-    expect(claudeCmd).toContain('--resume');
-    expect(claudeCmd).toContain('session-abc-123');
-  });
-
-  it('uses --continue when claude_session_id is null', async () => {
-    insertTask(db, { ...closedTask });
-    insertAgent(db, { status: 'stopped', claude_session_id: null });
-
-    await resumeTask(closedTask);
-
-    const sendKeysCall = findExecCall(vi.mocked(execFile), {
-      cmd: 'tmux',
-      argsInclude: ['send-keys'],
-    });
-    const args = sendKeysCall![1] as string[];
-    const claudeCmd = args.find((a: string) => a.includes('claude'));
-    expect(claudeCmd).toContain('--continue');
+    expect(claudeCmd).toContain(expectedFlag);
+    if (expectedId) expect(claudeCmd).toContain(expectedId);
   });
 
   it('creates new windows for agents after the first', async () => {

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -220,6 +220,28 @@ export function countExecCalls(mock: ReturnType<typeof vi.fn>, match: ShellCallM
   }).length;
 }
 
+// ─── Agent Activity Helper ───────────────────────────────────────────────────
+
+export function getAgentActivity(
+  db: Database.Database,
+  agentId: string,
+): { hook_activity: string } {
+  return db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get(agentId) as {
+    hook_activity: string;
+  };
+}
+
+// ─── Dead Session Mock ──────────────────────────────────────────────────────
+
+/**
+ * Creates an execFile mock implementation that simulates a dead tmux session.
+ */
+export function deadSessionMock(...args: any[]): any {
+  const cb = findCallback(...args);
+  if (cb) cb(new Error('session not found'));
+  return undefined as any;
+}
+
 // ─── Table-Driven Helpers ────────────────────────────────────────────────────
 
 export const TASKS_TABLE_COLUMNS = [


### PR DESCRIPTION
## Summary
- Add `getAgentActivity()` and `deadSessionMock()` helpers to `server/test-helpers.ts` to eliminate repeated inline patterns
- Convert duplicated test cases to table-driven `it.each()` / `describe.each()` across hooks, db, poller, and task-runner tests
- Net reduction of ~120 lines while maintaining full test coverage (505 tests, all passing)

## Test plan
- [x] `bun run test` — all 505 tests pass (22 files)
- [x] `bun run typecheck` — clean
- [x] No production code changed — only test files and test-helpers.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)