### PR TITLE
refactor(api): remove MAX_CONCURRENT_TASKS concurrency limit

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -22,7 +22,7 @@ All issues identified and fixed. See commit for details.
 11. **No request body size limit** — Added `{ limit: '1mb' }` to `express.json()`
 12. **Duplicated WebSocket handlers** — Extracted shared `attachToTmuxSession()` function
 13. **DB singleton fragility** — Kept as-is (adequate for localhost tool with existing `setDb()` pattern)
-14. **No concurrent task limit** — Added `MAX_CONCURRENT_TASKS` (default 10, configurable via env)
+14. **No concurrent task limit** — Removed (no longer enforced)
 
 ### Code Quality
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -36,7 +36,6 @@ import type {
 const execFile = promisify(execFileCb);
 
 const CLAUDE_TIMEOUT_MS = 120_000;
-const MAX_CONCURRENT_TASKS = parseInt(process.env.MAX_CONCURRENT_TASKS || '10', 10);
 
 /** Run claude CLI with prompt piped via stdin to avoid arg length issues. */
 function runClaude(prompt: string, env: NodeJS.ProcessEnv): Promise<string> {
@@ -282,17 +281,6 @@ export function setupRoutes(app: Express): void {
 
     const db = getDb();
 
-    if (!body.draft) {
-      const runningCount = db
-        .prepare("SELECT COUNT(*) as count FROM tasks WHERE status IN ('running', 'setting_up')")
-        .get() as { count: number };
-      if (runningCount.count >= MAX_CONCURRENT_TASKS) {
-        res.status(429).json({
-          error: `Maximum concurrent tasks reached (${MAX_CONCURRENT_TASKS}). Close some tasks first.`,
-        });
-        return;
-      }
-    }
     const id = nanoid(12);
     db.prepare(
       'INSERT INTO tasks (id, title, description, repo_path, branch, base_branch, initial_prompt) VALUES (?, ?, ?, ?, ?, ?, ?)',

--- a/server/orchestrator-prompt.md
+++ b/server/orchestrator-prompt.md
@@ -88,7 +88,7 @@ The `initial_prompt` is sent to the first Claude agent after it starts. Write pr
 ## Your Workflow
 
 1. **Understand the request**: When given work to do, break it into discrete, parallelizable tasks.
-2. **Check existing tasks**: `list-tasks` to see what's already running. Respect the concurrent task limit (default 10).
+2. **Check existing tasks**: `list-tasks` to see what's already running.
 3. **Create tasks**: Use `create-task` with clear title, description, and initial_prompt.
 4. **Monitor progress**: Poll `get-task <id>` to check status. Watch for `error` state.
 5. **Handle failures**: If a task errors, check the error message. Resume via REST API if the issue is transient.


### PR DESCRIPTION
## Summary
- Remove the `MAX_CONCURRENT_TASKS` constant, env var parsing, and the running-count check + 429 response from `POST /api/tasks`
- Remove "respect the concurrent task limit" instruction from orchestrator prompt
- Update REVIEW.md to reflect the removal

## Test plan
- [x] Tests pass (`bun run test` — 508 passing)
- [x] Verified no test files referenced `MAX_CONCURRENT_TASKS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)