### PR TITLE
feat(pkg): package octomux-agents as npm distributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,30 @@ Web dashboard for orchestrating autonomous Claude Code agents. Create tasks, wat
 - **Terminal:** xterm.js → node-pty → tmux
 - **Isolation:** git worktrees per task, tmux sessions per task
 
-## Setup
+## Install
+
+### From npm
+
+```bash
+npm install -g octomux-agents
+octomux-agents              # starts dashboard at http://localhost:7777
+```
+
+Or run without installing:
+
+```bash
+npx octomux-agents
+```
+
+### Prerequisites
+
+The following must be available on your system:
+
+- **tmux** — `brew install tmux` (macOS) or `apt install tmux` (Linux)
+- **git** — already installed on most systems
+- **claude** — [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+
+### From source (development)
 
 ```bash
 bun install

--- a/bin/octomux-agents.js
+++ b/bin/octomux-agents.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+
+// ─── Preflight checks ──────────────────────────────────────────────────────
+
+const required = [
+  { cmd: 'tmux', args: ['-V'], name: 'tmux' },
+  { cmd: 'git', args: ['--version'], name: 'git' },
+  { cmd: 'claude', args: ['--version'], name: 'claude (Claude Code CLI)' },
+];
+
+const missing = [];
+for (const { cmd, args, name } of required) {
+  try {
+    execFileSync(cmd, args, { stdio: 'ignore' });
+  } catch {
+    missing.push(name);
+  }
+}
+
+if (missing.length > 0) {
+  console.error('octomux-agents: missing required system dependencies:');
+  for (const name of missing) {
+    console.error(`  - ${name}`);
+  }
+  console.error('\nInstall them and try again.');
+  process.exit(1);
+}
+
+// ─── Start server ───────────────────────────────────────────────────────────
+
+process.env.NODE_ENV = 'production';
+await import('../dist-server/index.js');

--- a/package.json
+++ b/package.json
@@ -1,16 +1,25 @@
 {
   "name": "octomux-agents",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "bin": {
+    "octomux-agents": "./bin/octomux-agents.js",
     "octomux": "./cli/dist/index.js"
   },
+  "files": [
+    "bin/",
+    "dist/",
+    "dist-server/",
+    "!dist-server/*.test.*",
+    "!dist-server/test-helpers.*",
+    "cli/dist/",
+    "cli/package.json"
+  ],
   "scripts": {
     "dev": "concurrently \"bun:dev:server\" \"bun:dev:client\"",
     "dev:server": "tsx watch server/index.ts",
     "dev:client": "vite",
-    "build": "vite build && bun run build:server",
+    "build": "vite build && bun run build:server && bun run cli:build",
     "build:server": "tsc -p tsconfig.server.json",
     "start": "NODE_ENV=production node dist-server/index.js",
     "test": "vitest run",
@@ -23,6 +32,7 @@
     "format:check": "prettier --check .",
     "cli:build": "cd cli && tsc",
     "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build",
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true",
     "prepare": "husky"
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,8 +70,8 @@ startPolling();
 if (process.env.NODE_ENV === 'production') {
   const distPath = path.join(__dirname, '..', 'dist');
   app.use(express.static(distPath));
-  app.get('*', (_req, res) => {
-    res.sendFile(path.join(distPath, 'index.html'));
+  app.get('/{*path}', (_req, res) => {
+    res.sendFile('index.html', { root: distPath });
   });
 }
 


### PR DESCRIPTION
## Summary
- Package octomux-agents for npm distribution (`npm install -g octomux-agents` / `npx octomux-agents`)
- Add `bin/octomux-agents.js` entry point with preflight checks for system deps (tmux, git, claude)
- Fix Express 5 SPA fallback route (`*` → `/{*path}`, `sendFile` with `root` option)
- Include packaging analysis comparing 8 approaches (npm, bun compile, Docker, Homebrew, etc.)

## Test plan
- [x] All 509 unit tests pass (`bun run test`)
- [x] Full build succeeds (`bun run build` — frontend + server + CLI)
- [x] Production smoke test: API, SPA root, SPA fallback, static assets all return HTTP 200
- [x] `npm pack --dry-run` produces clean 305 kB package (42 files, test files excluded)