### PR TITLE
perf(ui): optimize rendering and reduce unnecessary re-renders

### DIFF
--- a/UI-PERFORMANCE-AUDIT.md
+++ b/UI-PERFORMANCE-AUDIT.md
@@ -1,0 +1,75 @@
+# UI Performance Audit
+
+> Audit of octomux-agents React frontend for rendering performance, data fetching efficiency, and perceived responsiveness.
+
+## Issues (Prioritized)
+
+### HIGH Impact
+
+#### 1. No Code Splitting — xterm.js Bundled on Dashboard
+
+- **Where:** `src/App.tsx:3-4` — static imports of Dashboard and TaskDetail
+- **Impact:** xterm.js (~200KB) loaded on Dashboard even when user never visits TaskDetail. Slows initial page load.
+- **Fix:** Lazy-load TaskDetail route with `React.lazy` + `Suspense`. TerminalView is only used inside TaskDetail and OrchestratorPanel, so lazy-loading TaskDetail saves the bulk of xterm.js on initial Dashboard load.
+
+#### 2. useTasks Hook Triggers Re-renders on Every WebSocket Event
+
+- **Where:** `src/lib/hooks.ts:54-64` — `useTasks()` calls `setTasks(data)` on every event
+- **Impact:** Every server event (any task change, agent activity update) causes Dashboard to re-render the entire task list. Unlike `useTask()` which has a `JSON.stringify` guard (line 86-90), `useTasks()` always sets new state.
+- **Fix:** Add the same `JSON.stringify` comparison guard to `useTasks()`.
+
+#### 3. TaskCard Re-renders on Every Parent Update
+
+- **Where:** `src/components/TaskCard.tsx` — no `React.memo`
+- **Impact:** When `useTasks` triggers a Dashboard re-render, every TaskCard re-renders even if its task data hasn't changed. With 20+ tasks, this is noticeable.
+- **Fix:** Wrap TaskCard export in `React.memo`.
+
+#### 4. Dashboard Callbacks Recreated Every Render
+
+- **Where:** `src/pages/Dashboard.tsx:13-29` — `handleDelete` and `handleResume` are plain functions
+- **Impact:** New function references on every render break `React.memo` on TaskCard (if added).
+- **Fix:** Convert to `useCallback` with `[refresh]` dependency.
+
+### MEDIUM Impact
+
+#### 5. Leaf Components Missing React.memo
+
+- **Where:** `StatusBadge.tsx`, `AgentActivityDot.tsx`, `TaskFilterBar.tsx`, `PermissionPromptRow.tsx`
+- **Impact:** These pure display components re-render when parent re-renders, even with identical props.
+- **Fix:** Add `React.memo` to each.
+
+#### 6. ResizeObserver Handler Not Debounced in TerminalView
+
+- **Where:** `src/components/TerminalView.tsx:180-194` — ResizeObserver fires `fitAndSendResize` directly
+- **Impact:** During animated resizes (e.g., dragging browser edge), fit+WebSocket-send fires every frame. The fit() call is expensive as it recalculates terminal dimensions and triggers a full re-layout.
+- **Fix:** Debounce the ResizeObserver callback with `requestAnimationFrame` guard.
+
+#### 7. No Loading Skeleton — Layout Shift on Data Load
+
+- **Where:** `src/pages/Dashboard.tsx:49-51` — "Loading..." text, then card list appears
+- **Impact:** Content jumps from centered text to left-aligned cards. Jarring on slower connections.
+- **Fix:** Add skeleton cards that match TaskCard dimensions.
+
+### LOW Impact
+
+#### 8. OrchestratorPanel Subscribes to WebSocket When Collapsed
+
+- **Where:** `src/components/OrchestratorPanel.tsx:10` — `useOrchestrator()` runs unconditionally
+- **Impact:** Unnecessary API calls when panel is collapsed. Minor since the WebSocket is shared.
+- **Fix:** Skip implementation — complexity not worth the gain for a localhost tool.
+
+#### 9. filteredBranches Recomputed Every Render in CreateTaskDialog
+
+- **Where:** `src/components/CreateTaskDialog.tsx:102-104` — filter runs on every keystroke
+- **Impact:** Negligible unless repo has thousands of branches.
+- **Fix:** Skip implementation — dialog is already behind a user action.
+
+## Implementation Order (Quick Wins First)
+
+1. **Add JSON.stringify guard to useTasks** — 5 min, prevents cascade re-renders
+2. **useCallback for Dashboard handlers** — 2 min, enables memo benefits
+3. **React.memo on TaskCard** — 1 min, biggest bang-for-buck with #1 and #2
+4. **React.memo on leaf components** — 5 min, prevents unnecessary sub-tree renders
+5. **Lazy-load TaskDetail route** — 5 min, reduces initial bundle
+6. **Debounce ResizeObserver** — 5 min, smoother terminal resize
+7. **Add loading skeletons** — 10 min, better perceived performance

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { Component, type ReactNode } from 'react';
+import { Component, lazy, Suspense, type ReactNode } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
-import TaskDetail from './pages/TaskDetail';
+
+const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state = { error: null as Error | null };
@@ -40,7 +41,20 @@ export default function App() {
       <div className="min-h-screen bg-background text-foreground">
         <Routes>
           <Route path="/" element={<Dashboard />} />
-          <Route path="/tasks/:id" element={<TaskDetail />} />
+          <Route
+            path="/tasks/:id"
+            element={
+              <Suspense
+                fallback={
+                  <div className="flex h-screen items-center justify-center text-muted-foreground">
+                    Loading...
+                  </div>
+                }
+              >
+                <TaskDetail />
+              </Suspense>
+            }
+          />
         </Routes>
       </div>
     </ErrorBoundary>

--- a/src/components/AgentActivityDot.tsx
+++ b/src/components/AgentActivityDot.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { HookActivity } from '../../server/types';
 
 const ACTIVITY_STYLES: Record<HookActivity, { dot: string; label: string }> = {
@@ -6,7 +7,11 @@ const ACTIVITY_STYLES: Record<HookActivity, { dot: string; label: string }> = {
   waiting: { dot: 'bg-amber-500', label: 'waiting' },
 };
 
-export function AgentActivityDot({ activity }: { activity: HookActivity }) {
+export const AgentActivityDot = memo(function AgentActivityDot({
+  activity,
+}: {
+  activity: HookActivity;
+}) {
   const style = ACTIVITY_STYLES[activity] || ACTIVITY_STYLES.active;
   return (
     <span className="inline-flex items-center gap-1 text-xs text-zinc-400">
@@ -16,4 +21,4 @@ export function AgentActivityDot({ activity }: { activity: HookActivity }) {
       {style.label}
     </span>
   );
-}
+});

--- a/src/components/PermissionPromptRow.tsx
+++ b/src/components/PermissionPromptRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { PermissionPrompt } from '../../server/types';
 
@@ -16,7 +17,7 @@ function abbreviateInput(toolInput: Record<string, unknown>): string {
   return str.length > 40 ? str.slice(0, 37) + '...' : str;
 }
 
-export function PermissionPromptRow({
+export const PermissionPromptRow = memo(function PermissionPromptRow({
   prompt,
   taskId,
 }: {
@@ -43,4 +44,4 @@ export function PermissionPromptRow({
       <span className="ml-auto text-zinc-500">{timeAgo(prompt.created_at)}</span>
     </button>
   );
-}
+});

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Badge } from '@/components/ui/badge';
 
 const statusConfig: Record<string, { label: string; className: string }> = {
@@ -22,7 +23,7 @@ const fallbackConfig = {
   className: 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30',
 };
 
-export function StatusBadge({ status }: { status: string }) {
+export const StatusBadge = memo(function StatusBadge({ status }: { status: string }) {
   const config = statusConfig[status] || fallbackConfig;
   return (
     <Badge variant="outline" className={config.className}>
@@ -32,4 +33,4 @@ export function StatusBadge({ status }: { status: string }) {
       {config.label}
     </Badge>
   );
-}
+});

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -28,7 +29,7 @@ interface TaskCardProps {
   onResume?: (id: string) => void;
 }
 
-export function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
+export const TaskCard = memo(function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
   const navigate = useNavigate();
   const canResume = (task.status === 'closed' || task.status === 'error') && !!task.worktree;
 
@@ -148,4 +149,4 @@ export function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
       </CardContent>
     </Card>
   );
-}
+});

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 interface TaskFilterBarProps {
   activeStatus: 'open' | 'closed';
   counts: { open: number; closed: number };
@@ -11,7 +13,7 @@ function repoName(repoPath: string): string {
   return repoPath.split('/').pop() || repoPath;
 }
 
-export function TaskFilterBar({
+export const TaskFilterBar = memo(function TaskFilterBar({
   activeStatus,
   counts,
   onStatusChange,
@@ -58,4 +60,4 @@ export function TaskFilterBar({
       )}
     </div>
   );
-}
+});

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -176,10 +176,16 @@ export function TerminalView({
   }, [connect]);
 
   // Handle resize (window + container size changes)
+  // Debounce with rAF to avoid excessive fit+resize during animated resizes.
   useEffect(() => {
+    let rafId: number | null = null;
     const handleResize = () => {
-      const ws = wsRef.current;
-      if (ws) fitAndSendResize(ws);
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        const ws = wsRef.current;
+        if (ws) fitAndSendResize(ws);
+      });
     };
 
     window.addEventListener('resize', handleResize);
@@ -190,6 +196,7 @@ export function TerminalView({
     return () => {
       window.removeEventListener('resize', handleResize);
       observer.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
     };
   }, [fitAndSendResize]);
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -50,11 +50,19 @@ export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const lastJsonRef = useRef<string>('');
 
   const refresh = useCallback(async () => {
     try {
       const data = await api.listTasks();
-      setTasks(data);
+      // Only trigger a re-render when the task list actually changed.
+      // Without this, every WebSocket event creates a new array reference
+      // and causes the entire Dashboard + TaskList tree to re-render.
+      const json = JSON.stringify(data);
+      if (json !== lastJsonRef.current) {
+        lastJsonRef.current = json;
+        setTasks(data);
+      }
       setError(null);
     } catch (err) {
       setError((err as Error).message);

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -32,8 +32,9 @@ describe('Dashboard', () => {
 
   it('shows loading state initially', () => {
     apiMock.listTasks.mockReturnValue(new Promise(() => {})); // never resolves
-    renderWithRouter(<Dashboard />);
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    const { container } = renderWithRouter(<Dashboard />);
+    // Loading state now shows skeleton cards instead of text
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
   it('renders header and new task button', async () => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useTasks } from '@/lib/hooks';
 import { useTaskFilters } from '@/lib/use-task-filters';
 import { TaskList } from '@/components/TaskList';
@@ -10,23 +11,29 @@ export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
 
-  async function handleDelete(id: string) {
-    try {
-      await api.deleteTask(id);
-      refresh();
-    } catch (err) {
-      console.error('Failed to delete task:', err);
-    }
-  }
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await api.deleteTask(id);
+        refresh();
+      } catch (err) {
+        console.error('Failed to delete task:', err);
+      }
+    },
+    [refresh],
+  );
 
-  async function handleResume(id: string) {
-    try {
-      await api.updateTask(id, { status: 'running' });
-      refresh();
-    } catch (err) {
-      console.error('Failed to resume task:', err);
-    }
-  }
+  const handleResume = useCallback(
+    async (id: string) => {
+      try {
+        await api.updateTask(id, { status: 'running' });
+        refresh();
+      } catch (err) {
+        console.error('Failed to resume task:', err);
+      }
+    },
+    [refresh],
+  );
 
   return (
     <div className="flex h-screen">
@@ -47,8 +54,20 @@ export default function Dashboard() {
           )}
 
           {loading ? (
-            <div className="flex items-center justify-center py-16 text-muted-foreground">
-              Loading...
+            <div className="flex flex-col gap-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="animate-pulse rounded-xl border border-border bg-card p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="h-5 w-48 rounded bg-muted" />
+                    <div className="h-5 w-16 rounded bg-muted" />
+                  </div>
+                  <div className="mt-2 h-4 w-64 rounded bg-muted" />
+                  <div className="mt-3 flex items-center gap-2">
+                    <div className="h-5 w-20 rounded bg-muted" />
+                    <div className="h-4 w-32 rounded bg-muted" />
+                  </div>
+                </div>
+              ))}
             </div>
           ) : (
             <>


### PR DESCRIPTION
## What
- Add `React.memo` to TaskCard, StatusBadge, AgentActivityDot, TaskFilterBar, and PermissionPromptRow
- Add JSON.stringify comparison guard to `useTasks()` hook (matching existing pattern in `useTask()`)
- Convert Dashboard handlers to `useCallback` to enable memo benefits
- Lazy-load TaskDetail route with `React.lazy` + `Suspense` (keeps xterm.js out of Dashboard bundle)
- Debounce ResizeObserver in TerminalView with rAF guard
- Replace "Loading..." text with skeleton cards on Dashboard
- Add `UI-PERFORMANCE-AUDIT.md` documenting all findings

## Why
Every WebSocket event was causing the entire Dashboard + TaskList tree to re-render, even when task data hadn't changed. With 20+ tasks, this creates noticeable jank. The `useTasks` hook lacked the JSON.stringify guard that `useTask` already had, and no components used `React.memo`.

## Testing
- All 509 tests pass (`bun run test`)
- TypeScript clean (`bun run typecheck`)
- ESLint clean (0 errors, 3 pre-existing warnings)
- Updated Dashboard loading state test to match new skeleton UI