### PR TITLE
feat(ui): show close button for running tasks, delete for inactive

### DIFF
--- a/src/components/TaskCard.test.tsx
+++ b/src/components/TaskCard.test.tsx
@@ -11,6 +11,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 describe('TaskCard', () => {
+  const onClose = vi.fn();
   const onDelete = vi.fn();
 
   beforeEach(() => {
@@ -27,7 +28,7 @@ describe('TaskCard', () => {
   ];
 
   it.each(contentCases)('renders $name', ({ task, expected }) => {
-    renderWithRouter(<TaskCard task={task} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={task} onClose={onClose} onDelete={onDelete} />);
     expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
@@ -35,7 +36,7 @@ describe('TaskCard', () => {
 
   it('shows PR link when pr_url is set', () => {
     const task = makeTask({ pr_url: 'https://github.com/org/repo/pull/42', pr_number: 42 });
-    renderWithRouter(<TaskCard task={task} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={task} onClose={onClose} onDelete={onDelete} />);
     const link = screen.getByText('PR #42');
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
@@ -43,7 +44,7 @@ describe('TaskCard', () => {
   });
 
   it('does not show PR link when pr_url is null', () => {
-    renderWithRouter(<TaskCard task={makeTask()} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
     expect(screen.queryByText(/PR #/)).not.toBeInTheDocument();
   });
 
@@ -51,22 +52,22 @@ describe('TaskCard', () => {
 
   it('shows error span when error is set', () => {
     const task = makeTask({ status: 'error', error: 'Something failed' });
-    renderWithRouter(<TaskCard task={task} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={task} onClose={onClose} onDelete={onDelete} />);
     const errorSpan = screen.getByTitle('Something failed');
     expect(errorSpan).toBeInTheDocument();
     expect(errorSpan).toHaveTextContent('Error');
   });
 
   it('does not show error span when error is null', () => {
-    renderWithRouter(<TaskCard task={makeTask()} onDelete={onDelete} />);
-    expect(screen.queryByTitle(/./)).not.toBeInTheDocument();
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
+    expect(screen.queryByText('Error')).not.toBeInTheDocument();
   });
 
   // ─── Branch display ───────────────────────────────────────────────────────
 
   it('does not render branch when null', () => {
     const task = makeTask({ branch: null });
-    renderWithRouter(<TaskCard task={task} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={task} onClose={onClose} onDelete={onDelete} />);
     expect(screen.queryByText(/agents\//)).not.toBeInTheDocument();
   });
 
@@ -74,28 +75,61 @@ describe('TaskCard', () => {
 
   it('navigates to task detail on card click', async () => {
     const user = userEvent.setup();
-    renderWithRouter(<TaskCard task={makeTask()} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
     await user.click(screen.getByText('Fix order validation'));
     expect(mockNavigate).toHaveBeenCalledWith('/tasks/test-task-01');
   });
 
-  // ─── Delete ───────────────────────────────────────────────────────────────
+  // ─── Close (running tasks) ────────────────────────────────────────────────
 
-  it('calls onDelete with task id when delete button clicked', async () => {
-    const user = userEvent.setup();
-    renderWithRouter(<TaskCard task={makeTask()} onDelete={onDelete} />);
-    // The delete button is the last button in the card
-    const buttons = screen.getAllByRole('button');
-    await user.click(buttons[buttons.length - 1]);
-    expect(onDelete).toHaveBeenCalledWith('test-task-01');
+  it('shows close button for running tasks', () => {
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
+    expect(screen.getByTitle('Close task')).toBeInTheDocument();
+    expect(screen.queryByTitle('Delete task')).not.toBeInTheDocument();
   });
 
-  it('delete click does not trigger navigation', async () => {
+  it('calls onClose with task id when close button clicked', async () => {
     const user = userEvent.setup();
-    renderWithRouter(<TaskCard task={makeTask()} onDelete={onDelete} />);
-    const buttons = screen.getAllByRole('button');
-    await user.click(buttons[buttons.length - 1]);
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
+    await user.click(screen.getByTitle('Close task'));
+    expect(onClose).toHaveBeenCalledWith('test-task-01');
+  });
+
+  it('close click does not trigger navigation', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<TaskCard task={makeTask()} onClose={onClose} onDelete={onDelete} />);
+    await user.click(screen.getByTitle('Close task'));
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows close button for setting_up tasks', () => {
+    renderWithRouter(
+      <TaskCard task={makeTask({ status: 'setting_up' })} onClose={onClose} onDelete={onDelete} />,
+    );
+    expect(screen.getByTitle('Close task')).toBeInTheDocument();
+    expect(screen.queryByTitle('Delete task')).not.toBeInTheDocument();
+  });
+
+  // ─── Delete (closed/error/draft tasks) ──────────────────────────────────
+
+  it.each(['closed', 'error', 'draft'] as const)(
+    'shows delete button for %s tasks',
+    (status) => {
+      renderWithRouter(
+        <TaskCard task={makeTask({ status })} onClose={onClose} onDelete={onDelete} />,
+      );
+      expect(screen.getByTitle('Delete task')).toBeInTheDocument();
+      expect(screen.queryByTitle('Close task')).not.toBeInTheDocument();
+    },
+  );
+
+  it('calls onDelete with task id when delete button clicked on closed task', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <TaskCard task={makeTask({ status: 'closed' })} onClose={onClose} onDelete={onDelete} />,
+    );
+    await user.click(screen.getByTitle('Delete task'));
+    expect(onDelete).toHaveBeenCalledWith('test-task-01');
   });
 
   // ─── Repo name extraction (table-driven) ──────────────────────────────────
@@ -107,7 +141,7 @@ describe('TaskCard', () => {
   ];
 
   it.each(repoPaths)('extracts repo name "$expected" from "$path"', ({ path, expected }) => {
-    renderWithRouter(<TaskCard task={makeTask({ repo_path: path })} onDelete={onDelete} />);
+    renderWithRouter(<TaskCard task={makeTask({ repo_path: path })} onClose={onClose} onDelete={onDelete} />);
     expect(screen.getByText(expected)).toBeInTheDocument();
   });
 });

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -25,13 +25,20 @@ function repoName(repoPath: string): string {
 
 interface TaskCardProps {
   task: Task;
+  onClose: (id: string) => void;
   onDelete: (id: string) => void;
   onResume?: (id: string) => void;
 }
 
-export const TaskCard = memo(function TaskCard({ task, onDelete, onResume }: TaskCardProps) {
+export const TaskCard = memo(function TaskCard({
+  task,
+  onClose,
+  onDelete,
+  onResume,
+}: TaskCardProps) {
   const navigate = useNavigate();
   const canResume = (task.status === 'closed' || task.status === 'error') && !!task.worktree;
+  const isActive = task.status === 'running' || task.status === 'setting_up';
 
   return (
     <Card
@@ -100,31 +107,60 @@ export const TaskCard = memo(function TaskCard({ task, onDelete, onResume }: Tas
                 </svg>
               </Button>
             )}
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              className="text-muted-foreground hover:text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(task.id);
-              }}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+            {isActive ? (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground hover:text-yellow-500"
+                title="Close task"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(task.id);
+                }}
               >
-                <path d="M3 6h18" />
-                <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-                <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-              </svg>
-            </Button>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="6" y="4" width="4" height="16" />
+                  <rect x="14" y="4" width="4" height="16" />
+                </svg>
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground hover:text-destructive"
+                title="Delete task"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(task.id);
+                }}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M3 6h18" />
+                  <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                  <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                </svg>
+              </Button>
+            )}
           </div>
         </div>
         {task.agents && task.agents.length > 0 && task.status === 'running' && (

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -9,12 +9,13 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 describe('TaskList', () => {
+  const onClose = vi.fn();
   const onDelete = vi.fn();
 
   // ─── Empty state ──────────────────────────────────────────────────────────
 
   it('shows empty state when no tasks', () => {
-    renderWithRouter(<TaskList tasks={[]} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[]} onClose={onClose} onDelete={onDelete} />);
     expect(screen.getByText('No tasks yet')).toBeInTheDocument();
     expect(screen.getByText('Create a task to get started')).toBeInTheDocument();
   });
@@ -22,7 +23,7 @@ describe('TaskList', () => {
   // ─── Rendering tasks ─────────────────────────────────────────────────────
 
   it('renders one task card', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} />);
     expect(screen.getByText('Fix order validation')).toBeInTheDocument();
   });
 
@@ -32,14 +33,14 @@ describe('TaskList', () => {
       makeTask({ id: 't2', title: 'Task Two' }),
       makeTask({ id: 't3', title: 'Task Three' }),
     ];
-    renderWithRouter(<TaskList tasks={tasks} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={tasks} onClose={onClose} onDelete={onDelete} />);
     expect(screen.getByText('Task One')).toBeInTheDocument();
     expect(screen.getByText('Task Two')).toBeInTheDocument();
     expect(screen.getByText('Task Three')).toBeInTheDocument();
   });
 
   it('does not show empty state when tasks exist', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} />);
     expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -3,11 +3,12 @@ import { TaskCard } from './TaskCard';
 
 interface TaskListProps {
   tasks: Task[];
+  onClose: (id: string) => void;
   onDelete: (id: string) => void;
   onResume?: (id: string) => void;
 }
 
-export function TaskList({ tasks, onDelete, onResume }: TaskListProps) {
+export function TaskList({ tasks, onClose, onDelete, onResume }: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
@@ -20,7 +21,13 @@ export function TaskList({ tasks, onDelete, onResume }: TaskListProps) {
   return (
     <div className="flex flex-col gap-3">
       {tasks.map((task) => (
-        <TaskCard key={task.id} task={task} onDelete={onDelete} onResume={onResume} />
+        <TaskCard
+          key={task.id}
+          task={task}
+          onClose={onClose}
+          onDelete={onDelete}
+          onResume={onResume}
+        />
       ))}
     </div>
   );

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -125,23 +125,42 @@ describe('Dashboard', () => {
     });
   });
 
-  // ─── Delete ───────────────────────────────────────────────────────────────
+  // ─── Close ───────────────────────────────────────────────────────────────
 
-  it('calls deleteTask when delete button is clicked', async () => {
+  it('calls updateTask to close when close button is clicked on running task', async () => {
     const user = userEvent.setup();
-    apiMock.listTasks.mockResolvedValue([makeTask()]);
+    apiMock.listTasks.mockResolvedValue([makeTask({ status: 'running' })]);
     renderWithRouter(<Dashboard />);
 
     await waitFor(() => {
       expect(screen.getByText('Fix order validation')).toBeInTheDocument();
     });
 
-    // Click the delete button (last button in the card)
-    const buttons = screen.getAllByRole('button');
-    const deleteBtn = buttons.find(
-      (btn) => btn.querySelector('svg') && !btn.textContent?.includes('New Task'),
-    );
-    if (deleteBtn) await user.click(deleteBtn);
+    await user.click(screen.getByTitle('Close task'));
+
+    await waitFor(() => {
+      expect(apiMock.updateTask).toHaveBeenCalledWith('test-task-01', { status: 'closed' });
+    });
+  });
+
+  // ─── Delete ───────────────────────────────────────────────────────────────
+
+  it('calls deleteTask when delete button is clicked on closed task', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([makeTask({ status: 'closed' })]);
+    renderWithRouter(<Dashboard />);
+
+    // Switch to Closed filter to see closed tasks
+    await waitFor(() => {
+      expect(screen.getByText(/^Closed/)).toBeInTheDocument();
+    });
+    await user.click(screen.getByText(/^Closed/));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fix order validation')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTitle('Delete task'));
 
     await waitFor(() => {
       expect(apiMock.deleteTask).toHaveBeenCalledWith('test-task-01');

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,18 @@ export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
 
+  const handleClose = useCallback(
+    async (id: string) => {
+      try {
+        await api.updateTask(id, { status: 'closed' });
+        refresh();
+      } catch (err) {
+        console.error('Failed to close task:', err);
+      }
+    },
+    [refresh],
+  );
+
   const handleDelete = useCallback(
     async (id: string) => {
       try {
@@ -79,7 +91,12 @@ export default function Dashboard() {
                 activeRepo={filters.repo}
                 onRepoChange={(r) => setFilter('repo', r)}
               />
-              <TaskList tasks={filtered} onDelete={handleDelete} onResume={handleResume} />
+              <TaskList
+                tasks={filtered}
+                onClose={handleClose}
+                onDelete={handleDelete}
+                onResume={handleResume}
+              />
             </>
           )}
         </div>


### PR DESCRIPTION
## What
- Running/setting_up tasks now show a Close button (pause icon, yellow hover) instead of Delete
- Closed/error/draft tasks show the Delete button (trash icon, red hover) as before
- Close calls `PATCH /api/tasks/:id` with `{ status: 'closed' }`, preserving worktree for resume

## Why
Running tasks should be closed (stopping agents but preserving worktree/branch) rather than deleted. This prevents accidental full cleanup of active work.

## Testing
- `bun run test` — all 523 tests pass
- `bun run typecheck` — passes
- New tests cover: close/delete button visibility per status, close callback, navigation prevention, Dashboard close/delete integration