### PR TITLE
fix(server): replace fixed init delay with prompt-ready polling for initial dispatch

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -62,6 +62,7 @@ const {
   stopAgent,
   resumeTask,
   dispatchToWindow,
+  waitForClaudeReady,
   slugifyTitle,
   createUserTerminal,
   cleanupLinkedSessions,
@@ -521,10 +522,10 @@ describe('dispatchToWindow', () => {
     expect(call![1] as string[]).toContain('-b');
   });
 
-  it('writes text + newline to stdin', async () => {
+  it('writes text without trailing newline to stdin', async () => {
     await dispatchToWindow('test-session', 0, 'Hello');
     const spawnCall = vi.mocked(spawn).mock.results[0].value;
-    expect(spawnCall.stdin.write).toHaveBeenCalledWith('Hello\n');
+    expect(spawnCall.stdin.write).toHaveBeenCalledWith('Hello');
     expect(spawnCall.stdin.end).toHaveBeenCalled();
   });
 
@@ -1024,5 +1025,55 @@ describe('deleteTask linked session cleanup', () => {
 
     // Linked session killed before main session
     expect(callOrder).toEqual([`${session}-v-xyz789`, session]);
+  });
+});
+
+// ─── waitForClaudeReady ──────────────────────────────────────────────────────
+// Placed last because these tests override the execFile mock implementation.
+
+describe('waitForClaudeReady', () => {
+  it('returns immediately when timeout is 0 (test env)', async () => {
+    await expect(waitForClaudeReady('session', 0, 0)).resolves.not.toThrow();
+    // Should not call capture-pane at all
+    expect(
+      findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['capture-pane'] }),
+    ).toBeUndefined();
+  });
+
+  it('returns when pane contains > prompt', async () => {
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        cb(null, { stdout: '  >\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
+  });
+
+  it('proceeds after timeout if Claude never shows prompt', async () => {
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        cb(null, { stdout: 'loading...\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    // Use a very short timeout so the test doesn't hang
+    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
+  });
+
+  it('handles capture-pane errors gracefully', async () => {
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        cb(new Error('pane not found'), null);
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
   });
 });

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -10,7 +10,8 @@ import type { Task, Agent } from './types.js';
 
 const execFile = promisify(execFileCb);
 
-const CLAUDE_INIT_DELAY = process.env.NODE_ENV === 'test' ? 0 : 3000;
+const CLAUDE_READY_TIMEOUT = process.env.NODE_ENV === 'test' ? 0 : 30_000;
+const CLAUDE_READY_POLL_INTERVAL = 500;
 
 /** Get the active window index of a tmux session. */
 async function getActiveWindowIndex(session: string): Promise<number> {
@@ -39,6 +40,36 @@ async function getLastWindowIndex(session: string): Promise<number> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll tmux pane content until Claude Code's TUI is ready for input.
+ * Detects readiness by looking for the `>` input prompt character that
+ * Claude renders once its ink-based TUI has fully initialized.
+ * Falls back to proceeding after timeout (best-effort).
+ */
+export async function waitForClaudeReady(
+  session: string,
+  windowIndex: number,
+  timeoutMs: number = CLAUDE_READY_TIMEOUT,
+): Promise<void> {
+  if (timeoutMs === 0) return; // skip in tests
+  const target = `${session}:${windowIndex}`;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
+      // Claude Code renders a ">" prompt when ready for input
+      const lines = stdout.split('\n');
+      if (lines.some((line) => /^\s*>/.test(line))) {
+        return;
+      }
+    } catch {
+      // pane may not exist yet — keep polling
+    }
+    await sleep(CLAUDE_READY_POLL_INTERVAL);
+  }
+  // Timeout — proceed anyway (best-effort)
 }
 
 /**
@@ -169,11 +200,9 @@ export async function startTask(task: Task): Promise<void> {
       'Enter',
     ]);
 
-    // 10. Wait for claude to initialize
-    await sleep(CLAUDE_INIT_DELAY);
-
-    // 11. Dispatch initial prompt (if provided)
+    // 10. Wait for Claude to be ready, then dispatch initial prompt
     if (task.initial_prompt) {
+      await waitForClaudeReady(session, windowIndex);
       await dispatchToWindow(session, windowIndex, task.initial_prompt);
     }
 
@@ -222,7 +251,7 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
 
   // Dispatch prompt if provided
   if (prompt) {
-    await sleep(CLAUDE_INIT_DELAY);
+    await waitForClaudeReady(task.tmux_session!, windowIndex);
     await dispatchToWindow(task.tmux_session!, windowIndex, prompt);
   }
 
@@ -415,10 +444,11 @@ export async function dispatchToWindow(
   const target = `${session}:${windowIndex}`;
   const bufferName = `octomux-${nanoid(8)}`;
 
-  // Load text into a named tmux buffer (avoids race with concurrent dispatches)
+  // Load text into a named tmux buffer (avoids race with concurrent dispatches).
+  // Do NOT append '\n' — send-keys Enter handles submission separately.
   await new Promise<void>((resolve, reject) => {
     const proc = spawn('tmux', ['load-buffer', '-b', bufferName, '-']);
-    proc.stdin.write(text + '\n');
+    proc.stdin.write(text);
     proc.stdin.end();
     proc.on('close', (code) => {
       if (code === 0) resolve();


### PR DESCRIPTION
## What
- Replace the static 3-second `CLAUDE_INIT_DELAY` with `waitForClaudeReady()` — polls `tmux capture-pane` every 500ms for Claude's `>` input prompt (up to 30s timeout with best-effort fallback)
- Remove trailing `\n` from `dispatchToWindow`'s paste buffer — `send-keys Enter` already handles submission separately
- Add 4 tests for `waitForClaudeReady` (timeout skip, prompt detection, timeout fallback, error handling)

## Why
The initial prompt was not being automatically submitted to Claude agents when tasks were created. The root cause was a static 3-second delay that was insufficient for Claude Code to fully initialize its TUI — text dispatched before Claude was ready was lost during terminal mode transitions.

## Testing
- `bun run test` — 520/520 tests pass (516 via pre-push hook on main worktree)
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (3 pre-existing warnings in unrelated file)