### PR TITLE
feat: add inter-agent messaging via tmux send-keys

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -44,6 +44,7 @@ export interface OctomuxClient {
   updateTask(id: string, data: { status: string }): Promise<Task>;
   deleteTask(id: string): Promise<void>;
   addAgent(taskId: string, data?: { prompt?: string }): Promise<Agent>;
+  sendMessage(taskId: string, agentId: string, message: string): Promise<{ success: boolean }>;
 }
 
 async function request<T>(baseUrl: string, path: string, options?: RequestInit): Promise<T> {
@@ -98,6 +99,13 @@ export function createClient(serverUrl: string): OctomuxClient {
         method: 'POST',
         body: JSON.stringify(data || {}),
       });
+    },
+    sendMessage(taskId, agentId, message) {
+      return request<{ success: boolean }>(
+        baseUrl,
+        `/tasks/${encodeURIComponent(taskId)}/agents/${encodeURIComponent(agentId)}/message`,
+        { method: 'POST', body: JSON.stringify({ message }) },
+      );
     },
   };
 }

--- a/cli/src/commands/send-message.ts
+++ b/cli/src/commands/send-message.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson, success } from '../format.js';
+
+export function registerSendMessage(program: Command): void {
+  program
+    .command('send-message <message>')
+    .description('Send a message to an agent via tmux send-keys')
+    .requiredOption('-t, --task <task-id>', 'task ID')
+    .requiredOption('-a, --agent <agent-id>', 'agent ID')
+    .action(async (message: string, opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+
+      const result = await client.sendMessage(opts.task, opts.agent, message);
+
+      if (isJsonMode(globals.json)) {
+        outputJson(result);
+        return;
+      }
+
+      success(`Message sent to agent ${opts.agent} on task ${opts.task}`);
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { registerCloseTask } from './commands/close-task.js';
 import { registerDeleteTask } from './commands/delete-task.js';
 import { registerResumeTask } from './commands/resume-task.js';
 import { registerAddAgent } from './commands/add-agent.js';
+import { registerSendMessage } from './commands/send-message.js';
 
 const program = new Command();
 
@@ -31,6 +32,7 @@ registerCloseTask(program);
 registerDeleteTask(program);
 registerResumeTask(program);
 registerAddAgent(program);
+registerSendMessage(program);
 
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -129,6 +129,12 @@ const notFoundCases = [
     method: 'post' as const,
     url: '/api/tasks/nonexistent/user-terminal',
   },
+  {
+    name: 'POST /api/tasks/:id/agents/:agentId/message',
+    method: 'post' as const,
+    url: '/api/tasks/nonexistent/agents/agent1/message',
+    body: { message: 'hello' },
+  },
 ];
 
 describe('404 for nonexistent resources', () => {
@@ -879,5 +885,91 @@ describe('GET /api/tasks with permission prompts', () => {
     const res = await request(app).get('/api/tasks/t1').expect(200);
     expect(res.body.pending_prompts).toHaveLength(1);
     expect(res.body.derived_status).toBe('working');
+  });
+});
+
+// ─── POST /api/tasks/:id/agents/:agentId/message ────────────────────────────
+
+describe('POST /api/tasks/:id/agents/:agentId/message', () => {
+  it('sends message via tmux send-keys and returns success', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const { execFile: execFileMock } = await import('child_process');
+    vi.mocked(execFileMock).mockImplementation(((
+      _cmd: string,
+      _args: any,
+      ...rest: any[]
+    ) => {
+      const cb = rest.find((a: any) => typeof a === 'function');
+      if (cb) cb(null, { stdout: '', stderr: '' });
+      return undefined as any;
+    }) as any);
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .send({ message: 'hello agent' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const calls = vi.mocked(execFileMock).mock.calls;
+    const tmuxCall = calls.find(
+      (c: any[]) => c[0] === 'tmux' && (c[1] as string[]).includes('send-keys'),
+    );
+    expect(tmuxCall).toBeDefined();
+    const args = tmuxCall![1] as string[];
+    expect(args).toContain('send-keys');
+    expect(args).toContain('-t');
+    expect(args).toContain(`${DEFAULTS.runningTask.tmux_session}:${DEFAULTS.agent.window_index}`);
+    expect(args).toContain('hello agent');
+    expect(args).toContain('Enter');
+  });
+
+  it('returns 404 when agent not found on existing task', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/agents/nonexistent/message`)
+      .send({ message: 'hello' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('Agent not found');
+  });
+
+  it('returns 400 when task is not running', async () => {
+    insertTask(db, { status: 'closed' });
+    insertAgent(db);
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .send({ message: 'hello' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('not running');
+  });
+
+  it('returns 400 when message is missing', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('message is required');
+  });
+
+  it('returns 400 when message is empty string', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const res = await request(app)
+      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .send({ message: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('message is required');
   });
 });

--- a/server/api.ts
+++ b/server/api.ts
@@ -436,6 +436,52 @@ export function setupRoutes(app: Express): void {
     }
   });
 
+  // Send message to agent via tmux send-keys
+  app.post(
+    '/api/tasks/:id/agents/:agentId/message',
+    async (req: Request, res: Response) => {
+      const db = getDb();
+      const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id) as
+        | Task
+        | undefined;
+
+      if (!task) {
+        res.status(404).json({ error: 'Task not found' });
+        return;
+      }
+
+      if (task.status !== 'running') {
+        res.status(400).json({ error: 'Task is not running' });
+        return;
+      }
+
+      const agent = db
+        .prepare('SELECT * FROM agents WHERE id = ? AND task_id = ?')
+        .get(req.params.agentId, req.params.id) as Agent | undefined;
+
+      if (!agent) {
+        res.status(404).json({ error: 'Agent not found' });
+        return;
+      }
+
+      const { message } = req.body as { message?: string };
+      if (!message) {
+        res.status(400).json({ error: 'message is required' });
+        return;
+      }
+
+      await execFile('tmux', [
+        'send-keys',
+        '-t',
+        `${task.tmux_session}:${agent.window_index}`,
+        message,
+        'Enter',
+      ]);
+
+      res.json({ success: true });
+    },
+  );
+
   // ─── Orchestrator ──────────────────────────────────────────────────────────
 
   app.get('/api/orchestrator/status', async (_req: Request, res: Response) => {


### PR DESCRIPTION
## What
Add the ability to send text messages to agents via tmux send-keys. This includes:
- API endpoint: `POST /api/tasks/:id/agents/:agentId/message`
- CLI command: `octomux send-message --task <id> --agent <id> "message"`
- Client method on `OctomuxClient`
- Tests covering success, 404, and validation cases

## Why
Enables inter-agent communication — agents can send text to each other's terminal sessions, which is needed for orchestration workflows.

## Testing
- `bun run test` — all tests pass including 6 new tests for the message endpoint
- CLI compiles cleanly (`bun run build` in cli/)
- Pre-commit hooks (lint, format, tests) all pass