### PR TITLE
feat(ui): add browser desktop notifications for agent state changes

### DIFF
--- a/src/components/NotificationToggle.tsx
+++ b/src/components/NotificationToggle.tsx
@@ -1,0 +1,112 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  getNotificationsEnabled,
+  setNotificationsEnabled,
+  getBrowserPermission,
+  requestPermission,
+} from '@/lib/notification-settings';
+
+export function NotificationToggle() {
+  const [enabled, setEnabled] = useState(getNotificationsEnabled);
+  const [permission, setPermission] = useState(getBrowserPermission);
+
+  const toggle = useCallback(async () => {
+    if (enabled) {
+      setNotificationsEnabled(false);
+      setEnabled(false);
+      return;
+    }
+
+    // Need to request browser permission first
+    if (permission !== 'granted') {
+      const result = await requestPermission();
+      setPermission(result);
+      if (result !== 'granted') return;
+    }
+
+    setNotificationsEnabled(true);
+    setEnabled(true);
+  }, [enabled, permission]);
+
+  const isDenied = permission === 'denied' && !enabled;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      title={
+        isDenied
+          ? 'Notifications blocked — enable in browser settings'
+          : enabled
+            ? 'Disable notifications'
+            : 'Enable notifications'
+      }
+      className="relative h-8 w-8"
+    >
+      {enabled ? (
+        <BellIcon className="h-4 w-4" />
+      ) : isDenied ? (
+        <BellSlashIcon className="h-4 w-4 text-muted-foreground" />
+      ) : (
+        <BellOffIcon className="h-4 w-4 text-muted-foreground" />
+      )}
+    </Button>
+  );
+}
+
+function BellIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.25 9a6.75 6.75 0 0 1 13.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 0 1-.573 1.23H3.705a.75.75 0 0 1-.573-1.23A8.973 8.973 0 0 0 5.25 9.75V9ZM8.159 18.753a.75.75 0 0 1 .932-.514 3.756 3.756 0 0 0 5.818 0 .75.75 0 0 1 1.446.418 5.256 5.256 0 0 1-7.678 0 .75.75 0 0 1-.518-.904Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function BellOffIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+      />
+    </svg>
+  );
+}
+
+function BellSlashIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.143 17.082a24.248 24.248 0 0 0 5.714 0m-5.714 0a3 3 0 1 0 5.714 0M9.143 17.082a23.848 23.848 0 0 1-5.454-1.31A8.967 8.967 0 0 0 6 9.75V9a6 6 0 0 1 .258-1.758M18 9.75V9a5.98 5.98 0 0 0-.258-1.758M2 2l20 20"
+      />
+    </svg>
+  );
+}

--- a/src/lib/notification-settings.ts
+++ b/src/lib/notification-settings.ts
@@ -1,0 +1,42 @@
+const STORAGE_KEY = 'octomux-notifications-enabled';
+
+export type NotificationPermission = 'default' | 'granted' | 'denied';
+
+export function getNotificationsEnabled(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === 'true';
+}
+
+export function setNotificationsEnabled(enabled: boolean): void {
+  localStorage.setItem(STORAGE_KEY, String(enabled));
+}
+
+export function getBrowserPermission(): NotificationPermission {
+  if (!('Notification' in window)) return 'denied';
+  return Notification.permission as NotificationPermission;
+}
+
+export async function requestPermission(): Promise<NotificationPermission> {
+  if (!('Notification' in window)) return 'denied';
+  const result = await Notification.requestPermission();
+  return result as NotificationPermission;
+}
+
+export function sendNotification(
+  title: string,
+  options?: NotificationOptions & { onClick?: () => void },
+): Notification | null {
+  if (!('Notification' in window)) return null;
+  if (Notification.permission !== 'granted') return null;
+  if (!getNotificationsEnabled()) return null;
+
+  const { onClick, ...notifOptions } = options ?? {};
+  const notification = new Notification(title, notifOptions);
+  if (onClick) {
+    notification.onclick = () => {
+      window.focus();
+      onClick();
+      notification.close();
+    };
+  }
+  return notification;
+}

--- a/src/lib/use-notifications.ts
+++ b/src/lib/use-notifications.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react';
+import type { Task, Agent } from '../../server/types';
+import { sendNotification, getNotificationsEnabled } from './notification-settings';
+
+interface AgentSnapshot {
+  status: Agent['status'];
+  hookActivity: Agent['hook_activity'];
+}
+
+/**
+ * Watches tasks for agent state transitions and fires desktop notifications.
+ * Accepts the tasks array from useTasks() — no extra fetching.
+ */
+export function useNotifications(tasks: Task[], navigate: (path: string) => void) {
+  const prevAgents = useRef<Map<string, AgentSnapshot>>(new Map());
+  const notifiedPrompts = useRef<Set<string>>(new Set());
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!getNotificationsEnabled()) return;
+    if (tasks.length === 0) return;
+
+    const currentAgents = new Map<string, AgentSnapshot>();
+
+    for (const task of tasks) {
+      if (!task.agents) continue;
+
+      for (const agent of task.agents) {
+        currentAgents.set(agent.id, {
+          status: agent.status,
+          hookActivity: agent.hook_activity,
+        });
+
+        // Skip notifications on first load to avoid spamming existing state
+        if (!initialized.current) continue;
+
+        const prev = prevAgents.current.get(agent.id);
+        if (!prev) continue;
+
+        // Agent stopped transition
+        if (prev.status !== 'stopped' && agent.status === 'stopped') {
+          sendNotification(`${agent.label} stopped`, {
+            body: task.title,
+            tag: `agent-stopped-${agent.id}`,
+            onClick: () => navigate(`/tasks/${task.id}`),
+          });
+        }
+      }
+
+      // Task moved to closed/error
+      if (initialized.current) {
+        // Check for new pending permission prompts
+        if (task.pending_prompts) {
+          for (const prompt of task.pending_prompts) {
+            if (
+              prompt.status === 'pending' &&
+              !notifiedPrompts.current.has(prompt.id)
+            ) {
+              notifiedPrompts.current.add(prompt.id);
+              sendNotification(`${prompt.agent_label} needs permission`, {
+                body: `${prompt.tool_name} — ${task.title}`,
+                tag: `permission-${prompt.id}`,
+                onClick: () =>
+                  navigate(`/tasks/${task.id}?agent=${prompt.agent_id}`),
+              });
+            }
+          }
+        }
+      }
+    }
+
+    // Task-level transitions (closed/error)
+    if (initialized.current) {
+      for (const task of tasks) {
+        if (task.status === 'closed' || task.status === 'error') {
+          // Check if any agent was previously non-stopped (task just ended)
+          const hadActiveAgents = task.agents?.some((a) => {
+            const prev = prevAgents.current.get(a.id);
+            return prev && prev.status !== 'stopped';
+          });
+          if (hadActiveAgents) {
+            sendNotification(
+              task.status === 'error' ? `Task errored` : `Task closed`,
+              {
+                body: task.title,
+                tag: `task-${task.status}-${task.id}`,
+                onClick: () => navigate(`/tasks/${task.id}`),
+              },
+            );
+          }
+        }
+      }
+    }
+
+    prevAgents.current = currentAgents;
+
+    // Seed initial prompts so we don't notify for pre-existing ones
+    if (!initialized.current) {
+      for (const task of tasks) {
+        if (task.pending_prompts) {
+          for (const prompt of task.pending_prompts) {
+            notifiedPrompts.current.add(prompt.id);
+          }
+        }
+      }
+      initialized.current = true;
+    }
+  }, [tasks, navigate]);
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,15 +1,20 @@
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTasks } from '@/lib/hooks';
 import { useTaskFilters } from '@/lib/use-task-filters';
+import { useNotifications } from '@/lib/use-notifications';
 import { TaskList } from '@/components/TaskList';
 import { TaskFilterBar } from '@/components/TaskFilterBar';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
+import { NotificationToggle } from '@/components/NotificationToggle';
 import { OrchestratorPanel } from '@/components/OrchestratorPanel';
 import { api } from '@/lib/api';
 
 export default function Dashboard() {
+  const navigate = useNavigate();
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
+  useNotifications(tasks, navigate);
 
   const handleClose = useCallback(
     async (id: string) => {
@@ -56,7 +61,10 @@ export default function Dashboard() {
               <h1 className="text-2xl font-bold tracking-tight">octomux-agents</h1>
               <p className="text-sm text-muted-foreground">Autonomous agent fleet</p>
             </div>
-            <CreateTaskDialog onCreated={refresh} />
+            <div className="flex items-center gap-2">
+              <NotificationToggle />
+              <CreateTaskDialog onCreated={refresh} />
+            </div>
           </div>
 
           {error && (


### PR DESCRIPTION
## What
Add browser desktop notifications so the user gets alerted when agents stop or have pending permission prompts.

- `useNotifications` hook diffs task/agent state on each poll cycle, fires notifications only on transitions
- `NotificationToggle` bell icon in dashboard header with three states (enabled/disabled/denied)
- Notification preference persisted in localStorage; browser permission requested on first enable
- Clicking a notification focuses the tab and navigates to the relevant task

## Why
When running multiple agents, it's easy to miss when one stops or needs permission approval — especially if the browser tab is in the background.

## Testing
- `bun run typecheck` — passes
- `bun run lint` — passes (no new errors)
- `bun run test` — all 492 tests pass