### PR TITLE
feat(sidebar): add collapsible task navigation sidebar on detail pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { Component, lazy, Suspense, type ReactNode } from 'react';
+import { Component, lazy, type ReactNode } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
+import TaskDetailLayout from './components/TaskDetailLayout';
 
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 
@@ -41,20 +42,9 @@ export default function App() {
       <div className="min-h-screen bg-background text-foreground">
         <Routes>
           <Route path="/" element={<Dashboard />} />
-          <Route
-            path="/tasks/:id"
-            element={
-              <Suspense
-                fallback={
-                  <div className="flex h-screen items-center justify-center text-muted-foreground">
-                    Loading...
-                  </div>
-                }
-              >
-                <TaskDetail />
-              </Suspense>
-            }
-          />
+          <Route element={<TaskDetailLayout />}>
+            <Route path="/tasks/:id" element={<TaskDetail />} />
+          </Route>
         </Routes>
       </div>
     </ErrorBoundary>

--- a/src/components/TaskDetailLayout.tsx
+++ b/src/components/TaskDetailLayout.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react';
+import { Outlet } from 'react-router-dom';
+import { TaskSidebar } from './TaskSidebar';
+
+export default function TaskDetailLayout() {
+  return (
+    <div className="flex h-screen">
+      <TaskSidebar />
+      <div className="min-w-0 flex-1">
+        <Suspense
+          fallback={
+            <div className="flex h-full items-center justify-center text-muted-foreground">
+              Loading...
+            </div>
+          }
+        >
+          <Outlet />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskSidebar.test.tsx
+++ b/src/components/TaskSidebar.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TaskSidebar } from './TaskSidebar';
+import { makeTask, renderWithRouter, mockApi } from '@/test-helpers';
+
+const apiMock = mockApi();
+
+vi.mock('@/lib/api', () => ({
+  api: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) => apiMock[prop as keyof typeof apiMock],
+    },
+  ),
+}));
+vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => vi.fn()) }));
+
+const TASKS = [
+  makeTask({ id: 't1', title: 'Running task', status: 'running', repo_path: '/dev/repo-a' }),
+  makeTask({ id: 't2', title: 'Error task', status: 'error', repo_path: '/dev/repo-a' }),
+  makeTask({ id: 't3', title: 'Draft task', status: 'draft', repo_path: '/dev/repo-a' }),
+];
+
+beforeEach(() => {
+  apiMock.listTasks.mockResolvedValue(TASKS);
+  localStorage.clear();
+});
+
+describe('TaskSidebar', () => {
+  it('renders active tasks and excludes draft', async () => {
+    renderWithRouter(<TaskSidebar />, { route: '/tasks/t1', path: '/tasks/:id' });
+    expect(await screen.findByText('Running task')).toBeInTheDocument();
+    expect(screen.getByText('Error task')).toBeInTheDocument();
+    expect(screen.queryByText('Draft task')).not.toBeInTheDocument();
+  });
+
+  it('highlights the active task', async () => {
+    renderWithRouter(<TaskSidebar />, { route: '/tasks/t1', path: '/tasks/:id' });
+    const activeItem = await screen.findByText('Running task');
+    expect(activeItem.closest('a')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('collapses and expands on toggle click', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<TaskSidebar />, { route: '/tasks/t1', path: '/tasks/:id' });
+    await screen.findByText('Running task');
+
+    const toggle = screen.getByRole('button', { name: /collapse/i });
+    await user.click(toggle);
+    expect(screen.queryByText('Running task')).not.toBeVisible();
+
+    const expand = screen.getByRole('button', { name: /expand/i });
+    await user.click(expand);
+    expect(await screen.findByText('Running task')).toBeVisible();
+  });
+
+  it('persists collapsed state to localStorage', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<TaskSidebar />, { route: '/tasks/t1', path: '/tasks/:id' });
+    await screen.findByText('Running task');
+
+    const toggle = screen.getByRole('button', { name: /collapse/i });
+    await user.click(toggle);
+    expect(localStorage.getItem('octomux-sidebar-collapsed')).toBe('true');
+  });
+
+  it('shows attention count badge when tasks need attention', async () => {
+    const tasksWithAttention = [
+      makeTask({ id: 't1', status: 'running', derived_status: 'needs_attention' }),
+      makeTask({ id: 't2', status: 'error' }),
+    ];
+    apiMock.listTasks.mockResolvedValue(tasksWithAttention);
+    renderWithRouter(<TaskSidebar />, { route: '/tasks/t1', path: '/tasks/:id' });
+
+    const badge = await screen.findByTestId('attention-count');
+    expect(badge).toHaveTextContent('2');
+  });
+});

--- a/src/components/TaskSidebar.test.tsx
+++ b/src/components/TaskSidebar.test.tsx
@@ -48,11 +48,11 @@ describe('TaskSidebar', () => {
 
     const toggle = screen.getByRole('button', { name: /collapse/i });
     await user.click(toggle);
-    expect(screen.queryByText('Running task')).not.toBeVisible();
+    expect(screen.queryByText('Running task')).not.toBeInTheDocument();
 
     const expand = screen.getByRole('button', { name: /expand/i });
     await user.click(expand);
-    expect(await screen.findByText('Running task')).toBeVisible();
+    expect(await screen.findByText('Running task')).toBeInTheDocument();
   });
 
   it('persists collapsed state to localStorage', async () => {

--- a/src/components/TaskSidebar.tsx
+++ b/src/components/TaskSidebar.tsx
@@ -122,7 +122,10 @@ export function TaskSidebar() {
 
   const attentionCount = useMemo(
     () =>
-      allItems.filter((i) => i.status === 'error' || i.derivedStatus === 'needs_attention').length,
+      allItems.filter((i) => {
+        const effective = i.derivedStatus ?? i.status;
+        return effective === 'error' || effective === 'needs_attention';
+      }).length,
     [allItems],
   );
 
@@ -183,18 +186,14 @@ export function TaskSidebar() {
             )}
           </svg>
         </button>
-        {!collapsed && attentionCount > 0 && (
+        {attentionCount > 0 && (
           <span
             data-testid="attention-count"
-            className="ml-auto inline-flex items-center justify-center rounded-full bg-red-500/20 text-red-400 text-xs font-medium min-w-5 h-5 px-1.5"
-          >
-            {attentionCount}
-          </span>
-        )}
-        {collapsed && attentionCount > 0 && (
-          <span
-            data-testid="attention-count"
-            className="sr-only"
+            className={
+              collapsed
+                ? 'sr-only'
+                : 'ml-auto inline-flex items-center justify-center rounded-full bg-red-500/20 text-red-400 text-xs font-medium min-w-5 h-5 px-1.5'
+            }
           >
             {attentionCount}
           </span>
@@ -225,15 +224,11 @@ export function TaskSidebar() {
                   }`}
                 >
                   <StatusIcon item={item} />
-                  <span
-                    className="truncate"
-                    style={{
-                      maxWidth: 180,
-                      display: collapsed ? 'none' : undefined,
-                    }}
-                  >
-                    {item.title}
-                  </span>
+                  {!collapsed && (
+                    <span className="truncate max-w-[180px]">
+                      {item.title}
+                    </span>
+                  )}
                 </Link>
               );
             })}

--- a/src/components/TaskSidebar.tsx
+++ b/src/components/TaskSidebar.tsx
@@ -1,0 +1,245 @@
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useTasks } from '@/lib/hooks';
+import { groupTasksForSidebar, type SidebarItem } from '@/lib/sidebar-utils';
+
+const STORAGE_KEY = 'octomux-sidebar-collapsed';
+
+function getInitialCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// ─── Status Icons (16x16 inline SVGs) ──────────────────────────────────────
+
+function StatusIcon({ item }: { item: SidebarItem }) {
+  const effectiveStatus = item.derivedStatus ?? item.status;
+
+  switch (effectiveStatus) {
+    case 'working':
+    case 'running':
+      return (
+        <svg
+          className="h-4 w-4 shrink-0 text-green-400 animate-spin"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+          <path
+            d="M14 8a6 6 0 0 0-6-6"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case 'setting_up':
+      return (
+        <svg
+          className="h-4 w-4 shrink-0 text-yellow-400"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" strokeDasharray="4 2" />
+        </svg>
+      );
+    case 'needs_attention':
+      return (
+        <svg
+          className="h-4 w-4 shrink-0 text-amber-400"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 1.5l6.5 12H1.5L8 1.5z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinejoin="round"
+          />
+          <line x1="8" y1="6" x2="8" y2="9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <circle cx="8" cy="11.5" r="0.75" fill="currentColor" />
+        </svg>
+      );
+    case 'error':
+      return (
+        <svg
+          className="h-4 w-4 shrink-0 text-red-400"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      );
+    default:
+      return (
+        <svg
+          className="h-4 w-4 shrink-0 text-muted-foreground"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
+  }
+}
+
+function statusLabel(item: SidebarItem): string {
+  const effective = item.derivedStatus ?? item.status;
+  switch (effective) {
+    case 'working':
+    case 'running':
+      return 'Running';
+    case 'setting_up':
+      return 'Setting up';
+    case 'needs_attention':
+      return 'Needs attention';
+    case 'error':
+      return 'Error';
+    default:
+      return item.status;
+  }
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function TaskSidebar() {
+  const [collapsed, setCollapsed] = useState(getInitialCollapsed);
+  const { tasks } = useTasks();
+  const { id: activeId } = useParams<{ id: string }>();
+
+  const groups = useMemo(() => groupTasksForSidebar(tasks), [tasks]);
+
+  const allItems = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+
+  const attentionCount = useMemo(
+    () =>
+      allItems.filter((i) => i.status === 'error' || i.derivedStatus === 'needs_attention').length,
+    [allItems],
+  );
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {
+        // ignore storage errors
+      }
+      return next;
+    });
+  }, []);
+
+  // Cmd/Ctrl+B keyboard shortcut
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'b') {
+        e.preventDefault();
+        toggleCollapsed();
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleCollapsed]);
+
+  return (
+    <nav
+      aria-label="Task list"
+      className="hidden md:flex flex-col border-r border-border bg-muted/30 overflow-y-auto overflow-x-hidden transition-[width] duration-150 ease-out"
+      style={{ width: collapsed ? 48 : 240 }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 p-2 border-b border-border shrink-0">
+        <button
+          onClick={toggleCollapsed}
+          className="p-1 rounded hover:bg-muted"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            {collapsed ? (
+              <path
+                d="M6 3l5 5-5 5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            ) : (
+              <path
+                d="M10 3l-5 5 5 5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            )}
+          </svg>
+        </button>
+        {!collapsed && attentionCount > 0 && (
+          <span
+            data-testid="attention-count"
+            className="ml-auto inline-flex items-center justify-center rounded-full bg-red-500/20 text-red-400 text-xs font-medium min-w-5 h-5 px-1.5"
+          >
+            {attentionCount}
+          </span>
+        )}
+        {collapsed && attentionCount > 0 && (
+          <span
+            data-testid="attention-count"
+            className="sr-only"
+          >
+            {attentionCount}
+          </span>
+        )}
+      </div>
+
+      {/* Task list */}
+      <div className="flex-1 py-1">
+        {groups.map((group) => (
+          <div key={group.repo}>
+            {!collapsed && (
+              <div className="px-3 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider truncate">
+                {group.repo}
+              </div>
+            )}
+            {group.items.map((item) => {
+              const isActive = item.id === activeId;
+              return (
+                <Link
+                  key={item.id}
+                  to={`/tasks/${item.id}`}
+                  aria-current={isActive ? 'page' : undefined}
+                  title={collapsed ? `${item.title} — ${statusLabel(item)}` : undefined}
+                  className={`flex items-center gap-2 px-2 py-1.5 text-sm transition-colors hover:bg-muted/60 ${
+                    isActive
+                      ? 'bg-muted border-l-2 border-l-primary'
+                      : 'border-l-2 border-l-transparent'
+                  }`}
+                >
+                  <StatusIcon item={item} />
+                  <span
+                    className="truncate"
+                    style={{
+                      maxWidth: 180,
+                      display: collapsed ? 'none' : undefined,
+                    }}
+                  >
+                    {item.title}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -52,6 +52,14 @@ describe('groupTasksForSidebar', () => {
       ],
       expectedOrder: ['2', '1'],
     },
+    {
+      name: 'needs_attention before error',
+      tasks: [
+        makeTask({ id: '1', status: 'error' }),
+        makeTask({ id: '2', status: 'running', derived_status: 'needs_attention' }),
+      ],
+      expectedOrder: ['2', '1'],
+    },
   ])('sorts $name', ({ tasks, expectedOrder }) => {
     const groups = groupTasksForSidebar(tasks);
     const ids = groups.flatMap((g) => g.items.map((i) => i.id));

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -93,20 +93,6 @@ describe('groupTasksForSidebar', () => {
         title: 'My Task',
         repo_path: '/home/dev/repo',
         derived_status: 'needs_attention',
-        pending_prompts: [
-          {
-            id: 'p1',
-            task_id: '1',
-            agent_id: 'a1',
-            agent_label: 'Agent 1',
-            session_id: 'sess-1',
-            tool_name: 'bash',
-            tool_input: { command: 'rm -rf' },
-            status: 'pending' as const,
-            created_at: '2026-01-01 00:00:00',
-            resolved_at: null,
-          },
-        ],
       }),
     ];
     const groups = groupTasksForSidebar(tasks);
@@ -116,8 +102,17 @@ describe('groupTasksForSidebar', () => {
       title: 'My Task',
       status: 'running',
       derivedStatus: 'needs_attention',
-      pendingPromptCount: 1,
     });
+  });
+
+  it('sorts groups alphabetically by repo name', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', repo_path: '/home/dev/zebra' }),
+      makeTask({ id: '2', status: 'running', repo_path: '/home/dev/alpha' }),
+      makeTask({ id: '3', status: 'running', repo_path: '/home/dev/middle' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups.map((g) => g.repo)).toEqual(['alpha', 'middle', 'zebra']);
   });
 
   // Type-only checks — these ensure the exported types satisfy the expected shape
@@ -127,7 +122,6 @@ describe('groupTasksForSidebar', () => {
       title: 'T',
       status: 'running',
       derivedStatus: null,
-      pendingPromptCount: 0,
     };
     const group: SidebarGroup = { repo: 'r', items: [item] };
     expect(group.repo).toBe('r');

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { groupTasksForSidebar, type SidebarItem, type SidebarGroup } from './sidebar-utils';
+import { makeTask } from '@/test-helpers';
+
+describe('groupTasksForSidebar', () => {
+  it('excludes draft and closed tasks', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', title: 'A' }),
+      makeTask({ id: '2', status: 'draft', title: 'B' }),
+      makeTask({ id: '3', status: 'closed', title: 'C' }),
+      makeTask({ id: '4', status: 'error', title: 'D' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    const ids = groups.flatMap((g) => g.items.map((i) => i.id));
+    expect(ids).toEqual(['1', '4']);
+  });
+
+  it('groups by repo basename', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', repo_path: '/home/dev/repo-a' }),
+      makeTask({ id: '2', status: 'running', repo_path: '/home/dev/repo-b' }),
+      makeTask({ id: '3', status: 'error', repo_path: '/home/dev/repo-a' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups.map((g) => g.repo)).toEqual(['repo-a', 'repo-b']);
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups[1].items).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: 'running before error',
+      tasks: [
+        makeTask({ id: '1', status: 'error' }),
+        makeTask({ id: '2', status: 'running' }),
+      ],
+      expectedOrder: ['2', '1'],
+    },
+    {
+      name: 'setting_up before error',
+      tasks: [
+        makeTask({ id: '1', status: 'error' }),
+        makeTask({ id: '2', status: 'setting_up' }),
+      ],
+      expectedOrder: ['2', '1'],
+    },
+    {
+      name: 'running before needs_attention',
+      tasks: [
+        makeTask({ id: '1', status: 'running', derived_status: 'needs_attention' }),
+        makeTask({ id: '2', status: 'running', derived_status: 'working' }),
+      ],
+      expectedOrder: ['2', '1'],
+    },
+  ])('sorts $name', ({ tasks, expectedOrder }) => {
+    const groups = groupTasksForSidebar(tasks);
+    const ids = groups.flatMap((g) => g.items.map((i) => i.id));
+    expect(ids).toEqual(expectedOrder);
+  });
+
+  it('uses recency as tiebreaker within same priority', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', created_at: '2026-01-01 00:00:00' }),
+      makeTask({ id: '2', status: 'running', created_at: '2026-01-02 00:00:00' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    const ids = groups.flatMap((g) => g.items.map((i) => i.id));
+    expect(ids).toEqual(['2', '1']); // newer first
+  });
+
+  it('returns empty array for no active tasks', () => {
+    const tasks = [makeTask({ id: '1', status: 'draft' })];
+    expect(groupTasksForSidebar(tasks)).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(groupTasksForSidebar([])).toEqual([]);
+  });
+
+  it('extracts only sidebar-relevant fields into SidebarItem', () => {
+    const tasks = [
+      makeTask({
+        id: '1',
+        status: 'running',
+        title: 'My Task',
+        repo_path: '/home/dev/repo',
+        derived_status: 'needs_attention',
+        pending_prompts: [
+          {
+            id: 'p1',
+            task_id: '1',
+            agent_id: 'a1',
+            agent_label: 'Agent 1',
+            session_id: 'sess-1',
+            tool_name: 'bash',
+            tool_input: { command: 'rm -rf' },
+            status: 'pending' as const,
+            created_at: '2026-01-01 00:00:00',
+            resolved_at: null,
+          },
+        ],
+      }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    const item = groups[0].items[0];
+    expect(item).toEqual({
+      id: '1',
+      title: 'My Task',
+      status: 'running',
+      derivedStatus: 'needs_attention',
+      pendingPromptCount: 1,
+    });
+  });
+
+  // Type-only checks — these ensure the exported types satisfy the expected shape
+  it('SidebarItem and SidebarGroup types are exported', () => {
+    const item: SidebarItem = {
+      id: 'x',
+      title: 'T',
+      status: 'running',
+      derivedStatus: null,
+      pendingPromptCount: 0,
+    };
+    const group: SidebarGroup = { repo: 'r', items: [item] };
+    expect(group.repo).toBe('r');
+  });
+});

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -1,0 +1,61 @@
+import type { Task, TaskStatus, DerivedTaskStatus } from '../../server/types';
+
+export interface SidebarItem {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  derivedStatus: DerivedTaskStatus | null;
+  pendingPromptCount: number;
+}
+
+export interface SidebarGroup {
+  repo: string;
+  items: SidebarItem[];
+}
+
+const ACTIVE_STATUSES: TaskStatus[] = ['running', 'setting_up', 'error'];
+
+/** Sort priority: running/setting_up first, then error/needs_attention, then rest.
+ *  Within running: needs_attention sorts after normal running. */
+function sortPriority(item: SidebarItem): number {
+  if (item.status === 'error') return 2;
+  if (item.derivedStatus === 'needs_attention') return 1;
+  if (item.status === 'running' || item.status === 'setting_up') return 0;
+  return 3;
+}
+
+export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
+  const active = tasks.filter((t) => ACTIVE_STATUSES.includes(t.status));
+
+  const grouped = new Map<string, { items: SidebarItem[]; tasks: Task[] }>();
+  for (const task of active) {
+    const repo = task.repo_path.split('/').pop() || task.repo_path;
+    const item: SidebarItem = {
+      id: task.id,
+      title: task.title,
+      status: task.status,
+      derivedStatus: task.derived_status ?? null,
+      pendingPromptCount: task.pending_prompts?.length ?? 0,
+    };
+    const existing = grouped.get(repo);
+    if (existing) {
+      existing.items.push(item);
+      existing.tasks.push(task);
+    } else {
+      grouped.set(repo, { items: [item], tasks: [task] });
+    }
+  }
+
+  const groups: SidebarGroup[] = [];
+  for (const [repo, { items, tasks: groupTasks }] of grouped) {
+    const createdAt = new Map(groupTasks.map((t) => [t.id, t.created_at]));
+    items.sort((a, b) => {
+      const priorityDiff = sortPriority(a) - sortPriority(b);
+      if (priorityDiff !== 0) return priorityDiff;
+      return (createdAt.get(b.id) ?? '').localeCompare(createdAt.get(a.id) ?? '');
+    });
+    groups.push({ repo, items });
+  }
+
+  return groups;
+}

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -15,8 +15,7 @@ export interface SidebarGroup {
 
 const ACTIVE_STATUSES: TaskStatus[] = ['running', 'setting_up', 'error'];
 
-/** Sort priority: running/setting_up first, then error/needs_attention, then rest.
- *  Within running: needs_attention sorts after normal running. */
+/** Sort priority: running/setting_up (0), needs_attention (1), error (2), rest (3). */
 function sortPriority(item: SidebarItem): number {
   if (item.status === 'error') return 2;
   if (item.derivedStatus === 'needs_attention') return 1;

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -5,7 +5,6 @@ export interface SidebarItem {
   title: string;
   status: TaskStatus;
   derivedStatus: DerivedTaskStatus | null;
-  pendingPromptCount: number;
 }
 
 export interface SidebarGroup {
@@ -34,7 +33,6 @@ export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
       title: task.title,
       status: task.status,
       derivedStatus: task.derived_status ?? null,
-      pendingPromptCount: task.pending_prompts?.length ?? 0,
     };
     const existing = grouped.get(repo);
     if (existing) {
@@ -56,5 +54,6 @@ export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
     groups.push({ repo, items });
   }
 
+  groups.sort((a, b) => a.repo.localeCompare(b.repo));
   return groups;
 }

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -144,7 +144,7 @@ export default function TaskDetail() {
 
   if (loading) {
     return (
-      <div className="flex h-screen items-center justify-center text-muted-foreground">
+      <div className="flex h-full items-center justify-center text-muted-foreground">
         Loading...
       </div>
     );
@@ -152,7 +152,7 @@ export default function TaskDetail() {
 
   if (!task) {
     return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4">
+      <div className="flex h-full flex-col items-center justify-center gap-4">
         <p className="text-destructive">{error || 'Task not found'}</p>
         <Button variant="outline" onClick={() => navigate('/')}>
           Back to Dashboard
@@ -171,7 +171,7 @@ export default function TaskDetail() {
     !!task.tmux_session && agents.length > 0 && activeWindow !== null && isTerminalAlive;
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-full flex-col">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-3">


### PR DESCRIPTION
## What
Add a collapsible left sidebar on task detail pages for direct task-to-task navigation without returning to the dashboard.

- **TaskSidebar** component: lists active tasks (running/setting_up/error) grouped by repo, with colorblind-accessible status icons, attention count badge, localStorage-persisted collapse state, and Cmd/Ctrl+B keyboard shortcut
- **TaskDetailLayout** wrapper: React Router layout route with sidebar + Outlet + Suspense
- **sidebar-utils**: pure utility for filtering, grouping by repo, and sorting tasks by priority (running → needs_attention → error) with recency tiebreaker
- TaskDetail updated from `h-screen` to `h-full` (3 locations) to work within the layout wrapper

## Why
Managing multiple concurrent agents requires frequent switching between task detail pages. Previously this required navigating back to the dashboard each time, adding friction to the monitoring workflow.

## Testing
- 16 new tests (11 unit for sidebar-utils, 5 component for TaskSidebar)
- All 508 tests passing (`bun run test`)
- `bun run typecheck` clean
- `bun run lint` clean
- 2 pre-existing failures in `server/hook-settings.test.ts` (unrelated to this PR)