### PR TITLE
feat(skills): bundle claude code skills in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,4 @@ Each task gets a **git worktree** for isolation, a **tmux session** for process 
 ## Links
 
 - [octomux.dev](https://octomux.dev) (coming soon)
-- [GitHub](https://github.com/ShreyPaharia/octomux-agents)
 - [npm](https://www.npmjs.com/package/octomux)

--- a/bin/octomux.js
+++ b/bin/octomux.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, exec as execCb } from 'child_process';
-import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, cpSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, readdirSync, cpSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import os from 'os';

--- a/bin/octomux.js
+++ b/bin/octomux.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { execFileSync, exec as execCb } from 'child_process';
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, cpSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import os from 'os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -18,8 +19,6 @@ const command = args[0];
 
 if (command === 'start') {
   await runStart(args.slice(1));
-} else if (command === 'init') {
-  runInit();
 } else {
   // Delegate to CLI (commander-based) for all other commands
   await import('../cli/dist/index.js');
@@ -43,6 +42,9 @@ async function runStart(startArgs) {
 
   // Welcome banner
   console.log(`\n\uD83D\uDC19 octomux v${version}\n`);
+
+  // Install bundled skills
+  installSkills();
 
   // Preflight checks
   const required = [
@@ -108,32 +110,24 @@ async function runStart(startArgs) {
   }
 }
 
-// ─── init command ────────────────────────────────────────────────────────────
+// ─── skill installer ─────────────────────────────────────────────────────────
 
-function runInit() {
-  // Verify git repo
-  if (!existsSync('.git')) {
-    console.error('Error: Current directory is not a git repository.');
-    console.error('Run this command from the root of a git repo.');
-    process.exit(1);
+function installSkills() {
+  const skillsSource = path.join(__dirname, '..', 'skills');
+  const skillsTarget = path.join(os.homedir(), '.claude', 'skills');
+
+  if (!existsSync(skillsSource)) return;
+
+  let installed = false;
+  for (const skill of readdirSync(skillsSource)) {
+    const target = path.join(skillsTarget, skill);
+    if (!existsSync(target)) {
+      mkdirSync(target, { recursive: true });
+      cpSync(path.join(skillsSource, skill), target, { recursive: true });
+      installed = true;
+    }
   }
-
-  const settingsPath = path.join('.claude', 'settings.local.json');
-
-  if (existsSync(settingsPath)) {
-    console.log(`${settingsPath} already exists. No changes made.`);
-    return;
+  if (installed) {
+    console.log('Installed octomux skills for Claude Code');
   }
-
-  const settings = {
-    permissions: {
-      allow: ['Bash(git *)', 'Bash(npm *)', 'Bash(bun *)', 'Read', 'Write', 'Edit'],
-    },
-  };
-
-  mkdirSync('.claude', { recursive: true });
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-
-  console.log(`Created ${settingsPath} with recommended agent permissions.`);
-  console.log(`Add to .gitignore: .claude/settings.local.json`);
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "!dist-server/*.test.*",
     "!dist-server/test-helpers.*",
     "cli/dist/",
-    "cli/package.json"
+    "cli/package.json",
+    "skills/"
   ],
   "scripts": {
     "dev": "concurrently \"bun:dev:server\" \"bun:dev:client\"",

--- a/skills/octomux-create-commit/SKILL.md
+++ b/skills/octomux-create-commit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: octomux-create-commit
+description: Generate a conventional commit message from staged changes and commit. Use when the user asks to commit, says /commit, or wants to save their changes.
+---
+
+# Commit
+
+Generate a commit message from staged changes using conventional commits, then commit.
+
+## Steps
+
+1. **Check for staged changes:**
+
+   ```bash
+   git diff --cached --stat
+   ```
+
+   If nothing is staged, tell the user and stop.
+
+2. **Get the staged diff:**
+
+   ```bash
+   git diff --cached
+   ```
+
+3. **Generate the commit message** by analyzing the diff. Follow these rules exactly:
+
+   ### Format
+
+   ```
+   <type>(<scope>): <description>
+   ```
+
+   Scope is optional. If changes span multiple scopes, omit scope.
+
+   ### Allowed Types
+
+   | Type       | When to use                                  |
+   | ---------- | -------------------------------------------- |
+   | `feat`     | A new feature                                |
+   | `fix`      | A bug fix                                    |
+   | `docs`     | Documentation only changes                   |
+   | `style`    | Code style changes (formatting, etc.)        |
+   | `refactor` | Code refactoring (no new feature or bug fix) |
+   | `perf`     | Performance improvements                     |
+   | `test`     | Adding or fixing tests                       |
+   | `build`    | Build system or dependencies                 |
+   | `ci`       | CI configuration changes                     |
+   | `chore`    | Other changes                                |
+   | `revert`   | Revert a commit                              |
+
+   ### Rules
+   - Description must be at least 10 characters
+   - Use lowercase for the description
+   - Do not end with a period
+   - Cover ALL changes in the diff
+   - Keep the message concise — one line unless a body is truly needed
+   - If a body is needed, add a blank line after the subject, then bullet points
+
+4. **Show the message to the user** and ask for confirmation before committing.
+
+5. **Commit** using a heredoc for proper formatting:
+
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <generated message>
+   EOF
+   )"
+   ```
+
+6. **Verify** by running `git log --oneline -1` to confirm.
+
+## Notes
+
+- NEVER amend a previous commit unless the user explicitly asks
+- NEVER push unless the user explicitly asks
+- If the diff is large, summarize the key changes — don't list every file
+- If unsure about the type, prefer `feat` for new code, `fix` for corrections, `refactor` for restructuring

--- a/skills/octomux-create-pr/SKILL.md
+++ b/skills/octomux-create-pr/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: octomux-create-pr
+description: Use when creating a pull request, opening a PR, or pushing and creating a PR for an octomux task
+---
+
+# Create PR for an octomux task
+
+Create a GitHub pull request directly using `gh pr create`. The octomux dashboard will auto-detect the PR within 30 seconds.
+
+## Steps
+
+1. **Identify the task branch and repo:**
+   - Ask the user which task, or infer from context
+   - Get the task details (branch, repo_path, worktree):
+     ```bash
+     octomux get-task <task-id>
+     ```
+   - You need `branch`, `repo_path`, and `base_branch` (if set). If no base_branch, default to `main`.
+
+2. **Gather context for the PR description:**
+
+   ```bash
+   git -C <worktree> log <base>..HEAD --oneline
+   git -C <worktree> diff <base>...HEAD --stat
+   ```
+
+3. **Check if branch is pushed and push if needed:**
+
+   ```bash
+   # Check if remote tracking branch exists
+   git -C <repo_path> ls-remote --heads origin <branch>
+   ```
+
+   If the branch is not pushed yet, push it:
+
+   ```bash
+   git -C <repo_path> push -u origin <branch>
+   ```
+
+   If already pushed, check if local is ahead and push any new commits:
+
+   ```bash
+   git -C <worktree> status -sb  # check if ahead of remote
+   git -C <repo_path> push origin <branch>  # push if ahead
+   ```
+
+4. **Draft the PR title and body, then confirm with the user:**
+
+   **Title:** Conventional commit format, under 70 chars, min 10 char description:
+
+   ```
+   <type>(<scope>): <description>
+   ```
+
+   Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`
+   Examples: `feat(hooks): add permission prompt tracking`, `fix(terminal): clean up orphaned tmux sessions`
+
+   **Body:** Must include all three sections — What, Why, and Testing:
+
+   ```markdown
+   ## What
+
+   <Description of what this PR does — summarize the changes>
+
+   ## Why
+
+   <Explanation of why this change is needed — the motivation>
+
+   Resolves <link>
+
+   ## Testing
+
+   <How this was tested — commands run, manual verification, etc.>
+   ```
+
+   **Linking tickets/issues:**
+   - If the task was created from a **Jira ticket**, include the Jira link
+   - If the task was created from a **GitHub issue**, include: `Resolves #<issue-number>`
+   - Infer the ticket/issue from the branch name (e.g., `feat/IN-123-...` -> IN-123, `fix/42-...` -> #42)
+   - If no ticket/issue is associated, omit the `Resolves` line
+
+   **IMPORTANT: Present the title and body to the user and WAIT for their confirmation before creating the PR.** Do NOT create the PR without explicit user approval. The user may want to adjust the title, description, or add context.
+
+5. **After user confirms, create the PR using `gh`:**
+
+   ```bash
+   gh pr create \
+     --head <branch> \
+     --base <base> \
+     --title "<title>" \
+     --body "<body>" \
+     --repo <repo_path>
+   ```
+
+6. **Report** — Print the PR URL. The octomux dashboard at localhost:7777 will auto-detect and link it to the task within ~30 seconds via the PR poller.
+
+## Notes
+
+- Do NOT use the octomux API PR endpoints (`/pr/preview`, `/pr`) — create directly with `gh` for better context and speed
+- The dashboard auto-detects PRs by matching the branch name — no manual DB update needed
+- If `gh pr create` fails with "already exists", the PR was likely already created
+- The task must have a `branch` set (created automatically when octomux starts the task)
+- Use `--repo` flag with the repo path so `gh` knows which repo to target

--- a/skills/octomux-create-task/SKILL.md
+++ b/skills/octomux-create-task/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: octomux-create-task
+description: Use when creating an octomux task to dispatch autonomous Claude Code agents for building features, fixing bugs, or any code changes
+---
+
+# Create an octomux task
+
+Dispatch an autonomous Claude Code agent to work on a feature, bugfix, or code change via octomux.
+
+## Steps
+
+1. **Understand the goal:**
+   - Ask the user what they want built/fixed, or infer from context (e.g. a Jira ticket URL, a bug description, a feature request)
+   - If given a Jira ticket URL, fetch the ticket details to extract title, description, and acceptance criteria
+
+2. **Resolve the repo:**
+   - Query the octomux API for recent repos:
+     ```bash
+     curl -s http://localhost:7777/api/recent-repos | jq .
+     ```
+   - If the repo is ambiguous, ask the user
+
+3. **Detect base branch:**
+
+   ```bash
+   curl -s 'http://localhost:7777/api/default-branch?repo_path=<resolved_path>' | jq -r .branch
+   ```
+
+4. **Generate the branch name:**
+   Follow GitHub/conventional branch naming best practices. The branch name doubles as the worktree directory name.
+
+   **Format:** `<type>/<scope>` where:
+   - `<type>` = `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf` (match the nature of the work)
+   - `<scope>` = kebab-case short description (max ~40 chars, no task ID suffix)
+
+   **From a Jira ticket** (e.g. IN-123):
+
+   ```
+   feat/IN-123-add-position-sync
+   fix/IN-456-decimal-exponent-bloat
+   ```
+
+   **From a GitHub issue** (e.g. #42):
+
+   ```
+   feat/42-websocket-real-time-updates
+   fix/42-terminal-resize-bug
+   ```
+
+   **Without a ticket/issue:**
+
+   ```
+   fix/tmux-session-leak
+   feat/cli-arg-parsing
+   chore/cleanup-packaging
+   refactor/split-task-runner
+   perf/optimize-ui-rendering
+   ```
+
+   Pass it via `--branch`:
+
+   ```bash
+   --branch 'fix/tmux-session-leak'
+   ```
+
+5. **Craft the initial prompt:**
+   Build a well-structured prompt that includes:
+   - Clear description of the goal
+   - Acceptance criteria (if available from a ticket)
+   - Standard instructions: `Run tests before finishing. Follow conventional commits. Keep changes minimal and focused.`
+
+   The prompt should be specific and actionable — vague prompts lead to agents going in circles.
+
+6. **Create the task:**
+
+   ```bash
+   octomux create-task \
+     --title '<title>' \
+     --description '<description>' \
+     --repo-path '<resolved_path>' \
+     --branch '<branch_name>' \
+     --base-branch '<detected_branch>' \
+     --initial-prompt '<crafted_prompt>'
+   ```
+
+7. **Report:**
+   - Print the task ID returned by the CLI
+   - Tell the user to monitor at the dashboard: http://localhost:7777
+   - Or via CLI: `octomux list-tasks`
+
+## Notes
+
+- The octomux server must be running at localhost:7777
+- Tasks start immediately by default — agents begin working right away
+- Each task gets its own git worktree and tmux session for isolation
+- Keep titles short (under 60 chars) and descriptive
+- Initial prompts should be specific and actionable
+- The user can monitor tasks at the dashboard or via the CLI
+- To create PRs for completed tasks, use the `octomux-create-pr` skill


### PR DESCRIPTION
## What
Bundle Claude Code skills (create-task, create-pr, create-commit) inside the octomux npm package so users get slash commands automatically when they run `octomux start`.

- Generalized skills in `skills/` with `octomux` CLI commands instead of hardcoded paths
- Auto-install to `~/.claude/skills/` on `octomux start` (skips if already installed)
- Replaced `octomux init` command with automatic skill installation
- Added `skills/` to package.json `files` array

## Why
Users installing octomux via npm should get the Claude Code slash commands (/commit, /create-task, /create-pr) out of the box without manual setup.

## Testing
- `bun run build` passes
- `bun run test` — all 519 tests pass
- `npm pack --dry-run` confirms skills/ included in tarball