### PR TITLE
fix(hooks): ignore subagent stop events to suppress spurious idle notifications

### DIFF
--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -166,5 +166,15 @@ describe('Hook endpoints', () => {
 
       expect(getAgentActivity(db, 'a1').hook_activity).toBe('idle');
     });
+
+    it('ignores subagent stops (agent_id present in payload)', async () => {
+      await request(app)
+        .post('/api/hooks/stop')
+        .send({ session_id: 'sess-123', agent_id: 'subagent-abc' })
+        .expect(200);
+
+      // Agent should remain active — subagent stop must not set it to idle
+      expect(getAgentActivity(db, 'a1').hook_activity).toBe('active');
+    });
   });
 });

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -126,8 +126,15 @@ router.post('/post-tool-use', (req, res) => {
 
 // POST /api/hooks/stop
 router.post('/stop', (req, res) => {
-  const { session_id } = req.body;
+  const { session_id, agent_id: subagentId } = req.body;
   if (!session_id) {
+    res.status(200).send();
+    return;
+  }
+
+  // Ignore subagent stops — agent_id is only present when a Claude Code
+  // subagent (spawned via the Agent tool) finishes, not the main session.
+  if (subagentId) {
     res.status(200).send();
     return;
   }


### PR DESCRIPTION
## What
Skip Stop hook processing when the payload contains `agent_id`, which indicates the stop was fired by a Claude Code subagent (spawned via the Agent tool) rather than the main session. This prevents subagent completions from setting the parent agent's `hook_activity` to idle and triggering false "Agent finished" toast notifications.

## Why
When a Claude Code agent spawns subagents, each subagent fires the Stop hook with the parent's `session_id` on completion. This briefly set the parent agent to idle, causing spurious "Agent finished" notifications in the dashboard — even though the main agent was still working.

## Testing
- Added test: subagent stops (with `agent_id` in payload) do not change agent activity
- All 520 tests pass, typecheck clean