### PR TITLE
feat(install): auto-install subdirectory deps and system dependencies

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "octomux-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "octomux-cli",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cli:build": "cd cli && tsc",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run build",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true",
+    "postinstall": "bash scripts/postinstall.sh",
     "prepare": "husky",
     "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s"
   },

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# postinstall.sh — runs after npm/bun install
+# Installs subdirectory deps, fixes node-pty, and installs missing system deps.
+# Never exits non-zero — failures print warnings but don't block install.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ─── 1. Install cli/ subdirectory dependencies ──────────────────────────────
+
+if [ -d "$ROOT_DIR/cli" ] && [ -f "$ROOT_DIR/cli/package.json" ]; then
+  if [ ! -d "$ROOT_DIR/cli/node_modules" ]; then
+    echo "Installing cli/ dependencies..."
+    (cd "$ROOT_DIR/cli" && npm install --ignore-scripts 2>/dev/null) || {
+      echo "⚠  Could not install cli/ dependencies. Run manually: cd cli && npm install"
+    }
+  fi
+fi
+
+# ─── 2. Fix node-pty spawn-helper permissions (macOS) ────────────────────────
+
+chmod +x "$ROOT_DIR/node_modules/node-pty/prebuilds/darwin-"*/spawn-helper 2>/dev/null || true
+
+# ─── 3. Install missing system dependencies ──────────────────────────────────
+
+install_with_brew() {
+  local pkg="$1"
+  local name="$2"
+  local hint="$3"
+
+  if command -v "$pkg" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "$name not found. Attempting to install..."
+
+  if command -v brew >/dev/null 2>&1; then
+    if brew install "$pkg" 2>/dev/null; then
+      echo "✓ Installed $name via Homebrew"
+      return 0
+    fi
+  fi
+
+  echo "⚠  Could not install $name automatically. $hint"
+}
+
+install_with_npm_global() {
+  local cmd="$1"
+  local pkg="$2"
+  local name="$3"
+  local hint="$4"
+
+  if command -v "$cmd" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "$name not found. Attempting to install..."
+
+  if npm install -g "$pkg" 2>/dev/null; then
+    echo "✓ Installed $name via npm"
+    return 0
+  fi
+
+  echo "⚠  Could not install $name automatically. $hint"
+}
+
+# tmux
+install_with_brew "tmux" "tmux" "Install with: brew install tmux"
+
+# git
+install_with_brew "git" "git" "Install with: brew install git"
+
+# Claude Code CLI
+install_with_npm_global "claude" "@anthropic-ai/claude-code" "Claude Code CLI" \
+  "See: https://docs.anthropic.com/en/docs/claude-code"


### PR DESCRIPTION
## What
Replace the inline postinstall chmod command with a shell script that:
- Installs cli/ subdirectory dependencies when node_modules is missing
- Preserves the node-pty spawn-helper permission fix
- Attempts to install missing system deps (tmux, git via brew; Claude CLI via npm)
- All failures are non-blocking warnings — never breaks the install
- Adds cli/package-lock.json for deterministic installs

## Why
First-time users hit confusing errors when cli/ deps aren't installed or system
dependencies are missing. This provides a smooth first-install experience.

## Testing
- Ran `bash scripts/postinstall.sh` — cli/ deps installed, node-pty chmod ran, system deps detected as present
- All 520 unit tests pass (`bun run test`)