### PR TITLE
fix(task-runner): pass initial prompt as CLI arg instead of polling + paste

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -48,12 +48,6 @@ vi.mock('child_process', () => ({
       cb(null, { stdout: 'true', stderr: '' });
     }
   }),
-  spawn: vi.fn(() => ({
-    stdin: { write: vi.fn(), end: vi.fn() },
-    on: vi.fn((event: string, cb: Function) => {
-      if (event === 'close') cb(0);
-    }),
-  })),
 }));
 
 const {
@@ -63,14 +57,12 @@ const {
   addAgent,
   stopAgent,
   resumeTask,
-  dispatchToWindow,
-  waitForClaudeReady,
   slugifyTitle,
   createUserTerminal,
   cleanupLinkedSessions,
   cleanupOrphanedViewerSessions,
 } = await import('./task-runner.js');
-const { execFile, spawn } = await import('child_process');
+const { execFile } = await import('child_process');
 const fs = await import('fs');
 const { installHookSettings } = await import('./hook-settings.js');
 
@@ -547,53 +539,6 @@ describe('stopAgent', () => {
   });
 });
 
-// ─── dispatchToWindow ─────────────────────────────────────────────────────────
-
-describe('dispatchToWindow', () => {
-  it('uses tmux load-buffer with named buffer via spawn', async () => {
-    await dispatchToWindow('test-session', 0, 'Hello');
-    const call = vi
-      .mocked(spawn)
-      .mock.calls.find((c) => c[0] === 'tmux' && (c[1] as string[]).includes('load-buffer'));
-    expect(call).toBeDefined();
-    expect(call![1] as string[]).toContain('-b');
-  });
-
-  it('writes text without trailing newline to stdin', async () => {
-    await dispatchToWindow('test-session', 0, 'Hello');
-    const spawnCall = vi.mocked(spawn).mock.results[0].value;
-    expect(spawnCall.stdin.write).toHaveBeenCalledWith('Hello');
-    expect(spawnCall.stdin.end).toHaveBeenCalled();
-  });
-
-  it('pastes buffer to correct target', async () => {
-    await dispatchToWindow('my-session', 2, 'text');
-    const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] });
-    expect(call![1]).toContain('my-session:2');
-  });
-
-  it('sends Enter key after pasting buffer', async () => {
-    await dispatchToWindow('my-session', 2, 'text');
-    const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['send-keys'] });
-    expect(call).toBeTruthy();
-    expect(call![1]).toContain('my-session:2');
-    expect(call![1]).toContain('Enter');
-  });
-
-  it('rejects when load-buffer exits non-zero', async () => {
-    vi.mocked(spawn).mockReturnValueOnce({
-      stdin: { write: vi.fn(), end: vi.fn() },
-      on: vi.fn((event: string, cb: Function) => {
-        if (event === 'close') cb(1);
-      }),
-    } as any);
-
-    await expect(dispatchToWindow('s', 0, 'text')).rejects.toThrow(
-      'tmux load-buffer exited with code 1',
-    );
-  });
-});
-
 // ─── resumeTask ──────────────────────────────────────────────────────────────
 
 describe('resumeTask', () => {
@@ -1065,52 +1010,3 @@ describe('deleteTask linked session cleanup', () => {
   });
 });
 
-// ─── waitForClaudeReady ──────────────────────────────────────────────────────
-// Placed last because these tests override the execFile mock implementation.
-
-describe('waitForClaudeReady', () => {
-  it('returns immediately when timeout is 0 (test env)', async () => {
-    await expect(waitForClaudeReady('session', 0, 0)).resolves.not.toThrow();
-    // Should not call capture-pane at all
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['capture-pane'] }),
-    ).toBeUndefined();
-  });
-
-  it('returns when pane contains > prompt', async () => {
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        cb(null, { stdout: '  >\n', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
-  });
-
-  it('proceeds after timeout if Claude never shows prompt', async () => {
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        cb(null, { stdout: 'loading...\n', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    // Use a very short timeout so the test doesn't hang
-    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
-  });
-
-  it('handles capture-pane errors gracefully', async () => {
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        cb(new Error('pane not found'), null);
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
-  });
-});

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -23,6 +23,8 @@ vi.mock('fs', async (importOriginal) => {
     existsSync: vi.fn(() => true),
     mkdirSync: vi.fn(),
     copyFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
   };
   return { ...mocked, default: mocked };
 });
@@ -149,7 +151,6 @@ describe('startTask', () => {
     { name: 'creates tmux session', cmd: 'tmux', argsInclude: ['new-session'] },
     { name: 'queries window index', cmd: 'tmux', argsInclude: ['display-message'] },
     { name: 'launches claude', cmd: 'tmux', argsInclude: ['send-keys', 'Enter'] },
-    { name: 'dispatches prompt', cmd: 'tmux', argsInclude: ['paste-buffer'] },
   ];
 
   it.each(expectedShellCalls)('$name', async ({ cmd, argsInclude }) => {
@@ -158,26 +159,38 @@ describe('startTask', () => {
     expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeDefined();
   });
 
-  it('uses tmux load-buffer with named buffer via spawn for prompt dispatch', async () => {
+  it('includes prompt via temp file in claude launch command', async () => {
     insertTask(db, { initial_prompt: 'Do the thing' });
     await startTask({ ...DEFAULTS.task, initial_prompt: 'Do the thing' } as Task);
-    const call = vi
-      .mocked(spawn)
-      .mock.calls.find((c) => c[0] === 'tmux' && (c[1] as string[]).includes('load-buffer'));
-    expect(call).toBeDefined();
-    expect(call![1] as string[]).toContain('-b');
+
+    const sendKeysCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['send-keys', 'Enter'],
+    });
+    expect(sendKeysCall).toBeDefined();
+    const claudeCmd = (sendKeysCall![1] as string[]).find((a: string) =>
+      a.includes('claude --session-id'),
+    );
+    expect(claudeCmd).toContain('$(cat ');
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('.claude-prompt-'),
+      'Do the thing',
+    );
   });
 
-  it('skips prompt dispatch when initial_prompt is null', async () => {
+  it('launches claude without prompt file when initial_prompt is null', async () => {
     insertTask(db);
     await startTask({ ...DEFAULTS.task } as Task);
-    expect(
-      findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] }),
-    ).toBeUndefined();
-    const loadBufferCall = vi
-      .mocked(spawn)
-      .mock.calls.find((c) => c[0] === 'tmux' && (c[1] as string[]).includes('load-buffer'));
-    expect(loadBufferCall).toBeUndefined();
+
+    const sendKeysCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['send-keys', 'Enter'],
+    });
+    const claudeCmd = (sendKeysCall![1] as string[]).find((a: string) =>
+      a.includes('claude --session-id'),
+    );
+    expect(claudeCmd).not.toContain('$(cat ');
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalled();
   });
 
   // ─── Custom branch and base branch ─────────────────────────────────────
@@ -343,20 +356,44 @@ describe('addAgent', () => {
     expect(findExecCall(vi.mocked(execFile), { cmd, argsInclude })).toBeDefined();
   });
 
-  const promptDispatchCases = [
-    { name: 'dispatches prompt when provided', prompt: 'Write tests', expectPaste: true },
-    { name: 'does not dispatch when no prompt', prompt: undefined, expectPaste: false },
-  ];
-
-  it.each(promptDispatchCases)('$name', async ({ prompt, expectPaste }) => {
+  it('includes prompt via temp file in claude launch command when provided', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
-    await addAgent(runningTask, prompt);
-    const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['paste-buffer'] });
-    if (expectPaste) {
-      expect(call).toBeDefined();
-    } else {
-      expect(call).toBeUndefined();
-    }
+    await addAgent(runningTask, 'Write tests');
+
+    const sendKeysCalls = vi
+      .mocked(execFile)
+      .mock.calls.filter(
+        (c: any[]) =>
+          c[0] === 'tmux' &&
+          (c[1] as string[]).includes('send-keys') &&
+          (c[1] as string[]).some((a: string) => a.includes('claude --session-id')),
+      );
+    const claudeCmd = (sendKeysCalls[0][1] as string[]).find((a: string) =>
+      a.includes('claude --session-id'),
+    );
+    expect(claudeCmd).toContain('$(cat ');
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      expect.stringContaining('.claude-prompt-'),
+      'Write tests',
+    );
+  });
+
+  it('launches claude without prompt file when no prompt provided', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    await addAgent(runningTask);
+
+    const sendKeysCalls = vi
+      .mocked(execFile)
+      .mock.calls.filter(
+        (c: any[]) =>
+          c[0] === 'tmux' &&
+          (c[1] as string[]).includes('send-keys') &&
+          (c[1] as string[]).some((a: string) => a.includes('claude --session-id')),
+      );
+    const claudeCmd = (sendKeysCalls[0][1] as string[]).find((a: string) =>
+      a.includes('claude --session-id'),
+    );
+    expect(claudeCmd).not.toContain('$(cat ');
   });
 
   it('persists agent to database', async () => {
@@ -1040,67 +1077,16 @@ describe('waitForClaudeReady', () => {
     ).toBeUndefined();
   });
 
-  it('returns when pane contains bare > prompt (no launch command visible)', async () => {
+  it('returns when pane contains > prompt', async () => {
     vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
       if (args.includes('capture-pane')) {
-        cb(null, { stdout: 'Claude Code v2.1\n  >\n', stderr: '' });
+        cb(null, { stdout: '  >\n', stderr: '' });
       } else {
         cb(null, { stdout: '', stderr: '' });
       }
     }) as any);
 
     await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
-  });
-
-  it('returns when pane contains bare ❯ prompt', async () => {
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        cb(null, { stdout: 'Claude Code v2.1\n❯ \n', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
-  });
-
-  it('waits through phase 1 while launch command is visible', async () => {
-    let callCount = 0;
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        callCount++;
-        if (callCount <= 2) {
-          // Phase 1: shell still shows the launch command
-          cb(null, { stdout: '❯ claude --session-id abc-123\n', stderr: '' });
-        } else {
-          // Phase 2: Claude TUI has taken over
-          cb(null, { stdout: 'Claude Code v2.1\n❯ \n', stderr: '' });
-        }
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
-    // Should have polled multiple times (at least through phase 1 + phase 2)
-    expect(callCount).toBeGreaterThanOrEqual(3);
-  });
-
-  it('does not match trust dialog select cursor as ready', async () => {
-    let callCount = 0;
-    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
-      if (args.includes('capture-pane')) {
-        callCount++;
-        // Trust dialog shows ❯ with text after it — should NOT match
-        cb(null, { stdout: ' ❯ 1. Yes, I trust this folder\n', stderr: '' });
-      } else {
-        cb(null, { stdout: '', stderr: '' });
-      }
-    }) as any);
-
-    // Should timeout because the trust dialog prompt is not the bare input prompt
-    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
-    expect(callCount).toBeGreaterThanOrEqual(1);
   });
 
   it('proceeds after timeout if Claude never shows prompt', async () => {

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -1040,16 +1040,67 @@ describe('waitForClaudeReady', () => {
     ).toBeUndefined();
   });
 
-  it('returns when pane contains > prompt', async () => {
+  it('returns when pane contains bare > prompt (no launch command visible)', async () => {
     vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
       if (args.includes('capture-pane')) {
-        cb(null, { stdout: '  >\n', stderr: '' });
+        cb(null, { stdout: 'Claude Code v2.1\n  >\n', stderr: '' });
       } else {
         cb(null, { stdout: '', stderr: '' });
       }
     }) as any);
 
     await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
+  });
+
+  it('returns when pane contains bare ❯ prompt', async () => {
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        cb(null, { stdout: 'Claude Code v2.1\n❯ \n', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
+  });
+
+  it('waits through phase 1 while launch command is visible', async () => {
+    let callCount = 0;
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        callCount++;
+        if (callCount <= 2) {
+          // Phase 1: shell still shows the launch command
+          cb(null, { stdout: '❯ claude --session-id abc-123\n', stderr: '' });
+        } else {
+          // Phase 2: Claude TUI has taken over
+          cb(null, { stdout: 'Claude Code v2.1\n❯ \n', stderr: '' });
+        }
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    await expect(waitForClaudeReady('session', 0, 5000)).resolves.not.toThrow();
+    // Should have polled multiple times (at least through phase 1 + phase 2)
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does not match trust dialog select cursor as ready', async () => {
+    let callCount = 0;
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('capture-pane')) {
+        callCount++;
+        // Trust dialog shows ❯ with text after it — should NOT match
+        cb(null, { stdout: ' ❯ 1. Yes, I trust this folder\n', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    // Should timeout because the trust dialog prompt is not the bare input prompt
+    await expect(waitForClaudeReady('session', 0, 50)).resolves.not.toThrow();
+    expect(callCount).toBeGreaterThanOrEqual(1);
   });
 
   it('proceeds after timeout if Claude never shows prompt', async () => {

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -12,8 +12,6 @@ const execFile = promisify(execFileCb);
 
 const CLAUDE_READY_TIMEOUT = process.env.NODE_ENV === 'test' ? 0 : 30_000;
 const CLAUDE_READY_POLL_INTERVAL = 500;
-const POST_READY_SETTLE_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
-const PASTE_TO_ENTER_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 150;
 
 /** Get the active window index of a tmux session. */
 async function getActiveWindowIndex(session: string): Promise<number> {
@@ -46,16 +44,8 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Poll tmux pane content until Claude Code's TUI is ready for input.
- *
- * Two-phase detection prevents false positives:
- *   Phase 1 — Wait for the pane content to show that Claude's TUI has taken
- *             over from the shell.  The shell prompt (which may itself contain
- *             `>` or `❯`) must no longer be visible.  We detect this by waiting
- *             until the pane no longer contains the `claude` launch command text.
- *   Phase 2 — Poll for Claude's `❯` (or `>`) input prompt, which appears once
- *             the Ink-based TUI has fully initialized.
- *
- * A post-ready settle delay lets Ink wire up its stdin handler before dispatch.
+ * Detects readiness by looking for the `>` input prompt character that
+ * Claude renders once its ink-based TUI has fully initialized.
  * Falls back to proceeding after timeout (best-effort).
  */
 export async function waitForClaudeReady(
@@ -66,51 +56,20 @@ export async function waitForClaudeReady(
   if (timeoutMs === 0) return; // skip in tests
   const target = `${session}:${windowIndex}`;
   const start = Date.now();
-  const elapsed = () => Date.now() - start;
-
-  // Phase 1: Wait for the shell to hand off to Claude's TUI.
-  // After `send-keys "claude ..." Enter`, the pane still shows the shell prompt
-  // and the command text.  Once Ink clears the screen, that text disappears.
-  while (elapsed() < timeoutMs) {
+  while (Date.now() - start < timeoutMs) {
     try {
       const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
-      const content = stdout.trim();
-      // Ink has taken over once the launch command is no longer visible
-      if (
-        content.length > 0 &&
-        !content.includes('claude --session-id') &&
-        !content.includes('claude --resume')
-      ) {
-        break;
+      // Claude Code renders a "❯" (or ">") prompt when ready for input
+      const lines = stdout.split('\n');
+      if (lines.some((line) => /^\s*[>❯]/.test(line))) {
+        return;
       }
     } catch {
       // pane may not exist yet — keep polling
     }
     await sleep(CLAUDE_READY_POLL_INTERVAL);
   }
-
-  // Phase 2: Poll for Claude's input prompt character.
-  while (elapsed() < timeoutMs) {
-    try {
-      const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
-      const lines = stdout.split('\n');
-      // Match the bare prompt line (e.g. "❯ " or "> ") — not a trust-dialog
-      // select cursor like "❯ 1. Yes, I trust this folder".
-      if (lines.some((line) => /^\s*[>❯]\s*$/.test(line))) {
-        // Let Ink's input handler finish wiring up before we dispatch.
-        await sleep(POST_READY_SETTLE_MS);
-        return;
-      }
-    } catch {
-      // keep polling
-    }
-    await sleep(CLAUDE_READY_POLL_INTERVAL);
-  }
-
   // Timeout — proceed anyway (best-effort)
-  console.warn(
-    `[octomux] waitForClaudeReady timed out after ${timeoutMs}ms for ${target} — proceeding best-effort`,
-  );
 }
 
 /**
@@ -232,19 +191,27 @@ export async function startTask(task: Task): Promise<void> {
       'INSERT INTO agents (id, task_id, window_index, label, claude_session_id) VALUES (?, ?, ?, ?, ?)',
     ).run(agentId, id, windowIndex, 'Agent 1', claudeSessionId);
 
-    // 9. Launch claude in the window with session tracking
+    // 9. Launch claude in the window, passing initial prompt as a CLI argument
+    //    so it is submitted at startup without needing readiness polling.
+    //    The prompt is written to a temp file to avoid shell-escaping issues.
+    let claudeCmd = `claude --session-id ${claudeSessionId}`;
+    let promptFile: string | null = null;
+    if (task.initial_prompt) {
+      promptFile = path.join(worktreePath, `.claude-prompt-${agentId}`);
+      fs.writeFileSync(promptFile, task.initial_prompt);
+      claudeCmd += ` "$(cat ${promptFile})"`;
+    }
     await execFile('tmux', [
       'send-keys',
       '-t',
       `${session}:${windowIndex}`,
-      `claude --session-id ${claudeSessionId}`,
+      claudeCmd,
       'Enter',
     ]);
-
-    // 10. Wait for Claude to be ready, then dispatch initial prompt
-    if (task.initial_prompt) {
-      await waitForClaudeReady(session, windowIndex);
-      await dispatchToWindow(session, windowIndex, task.initial_prompt);
+    // Clean up the temp prompt file after a short delay (shell has read it)
+    if (promptFile) {
+      const pf = promptFile;
+      setTimeout(() => fs.unlinkSync(pf), 5000);
     }
 
     // 12. Mark as running
@@ -281,19 +248,24 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
     'INSERT INTO agents (id, task_id, window_index, label, claude_session_id) VALUES (?, ?, ?, ?, ?)',
   ).run(agentId, task.id, windowIndex, label, claudeSessionId);
 
-  // Launch claude with session tracking
+  // Launch claude with session tracking, passing prompt as CLI argument
+  let claudeCmd = `claude --session-id ${claudeSessionId}`;
+  let promptFile: string | null = null;
+  if (prompt) {
+    promptFile = path.join(task.worktree!, `.claude-prompt-${agentId}`);
+    fs.writeFileSync(promptFile, prompt);
+    claudeCmd += ` "$(cat ${promptFile})"`;
+  }
   await execFile('tmux', [
     'send-keys',
     '-t',
     `${task.tmux_session}:${windowIndex}`,
-    `claude --session-id ${claudeSessionId}`,
+    claudeCmd,
     'Enter',
   ]);
-
-  // Dispatch prompt if provided
-  if (prompt) {
-    await waitForClaudeReady(task.tmux_session!, windowIndex);
-    await dispatchToWindow(task.tmux_session!, windowIndex, prompt);
+  if (promptFile) {
+    const pf = promptFile;
+    setTimeout(() => fs.unlinkSync(pf), 5000);
   }
 
   return {
@@ -499,9 +471,6 @@ export async function dispatchToWindow(
 
   // Paste named buffer into the target window, -d deletes buffer after paste
   await execFile('tmux', ['paste-buffer', '-b', bufferName, '-d', '-t', target]);
-
-  // Let the TUI process the pasted text before submitting
-  await sleep(PASTE_TO_ENTER_DELAY_MS);
 
   // Press Enter to submit the prompt
   await execFile('tmux', ['send-keys', '-t', target, 'Enter']);

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -1,4 +1,4 @@
-import { execFile as execFileCb, spawn } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import crypto from 'crypto';
 import path from 'path';
@@ -9,9 +9,6 @@ import { installHookSettings } from './hook-settings.js';
 import type { Task, Agent } from './types.js';
 
 const execFile = promisify(execFileCb);
-
-const CLAUDE_READY_TIMEOUT = process.env.NODE_ENV === 'test' ? 0 : 30_000;
-const CLAUDE_READY_POLL_INTERVAL = 500;
 
 /** Get the active window index of a tmux session. */
 async function getActiveWindowIndex(session: string): Promise<number> {
@@ -36,40 +33,6 @@ async function getLastWindowIndex(session: string): Promise<number> {
   ]);
   const indices = stdout.trim().split('\n').map(Number);
   return Math.max(...indices);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Poll tmux pane content until Claude Code's TUI is ready for input.
- * Detects readiness by looking for the `>` input prompt character that
- * Claude renders once its ink-based TUI has fully initialized.
- * Falls back to proceeding after timeout (best-effort).
- */
-export async function waitForClaudeReady(
-  session: string,
-  windowIndex: number,
-  timeoutMs: number = CLAUDE_READY_TIMEOUT,
-): Promise<void> {
-  if (timeoutMs === 0) return; // skip in tests
-  const target = `${session}:${windowIndex}`;
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
-      // Claude Code renders a "❯" (or ">") prompt when ready for input
-      const lines = stdout.split('\n');
-      if (lines.some((line) => /^\s*[>❯]/.test(line))) {
-        return;
-      }
-    } catch {
-      // pane may not exist yet — keep polling
-    }
-    await sleep(CLAUDE_READY_POLL_INTERVAL);
-  }
-  // Timeout — proceed anyway (best-effort)
 }
 
 /**
@@ -449,29 +412,4 @@ export async function resumeTask(task: Task): Promise<void> {
   }
 }
 
-export async function dispatchToWindow(
-  session: string,
-  windowIndex: number,
-  text: string,
-): Promise<void> {
-  const target = `${session}:${windowIndex}`;
-  const bufferName = `octomux-${nanoid(8)}`;
 
-  // Load text into a named tmux buffer (avoids race with concurrent dispatches).
-  // Do NOT append '\n' — send-keys Enter handles submission separately.
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn('tmux', ['load-buffer', '-b', bufferName, '-']);
-    proc.stdin.write(text);
-    proc.stdin.end();
-    proc.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`tmux load-buffer exited with code ${code}`));
-    });
-  });
-
-  // Paste named buffer into the target window, -d deletes buffer after paste
-  await execFile('tmux', ['paste-buffer', '-b', bufferName, '-d', '-t', target]);
-
-  // Press Enter to submit the prompt
-  await execFile('tmux', ['send-keys', '-t', target, 'Enter']);
-}

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -12,6 +12,8 @@ const execFile = promisify(execFileCb);
 
 const CLAUDE_READY_TIMEOUT = process.env.NODE_ENV === 'test' ? 0 : 30_000;
 const CLAUDE_READY_POLL_INTERVAL = 500;
+const POST_READY_SETTLE_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
+const PASTE_TO_ENTER_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 150;
 
 /** Get the active window index of a tmux session. */
 async function getActiveWindowIndex(session: string): Promise<number> {
@@ -44,8 +46,16 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Poll tmux pane content until Claude Code's TUI is ready for input.
- * Detects readiness by looking for the `>` input prompt character that
- * Claude renders once its ink-based TUI has fully initialized.
+ *
+ * Two-phase detection prevents false positives:
+ *   Phase 1 — Wait for the pane content to show that Claude's TUI has taken
+ *             over from the shell.  The shell prompt (which may itself contain
+ *             `>` or `❯`) must no longer be visible.  We detect this by waiting
+ *             until the pane no longer contains the `claude` launch command text.
+ *   Phase 2 — Poll for Claude's `❯` (or `>`) input prompt, which appears once
+ *             the Ink-based TUI has fully initialized.
+ *
+ * A post-ready settle delay lets Ink wire up its stdin handler before dispatch.
  * Falls back to proceeding after timeout (best-effort).
  */
 export async function waitForClaudeReady(
@@ -56,20 +66,51 @@ export async function waitForClaudeReady(
   if (timeoutMs === 0) return; // skip in tests
   const target = `${session}:${windowIndex}`;
   const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
+  const elapsed = () => Date.now() - start;
+
+  // Phase 1: Wait for the shell to hand off to Claude's TUI.
+  // After `send-keys "claude ..." Enter`, the pane still shows the shell prompt
+  // and the command text.  Once Ink clears the screen, that text disappears.
+  while (elapsed() < timeoutMs) {
     try {
       const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
-      // Claude Code renders a "❯" (or ">") prompt when ready for input
-      const lines = stdout.split('\n');
-      if (lines.some((line) => /^\s*[>❯]/.test(line))) {
-        return;
+      const content = stdout.trim();
+      // Ink has taken over once the launch command is no longer visible
+      if (
+        content.length > 0 &&
+        !content.includes('claude --session-id') &&
+        !content.includes('claude --resume')
+      ) {
+        break;
       }
     } catch {
       // pane may not exist yet — keep polling
     }
     await sleep(CLAUDE_READY_POLL_INTERVAL);
   }
+
+  // Phase 2: Poll for Claude's input prompt character.
+  while (elapsed() < timeoutMs) {
+    try {
+      const { stdout } = await execFile('tmux', ['capture-pane', '-t', target, '-p']);
+      const lines = stdout.split('\n');
+      // Match the bare prompt line (e.g. "❯ " or "> ") — not a trust-dialog
+      // select cursor like "❯ 1. Yes, I trust this folder".
+      if (lines.some((line) => /^\s*[>❯]\s*$/.test(line))) {
+        // Let Ink's input handler finish wiring up before we dispatch.
+        await sleep(POST_READY_SETTLE_MS);
+        return;
+      }
+    } catch {
+      // keep polling
+    }
+    await sleep(CLAUDE_READY_POLL_INTERVAL);
+  }
+
   // Timeout — proceed anyway (best-effort)
+  console.warn(
+    `[octomux] waitForClaudeReady timed out after ${timeoutMs}ms for ${target} — proceeding best-effort`,
+  );
 }
 
 /**
@@ -458,6 +499,9 @@ export async function dispatchToWindow(
 
   // Paste named buffer into the target window, -d deletes buffer after paste
   await execFile('tmux', ['paste-buffer', '-b', bufferName, '-d', '-t', target]);
+
+  // Let the TUI process the pasted text before submitting
+  await sleep(PASTE_TO_ENTER_DELAY_MS);
 
   // Press Enter to submit the prompt
   await execFile('tmux', ['send-keys', '-t', target, 'Enter']);


### PR DESCRIPTION
## What
Replace the unreliable readiness-polling + paste-buffer dispatch mechanism with passing
the initial prompt directly as a CLI argument to `claude`. Prompts are written to a temp
file and expanded via `$(cat file)` to avoid shell-escaping issues. Removes the now-unused
`waitForClaudeReady`, `dispatchToWindow`, and `sleep` helpers along with their tests.

## Why
The autosubmit flow (launching Claude then detecting readiness via tmux capture-pane
polling, then pasting the prompt via tmux buffers) had multiple race conditions:
- Shell prompt characters (`❯`, `>`) caused false-positive readiness detection
- Trust dialog `❯` cursor matched the readiness regex before input was active
- Zero delay between paste-buffer and Enter caused dropped submissions
- Timeout fallback silently dispatched to unready agents

Passing the prompt as a positional arg to `claude` eliminates the entire class of timing
bugs — Claude receives the prompt at startup with no intermediate steps.

## Testing
- All 510 tests pass (`bun run test`)
- Typecheck clean (`bun run typecheck`)
- Lint clean (only pre-existing warnings)
- Manual end-to-end verification: launched Claude in tmux with prompt via temp file +
  `$(cat ...)` expansion — prompt was received and executed immediately on startup