### PR TITLE
fix(ui): disambiguate sidebar collapse icon from back button

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -1009,4 +1009,3 @@ describe('deleteTask linked session cleanup', () => {
     expect(callOrder).toEqual([`${session}-v-xyz789`, session]);
   });
 });
-

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -164,13 +164,7 @@ export async function startTask(task: Task): Promise<void> {
       fs.writeFileSync(promptFile, task.initial_prompt);
       claudeCmd += ` "$(cat ${promptFile})"`;
     }
-    await execFile('tmux', [
-      'send-keys',
-      '-t',
-      `${session}:${windowIndex}`,
-      claudeCmd,
-      'Enter',
-    ]);
+    await execFile('tmux', ['send-keys', '-t', `${session}:${windowIndex}`, claudeCmd, 'Enter']);
     // Clean up the temp prompt file after a short delay (shell has read it)
     if (promptFile) {
       const pf = promptFile;
@@ -411,5 +405,3 @@ export async function resumeTask(task: Task): Promise<void> {
     ).run((err as Error).message, task.id);
   }
 }
-
-

--- a/src/components/TaskSidebar.tsx
+++ b/src/components/TaskSidebar.tsx
@@ -180,17 +180,31 @@ export function TaskSidebar() {
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         >
           <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            {/* Panel outline */}
+            <rect
+              x="1.5"
+              y="2.5"
+              width="13"
+              height="11"
+              rx="1.5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            {/* Sidebar divider */}
+            <path d="M5.5 2.5v11" stroke="currentColor" strokeWidth="1.5" />
             {collapsed ? (
+              /* Arrow pointing right (expand) */
               <path
-                d="M6 3l5 5-5 5"
+                d="M9 6l2 2-2 2"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
             ) : (
+              /* Arrow pointing left (collapse) */
               <path
-                d="M10 3l-5 5 5 5"
+                d="M11 6l-2 2 2 2"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"


### PR DESCRIPTION
## What
Replace the sidebar collapse/expand chevron icon with a distinct sidebar panel icon (rectangle with divider + directional arrow). The expanded state shows a left arrow (collapse), and the collapsed state shows a right arrow (expand).

## Why
Users frequently confuse the sidebar collapse button with the navigation back button in TaskDetail because both used identical left-pointing chevrons. This was the #1 UX complaint.

## Testing
- `bun run lint` — passes (0 errors)
- `bun run typecheck` — passes
- `bun run test` — all 510 tests pass
- Visual verification: icon is now a panel outline with directional arrow, clearly distinct from the back chevron