### PR TITLE
fix(ui): polish dashboard with 4 small UX improvements

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -1009,4 +1009,3 @@ describe('deleteTask linked session cleanup', () => {
     expect(callOrder).toEqual([`${session}-v-xyz789`, session]);
   });
 });
-

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -164,13 +164,7 @@ export async function startTask(task: Task): Promise<void> {
       fs.writeFileSync(promptFile, task.initial_prompt);
       claudeCmd += ` "$(cat ${promptFile})"`;
     }
-    await execFile('tmux', [
-      'send-keys',
-      '-t',
-      `${session}:${windowIndex}`,
-      claudeCmd,
-      'Enter',
-    ]);
+    await execFile('tmux', ['send-keys', '-t', `${session}:${windowIndex}`, claudeCmd, 'Enter']);
     // Clean up the temp prompt file after a short delay (shell has read it)
     if (promptFile) {
       const pf = promptFile;
@@ -411,5 +405,3 @@ export async function resumeTask(task: Task): Promise<void> {
     ).run((err as Error).message, task.id);
   }
 }
-
-

--- a/src/components/CreateTaskDialog.tsx
+++ b/src/components/CreateTaskDialog.tsx
@@ -477,13 +477,15 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
 
           {/* Initial Prompt (optional) */}
           <div className="flex flex-col gap-2">
-            <button
+            <Button
               type="button"
-              className="w-fit cursor-pointer border-0 bg-transparent p-0 text-xs text-muted-foreground outline-0 ring-0 hover:text-foreground transition-colors text-left focus:outline-0 focus:ring-0 focus-visible:outline-0 focus-visible:ring-0"
+              variant="ghost"
+              size="sm"
+              className="w-fit h-auto px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
               onClick={() => setShowPrompt(!showPrompt)}
             >
               {showPrompt ? '- Hide initial prompt' : '+ Add initial prompt'}
-            </button>
+            </Button>
             {showPrompt && (
               <Textarea
                 id="initial-prompt"

--- a/src/components/TaskFilterBar.test.tsx
+++ b/src/components/TaskFilterBar.test.tsx
@@ -45,23 +45,23 @@ describe('TaskFilterBar', () => {
 
   it('renders repo dropdown when multiple repos exist', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    const select = screen.getByRole('combobox');
-    expect(select).toBeInTheDocument();
-    expect(screen.getByText('All projects')).toBeInTheDocument();
-    expect(screen.getByText('alpha')).toBeInTheDocument();
-    expect(screen.getByText('beta')).toBeInTheDocument();
+    const trigger = screen.getByText('All projects');
+    expect(trigger).toBeInTheDocument();
   });
 
   it('hides repo dropdown when only one repo exists', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} repos={['/path/to/only-one']} />);
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText('All projects')).not.toBeInTheDocument();
   });
 
   it('calls onRepoChange when selecting a repo', async () => {
     const user = userEvent.setup();
     const onRepoChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onRepoChange={onRepoChange} />);
-    await user.selectOptions(screen.getByRole('combobox'), '/path/to/beta');
+    // Open the popover
+    await user.click(screen.getByText('All projects'));
+    // Click the repo option
+    await user.click(screen.getByText('beta'));
     expect(onRepoChange).toHaveBeenCalledWith('/path/to/beta');
   });
 });

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -1,4 +1,6 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Badge } from '@/components/ui/badge';
 import type { StatusTab } from '@/lib/use-task-filters';
 
 interface TaskFilterBarProps {
@@ -12,6 +14,82 @@ interface TaskFilterBarProps {
 
 function repoName(repoPath: string): string {
   return repoPath.split('/').pop() || repoPath;
+}
+
+function RepoFilterDropdown({
+  repos,
+  activeRepo,
+  onRepoChange,
+}: {
+  repos: string[];
+  activeRepo: string;
+  onRepoChange: (repo: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            className="mb-1 flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs transition-colors hover:bg-muted"
+          >
+            {activeRepo ? (
+              <Badge variant="outline" className="text-xs font-normal">
+                {repoName(activeRepo)}
+              </Badge>
+            ) : (
+              <span>All projects</span>
+            )}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-muted-foreground"
+            >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </button>
+        }
+      />
+      <PopoverContent align="end" side="bottom" sideOffset={4} className="w-[200px] p-0">
+        <div className="flex flex-col">
+          <button
+            type="button"
+            className={`px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted ${!activeRepo ? 'bg-muted font-medium' : ''}`}
+            onClick={() => {
+              onRepoChange('');
+              setOpen(false);
+            }}
+          >
+            All projects
+          </button>
+          {repos.map((repo) => (
+            <button
+              key={repo}
+              type="button"
+              className={`flex items-center px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted ${repo === activeRepo ? 'bg-muted font-medium' : ''}`}
+              onClick={() => {
+                onRepoChange(repo);
+                setOpen(false);
+              }}
+            >
+              <Badge variant="outline" className="text-xs font-normal">
+                {repoName(repo)}
+              </Badge>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 export const TaskFilterBar = memo(function TaskFilterBar({
@@ -46,19 +124,11 @@ export const TaskFilterBar = memo(function TaskFilterBar({
         ))}
       </div>
       {repos.length > 1 && (
-        <select
-          value={activeRepo}
-          onChange={(e) => onRepoChange(e.target.value)}
-          title={activeRepo || 'All projects'}
-          className="mb-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground"
-        >
-          <option value="">All projects</option>
-          {repos.map((repo) => (
-            <option key={repo} value={repo}>
-              {repoName(repo)}
-            </option>
-          ))}
-        </select>
+        <RepoFilterDropdown
+          repos={repos}
+          activeRepo={activeRepo}
+          onRepoChange={onRepoChange}
+        />
       )}
     </div>
   );

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -354,14 +354,6 @@ export default function TaskDetail() {
                 </Badge>
               </>
             )}
-            {task.description && (
-              <>
-                <span className="text-muted-foreground">Description</span>
-                <span className="whitespace-pre-wrap text-muted-foreground">
-                  {task.description}
-                </span>
-              </>
-            )}
             {task.pr_url && (
               <>
                 <span className="text-muted-foreground">PR</span>
@@ -422,15 +414,45 @@ export default function TaskDetail() {
         <div
           className={
             mode === 'agents'
-              ? 'flex flex-1 items-center justify-center text-muted-foreground'
+              ? 'flex flex-1 flex-col items-center justify-center gap-3 text-muted-foreground'
               : 'hidden'
           }
         >
-          {task.status === 'setting_up'
-            ? 'Setting up terminal...'
-            : task.status === 'closed' || task.status === 'error'
-              ? 'Terminal session ended'
-              : 'No terminal available'}
+          {task.status === 'setting_up' ? (
+            'Setting up terminal...'
+          ) : task.status === 'closed' || task.status === 'error' ? (
+            <>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-muted-foreground/50"
+              >
+                <rect width="18" height="18" x="3" y="3" rx="2" />
+                <path d="m7 8 4 4-4 4" />
+                <path d="M13 16h4" />
+              </svg>
+              <span className="text-sm">Terminal session ended</span>
+              {canResume && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={resuming}
+                  onClick={handleResume}
+                >
+                  {resuming ? 'Resuming...' : 'Resume Task'}
+                </Button>
+              )}
+            </>
+          ) : (
+            'No terminal available'
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## What
- Improved empty state for closed/error tasks with a terminal icon, styled message, and inline Resume button
- Replaced native `<select>` for repo filter with a custom Popover dropdown using Badge-styled repo names
- Removed duplicate description row from TaskDetail metadata panel (already shown in header)
- Styled the "Add initial prompt" toggle as a ghost Button with proper hover/focus affordance

## Why
These are quick wins that collectively make the dashboard feel more polished. Each is a minor friction point that compounds over daily use.

## Testing
- `bun run lint` — 0 errors (only pre-existing warnings)
- `bun run typecheck` — passes cleanly
- All 510 tests pass