### PR TITLE
fix(ui): move orchestrator toggle from hidden edge button to header toolbar

### DIFF
--- a/src/components/OrchestratorPanel.tsx
+++ b/src/components/OrchestratorPanel.tsx
@@ -21,35 +21,63 @@ function useIsMobile() {
   return isMobile;
 }
 
-export function OrchestratorPanel() {
+export function useOrchestratorPanel() {
   const [isOpen, setIsOpen] = useState(() => localStorage.getItem(STORAGE_KEY) === 'true');
-  const { running, loading, start, stop } = useOrchestrator();
-  const isMobile = useIsMobile();
+  const orchestrator = useOrchestrator();
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, String(isOpen));
   }, [isOpen]);
 
-  const closePanel = useCallback(() => setIsOpen(false), []);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
 
-  if (!isOpen) {
-    return (
-      <button
-        onClick={() => setIsOpen(true)}
-        className={`hidden md:block fixed right-0 top-1/2 -translate-y-1/2 z-50 rounded-l-md border-2 border-r-0 px-1.5 py-3 text-xs font-medium transition-colors ${
-          running
-            ? 'border-emerald-500/50 bg-card/90 text-foreground shadow-[0_0_8px_rgba(16,185,129,0.2)]'
-            : 'border-border bg-card/80 text-muted-foreground hover:bg-muted hover:text-foreground'
-        }`}
-        style={{ writingMode: 'vertical-rl' }}
-      >
-        Orchestrator
-        {running && (
-          <span className="ml-1 inline-block h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
-        )}
-      </button>
-    );
-  }
+  return { isOpen, open, close, toggle, ...orchestrator };
+}
+
+export type OrchestratorPanelState = ReturnType<typeof useOrchestratorPanel>;
+
+/** Header toggle button — renders in the Dashboard toolbar */
+export function OrchestratorToggle({
+  isOpen,
+  running,
+  toggle,
+}: {
+  isOpen: boolean;
+  running: boolean;
+  toggle: () => void;
+}) {
+  return (
+    <Button
+      variant={isOpen ? 'secondary' : 'ghost'}
+      size="sm"
+      onClick={toggle}
+      title="Toggle orchestrator panel"
+      className="relative gap-1.5 hidden md:inline-flex"
+    >
+      <TerminalIcon className="h-4 w-4" />
+      <span className="text-xs">Orchestrator</span>
+      {running && (
+        <span className="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500" />
+        </span>
+      )}
+    </Button>
+  );
+}
+
+/** Side panel — only renders content when open */
+export function OrchestratorPanel({
+  state,
+}: {
+  state: OrchestratorPanelState;
+}) {
+  const { isOpen, close, running, loading, start, stop } = state;
+  const isMobile = useIsMobile();
+
+  if (!isOpen) return null;
 
   const panelContent = (
     <>
@@ -68,7 +96,7 @@ export function OrchestratorPanel() {
             </Button>
           )}
           <button
-            onClick={closePanel}
+            onClick={close}
             className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             <svg
@@ -119,7 +147,7 @@ export function OrchestratorPanel() {
     return (
       <>
         {/* Backdrop */}
-        <div className="fixed inset-0 z-40 bg-black/50" onClick={closePanel} />
+        <div className="fixed inset-0 z-40 bg-black/50" onClick={close} />
         {/* Slide-out panel */}
         <div className="fixed inset-y-0 right-0 z-50 w-full bg-card flex flex-col animate-in slide-in-from-right duration-200">
           {panelContent}
@@ -133,5 +161,23 @@ export function OrchestratorPanel() {
     <div className="w-[500px] max-[1279px]:w-[400px] max-[1023px]:w-[350px] shrink-0 border-l border-border bg-card flex flex-col">
       {panelContent}
     </div>
+  );
+}
+
+function TerminalIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" x2="20" y1="19" y2="19" />
+    </svg>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,13 +5,18 @@ import { TaskList } from '@/components/TaskList';
 import { TaskFilterBar } from '@/components/TaskFilterBar';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
 import { NotificationToggle } from '@/components/NotificationToggle';
-import { OrchestratorPanel } from '@/components/OrchestratorPanel';
+import {
+  OrchestratorPanel,
+  OrchestratorToggle,
+  useOrchestratorPanel,
+} from '@/components/OrchestratorPanel';
 import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api';
 
 export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
+  const orchestrator = useOrchestratorPanel();
 
   const handleClose = useCallback(
     async (id: string) => {
@@ -65,6 +70,11 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="flex items-center gap-2">
+              <OrchestratorToggle
+                isOpen={orchestrator.isOpen}
+                running={orchestrator.running}
+                toggle={orchestrator.toggle}
+              />
               <NotificationToggle />
               <CreateTaskDialog onCreated={refresh} />
             </div>
@@ -122,7 +132,7 @@ export default function Dashboard() {
           )}
         </div>
       </div>
-      <OrchestratorPanel />
+      <OrchestratorPanel state={orchestrator} />
     </div>
   );
 }


### PR DESCRIPTION
## What
- Replace the rotated vertical "Orchestrator" text button on the right screen edge with a standard toolbar button in the Dashboard header
- New toggle sits next to the notification bell and New Task button with a terminal icon + label
- Active orchestrator sessions show a pinging green dot on the button corner
- Button variant switches to `secondary` when panel is open for clear visual state
- Extracted `useOrchestratorPanel()` hook to lift state to Dashboard, avoiding duplicate `useOrchestrator()` calls

## Why
The orchestrator is a key feature but the rotated edge button was nearly invisible — most users didn't notice it. Moving it to the header toolbar makes it immediately discoverable alongside other primary actions.

## Testing
- `bun run typecheck` — passes
- `bun run lint` — no new warnings
- `bun run test` — all 510 tests pass
- Manual verification: dev server confirmed button renders in header with activity indicator