### PR TITLE
feat(ui): add tab title and favicon attention indicators

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Component, lazy, type ReactNode } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { useTasks } from './lib/hooks';
+import { useAttentionIndicator } from './lib/use-attention-indicator';
 import { useNotifications } from './lib/use-notifications';
 import Dashboard from './pages/Dashboard';
 import TaskDetailLayout from './components/TaskDetailLayout';
@@ -12,6 +13,7 @@ const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 function GlobalNotifications() {
   const { tasks } = useTasks();
   const navigate = useNavigate();
+  useAttentionIndicator(tasks);
   useNotifications(tasks, navigate);
   return null;
 }

--- a/src/lib/use-attention-indicator.test.tsx
+++ b/src/lib/use-attention-indicator.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { makeTask } from '../test-helpers';
+import { useAttentionIndicator } from './use-attention-indicator';
+
+describe('useAttentionIndicator', () => {
+  beforeEach(() => {
+    document.title = 'octomux';
+  });
+
+  it.each([
+    {
+      name: 'no attention tasks → plain title',
+      tasks: [makeTask({ status: 'running', derived_status: 'working' })],
+      expected: 'octomux',
+    },
+    {
+      name: 'one needs_attention → (1) octomux',
+      tasks: [makeTask({ status: 'running', derived_status: 'needs_attention' })],
+      expected: '(1) octomux',
+    },
+    {
+      name: 'one error → (1) octomux',
+      tasks: [makeTask({ status: 'error' })],
+      expected: '(1) octomux',
+    },
+    {
+      name: 'mixed attention and normal → counts only attention',
+      tasks: [
+        makeTask({ id: '1', status: 'running', derived_status: 'needs_attention' }),
+        makeTask({ id: '2', status: 'error' }),
+        makeTask({ id: '3', status: 'running', derived_status: 'working' }),
+        makeTask({ id: '4', status: 'closed' }),
+      ],
+      expected: '(2) octomux',
+    },
+    {
+      name: 'empty tasks → plain title',
+      tasks: [],
+      expected: 'octomux',
+    },
+  ])('$name', ({ tasks, expected }) => {
+    renderHook(() => useAttentionIndicator(tasks));
+    expect(document.title).toBe(expected);
+  });
+
+  it('resets title on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useAttentionIndicator([makeTask({ status: 'error' })]),
+    );
+    expect(document.title).toBe('(1) octomux');
+    unmount();
+    expect(document.title).toBe('octomux');
+  });
+
+  it('updates when tasks change', () => {
+    const { rerender } = renderHook(({ tasks }) => useAttentionIndicator(tasks), {
+      initialProps: { tasks: [makeTask({ status: 'error' })] },
+    });
+    expect(document.title).toBe('(1) octomux');
+
+    rerender({ tasks: [makeTask({ status: 'running', derived_status: 'working' })] });
+    expect(document.title).toBe('octomux');
+  });
+});

--- a/src/lib/use-attention-indicator.ts
+++ b/src/lib/use-attention-indicator.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from 'react';
+import type { Task } from '../../server/types';
+
+const NORMAL_TITLE = 'octomux';
+const NORMAL_FAVICON = '/logo.png';
+
+function countAttention(tasks: Task[]): number {
+  return tasks.filter((t) => {
+    const effective = t.derived_status ?? t.status;
+    return effective === 'error' || effective === 'needs_attention';
+  }).length;
+}
+
+/** Canvas-generate a 32x32 favicon with a red notification dot in the top-right corner. */
+function createAlertFavicon(logo: HTMLImageElement): string {
+  const size = 32;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(logo, 0, 0, size, size);
+
+  // Red dot — top-right
+  const dotRadius = 7;
+  const cx = size - dotRadius - 1;
+  const cy = dotRadius + 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, dotRadius, 0, 2 * Math.PI);
+  ctx.fillStyle = '#ef4444';
+  ctx.fill();
+  ctx.strokeStyle = '#1a1a2e';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  return canvas.toDataURL('image/png');
+}
+
+function setFavicon(href: string) {
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  if (link.href !== href) {
+    link.href = href;
+  }
+}
+
+/**
+ * Updates the browser tab title and favicon based on how many tasks need attention.
+ * Call once at the app root with the full task list.
+ */
+export function useAttentionIndicator(tasks: Task[]) {
+  const alertFaviconRef = useRef<string | null>(null);
+
+  // Pre-render the alert favicon once
+  useEffect(() => {
+    const img = new Image();
+    img.onload = () => {
+      alertFaviconRef.current = createAlertFavicon(img);
+    };
+    img.src = NORMAL_FAVICON;
+  }, []);
+
+  useEffect(() => {
+    const count = countAttention(tasks);
+
+    // Update title
+    document.title = count > 0 ? `(${count}) ${NORMAL_TITLE}` : NORMAL_TITLE;
+
+    // Update favicon
+    if (count > 0 && alertFaviconRef.current) {
+      setFavicon(alertFaviconRef.current);
+    } else {
+      setFavicon(NORMAL_FAVICON);
+    }
+  }, [tasks]);
+
+  // Reset on unmount
+  useEffect(() => {
+    return () => {
+      document.title = NORMAL_TITLE;
+      setFavicon(NORMAL_FAVICON);
+    };
+  }, []);
+}


### PR DESCRIPTION
## What
- New `useAttentionIndicator` hook that updates the browser tab title with an attention count (`(2) octomux`) and swaps the favicon to a canvas-generated red-dot variant when tasks need attention
- Wired into the app root via `GlobalNotifications` so it updates in real-time on every page
- Includes 7 table-driven tests covering all states

## Why
Users often have the octomux dashboard in a background tab with no way to know when agents hit permission prompts or tasks error out. This adds the same kind of visual cue that Slack, Gmail, and GitHub use.

## Testing
- `bun run test -- --run src/lib/use-attention-indicator.test.tsx` — 7/7 pass
- `bun run lint` — no new errors/warnings
- `bun run typecheck` — passes clean
- Full test suite: 510/510 pass