### PR TITLE
feat(ui): increase dashboard density with table view toggle

### DIFF
--- a/src/components/TaskCard.test.tsx
+++ b/src/components/TaskCard.test.tsx
@@ -37,7 +37,7 @@ describe('TaskCard', () => {
   it('shows PR link when pr_url is set', () => {
     const task = makeTask({ pr_url: 'https://github.com/org/repo/pull/42', pr_number: 42 });
     renderWithRouter(<TaskCard task={task} onClose={onClose} onDelete={onDelete} />);
-    const link = screen.getByText('PR #42');
+    const link = screen.getByRole('link', { name: /PR #\s*42/ });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
     expect(link).toHaveAttribute('target', '_blank');

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -45,21 +45,21 @@ export const TaskCard = memo(function TaskCard({
       className="cursor-pointer transition-colors hover:bg-accent/50"
       onClick={() => navigate(`/tasks/${task.id}`)}
     >
-      <CardHeader className="pb-2">
+      <CardHeader className="px-4 py-3 pb-2">
         <div className="flex items-start justify-between gap-3">
           <CardTitle className="min-w-0 text-base leading-snug line-clamp-2">
             {task.title}
           </CardTitle>
           <div className="flex shrink-0 items-center gap-2">
             <StatusBadge status={task.derived_status || task.status} />
-            <span className="text-xs whitespace-nowrap text-muted-foreground">
+            <span className="text-xs tabular-nums whitespace-nowrap text-muted-foreground">
               {timeAgo(task.created_at)}
             </span>
           </div>
         </div>
         <CardDescription className="line-clamp-1">{task.description}</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-4 pb-3 pt-0">
         <div className="flex items-center justify-between text-sm">
           <div className="flex items-center gap-2 text-muted-foreground">
             <Badge variant="outline" className="text-xs font-normal">
@@ -76,7 +76,7 @@ export const TaskCard = memo(function TaskCard({
                 className="text-xs text-blue-400 hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
-                PR #{task.pr_number}
+                PR #<span className="tabular-nums">{task.pr_number}</span>
               </a>
             )}
             {task.error && (

--- a/src/components/TaskFilterBar.test.tsx
+++ b/src/components/TaskFilterBar.test.tsx
@@ -11,19 +11,24 @@ const defaultProps = {
   repos: ['/path/to/alpha', '/path/to/beta'],
   activeRepo: '',
   onRepoChange: () => {},
+  viewMode: 'cards' as const,
+  onViewChange: () => {},
 };
 
 describe('TaskFilterBar', () => {
   it('renders Open, Backlog, and Closed tabs with counts', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    expect(screen.getByText('Open (3)')).toBeInTheDocument();
-    expect(screen.getByText('Backlog (2)')).toBeInTheDocument();
-    expect(screen.getByText('Closed (1)')).toBeInTheDocument();
+    expect(screen.getByText(/^Open/)).toBeInTheDocument();
+    expect(screen.getByText('(3)')).toBeInTheDocument();
+    expect(screen.getByText(/^Backlog/)).toBeInTheDocument();
+    expect(screen.getByText('(2)')).toBeInTheDocument();
+    expect(screen.getByText(/^Closed/)).toBeInTheDocument();
+    expect(screen.getByText('(1)')).toBeInTheDocument();
   });
 
   it('highlights active tab', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    const openBtn = screen.getByText('Open (3)');
+    const openBtn = screen.getByText(/^Open/).closest('button')!;
     expect(openBtn.className).toContain('border-b-2');
   });
 
@@ -31,7 +36,7 @@ describe('TaskFilterBar', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onStatusChange={onChange} />);
-    await user.click(screen.getByText('Closed (1)'));
+    await user.click(screen.getByText(/^Closed/).closest('button')!);
     expect(onChange).toHaveBeenCalledWith('closed');
   });
 
@@ -39,7 +44,7 @@ describe('TaskFilterBar', () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onStatusChange={onChange} />);
-    await user.click(screen.getByText('Backlog (2)'));
+    await user.click(screen.getByText(/^Backlog/).closest('button')!);
     expect(onChange).toHaveBeenCalledWith('backlog');
   });
 

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -2,6 +2,7 @@ import { memo, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Badge } from '@/components/ui/badge';
 import type { StatusTab } from '@/lib/use-task-filters';
+import type { ViewMode } from './TaskList';
 
 interface TaskFilterBarProps {
   activeStatus: StatusTab;
@@ -10,6 +11,8 @@ interface TaskFilterBarProps {
   repos: string[];
   activeRepo: string;
   onRepoChange: (repo: string) => void;
+  viewMode: ViewMode;
+  onViewChange: (mode: ViewMode) => void;
 }
 
 function repoName(repoPath: string): string {
@@ -92,6 +95,64 @@ function RepoFilterDropdown({
   );
 }
 
+function ViewToggle({
+  viewMode,
+  onViewChange,
+}: {
+  viewMode: ViewMode;
+  onViewChange: (mode: ViewMode) => void;
+}) {
+  return (
+    <div className="mb-1 flex items-center rounded-md border border-border">
+      <button
+        type="button"
+        title="Card view"
+        className={`rounded-l-md px-1.5 py-1 transition-colors ${viewMode === 'cards' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+        onClick={() => onViewChange('cards')}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="3" width="7" height="7" />
+          <rect x="14" y="3" width="7" height="7" />
+          <rect x="3" y="14" width="7" height="7" />
+          <rect x="14" y="14" width="7" height="7" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        title="List view"
+        className={`rounded-r-md px-1.5 py-1 transition-colors ${viewMode === 'table' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+        onClick={() => onViewChange('table')}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
 export const TaskFilterBar = memo(function TaskFilterBar({
   activeStatus,
   counts,
@@ -99,15 +160,17 @@ export const TaskFilterBar = memo(function TaskFilterBar({
   repos,
   activeRepo,
   onRepoChange,
+  viewMode,
+  onViewChange,
 }: TaskFilterBarProps) {
   const tabs = [
-    { key: 'open' as const, label: `Open (${counts.open})` },
-    { key: 'backlog' as const, label: `Backlog (${counts.backlog})` },
-    { key: 'closed' as const, label: `Closed (${counts.closed})` },
+    { key: 'open' as const, label: 'Open', count: counts.open },
+    { key: 'backlog' as const, label: 'Backlog', count: counts.backlog },
+    { key: 'closed' as const, label: 'Closed', count: counts.closed },
   ];
 
   return (
-    <div className="mb-4 flex items-center justify-between border-b border-border">
+    <div className="mb-3 flex items-center justify-between border-b border-border">
       <div className="flex gap-1">
         {tabs.map((tab) => (
           <button
@@ -119,13 +182,17 @@ export const TaskFilterBar = memo(function TaskFilterBar({
             }`}
             onClick={() => onStatusChange(tab.key)}
           >
-            {tab.label}
+            {tab.label}{' '}
+            <span className="tabular-nums text-xs">({tab.count})</span>
           </button>
         ))}
       </div>
-      {repos.length > 1 && (
-        <RepoFilterDropdown repos={repos} activeRepo={activeRepo} onRepoChange={onRepoChange} />
-      )}
+      <div className="flex items-center gap-2">
+        {repos.length > 1 && (
+          <RepoFilterDropdown repos={repos} activeRepo={activeRepo} onRepoChange={onRepoChange} />
+        )}
+        <ViewToggle viewMode={viewMode} onViewChange={onViewChange} />
+      </div>
     </div>
   );
 });

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -15,7 +15,7 @@ describe('TaskList', () => {
   // ─── Empty state ──────────────────────────────────────────────────────────
 
   it('shows empty state when no tasks', () => {
-    renderWithRouter(<TaskList tasks={[]} onClose={onClose} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
     expect(screen.getByText('No tasks yet')).toBeInTheDocument();
     expect(screen.getByText('Create a task to get started')).toBeInTheDocument();
   });
@@ -23,7 +23,7 @@ describe('TaskList', () => {
   // ─── Rendering tasks ─────────────────────────────────────────────────────
 
   it('renders one task card', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
     expect(screen.getByText('Fix order validation')).toBeInTheDocument();
   });
 
@@ -33,14 +33,14 @@ describe('TaskList', () => {
       makeTask({ id: 't2', title: 'Task Two' }),
       makeTask({ id: 't3', title: 'Task Three' }),
     ];
-    renderWithRouter(<TaskList tasks={tasks} onClose={onClose} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={tasks} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
     expect(screen.getByText('Task One')).toBeInTheDocument();
     expect(screen.getByText('Task Two')).toBeInTheDocument();
     expect(screen.getByText('Task Three')).toBeInTheDocument();
   });
 
   it('does not show empty state when tasks exist', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} />);
+    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
     expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,25 +1,232 @@
+import { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Task } from '../../server/types';
 import { TaskCard } from './TaskCard';
+import { StatusBadge } from './StatusBadge';
+import { AgentActivityDot } from './AgentActivityDot';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+export type ViewMode = 'cards' | 'table';
 
 interface TaskListProps {
   tasks: Task[];
   onClose: (id: string) => void;
   onDelete: (id: string) => void;
   onResume?: (id: string) => void;
+  viewMode: ViewMode;
 }
 
-export function TaskList({ tasks, onClose, onDelete, onResume }: TaskListProps) {
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr + 'Z').getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function repoName(repoPath: string): string {
+  return repoPath.split('/').pop() || repoPath;
+}
+
+const TaskTableRow = memo(function TaskTableRow({
+  task,
+  onClose,
+  onDelete,
+  onResume,
+}: {
+  task: Task;
+  onClose: (id: string) => void;
+  onDelete: (id: string) => void;
+  onResume?: (id: string) => void;
+}) {
+  const navigate = useNavigate();
+  const canResume = (task.status === 'closed' || task.status === 'error') && !!task.worktree;
+  const isActive = task.status === 'running' || task.status === 'setting_up';
+  const activeAgents = task.agents?.filter((a) => a.status !== 'stopped') ?? [];
+
+  return (
+    <tr
+      className="cursor-pointer border-b border-border transition-colors last:border-b-0 hover:bg-accent/50"
+      onClick={() => navigate(`/tasks/${task.id}`)}
+    >
+      <td className="py-2 pr-3 pl-3">
+        <StatusBadge status={task.derived_status || task.status} />
+      </td>
+      <td className="py-2 pr-3">
+        <div className="min-w-0">
+          <span className="block truncate text-sm font-medium">{task.title}</span>
+          {task.description && (
+            <span className="block truncate text-xs text-muted-foreground">
+              {task.description}
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="py-2 pr-3">
+        <Badge variant="outline" className="text-xs font-normal">
+          {repoName(task.repo_path)}
+        </Badge>
+      </td>
+      <td className="py-2 pr-3">
+        {activeAgents.length > 0 && task.status === 'running' ? (
+          <div className="flex items-center gap-2">
+            {activeAgents.map((a) => (
+              <span key={a.id} className="inline-flex items-center gap-1">
+                <AgentActivityDot activity={a.hook_activity} />
+                <span className="text-xs text-zinc-500">{a.label}</span>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="tabular-nums text-xs text-muted-foreground">
+            {activeAgents.length > 0 ? `${activeAgents.length} agent${activeAgents.length > 1 ? 's' : ''}` : '—'}
+          </span>
+        )}
+      </td>
+      <td className="tabular-nums py-2 pr-3 text-xs text-muted-foreground whitespace-nowrap">
+        {timeAgo(task.created_at)}
+      </td>
+      <td className="py-2 pr-3">
+        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          {task.pr_url && (
+            <a
+              href={task.pr_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-blue-400 hover:underline"
+            >
+              PR #<span className="tabular-nums">{task.pr_number}</span>
+            </a>
+          )}
+          {canResume && onResume && (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground hover:text-green-400"
+              title="Resume agents"
+              onClick={() => onResume(task.id)}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                stroke="none"
+              >
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+            </Button>
+          )}
+          {isActive ? (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground hover:text-yellow-500"
+              title="Close task"
+              onClick={() => onClose(task.id)}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="6" y="4" width="4" height="16" />
+                <rect x="14" y="4" width="4" height="16" />
+              </svg>
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="text-muted-foreground hover:text-destructive"
+              title="Delete task"
+              onClick={() => onDelete(task.id)}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M3 6h18" />
+                <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+              </svg>
+            </Button>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+});
+
+function TaskTableView({
+  tasks,
+  onClose,
+  onDelete,
+  onResume,
+}: Omit<TaskListProps, 'viewMode'>) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-left">
+        <thead>
+          <tr className="border-b border-border bg-muted/50 text-xs text-muted-foreground">
+            <th className="py-2 pr-3 pl-3 font-medium">Status</th>
+            <th className="py-2 pr-3 font-medium">Task</th>
+            <th className="py-2 pr-3 font-medium">Project</th>
+            <th className="py-2 pr-3 font-medium">Agents</th>
+            <th className="py-2 pr-3 font-medium">Created</th>
+            <th className="py-2 pr-3 font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((task) => (
+            <TaskTableRow
+              key={task.id}
+              task={task}
+              onClose={onClose}
+              onDelete={onDelete}
+              onResume={onResume}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function TaskList({ tasks, onClose, onDelete, onResume, viewMode }: TaskListProps) {
   if (tasks.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
         <p className="text-lg">No tasks yet</p>
         <p className="text-sm">Create a task to get started</p>
       </div>
     );
   }
 
+  if (viewMode === 'table') {
+    return <TaskTableView tasks={tasks} onClose={onClose} onDelete={onDelete} onResume={onResume} />;
+  }
+
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-2">
       {tasks.map((task) => (
         <TaskCard
           key={task.id}

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -123,11 +123,11 @@ describe('Dashboard', () => {
     renderWithRouter(<Dashboard />);
     // Default filter is 'open', so draft should NOT appear
     await waitFor(() => {
-      expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
+      expect(screen.getByText(/^Backlog/)).toBeInTheDocument();
     });
     expect(screen.queryByText('Draft Task')).not.toBeInTheDocument();
     // Switch to backlog tab
-    await user.click(screen.getByText('Backlog (1)'));
+    await user.click(screen.getByText(/^Backlog/));
     await waitFor(() => {
       expect(screen.getByText('Draft Task')).toBeInTheDocument();
     });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useTasks } from '@/lib/hooks';
 import { useTaskFilters } from '@/lib/use-task-filters';
+import type { ViewMode } from '@/components/TaskList';
 import { TaskList } from '@/components/TaskList';
 import { TaskFilterBar } from '@/components/TaskFilterBar';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
@@ -17,6 +18,9 @@ export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
   const orchestrator = useOrchestratorPanel();
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    () => (localStorage.getItem('octomux-view-mode') as ViewMode) || 'cards',
+  );
 
   const handleClose = useCallback(
     async (id: string) => {
@@ -42,6 +46,11 @@ export default function Dashboard() {
     [refresh],
   );
 
+  const handleViewChange = useCallback((mode: ViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem('octomux-view-mode', mode);
+  }, []);
+
   const handleResume = useCallback(
     async (id: string) => {
       try {
@@ -57,7 +66,7 @@ export default function Dashboard() {
   return (
     <div className="flex h-screen">
       <div className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-3xl px-4 py-8">
+        <div className="mx-auto max-w-6xl px-4 py-4">
           <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="flex items-center gap-2.5">
@@ -121,12 +130,15 @@ export default function Dashboard() {
                 repos={repos}
                 activeRepo={filters.repo}
                 onRepoChange={(r) => setFilter('repo', r)}
+                viewMode={viewMode}
+                onViewChange={handleViewChange}
               />
               <TaskList
                 tasks={filtered}
                 onClose={handleClose}
                 onDelete={handleDelete}
                 onResume={handleResume}
+                viewMode={viewMode}
               />
             </>
           )}


### PR DESCRIPTION
## What
- Widen main content from `max-w-3xl` to `max-w-6xl` and reduce outer padding (`py-8` → `py-4`)
- Compact task card internal padding and reduce card list gap
- Add `tabular-nums` to all timestamps, counts, and PR numbers for stable alignment
- Add cards/table view toggle in the filter bar with localStorage persistence
- New compact table view with status, title, project, agents, time, and action columns

## Why
The dashboard wasted screen real estate with narrow centering and generous padding. Users with 10+ tasks need to see more at a glance. The table view provides a denser alternative for power users, similar to Linear/Grafana.

## Testing
- `bun run typecheck` — clean
- `bun run lint` — clean (no new warnings)
- `bun run test` — all 517 tests pass
- Manual verification of both card and table views in dev