### PR TITLE
feat(ui): add polished empty states across dashboard

### DIFF
--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -1,0 +1,41 @@
+// src/components/EmptyState.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  const icon = <svg data-testid="empty-icon" />;
+
+  it('renders heading and icon', () => {
+    render(<EmptyState icon={icon} heading="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+  });
+
+  it('renders optional subtext', () => {
+    render(<EmptyState icon={icon} heading="Empty" subtext="Try something" />);
+    expect(screen.getByText('Try something')).toBeInTheDocument();
+  });
+
+  it('does not render subtext when omitted', () => {
+    render(<EmptyState icon={icon} heading="Empty" />);
+    expect(screen.queryByText('Try something')).not.toBeInTheDocument();
+  });
+
+  it('renders optional action', () => {
+    render(<EmptyState icon={icon} heading="Empty" action={<button>Do it</button>} />);
+    expect(screen.getByRole('button', { name: 'Do it' })).toBeInTheDocument();
+  });
+
+  it('does not render action when omitted', () => {
+    render(<EmptyState icon={icon} heading="Empty" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <EmptyState icon={icon} heading="Empty" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,23 @@
+// src/components/EmptyState.tsx
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  icon: ReactNode;
+  heading: string;
+  subtext?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({ icon, heading, subtext, action, className = '' }: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-16 animate-in fade-in duration-300 ${className}`}
+    >
+      <div className="text-muted-foreground/40">{icon}</div>
+      <h3 className="mt-4 text-lg font-medium">{heading}</h3>
+      {subtext && <p className="mt-1 text-sm text-muted-foreground">{subtext}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/src/components/OrchestratorPanel.tsx
+++ b/src/components/OrchestratorPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { useOrchestrator } from '@/lib/hooks';
+import { EmptyState } from './EmptyState';
 
 const TerminalView = lazy(() =>
   import('@/components/TerminalView').then((m) => ({ default: m.TerminalView })),
@@ -119,10 +120,28 @@ export function OrchestratorPanel({ state }: { state: OrchestratorPanelState }) 
             Loading...
           </div>
         ) : !running ? (
-          <div className="flex flex-col items-center justify-center h-full gap-3">
-            <p className="text-sm text-muted-foreground">Orchestrator is not running</p>
-            <Button onClick={start}>Start Orchestrator</Button>
-          </div>
+          <EmptyState
+            icon={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="4 17 10 11 4 5" />
+                <line x1="12" x2="20" y1="19" y2="19" />
+              </svg>
+            }
+            heading="Orchestrator not running"
+            subtext="Start the orchestrator to manage task queues"
+            action={<Button onClick={start}>Start Orchestrator</Button>}
+            className="h-full"
+          />
         ) : (
           <Suspense
             fallback={

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -182,8 +182,7 @@ export const TaskFilterBar = memo(function TaskFilterBar({
             }`}
             onClick={() => onStatusChange(tab.key)}
           >
-            {tab.label}{' '}
-            <span className="tabular-nums text-xs">({tab.count})</span>
+            {tab.label} <span className="tabular-nums text-xs">({tab.count})</span>
           </button>
         ))}
       </div>

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -14,10 +14,48 @@ describe('TaskList', () => {
 
   // ─── Empty state ──────────────────────────────────────────────────────────
 
-  it('shows empty state when no tasks', () => {
-    renderWithRouter(<TaskList tasks={[]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
+  it('shows "no tasks" empty state when totalCount is 0', () => {
+    renderWithRouter(
+      <TaskList tasks={[]} totalCount={0} onClose={onClose} onDelete={onDelete} viewMode="cards" />,
+    );
     expect(screen.getByText('No tasks yet')).toBeInTheDocument();
-    expect(screen.getByText('Create a task to get started')).toBeInTheDocument();
+    expect(screen.getByText('Create your first task to start running agents')).toBeInTheDocument();
+  });
+
+  it('shows "no matching" empty state when totalCount > 0 but filtered to zero', () => {
+    renderWithRouter(
+      <TaskList tasks={[]} totalCount={5} onClose={onClose} onDelete={onDelete} viewMode="cards" />,
+    );
+    expect(screen.getByText('No matching tasks')).toBeInTheDocument();
+    expect(screen.getByText('Try adjusting your filters or status tab')).toBeInTheDocument();
+  });
+
+  it('renders emptyAction in no-tasks state', () => {
+    renderWithRouter(
+      <TaskList
+        tasks={[]}
+        totalCount={0}
+        emptyAction={<button>Create Task</button>}
+        onClose={onClose}
+        onDelete={onDelete}
+        viewMode="cards"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Create Task' })).toBeInTheDocument();
+  });
+
+  it('does not render emptyAction in filtered state', () => {
+    renderWithRouter(
+      <TaskList
+        tasks={[]}
+        totalCount={5}
+        emptyAction={<button>Create Task</button>}
+        onClose={onClose}
+        onDelete={onDelete}
+        viewMode="cards"
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Create Task' })).not.toBeInTheDocument();
   });
 
   // ─── Rendering tasks ─────────────────────────────────────────────────────

--- a/src/components/TaskList.test.tsx
+++ b/src/components/TaskList.test.tsx
@@ -61,7 +61,9 @@ describe('TaskList', () => {
   // ─── Rendering tasks ─────────────────────────────────────────────────────
 
   it('renders one task card', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
+    renderWithRouter(
+      <TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />,
+    );
     expect(screen.getByText('Fix order validation')).toBeInTheDocument();
   });
 
@@ -71,14 +73,18 @@ describe('TaskList', () => {
       makeTask({ id: 't2', title: 'Task Two' }),
       makeTask({ id: 't3', title: 'Task Three' }),
     ];
-    renderWithRouter(<TaskList tasks={tasks} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
+    renderWithRouter(
+      <TaskList tasks={tasks} onClose={onClose} onDelete={onDelete} viewMode="cards" />,
+    );
     expect(screen.getByText('Task One')).toBeInTheDocument();
     expect(screen.getByText('Task Two')).toBeInTheDocument();
     expect(screen.getByText('Task Three')).toBeInTheDocument();
   });
 
   it('does not show empty state when tasks exist', () => {
-    renderWithRouter(<TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />);
+    renderWithRouter(
+      <TaskList tasks={[makeTask()]} onClose={onClose} onDelete={onDelete} viewMode="cards" />,
+    );
     expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument();
   });
 });

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from './StatusBadge';
 import { AgentActivityDot } from './AgentActivityDot';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { EmptyState } from './EmptyState';
 
 export type ViewMode = 'cards' | 'table';
 
@@ -15,6 +16,8 @@ interface TaskListProps {
   onDelete: (id: string) => void;
   onResume?: (id: string) => void;
   viewMode: ViewMode;
+  totalCount?: number;
+  emptyAction?: React.ReactNode;
 }
 
 function timeAgo(dateStr: string): string {
@@ -211,13 +214,34 @@ function TaskTableView({
   );
 }
 
-export function TaskList({ tasks, onClose, onDelete, onResume, viewMode }: TaskListProps) {
+export function TaskList({ tasks, onClose, onDelete, onResume, viewMode, totalCount = 0, emptyAction }: TaskListProps) {
   if (tasks.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
-        <p className="text-lg">No tasks yet</p>
-        <p className="text-sm">Create a task to get started</p>
-      </div>
+    const isFiltered = totalCount > 0;
+    return isFiltered ? (
+      <EmptyState
+        icon={
+          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+            <path d="M8 11h6" />
+          </svg>
+        }
+        heading="No matching tasks"
+        subtext="Try adjusting your filters or status tab"
+      />
+    ) : (
+      <EmptyState
+        icon={
+          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="m7 8 4 4-4 4" />
+            <path d="M13 16h4" />
+          </svg>
+        }
+        heading="No tasks yet"
+        subtext="Create your first task to start running agents"
+        action={emptyAction}
+      />
     );
   }
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -63,9 +63,7 @@ const TaskTableRow = memo(function TaskTableRow({
         <div className="min-w-0">
           <span className="block truncate text-sm font-medium">{task.title}</span>
           {task.description && (
-            <span className="block truncate text-xs text-muted-foreground">
-              {task.description}
-            </span>
+            <span className="block truncate text-xs text-muted-foreground">{task.description}</span>
           )}
         </div>
       </td>
@@ -86,7 +84,9 @@ const TaskTableRow = memo(function TaskTableRow({
           </div>
         ) : (
           <span className="tabular-nums text-xs text-muted-foreground">
-            {activeAgents.length > 0 ? `${activeAgents.length} agent${activeAgents.length > 1 ? 's' : ''}` : '—'}
+            {activeAgents.length > 0
+              ? `${activeAgents.length} agent${activeAgents.length > 1 ? 's' : ''}`
+              : '—'}
           </span>
         )}
       </td>
@@ -179,12 +179,7 @@ const TaskTableRow = memo(function TaskTableRow({
   );
 });
 
-function TaskTableView({
-  tasks,
-  onClose,
-  onDelete,
-  onResume,
-}: Omit<TaskListProps, 'viewMode'>) {
+function TaskTableView({ tasks, onClose, onDelete, onResume }: Omit<TaskListProps, 'viewMode'>) {
   return (
     <div className="overflow-x-auto rounded-lg border border-border">
       <table className="w-full text-left">
@@ -214,13 +209,31 @@ function TaskTableView({
   );
 }
 
-export function TaskList({ tasks, onClose, onDelete, onResume, viewMode, totalCount = 0, emptyAction }: TaskListProps) {
+export function TaskList({
+  tasks,
+  onClose,
+  onDelete,
+  onResume,
+  viewMode,
+  totalCount = 0,
+  emptyAction,
+}: TaskListProps) {
   if (tasks.length === 0) {
     const isFiltered = totalCount > 0;
     return isFiltered ? (
       <EmptyState
         icon={
-          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.3-4.3" />
             <path d="M8 11h6" />
@@ -232,7 +245,17 @@ export function TaskList({ tasks, onClose, onDelete, onResume, viewMode, totalCo
     ) : (
       <EmptyState
         icon={
-          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <rect width="18" height="18" x="3" y="3" rx="2" />
             <path d="m7 8 4 4-4 4" />
             <path d="M13 16h4" />
@@ -246,7 +269,9 @@ export function TaskList({ tasks, onClose, onDelete, onResume, viewMode, totalCo
   }
 
   if (viewMode === 'table') {
-    return <TaskTableView tasks={tasks} onClose={onClose} onDelete={onDelete} onResume={onResume} />;
+    return (
+      <TaskTableView tasks={tasks} onClose={onClose} onDelete={onDelete} onResume={onResume} />
+    );
   }
 
   return (

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -42,7 +42,7 @@ describe('Dashboard', () => {
     await waitFor(() => {
       expect(screen.getByText('octomux')).toBeInTheDocument();
     });
-    expect(screen.getByText('New Task')).toBeInTheDocument();
+    expect(screen.getAllByText('New Task').length).toBeGreaterThan(0);
   });
 
   // ─── Task list rendering ──────────────────────────────────────────────────
@@ -72,7 +72,7 @@ describe('Dashboard', () => {
     apiMock.listTasks.mockRejectedValue(new Error('Network error'));
     renderWithRouter(<Dashboard />);
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText(/Network error/)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useTasks } from '@/lib/hooks';
 import { useTaskFilters } from '@/lib/use-task-filters';
 import type { ViewMode } from '@/components/TaskList';
 import { TaskList } from '@/components/TaskList';
+import { EmptyState } from '@/components/EmptyState';
 import { TaskFilterBar } from '@/components/TaskFilterBar';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
 import { NotificationToggle } from '@/components/NotificationToggle';
@@ -90,19 +91,32 @@ export default function Dashboard() {
           </div>
 
           {error && (
-            <div className="mb-4 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">
-                    Unable to load tasks. Check that the server is running on port 7777.
-                  </p>
-                  <p className="mt-1 text-xs text-destructive/70">{error}</p>
-                </div>
+            <EmptyState
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+                  <path d="M12 9v4" />
+                  <path d="M12 17h.01" />
+                </svg>
+              }
+              heading="Unable to load tasks"
+              subtext={`Check that the server is running on port 7777. ${error}`}
+              action={
                 <Button variant="outline" size="sm" onClick={refresh}>
                   Retry
                 </Button>
-              </div>
-            </div>
+              }
+            />
           )}
 
           {loading ? (
@@ -135,6 +149,8 @@ export default function Dashboard() {
               />
               <TaskList
                 tasks={filtered}
+                totalCount={tasks.length}
+                emptyAction={<CreateTaskDialog onCreated={refresh} />}
                 onClose={handleClose}
                 onDelete={handleDelete}
                 onResume={handleResume}

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from '@/components/StatusBadge';
 import { TerminalView } from '@/components/TerminalView';
 import { AgentTabs } from '@/components/AgentTabs';
 import { DraftEditForm } from '@/components/DraftEditForm';
+import { EmptyState } from '@/components/EmptyState';
 
 import { useTask } from '@/lib/hooks';
 import { api } from '@/lib/api';
@@ -451,7 +452,34 @@ export default function TaskDetail() {
               )}
             </>
           ) : (
-            'No terminal available'
+            <EmptyState
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect width="18" height="18" x="3" y="3" rx="2" />
+                  <path d="m7 8 4 4-4 4" />
+                  <path d="M13 16h4" />
+                </svg>
+              }
+              heading="No agents running"
+              subtext="Add an agent to start working on this task"
+              action={
+                isRunning ? (
+                  <Button variant="default" size="sm" onClick={() => handleAddAgent()}>
+                    Add Agent
+                  </Button>
+                ) : undefined
+              }
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
## What
- Add reusable `EmptyState` component with icon, heading, subtext, action, and fade-in animation
- Dashboard: "No tasks yet" with Create Task CTA, "No matching tasks" for filtered views, error state with retry
- Task Detail: "No agents running" with Add Agent button
- Orchestrator Panel: "Orchestrator not running" with Start button

## Why
Empty states are the first thing new users see. Professional apps use them to reinforce brand, guide users, and prevent confusion. Previously the app showed plain text or nothing.

## Testing
- 526 tests passing (`bun run test`)
- Typecheck clean (`bun run typecheck`)
- Lint clean — 0 errors (`bun run lint`)
- New tests for EmptyState component (6 tests) and TaskList variants (4 tests)