### PR TITLE
feat(orchestrator): add greeting on startup

### DIFF
--- a/server/orchestrator-prompt.md
+++ b/server/orchestrator-prompt.md
@@ -2,6 +2,33 @@
 
 You are the orchestrator for octomux-agents, a system that manages autonomous Claude Code agents working in isolated git worktrees. Your job is to coordinate task creation, monitoring, and lifecycle management.
 
+## Greeting
+
+When you receive the very first message of a conversation, greet the user with a brief, friendly introduction. Keep it concise — no more than 10 lines. Cover what you can do and suggest a few example prompts they can try. Use this template:
+
+---
+
+**Octomux Orchestrator** — ready to coordinate your agents.
+
+I can help you:
+
+- **Create tasks** to dispatch autonomous Claude Code agents
+- **Monitor** running tasks and their agents
+- **Close or resume** tasks as needed
+- **Add agents** to running tasks for parallel work
+- **Generate PR previews** and create PRs for completed work
+- **Check status** and troubleshoot errors
+
+Try something like:
+
+- "Create a task to fix the login bug in the auth service"
+- "Show me all running tasks"
+- "What is the status of task abc123?"
+
+---
+
+After the greeting, proceed to handle whatever the user asked (if anything).
+
 ## CLI (primary interface)
 
 The octomux CLI is at `node cli/dist/index.js`. Use it for all core operations:

--- a/server/orchestrator.test.ts
+++ b/server/orchestrator.test.ts
@@ -71,6 +71,7 @@ describe('startOrchestrator', () => {
     const claudeCmd = sendKeysArgs[sendKeysArgs.indexOf('-t') + 2];
     expect(claudeCmd).toContain('claude --system-prompt');
     expect(claudeCmd).toContain('orchestrator-prompt.md');
+    expect(claudeCmd).toContain('"Greet me and show what you can do"');
   });
 
   it('does not create session if already running', async () => {

--- a/server/orchestrator.ts
+++ b/server/orchestrator.ts
@@ -28,7 +28,7 @@ export async function startOrchestrator(cwd?: string): Promise<void> {
     '-c',
     cwd || process.cwd(),
   ]);
-  const claudeCmd = `claude --system-prompt "$(cat ${PROMPT_FILE})"`;
+  const claudeCmd = `claude --system-prompt "$(cat ${PROMPT_FILE})" "Greet me and show what you can do"`;
   await execFile('tmux', ['send-keys', '-t', ORCHESTRATOR_SESSION, claudeCmd, 'Enter']);
 }
 


### PR DESCRIPTION
## What
Add a greeting to the orchestrator so it introduces itself when launched. Adds a "Greeting" section to the system prompt with a template covering capabilities and example prompts. Passes an inline initial prompt (`"Greet me and show what you can do"`) as a CLI argument to claude on startup.

## Why
New users opening the orchestrator see a blank terminal with no context. A friendly greeting with capabilities and example prompts reduces the learning curve and makes the tool immediately useful.

## Testing
- `bun run test -- server/orchestrator.test.ts` — all 8 tests pass
- `bun run typecheck` — clean
- `bun run lint` — no new warnings
- Full test suite: 526 tests passing