### PR TITLE
feat(ui): add persistent header and orchestrator modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import { useAttentionIndicator } from './lib/use-attention-indicator';
 import { useNotifications } from './lib/use-notifications';
 import Dashboard from './pages/Dashboard';
 import TaskDetailLayout from './components/TaskDetailLayout';
+import { OrchestratorProvider } from './lib/orchestrator-context';
+import { AppHeader } from './components/AppHeader';
+import { OrchestratorModal } from './components/OrchestratorPanel';
 
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 
@@ -52,16 +55,22 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
 export default function App() {
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-background text-foreground">
-        <Toaster theme="dark" position="bottom-right" richColors />
-        <GlobalNotifications />
-        <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route element={<TaskDetailLayout />}>
-            <Route path="/tasks/:id" element={<TaskDetail />} />
-          </Route>
-        </Routes>
-      </div>
+      <OrchestratorProvider>
+        <div className="flex h-screen flex-col bg-background text-foreground">
+          <Toaster theme="dark" position="bottom-right" richColors />
+          <GlobalNotifications />
+          <AppHeader />
+          <div className="min-h-0 flex-1">
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route element={<TaskDetailLayout />}>
+                <Route path="/tasks/:id" element={<TaskDetail />} />
+              </Route>
+            </Routes>
+          </div>
+        </div>
+        <OrchestratorModal />
+      </OrchestratorProvider>
     </ErrorBoundary>
   );
 }

--- a/src/components/AppHeader.test.tsx
+++ b/src/components/AppHeader.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { AppHeader } from './AppHeader';
+import { renderWithRouter } from '../test-helpers';
+
+// Mock the orchestrator context
+vi.mock('@/lib/orchestrator-context', () => ({
+  useOrchestratorContext: () => ({
+    isOpen: false,
+    running: false,
+    loading: false,
+    open: vi.fn(),
+    close: vi.fn(),
+    toggle: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) }),
+}));
+
+describe('AppHeader', () => {
+  it('renders branding', () => {
+    renderWithRouter(<AppHeader />);
+    expect(screen.getByText('octomux')).toBeInTheDocument();
+    expect(screen.getByAltText('octomux')).toBeInTheDocument();
+  });
+
+  it('renders orchestrator toggle', () => {
+    renderWithRouter(<AppHeader />);
+    expect(screen.getByTitle('Toggle orchestrator')).toBeInTheDocument();
+  });
+
+  it('renders new task button', () => {
+    renderWithRouter(<AppHeader />);
+    expect(screen.getAllByText('New Task').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import { NotificationToggle } from './NotificationToggle';
+import { CreateTaskDialog } from './CreateTaskDialog';
+import { useOrchestratorContext } from '@/lib/orchestrator-context';
+import { OrchestratorToggle } from './OrchestratorPanel';
+
+export function AppHeader() {
+  const orchestrator = useOrchestratorContext();
+
+  return (
+    <header className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-card px-4">
+      <Link to="/" className="flex items-center gap-2.5">
+        <img src="/logo.png" alt="octomux" className="h-6 w-6 brightness-150 saturate-200" />
+        <span className="text-base font-semibold tracking-tight">octomux</span>
+      </Link>
+      <div className="flex items-center gap-2">
+        <OrchestratorToggle
+          isOpen={orchestrator.isOpen}
+          running={orchestrator.running}
+          toggle={orchestrator.toggle}
+        />
+        <NotificationToggle />
+        <CreateTaskDialog />
+      </div>
+    </header>
+  );
+}

--- a/src/components/CreateTaskDialog.tsx
+++ b/src/components/CreateTaskDialog.tsx
@@ -15,7 +15,7 @@ import { api } from '@/lib/api';
 import type { BrowseResult, RecentRepo } from '@/lib/api';
 
 interface CreateTaskDialogProps {
-  onCreated: () => void;
+  onCreated?: () => void;
 }
 
 function timeAgo(dateStr: string): string {
@@ -192,7 +192,7 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
       setRepoValidation('idle');
       setBranchIsAuto(true);
       setOpen(false);
-      onCreated();
+      onCreated?.();
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/src/components/OrchestratorPanel.tsx
+++ b/src/components/OrchestratorPanel.tsx
@@ -1,45 +1,13 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useEffect, lazy, Suspense } from 'react';
 import { Button } from '@/components/ui/button';
-import { useOrchestrator } from '@/lib/hooks';
+import { useOrchestratorContext } from '@/lib/orchestrator-context';
 import { EmptyState } from './EmptyState';
 
 const TerminalView = lazy(() =>
   import('@/components/TerminalView').then((m) => ({ default: m.TerminalView })),
 );
 
-const STORAGE_KEY = 'orchestrator-panel-open';
-
-function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
-
-  useEffect(() => {
-    const mql = window.matchMedia('(max-width: 767px)');
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mql.addEventListener('change', handler);
-    return () => mql.removeEventListener('change', handler);
-  }, []);
-
-  return isMobile;
-}
-
-export function useOrchestratorPanel() {
-  const [isOpen, setIsOpen] = useState(() => localStorage.getItem(STORAGE_KEY) === 'true');
-  const orchestrator = useOrchestrator();
-
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, String(isOpen));
-  }, [isOpen]);
-
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
-
-  return { isOpen, open, close, toggle, ...orchestrator };
-}
-
-export type OrchestratorPanelState = ReturnType<typeof useOrchestratorPanel>;
-
-/** Header toggle button — renders in the Dashboard toolbar */
+/** Header toggle button — renders in AppHeader */
 export function OrchestratorToggle({
   isOpen,
   running,
@@ -54,11 +22,11 @@ export function OrchestratorToggle({
       variant={isOpen ? 'secondary' : 'ghost'}
       size="sm"
       onClick={toggle}
-      title="Toggle orchestrator panel"
-      className="relative gap-1.5 hidden md:inline-flex"
+      title="Toggle orchestrator"
+      className="relative gap-1.5"
     >
       <TerminalIcon className="h-4 w-4" />
-      <span className="text-xs">Orchestrator</span>
+      <span className="text-xs hidden sm:inline">Orchestrator</span>
       {running && (
         <span className="absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
@@ -69,112 +37,107 @@ export function OrchestratorToggle({
   );
 }
 
-/** Side panel — only renders content when open */
-export function OrchestratorPanel({ state }: { state: OrchestratorPanelState }) {
-  const { isOpen, close, running, loading, start, stop } = state;
-  const isMobile = useIsMobile();
+/** Modal overlay for orchestrator terminal */
+export function OrchestratorModal() {
+  const { isOpen, close, running, loading, start, stop } = useOrchestratorContext();
 
-  if (!isOpen) return null;
+  // Close on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, close]);
 
-  const panelContent = (
-    <>
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-3 py-2">
-        <div className="flex items-center gap-2">
-          <span
-            className={`h-2 w-2 rounded-full ${running ? 'bg-emerald-500 animate-pulse' : 'bg-muted-foreground/30'}`}
-          />
-          <span className="text-sm font-medium">Orchestrator</span>
-        </div>
-        <div className="flex items-center gap-1">
-          {running && (
-            <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={stop}>
-              Stop
-            </Button>
-          )}
-          <button
-            onClick={close}
-            className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="m9 18 6-6-6-6" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {/* Body */}
-      <div className="flex-1 overflow-hidden">
-        {loading ? (
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            Loading...
-          </div>
-        ) : !running ? (
-          <EmptyState
-            icon={
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="48"
-                height="48"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="4 17 10 11 4 5" />
-                <line x1="12" x2="20" y1="19" y2="19" />
-              </svg>
-            }
-            heading="Orchestrator not running"
-            subtext="Start the orchestrator to manage task queues"
-            action={<Button onClick={start}>Start Orchestrator</Button>}
-            className="h-full"
-          />
-        ) : (
-          <Suspense
-            fallback={
-              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-                Loading terminal...
-              </div>
-            }
-          >
-            <TerminalView wsUrl="/ws/terminal/orchestrator" />
-          </Suspense>
-        )}
-      </div>
-    </>
-  );
-
-  // Mobile: full-width overlay
-  if (isMobile) {
-    return (
-      <>
-        {/* Backdrop */}
-        <div className="fixed inset-0 z-40 bg-black/50" onClick={close} />
-        {/* Slide-out panel */}
-        <div className="fixed inset-y-0 right-0 z-50 w-full bg-card flex flex-col animate-in slide-in-from-right duration-200">
-          {panelContent}
-        </div>
-      </>
-    );
-  }
-
-  // Desktop: inline panel with responsive width
   return (
-    <div className="w-[500px] max-[1279px]:w-[400px] max-[1023px]:w-[350px] shrink-0 border-l border-border bg-card flex flex-col">
-      {panelContent}
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center transition-all duration-200 ${
+        isOpen ? 'visible opacity-100' : 'invisible opacity-0 pointer-events-none'
+      }`}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={close} />
+
+      {/* Modal */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="orchestrator-title"
+        className={`relative z-10 flex h-[80vh] w-[90vw] max-w-5xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl transition-transform duration-200 ${
+          isOpen ? 'scale-100' : 'scale-95'
+        }`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2 w-2 rounded-full ${
+                running ? 'bg-emerald-500 animate-pulse' : 'bg-muted-foreground/30'
+              }`}
+            />
+            <span id="orchestrator-title" className="text-sm font-medium">
+              Orchestrator
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            {running && (
+              <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={stop}>
+                Stop
+              </Button>
+            )}
+            <button
+              onClick={close}
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <XIcon />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-hidden">
+          {loading ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Loading...
+            </div>
+          ) : !running ? (
+            <EmptyState
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="4 17 10 11 4 5" />
+                  <line x1="12" x2="20" y1="19" y2="19" />
+                </svg>
+              }
+              heading="Orchestrator not running"
+              subtext="Start the orchestrator to manage task queues"
+              action={<Button onClick={start}>Start Orchestrator</Button>}
+              className="h-full"
+            />
+          ) : (
+            <Suspense
+              fallback={
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Loading terminal...
+                </div>
+              }
+            >
+              <TerminalView wsUrl="/ws/terminal/orchestrator" visible={isOpen} />
+            </Suspense>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
@@ -193,6 +156,25 @@ function TerminalIcon({ className }: { className?: string }) {
     >
       <polyline points="4 17 10 11 4 5" />
       <line x1="12" x2="20" y1="19" y2="19" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
     </svg>
   );
 }

--- a/src/components/TaskDetailLayout.tsx
+++ b/src/components/TaskDetailLayout.tsx
@@ -4,7 +4,7 @@ import { TaskSidebar } from './TaskSidebar';
 
 export default function TaskDetailLayout() {
   return (
-    <div className="flex h-screen">
+    <div className="flex h-full">
       <TaskSidebar />
       <div className="min-w-0 flex-1">
         <Suspense

--- a/src/lib/orchestrator-context.tsx
+++ b/src/lib/orchestrator-context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { useOrchestrator } from './hooks';
+
+function useOrchestratorPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+  const orchestrator = useOrchestrator();
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  return { isOpen, open, close, toggle, ...orchestrator };
+}
+
+export type OrchestratorState = ReturnType<typeof useOrchestratorPanel>;
+
+const OrchestratorContext = createContext<OrchestratorState | null>(null);
+
+export function OrchestratorProvider({ children }: { children: ReactNode }) {
+  const state = useOrchestratorPanel();
+  return <OrchestratorContext.Provider value={state}>{children}</OrchestratorContext.Provider>;
+}
+
+export function useOrchestratorContext(): OrchestratorState {
+  const ctx = useContext(OrchestratorContext);
+  if (!ctx) throw new Error('useOrchestratorContext must be used within OrchestratorProvider');
+  return ctx;
+}

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -37,12 +37,11 @@ describe('Dashboard', () => {
     expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
   });
 
-  it('renders header and new task button', async () => {
+  it('renders new task button', async () => {
     renderWithRouter(<Dashboard />);
     await waitFor(() => {
-      expect(screen.getByText('octomux')).toBeInTheDocument();
+      expect(screen.getAllByText('New Task').length).toBeGreaterThan(0);
     });
-    expect(screen.getAllByText('New Task').length).toBeGreaterThan(0);
   });
 
   // ─── Task list rendering ──────────────────────────────────────────────────

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,19 +6,12 @@ import { TaskList } from '@/components/TaskList';
 import { EmptyState } from '@/components/EmptyState';
 import { TaskFilterBar } from '@/components/TaskFilterBar';
 import { CreateTaskDialog } from '@/components/CreateTaskDialog';
-import { NotificationToggle } from '@/components/NotificationToggle';
-import {
-  OrchestratorPanel,
-  OrchestratorToggle,
-  useOrchestratorPanel,
-} from '@/components/OrchestratorPanel';
 import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api';
 
 export default function Dashboard() {
   const { tasks, loading, error, refresh } = useTasks();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
-  const orchestrator = useOrchestratorPanel();
   const [viewMode, setViewMode] = useState<ViewMode>(
     () => (localStorage.getItem('octomux-view-mode') as ViewMode) || 'cards',
   );
@@ -65,102 +58,77 @@ export default function Dashboard() {
   );
 
   return (
-    <div className="flex h-screen">
-      <div className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-6xl px-4 py-4">
-          <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="flex items-center gap-2.5">
-                <img
-                  src="/logo.png"
-                  alt="octomux"
-                  className="h-8 w-8 brightness-150 saturate-200"
-                />
-                <h1 className="text-2xl font-bold tracking-tight">octomux</h1>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <OrchestratorToggle
-                isOpen={orchestrator.isOpen}
-                running={orchestrator.running}
-                toggle={orchestrator.toggle}
-              />
-              <NotificationToggle />
-              <CreateTaskDialog onCreated={refresh} />
-            </div>
-          </div>
+    <div className="h-full overflow-auto">
+      <div className="mx-auto max-w-6xl px-4 py-4">
+        {error && (
+          <EmptyState
+            icon={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+                <path d="M12 9v4" />
+                <path d="M12 17h.01" />
+              </svg>
+            }
+            heading="Unable to load tasks"
+            subtext={`Check that the server is running on port 7777. ${error}`}
+            action={
+              <Button variant="outline" size="sm" onClick={refresh}>
+                Retry
+              </Button>
+            }
+          />
+        )}
 
-          {error && (
-            <EmptyState
-              icon={
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="48"
-                  height="48"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
-                  <path d="M12 9v4" />
-                  <path d="M12 17h.01" />
-                </svg>
-              }
-              heading="Unable to load tasks"
-              subtext={`Check that the server is running on port 7777. ${error}`}
-              action={
-                <Button variant="outline" size="sm" onClick={refresh}>
-                  Retry
-                </Button>
-              }
-            />
-          )}
-
-          {loading ? (
-            <div className="flex flex-col gap-3">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="animate-pulse rounded-xl border border-border bg-card p-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="h-5 w-48 rounded bg-muted" />
-                    <div className="h-5 w-16 rounded bg-muted" />
-                  </div>
-                  <div className="mt-2 h-4 w-64 rounded bg-muted" />
-                  <div className="mt-3 flex items-center gap-2">
-                    <div className="h-5 w-20 rounded bg-muted" />
-                    <div className="h-4 w-32 rounded bg-muted" />
-                  </div>
+        {loading ? (
+          <div className="flex flex-col gap-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="animate-pulse rounded-xl border border-border bg-card p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="h-5 w-48 rounded bg-muted" />
+                  <div className="h-5 w-16 rounded bg-muted" />
                 </div>
-              ))}
-            </div>
-          ) : (
-            <>
-              <TaskFilterBar
-                activeStatus={filters.status}
-                counts={counts}
-                onStatusChange={(s) => setFilter('status', s)}
-                repos={repos}
-                activeRepo={filters.repo}
-                onRepoChange={(r) => setFilter('repo', r)}
-                viewMode={viewMode}
-                onViewChange={handleViewChange}
-              />
-              <TaskList
-                tasks={filtered}
-                totalCount={tasks.length}
-                emptyAction={<CreateTaskDialog onCreated={refresh} />}
-                onClose={handleClose}
-                onDelete={handleDelete}
-                onResume={handleResume}
-                viewMode={viewMode}
-              />
-            </>
-          )}
-        </div>
+                <div className="mt-2 h-4 w-64 rounded bg-muted" />
+                <div className="mt-3 flex items-center gap-2">
+                  <div className="h-5 w-20 rounded bg-muted" />
+                  <div className="h-4 w-32 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <>
+            <TaskFilterBar
+              activeStatus={filters.status}
+              counts={counts}
+              onStatusChange={(s) => setFilter('status', s)}
+              repos={repos}
+              activeRepo={filters.repo}
+              onRepoChange={(r) => setFilter('repo', r)}
+              viewMode={viewMode}
+              onViewChange={handleViewChange}
+            />
+            <TaskList
+              tasks={filtered}
+              totalCount={tasks.length}
+              emptyAction={<CreateTaskDialog onCreated={refresh} />}
+              onClose={handleClose}
+              onDelete={handleDelete}
+              onResume={handleResume}
+              viewMode={viewMode}
+            />
+          </>
+        )}
       </div>
-      <OrchestratorPanel state={orchestrator} />
     </div>
   );
 }


### PR DESCRIPTION
## What
- Add a persistent top header (`AppHeader`) rendered at the app layout level, visible on all pages, with branding, orchestrator toggle, notification toggle, and create task button
- Convert the orchestrator from a right side panel (350-500px) into a large centered modal overlay (90vw x 80vh)
- Lift orchestrator state into React context (`OrchestratorProvider`) so both the header toggle and modal can share state
- Terminal WebSocket survives modal open/close via CSS visibility toggling (no remount)

## Why
The dashboard and task detail views had inconsistent headers. The orchestrator side panel consumed significant horizontal space, squeezing the terminal content which is the primary viewport. A modal overlay gives the orchestrator full attention when open and zero layout impact when closed.

## Testing
- `bun run typecheck` — passes with 0 errors
- `bun run lint` — passes (only pre-existing warnings)
- `bun run test` — 529/529 tests pass
- Manual smoke test on localhost:5175