### PR TITLE
perf(task-runner): reduce tab creation delay from ~5s to <500ms

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -38,7 +38,8 @@ import type {
 
 const execFile = promisify(execFileCb);
 
-const TERMINALS_BY_TASK_SQL = 'SELECT * FROM user_terminals WHERE task_id = ? ORDER BY window_index';
+const TERMINALS_BY_TASK_SQL =
+  'SELECT * FROM user_terminals WHERE task_id = ? ORDER BY window_index';
 
 function safeParseJson(s: string): Record<string, unknown> {
   try {
@@ -193,9 +194,7 @@ export function setupRoutes(app: Express): void {
        WHERE pp.task_id = ? AND pp.status = 'pending'
        ORDER BY pp.created_at ASC`,
     );
-    const userTerminalsStmt = db.prepare(
-      TERMINALS_BY_TASK_SQL,
-    );
+    const userTerminalsStmt = db.prepare(TERMINALS_BY_TASK_SQL);
 
     const result = tasks.map((task) => {
       const agents = agentStmt.all(task.id) as Agent[];
@@ -243,9 +242,7 @@ export function setupRoutes(app: Express): void {
       ...pp,
       tool_input: safeParseJson(pp.tool_input as string),
     }));
-    const userTerminals = db
-      .prepare(TERMINALS_BY_TASK_SQL)
-      .all(task.id) as UserTerminal[];
+    const userTerminals = db.prepare(TERMINALS_BY_TASK_SQL).all(task.id) as UserTerminal[];
     res.json({
       ...task,
       agents,
@@ -290,9 +287,7 @@ export function setupRoutes(app: Express): void {
     created.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(id) as Agent[];
-    created.user_terminals = db
-      .prepare(TERMINALS_BY_TASK_SQL)
-      .all(id) as UserTerminal[];
+    created.user_terminals = db.prepare(TERMINALS_BY_TASK_SQL).all(id) as UserTerminal[];
     broadcast({ type: 'task:created', payload: { taskId: id } });
     res.status(201).json(created);
   });
@@ -383,9 +378,7 @@ export function setupRoutes(app: Express): void {
     updated.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(task.id) as Agent[];
-    updated.user_terminals = db
-      .prepare(TERMINALS_BY_TASK_SQL)
-      .all(task.id) as UserTerminal[];
+    updated.user_terminals = db.prepare(TERMINALS_BY_TASK_SQL).all(task.id) as UserTerminal[];
     broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.json(updated);
   });
@@ -413,9 +406,7 @@ export function setupRoutes(app: Express): void {
     updated.agents = db
       .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
       .all(task.id) as Agent[];
-    updated.user_terminals = db
-      .prepare(TERMINALS_BY_TASK_SQL)
-      .all(task.id) as UserTerminal[];
+    updated.user_terminals = db.prepare(TERMINALS_BY_TASK_SQL).all(task.id) as UserTerminal[];
     broadcast({ type: 'task:updated', payload: { taskId: task.id } });
     res.json(updated);
   });

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -1043,10 +1043,12 @@ describe('createShellTerminal', () => {
     expect(terminal.label).toBe('Terminal 1');
     expect(terminal.task_id).toBe(DEFAULTS.runningTask.id);
     expect(typeof terminal.window_index).toBe('number');
-    expect(findExecCall(execFile as any, {
-      cmd: 'tmux',
-      argsInclude: ['new-window'],
-    })).toBeTruthy();
+    expect(
+      findExecCall(execFile as any, {
+        cmd: 'tmux',
+        argsInclude: ['new-window'],
+      }),
+    ).toBeTruthy();
   });
 
   it('auto-increments terminal labels', async () => {
@@ -1072,10 +1074,12 @@ describe('closeShellTerminal', () => {
     insertTask(db, DEFAULTS.runningTask);
     insertUserTerminal(db, { task_id: DEFAULTS.runningTask.id });
     await closeShellTerminal(DEFAULTS.runningTask as Task, DEFAULTS.userTerminal as any);
-    expect(findExecCall(execFile as any, {
-      cmd: 'tmux',
-      argsInclude: ['kill-window'],
-    })).toBeTruthy();
+    expect(
+      findExecCall(execFile as any, {
+        cmd: 'tmux',
+        argsInclude: ['kill-window'],
+      }),
+    ).toBeTruthy();
     expect(getUserTerminals(db, DEFAULTS.runningTask.id)).toHaveLength(0);
   });
 });

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -400,6 +400,52 @@ describe('addAgent', () => {
     expect(dbAgents).toHaveLength(1);
     expect(dbAgents[0].id).toBe(agent.id);
   });
+
+  it('marks agent as stopped if async claude launch fails', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+
+    // Make send-keys fail (but let new-window and list-windows succeed)
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('new-window')) {
+        nextWindowIndex++;
+        cb(null, { stdout: '', stderr: '' });
+      } else if (args.includes('list-windows')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('send-keys')) {
+        cb(new Error('tmux send-keys failed'), null);
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    }) as any);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const agent = await addAgent(runningTask);
+    // Flush the fire-and-forget async IIFE
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Agent should be marked as stopped in DB
+    const agents = getAgents(db, DEFAULTS.task.id);
+    const dbAgent = agents.find((a) => a.id === agent.id)!;
+    expect(dbAgent.status).toBe('stopped');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[addAgent]'),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+    // Restore default execFile implementation for subsequent tests
+    vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+      if (args.includes('display-message')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('list-windows')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('new-window')) {
+        nextWindowIndex++;
+        cb(null, { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: 'true', stderr: '' });
+      }
+    }) as any);
+  });
 });
 
 // ─── closeTask ───────────────────────────────────────────────────────────────

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -367,8 +367,6 @@ export async function createShellTerminal(task: Task): Promise<UserTerminal> {
   const db = getDb();
   await execFile('tmux', ['new-window', '-t', task.tmux_session!, '-c', task.worktree!]);
   const windowIndex = await getLastWindowIndex(task.tmux_session!);
-  const target = `${task.tmux_session}:${windowIndex}`;
-  await waitForShellReady(target);
 
   const { count } = db
     .prepare('SELECT COUNT(*) as count FROM user_terminals WHERE task_id = ?')

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -255,10 +255,10 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
     } catch (err) {
       console.error(`[addAgent] Failed to launch claude in window ${windowIndex}:`, err);
       try {
-        getDb()
-          .prepare(`UPDATE agents SET status = 'stopped' WHERE id = ?`)
-          .run(agentId);
-      } catch { /* DB may be closed in edge cases */ }
+        getDb().prepare(`UPDATE agents SET status = 'stopped' WHERE id = ?`).run(agentId);
+      } catch {
+        /* DB may be closed in edge cases */
+      }
     }
   })().catch(() => {}); // inner try/catch handles all errors; this prevents unhandled rejection
 
@@ -401,7 +401,9 @@ export async function createShellTerminal(task: Task): Promise<UserTerminal> {
 export async function closeShellTerminal(task: Task, terminal: UserTerminal): Promise<void> {
   const db = getDb();
   await execFile('tmux', [
-    'kill-window', '-t', `${task.tmux_session}:${terminal.window_index}`,
+    'kill-window',
+    '-t',
+    `${task.tmux_session}:${terminal.window_index}`,
   ]).catch(() => {});
   db.prepare('DELETE FROM user_terminals WHERE id = ?').run(terminal.id);
 }

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -235,22 +235,32 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
     'INSERT INTO agents (id, task_id, window_index, label, claude_session_id) VALUES (?, ?, ?, ?, ?)',
   ).run(agentId, task.id, windowIndex, label, claudeSessionId);
 
-  // Launch claude with session tracking, passing prompt as CLI argument
-  let claudeCmd = `claude --session-id ${claudeSessionId}`;
-  let promptFile: string | null = null;
-  if (prompt) {
-    promptFile = path.join(task.worktree!, `.claude-prompt-${agentId}`);
-    fs.writeFileSync(promptFile, prompt);
-    claudeCmd += ` "$(cat ${promptFile})"`;
-  }
-  // Wait for shell to be ready before sending keys (prevents first char being swallowed)
+  // Launch claude asynchronously — do not block the HTTP response
   const addTarget = `${task.tmux_session}:${windowIndex}`;
-  await waitForShellReady(addTarget);
-  await execFile('tmux', ['send-keys', '-t', addTarget, claudeCmd, 'Enter']);
-  if (promptFile) {
-    const pf = promptFile;
-    setTimeout(() => fs.unlinkSync(pf), 5000);
-  }
+  (async () => {
+    try {
+      let promptFile: string | null = null;
+      let claudeCmd = `claude --session-id ${claudeSessionId}`;
+      if (prompt) {
+        promptFile = path.join(task.worktree!, `.claude-prompt-${agentId}`);
+        fs.writeFileSync(promptFile, prompt);
+        claudeCmd += ` "$(cat ${promptFile})"`;
+      }
+      await waitForShellReady(addTarget);
+      await execFile('tmux', ['send-keys', '-t', addTarget, claudeCmd, 'Enter']);
+      if (promptFile) {
+        const pf = promptFile;
+        setTimeout(() => fs.unlinkSync(pf), 5000);
+      }
+    } catch (err) {
+      console.error(`[addAgent] Failed to launch claude in window ${windowIndex}:`, err);
+      try {
+        getDb()
+          .prepare(`UPDATE agents SET status = 'stopped' WHERE id = ?`)
+          .run(agentId);
+      } catch { /* DB may be closed in edge cases */ }
+    }
+  })().catch(() => {}); // inner try/catch handles all errors; this prevents unhandled rejection
 
   return {
     id: agentId,

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -74,7 +74,10 @@ export const DEFAULTS = {
     created_at: new Date().toISOString(),
     resolved_at: null,
   },
-} satisfies Record<string, Partial<Task> | Partial<Agent> | Partial<UserTerminal> | Record<string, unknown>>;
+} satisfies Record<
+  string,
+  Partial<Task> | Partial<Agent> | Partial<UserTerminal> | Record<string, unknown>
+>;
 
 // Derived constants from defaults
 export const SESSION_PREFIX = 'octomux-agent-';

--- a/src/components/AgentTabs.test.tsx
+++ b/src/components/AgentTabs.test.tsx
@@ -80,7 +80,12 @@ describe('AgentTabs', () => {
 
   it('hides add button when canAddAgent is false', () => {
     renderWithRouter(
-      <AgentTabs {...defaultProps} agents={[makeAgent()]} canAddAgent={false} onAddTerminal={undefined} />,
+      <AgentTabs
+        {...defaultProps}
+        agents={[makeAgent()]}
+        canAddAgent={false}
+        onAddTerminal={undefined}
+      />,
     );
     expect(screen.queryByTitle('Add agent without prompt')).not.toBeInTheDocument();
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -61,7 +61,10 @@ export const api = {
   createUserTerminal: (taskId: string) =>
     request<{ user_window_index: number }>(`/tasks/${taskId}/user-terminal`, { method: 'POST' }),
   createTerminal: (taskId: string) =>
-    request<UserTerminal>(`/tasks/${taskId}/terminals`, { method: 'POST', body: JSON.stringify({}) }),
+    request<UserTerminal>(`/tasks/${taskId}/terminals`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }),
   closeTerminal: (taskId: string, terminalId: string) =>
     request<void>(`/tasks/${taskId}/terminals/${terminalId}`, { method: 'DELETE' }),
 

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -436,7 +436,7 @@ export default function TaskDetail() {
             onAddAgent={handleAddAgent}
             onStopAgent={handleStopAgent}
             canAddAgent={isRunning}
-            userTerminals={isRunning ? (task.user_terminals || []) : []}
+            userTerminals={isRunning ? task.user_terminals || [] : []}
             onAddTerminal={isRunning ? handleAddTerminal : undefined}
             onCloseTerminal={isRunning ? handleCloseTerminal : undefined}
           />


### PR DESCRIPTION
## What
- Remove unnecessary `waitForShellReady()` from `createShellTerminal` — shell terminals don't send-keys after creation, so the 5s poll was dead wait time
- Make `addAgent` return the agent record immediately after DB insert, deferring `waitForShellReady` + `send-keys` to a fire-and-forget async IIFE
- On async launch failure: log error and mark agent as `stopped` in DB

## Why
Clicking "+" to add an agent or terminal tab took up to 5 seconds before the tab appeared. This is the most common dashboard interaction and the delay made it feel sluggish.

## Testing
- New test: verifies failed async claude launch marks agent as `stopped`
- All 560 existing tests pass
- Typecheck clean, lint clean (0 errors)