### PR TITLE
feat(orchestrator): add draft option to create-task command

### DIFF
--- a/src/components/CommandFieldForm.tsx
+++ b/src/components/CommandFieldForm.tsx
@@ -113,6 +113,18 @@ export function CommandFieldForm({ command, onSubmit, onClose, sending }: Comman
         );
       case 'task-picker':
         return <TaskPickerField value={value} onChange={(v) => setValue(field.name, v)} />;
+      case 'checkbox':
+        return (
+          <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+            <input
+              type="checkbox"
+              checked={value === 'true'}
+              onChange={(e) => setValue(field.name, e.target.checked ? 'true' : '')}
+              className="rounded border-border"
+            />
+            {field.label}
+          </label>
+        );
       default:
         return null;
     }
@@ -163,13 +175,15 @@ export function CommandFieldForm({ command, onSubmit, onClose, sending }: Comman
       {/* Fields */}
       {command.fields?.map((field) => (
         <div key={field.name} className="flex flex-col gap-1.5">
-          <Label
-            htmlFor={field.name}
-            className="font-mono text-[10px] uppercase tracking-wider text-[#8a8a8a]"
-          >
-            {field.label}
-            {field.required && <span className="text-[#EF4444] ml-0.5">*</span>}
-          </Label>
+          {field.type !== 'checkbox' && (
+            <Label
+              htmlFor={field.name}
+              className="font-mono text-[10px] uppercase tracking-wider text-[#8a8a8a]"
+            >
+              {field.label}
+              {field.required && <span className="text-[#EF4444] ml-0.5">*</span>}
+            </Label>
+          )}
           {renderField(field)}
         </div>
       ))}

--- a/src/lib/orchestrator-commands.ts
+++ b/src/lib/orchestrator-commands.ts
@@ -1,7 +1,7 @@
 export interface CommandField {
   name: string;
   label: string;
-  type: 'text' | 'textarea' | 'repo-picker' | 'branch-picker' | 'task-picker';
+  type: 'text' | 'textarea' | 'repo-picker' | 'branch-picker' | 'task-picker' | 'checkbox';
   required?: boolean;
   placeholder?: string;
   dependsOn?: string;
@@ -36,9 +36,14 @@ export const COMMANDS: OrchestratorCommand[] = [
         type: 'textarea',
         placeholder: 'Tell the agent what to do...',
       },
+      {
+        name: 'draft',
+        label: 'Save as draft (start later)',
+        type: 'checkbox',
+      },
     ],
     buildMessage: (v) =>
-      `Create a task titled "${v.title}" in repo ${v.repo}${v.baseBranch ? ` with base branch ${v.baseBranch}` : ''}${v.description ? `. Description: ${v.description}` : ''} with prompt: ${v.prompt || v.description || v.title}`,
+      `Create a task titled "${v.title}" in repo ${v.repo}${v.baseBranch ? ` with base branch ${v.baseBranch}` : ''}${v.description ? `. Description: ${v.description}` : ''}${v.prompt ? `. Prompt: ${v.prompt}` : ''}${v.draft === 'true' ? '. Create it as a draft — do not start it yet.' : ''}`,
   },
   {
     slash: '/list-tasks',


### PR DESCRIPTION
## What
- Add a "Save as draft (start later)" checkbox to the `/create-task` command in the orchestrator command bar
- Add `checkbox` field type support to the `CommandFieldForm` component
- Stop auto-filling prompt from description/title when not provided — let the orchestrator agent generate one

## Why
Users should be able to create tasks as drafts from the orchestrator panel, matching the existing draft support in the standalone CreateTaskDialog. Previously the orchestrator's create-task flow had no way to create drafts.

## Testing
- All 606 tests pass (`bun run test`)
- Typecheck clean (`bun run typecheck`)
- Lint clean (no new warnings)