### PR TITLE
fix(npm): include scripts/ in package files for postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "!dist-server/test-helpers.*",
     "cli/dist/",
     "cli/package.json",
-    "skills/"
+    "skills/",
+    "scripts/"
   ],
   "scripts": {
     "dev": "concurrently \"bun:dev:server\" \"bun:dev:client\"",


### PR DESCRIPTION
## What
Add `scripts/` to the `files` array in `package.json` so that `scripts/postinstall.sh` is included in the published npm tarball.

## Why
`npm install -g octomux` fails with `scripts/postinstall.sh: No such file or directory` because the `files` field excluded the `scripts/` directory from the package. This completely blocks the primary install path.

## Testing
- Verified `npm pack --dry-run` now includes `scripts/postinstall.sh`
- `bun run typecheck` passes
- `bun run test` passes (596/596 tests)