### PR TITLE
feat(skills): add skills management to dashboard and CLI

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -45,6 +45,12 @@ export interface OctomuxClient {
   deleteTask(id: string): Promise<void>;
   addAgent(taskId: string, data?: { prompt?: string }): Promise<Agent>;
   sendMessage(taskId: string, agentId: string, message: string): Promise<{ success: boolean }>;
+  listSkills(): Promise<{ name: string; description: string }[]>;
+  getSkill(name: string): Promise<{ name: string; content: string }>;
+  createSkill(data: { name: string; content: string }): Promise<{ name: string; content: string }>;
+  deleteSkill(name: string): Promise<void>;
+  recentRepos(): Promise<{ repo_path: string; last_used: string }[]>;
+  defaultBranch(repoPath: string): Promise<{ branch: string }>;
 }
 
 async function request<T>(baseUrl: string, path: string, options?: RequestInit): Promise<T> {
@@ -107,6 +113,33 @@ export function createClient(serverUrl: string): OctomuxClient {
         baseUrl,
         `/tasks/${encodeURIComponent(taskId)}/agents/${encodeURIComponent(agentId)}/message`,
         { method: 'POST', body: JSON.stringify({ message }) },
+      );
+    },
+    listSkills() {
+      return request<{ name: string; description: string }[]>(baseUrl, '/skills');
+    },
+    getSkill(name) {
+      return request<{ name: string; content: string }>(
+        baseUrl,
+        `/skills/${encodeURIComponent(name)}`,
+      );
+    },
+    createSkill(data) {
+      return request<{ name: string; content: string }>(baseUrl, '/skills', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+    },
+    deleteSkill(name) {
+      return request<void>(baseUrl, `/skills/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    },
+    recentRepos() {
+      return request<{ repo_path: string; last_used: string }[]>(baseUrl, '/recent-repos');
+    },
+    defaultBranch(repoPath) {
+      return request<{ branch: string }>(
+        baseUrl,
+        `/default-branch?repo_path=${encodeURIComponent(repoPath)}`,
       );
     },
   };

--- a/cli/src/commands/create-skill.ts
+++ b/cli/src/commands/create-skill.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson, success } from '../format.js';
+
+export function registerCreateSkill(program: Command): void {
+  program
+    .command('create-skill')
+    .description('Create a new skill')
+    .requiredOption('-n, --name <name>', 'skill name (lowercase, hyphens)')
+    .option('-c, --content <content>', 'initial content', '')
+    .action(async (opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      const content = opts.content || `---\nname: ${opts.name}\ndescription: \n---\n\n`;
+      const skill = await client.createSkill({ name: opts.name, content });
+      if (isJsonMode(globals.json)) {
+        outputJson(skill);
+        return;
+      }
+      success(`Created skill "${skill.name}"`);
+    });
+}

--- a/cli/src/commands/default-branch.ts
+++ b/cli/src/commands/default-branch.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson } from '../format.js';
+
+export function registerDefaultBranch(program: Command): void {
+  program
+    .command('default-branch')
+    .description('Get default branch for a repository')
+    .requiredOption('-r, --repo-path <path>', 'path to the git repository')
+    .action(async (opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      const result = await client.defaultBranch(opts.repoPath);
+      if (isJsonMode(globals.json)) {
+        outputJson(result);
+        return;
+      }
+      console.log(result.branch);
+    });
+}

--- a/cli/src/commands/delete-skill.ts
+++ b/cli/src/commands/delete-skill.ts
@@ -1,0 +1,19 @@
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, success } from '../format.js';
+
+export function registerDeleteSkill(program: Command): void {
+  program
+    .command('delete-skill <name>')
+    .description('Delete a skill')
+    .action(async (name: string, _opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      await client.deleteSkill(name);
+      if (isJsonMode(globals.json)) {
+        console.log(JSON.stringify({ deleted: name }));
+        return;
+      }
+      success(`Deleted skill "${name}"`);
+    });
+}

--- a/cli/src/commands/get-skill.ts
+++ b/cli/src/commands/get-skill.ts
@@ -1,0 +1,21 @@
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson, heading } from '../format.js';
+
+export function registerGetSkill(program: Command): void {
+  program
+    .command('get-skill <name>')
+    .description('Get skill content')
+    .action(async (name: string, _opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      const skill = await client.getSkill(name);
+      if (isJsonMode(globals.json)) {
+        outputJson(skill);
+        return;
+      }
+      heading(`Skill: ${skill.name}`);
+      console.log('');
+      console.log(skill.content);
+    });
+}

--- a/cli/src/commands/list-skills.ts
+++ b/cli/src/commands/list-skills.ts
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson, heading } from '../format.js';
+
+export function registerListSkills(program: Command): void {
+  program
+    .command('list-skills')
+    .description('List all installed skills')
+    .action(async (_opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      const skills = await client.listSkills();
+      if (isJsonMode(globals.json)) {
+        outputJson(skills);
+        return;
+      }
+      if (skills.length === 0) {
+        console.log('No skills installed.');
+        return;
+      }
+      heading(`${'NAME'.padEnd(30)}DESCRIPTION`);
+      console.log(chalk.dim('─'.repeat(60)));
+      for (const s of skills) {
+        console.log(`${s.name.padEnd(30)}${chalk.dim(s.description || '—')}`);
+      }
+    });
+}

--- a/cli/src/commands/recent-repos.ts
+++ b/cli/src/commands/recent-repos.ts
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import type { OctomuxClient } from '../client.js';
+import { isJsonMode, outputJson, heading } from '../format.js';
+
+export function registerRecentRepos(program: Command): void {
+  program
+    .command('recent-repos')
+    .description('List recently used repositories')
+    .action(async (_opts, cmd) => {
+      const globals = cmd.optsWithGlobals();
+      const client: OctomuxClient = globals._client;
+      const repos = await client.recentRepos();
+      if (isJsonMode(globals.json)) {
+        outputJson(repos);
+        return;
+      }
+      if (repos.length === 0) {
+        console.log('No recent repos.');
+        return;
+      }
+      heading(`${'REPO PATH'.padEnd(50)}LAST USED`);
+      console.log(chalk.dim('─'.repeat(70)));
+      for (const r of repos) {
+        console.log(`${r.repo_path.padEnd(50)}${chalk.dim(r.last_used)}`);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,12 @@ import { registerDeleteTask } from './commands/delete-task.js';
 import { registerResumeTask } from './commands/resume-task.js';
 import { registerAddAgent } from './commands/add-agent.js';
 import { registerSendMessage } from './commands/send-message.js';
+import { registerListSkills } from './commands/list-skills.js';
+import { registerGetSkill } from './commands/get-skill.js';
+import { registerCreateSkill } from './commands/create-skill.js';
+import { registerDeleteSkill } from './commands/delete-skill.js';
+import { registerRecentRepos } from './commands/recent-repos.js';
+import { registerDefaultBranch } from './commands/default-branch.js';
 
 const program = new Command();
 
@@ -33,6 +39,12 @@ registerDeleteTask(program);
 registerResumeTask(program);
 registerAddAgent(program);
 registerSendMessage(program);
+registerListSkills(program);
+registerGetSkill(program);
+registerCreateSkill(program);
+registerDeleteSkill(program);
+registerRecentRepos(program);
+registerDefaultBranch(program);
 
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -105,6 +105,14 @@ vi.mock('child_process', () => ({
   }),
 }));
 
+vi.mock('./skills.js', () => ({
+  listSkills: vi.fn(),
+  getSkill: vi.fn(),
+  createSkill: vi.fn(),
+  updateSkill: vi.fn(),
+  deleteSkill: vi.fn(),
+}));
+
 const fs = (await import('fs')).default;
 
 const { createApp } = await import('./app.js');
@@ -121,6 +129,8 @@ const {
 } = await import('./task-runner.js');
 const { isOrchestratorRunning, startOrchestrator, sendToOrchestrator } =
   await import('./orchestrator.js');
+const { listSkills, getSkill, createSkill, updateSkill, deleteSkill } =
+  await import('./skills.js');
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -1172,5 +1182,84 @@ describe('POST /api/orchestrator/send', () => {
     const res = await request(app).post('/api/orchestrator/send').send({ message: 'hello' });
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ ok: false, error: 'tmux failed' });
+  });
+});
+
+// ─── Skills API ──────────────────────────────────────────────────────────────
+
+describe('Skills API', () => {
+  it('GET /api/skills returns skill list', async () => {
+    vi.mocked(listSkills).mockResolvedValue([
+      { name: 'my-skill', description: 'A test skill' },
+    ]);
+    const res = await request(app).get('/api/skills');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ name: 'my-skill', description: 'A test skill' }]);
+  });
+
+  it('GET /api/skills/:name returns skill content', async () => {
+    vi.mocked(getSkill).mockResolvedValue({ name: 'my-skill', content: '# My Skill' });
+    const res = await request(app).get('/api/skills/my-skill');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ name: 'my-skill', content: '# My Skill' });
+  });
+
+  it('GET /api/skills/:name returns 404 for missing', async () => {
+    vi.mocked(getSkill).mockRejectedValue(new Error('Skill not found: missing'));
+    const res = await request(app).get('/api/skills/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('not found');
+  });
+
+  it('POST /api/skills creates skill (201)', async () => {
+    vi.mocked(createSkill).mockResolvedValue({ name: 'new-skill', content: '# New' });
+    const res = await request(app)
+      .post('/api/skills')
+      .send({ name: 'new-skill', content: '# New' });
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ name: 'new-skill', content: '# New' });
+  });
+
+  it('POST /api/skills returns 400 when name missing', async () => {
+    const res = await request(app).post('/api/skills').send({ content: '# No name' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('name is required');
+  });
+
+  it('POST /api/skills returns 409 when exists', async () => {
+    vi.mocked(createSkill).mockRejectedValue(new Error('Skill already exists: dupe'));
+    const res = await request(app)
+      .post('/api/skills')
+      .send({ name: 'dupe', content: '# Dupe' });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('already exists');
+  });
+
+  it('PUT /api/skills/:name updates content', async () => {
+    vi.mocked(updateSkill).mockResolvedValue({ name: 'my-skill', content: '# Updated' });
+    const res = await request(app)
+      .put('/api/skills/my-skill')
+      .send({ content: '# Updated' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ name: 'my-skill', content: '# Updated' });
+  });
+
+  it('PUT /api/skills/:name returns 400 when content missing', async () => {
+    const res = await request(app).put('/api/skills/my-skill').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('content is required');
+  });
+
+  it('DELETE /api/skills/:name removes skill (204)', async () => {
+    vi.mocked(deleteSkill).mockResolvedValue(undefined);
+    const res = await request(app).delete('/api/skills/my-skill');
+    expect(res.status).toBe(204);
+  });
+
+  it('DELETE /api/skills/:name returns 404 for missing', async () => {
+    vi.mocked(deleteSkill).mockRejectedValue(new Error('Skill not found: missing'));
+    const res = await request(app).delete('/api/skills/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('not found');
   });
 });

--- a/server/api.ts
+++ b/server/api.ts
@@ -26,6 +26,7 @@ import {
   sendToOrchestrator,
   typeToOrchestrator,
 } from './orchestrator.js';
+import { listSkills, getSkill, createSkill, updateSkill, deleteSkill } from './skills.js';
 import { hookRoutes } from './hooks.js';
 import { broadcast } from './events.js';
 import type {
@@ -725,6 +726,91 @@ export function setupRoutes(app: Express): void {
       res.json({ ok: true, running: true });
     } catch (err) {
       res.status(500).json({ ok: false, error: (err as Error).message });
+    }
+  });
+
+  // ─── Skills ──────────────────────────────────────────────────────────────────
+
+  app.get('/api/skills', async (_req: Request, res: Response) => {
+    try {
+      const skills = await listSkills();
+      res.json(skills);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get('/api/skills/:name', async (req: Request, res: Response) => {
+    try {
+      const skill = await getSkill(req.params.name as string);
+      res.json(skill);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'ENOENT' || e.message.includes('not found') || e.message.includes('does not exist')) {
+        res.status(404).json({ error: e.message });
+      } else if (e.message.includes('Invalid skill name')) {
+        res.status(400).json({ error: e.message });
+      } else {
+        res.status(500).json({ error: e.message });
+      }
+    }
+  });
+
+  app.post('/api/skills', async (req: Request, res: Response) => {
+    const { name, content } = req.body as { name?: string; content?: string };
+    if (!name) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    try {
+      const skill = await createSkill(name, content || '');
+      res.status(201).json(skill);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.message.includes('already exists')) {
+        res.status(409).json({ error: e.message });
+      } else if (e.message.includes('Invalid skill name')) {
+        res.status(400).json({ error: e.message });
+      } else {
+        res.status(500).json({ error: e.message });
+      }
+    }
+  });
+
+  app.put('/api/skills/:name', async (req: Request, res: Response) => {
+    const { content } = req.body as { content?: string };
+    if (content === undefined || content === null) {
+      res.status(400).json({ error: 'content is required' });
+      return;
+    }
+    try {
+      const skill = await updateSkill(req.params.name as string, content);
+      res.json(skill);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'ENOENT' || e.message.includes('not found') || e.message.includes('does not exist')) {
+        res.status(404).json({ error: e.message });
+      } else if (e.message.includes('Invalid skill name')) {
+        res.status(400).json({ error: e.message });
+      } else {
+        res.status(500).json({ error: e.message });
+      }
+    }
+  });
+
+  app.delete('/api/skills/:name', async (req: Request, res: Response) => {
+    try {
+      await deleteSkill(req.params.name as string);
+      res.status(204).send();
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'ENOENT' || e.message.includes('not found') || e.message.includes('does not exist')) {
+        res.status(404).json({ error: e.message });
+      } else if (e.message.includes('Invalid skill name')) {
+        res.status(400).json({ error: e.message });
+      } else {
+        res.status(500).json({ error: e.message });
+      }
     }
   });
 }

--- a/server/skills.test.ts
+++ b/server/skills.test.ts
@@ -3,7 +3,17 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-vi.mock('fs');
+vi.mock('fs', () => {
+  const promises = {
+    access: vi.fn(),
+    mkdir: vi.fn(),
+    readdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rm: vi.fn(),
+  };
+  return { default: { promises }, promises };
+});
 vi.mock('os');
 
 const { listSkills, getSkill, createSkill, updateSkill, deleteSkill } = await import(
@@ -19,31 +29,31 @@ beforeEach(() => {
 
 describe('listSkills', () => {
   it('creates directory and returns empty array when dir does not exist', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
-    vi.mocked(fs.readdirSync).mockReturnValue([]);
+    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.readdir).mockResolvedValue([]);
 
     const result = await listSkills();
 
-    expect(fs.mkdirSync).toHaveBeenCalledWith(SKILLS_DIR, { recursive: true });
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(SKILLS_DIR, { recursive: true });
     expect(result).toEqual([]);
   });
 
   it('returns skills with descriptions parsed from YAML frontmatter', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
     const entries = [
       { name: 'my-skill', isDirectory: () => true },
       { name: 'another-skill', isDirectory: () => true },
     ];
-    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
-    vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+    vi.mocked(fs.promises.readdir).mockResolvedValue(entries as any);
+    vi.mocked(fs.promises.readFile).mockImplementation((filePath: any) => {
       if (filePath === path.join(SKILLS_DIR, 'my-skill', 'SKILL.md')) {
-        return '---\ndescription: A cool skill\n---\n# Content';
+        return Promise.resolve('---\ndescription: A cool skill\n---\n# Content');
       }
       if (filePath === path.join(SKILLS_DIR, 'another-skill', 'SKILL.md')) {
-        return '---\ndescription: Another skill\n---\n# More content';
+        return Promise.resolve('---\ndescription: Another skill\n---\n# More content');
       }
-      return '';
+      return Promise.resolve('');
     });
 
     const result = await listSkills();
@@ -55,13 +65,15 @@ describe('listSkills', () => {
   });
 
   it('skips non-directory entries', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
     const entries = [
       { name: 'my-skill', isDirectory: () => true },
       { name: 'readme.txt', isDirectory: () => false },
     ];
-    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
-    vi.mocked(fs.readFileSync).mockReturnValue('---\ndescription: A skill\n---\nContent');
+    vi.mocked(fs.promises.readdir).mockResolvedValue(entries as any);
+    vi.mocked(fs.promises.readFile).mockResolvedValue(
+      '---\ndescription: A skill\n---\nContent',
+    );
 
     const result = await listSkills();
 
@@ -70,10 +82,10 @@ describe('listSkills', () => {
   });
 
   it('returns empty description when no frontmatter', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
     const entries = [{ name: 'bare-skill', isDirectory: () => true }];
-    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
-    vi.mocked(fs.readFileSync).mockReturnValue('# Just content, no frontmatter');
+    vi.mocked(fs.promises.readdir).mockResolvedValue(entries as any);
+    vi.mocked(fs.promises.readFile).mockResolvedValue('# Just content, no frontmatter');
 
     const result = await listSkills();
 
@@ -83,37 +95,42 @@ describe('listSkills', () => {
 
 describe('getSkill', () => {
   it('returns skill content', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue('# My Skill\nSome content');
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.readFile).mockResolvedValue('# My Skill\nSome content');
 
     const result = await getSkill('my-skill');
 
     expect(result).toEqual({ name: 'my-skill', content: '# My Skill\nSome content' });
-    expect(fs.readFileSync).toHaveBeenCalledWith(
+    expect(fs.promises.readFile).toHaveBeenCalledWith(
       path.join(SKILLS_DIR, 'my-skill', 'SKILL.md'),
       'utf-8',
     );
   });
 
   it('throws on missing skill', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
 
     await expect(getSkill('nonexistent')).rejects.toThrow('Skill not found: nonexistent');
+  });
+
+  it('rejects path traversal names', async () => {
+    await expect(getSkill('..')).rejects.toThrow('Invalid skill name');
+    await expect(getSkill('../etc')).rejects.toThrow('Invalid skill name');
   });
 });
 
 describe('createSkill', () => {
   it('creates directory and SKILL.md', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
-    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
 
     const result = await createSkill('new-skill', '# New Skill');
 
-    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'new-skill'), {
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'new-skill'), {
       recursive: true,
     });
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
       path.join(SKILLS_DIR, 'new-skill', 'SKILL.md'),
       '# New Skill',
       'utf-8',
@@ -135,7 +152,7 @@ describe('createSkill', () => {
   });
 
   it('rejects duplicate skill', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
 
     await expect(createSkill('existing-skill', '# Dupe')).rejects.toThrow(
       'Skill already exists: existing-skill',
@@ -145,12 +162,12 @@ describe('createSkill', () => {
 
 describe('updateSkill', () => {
   it('writes content to existing skill', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
 
     const result = await updateSkill('my-skill', '# Updated');
 
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
       path.join(SKILLS_DIR, 'my-skill', 'SKILL.md'),
       '# Updated',
       'utf-8',
@@ -159,29 +176,33 @@ describe('updateSkill', () => {
   });
 
   it('throws on missing skill', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
 
     await expect(updateSkill('nonexistent', '# Content')).rejects.toThrow(
       'Skill not found: nonexistent',
     );
   });
+
+  it('rejects path traversal names', async () => {
+    await expect(updateSkill('..', '# Bad')).rejects.toThrow('Invalid skill name');
+    await expect(updateSkill('../etc', '# Bad')).rejects.toThrow('Invalid skill name');
+  });
 });
 
 describe('deleteSkill', () => {
   it('removes skill directory', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.rmSync).mockReturnValue(undefined);
+    vi.mocked(fs.promises.access).mockResolvedValue(undefined);
+    vi.mocked(fs.promises.rm).mockResolvedValue(undefined);
 
     await deleteSkill('my-skill');
 
-    expect(fs.rmSync).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'my-skill'), {
+    expect(fs.promises.rm).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'my-skill'), {
       recursive: true,
-      force: true,
     });
   });
 
   it('throws on missing skill', async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
 
     await expect(deleteSkill('nonexistent')).rejects.toThrow('Skill not found: nonexistent');
   });

--- a/server/skills.test.ts
+++ b/server/skills.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+vi.mock('fs');
+vi.mock('os');
+
+const { listSkills, getSkill, createSkill, updateSkill, deleteSkill } = await import(
+  './skills.js'
+);
+
+const SKILLS_DIR = '/mock-home/.claude/skills';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.mocked(os.homedir).mockReturnValue('/mock-home');
+});
+
+describe('listSkills', () => {
+  it('creates directory and returns empty array when dir does not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+
+    const result = await listSkills();
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(SKILLS_DIR, { recursive: true });
+    expect(result).toEqual([]);
+  });
+
+  it('returns skills with descriptions parsed from YAML frontmatter', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const entries = [
+      { name: 'my-skill', isDirectory: () => true },
+      { name: 'another-skill', isDirectory: () => true },
+    ];
+    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
+    vi.mocked(fs.readFileSync).mockImplementation((filePath: any) => {
+      if (filePath === path.join(SKILLS_DIR, 'my-skill', 'SKILL.md')) {
+        return '---\ndescription: A cool skill\n---\n# Content';
+      }
+      if (filePath === path.join(SKILLS_DIR, 'another-skill', 'SKILL.md')) {
+        return '---\ndescription: Another skill\n---\n# More content';
+      }
+      return '';
+    });
+
+    const result = await listSkills();
+
+    expect(result).toEqual([
+      { name: 'another-skill', description: 'Another skill' },
+      { name: 'my-skill', description: 'A cool skill' },
+    ]);
+  });
+
+  it('skips non-directory entries', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const entries = [
+      { name: 'my-skill', isDirectory: () => true },
+      { name: 'readme.txt', isDirectory: () => false },
+    ];
+    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('---\ndescription: A skill\n---\nContent');
+
+    const result = await listSkills();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('my-skill');
+  });
+
+  it('returns empty description when no frontmatter', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const entries = [{ name: 'bare-skill', isDirectory: () => true }];
+    vi.mocked(fs.readdirSync).mockReturnValue(entries as any);
+    vi.mocked(fs.readFileSync).mockReturnValue('# Just content, no frontmatter');
+
+    const result = await listSkills();
+
+    expect(result).toEqual([{ name: 'bare-skill', description: '' }]);
+  });
+});
+
+describe('getSkill', () => {
+  it('returns skill content', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('# My Skill\nSome content');
+
+    const result = await getSkill('my-skill');
+
+    expect(result).toEqual({ name: 'my-skill', content: '# My Skill\nSome content' });
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      path.join(SKILLS_DIR, 'my-skill', 'SKILL.md'),
+      'utf-8',
+    );
+  });
+
+  it('throws on missing skill', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await expect(getSkill('nonexistent')).rejects.toThrow('Skill not found: nonexistent');
+  });
+});
+
+describe('createSkill', () => {
+  it('creates directory and SKILL.md', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+    const result = await createSkill('new-skill', '# New Skill');
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'new-skill'), {
+      recursive: true,
+    });
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join(SKILLS_DIR, 'new-skill', 'SKILL.md'),
+      '# New Skill',
+      'utf-8',
+    );
+    expect(result).toEqual({ name: 'new-skill', content: '# New Skill' });
+  });
+
+  it('rejects path traversal names', async () => {
+    await expect(createSkill('..', '# Bad')).rejects.toThrow('Invalid skill name');
+    await expect(createSkill('../etc', '# Bad')).rejects.toThrow('Invalid skill name');
+  });
+
+  it('rejects names with spaces', async () => {
+    await expect(createSkill('my skill', '# Bad')).rejects.toThrow('Invalid skill name');
+  });
+
+  it('rejects names with uppercase', async () => {
+    await expect(createSkill('MySkill', '# Bad')).rejects.toThrow('Invalid skill name');
+  });
+
+  it('rejects duplicate skill', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    await expect(createSkill('existing-skill', '# Dupe')).rejects.toThrow(
+      'Skill already exists: existing-skill',
+    );
+  });
+});
+
+describe('updateSkill', () => {
+  it('writes content to existing skill', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+
+    const result = await updateSkill('my-skill', '# Updated');
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join(SKILLS_DIR, 'my-skill', 'SKILL.md'),
+      '# Updated',
+      'utf-8',
+    );
+    expect(result).toEqual({ name: 'my-skill', content: '# Updated' });
+  });
+
+  it('throws on missing skill', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await expect(updateSkill('nonexistent', '# Content')).rejects.toThrow(
+      'Skill not found: nonexistent',
+    );
+  });
+});
+
+describe('deleteSkill', () => {
+  it('removes skill directory', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.rmSync).mockReturnValue(undefined);
+
+    await deleteSkill('my-skill');
+
+    expect(fs.rmSync).toHaveBeenCalledWith(path.join(SKILLS_DIR, 'my-skill'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('throws on missing skill', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await expect(deleteSkill('nonexistent')).rejects.toThrow('Skill not found: nonexistent');
+  });
+
+  it('rejects path traversal names', async () => {
+    await expect(deleteSkill('..')).rejects.toThrow('Invalid skill name');
+  });
+});

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -14,7 +14,7 @@ export interface SkillDetail {
 
 const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-function getSkillsDir(): string {
+function skillsDir(): string {
   return path.join(os.homedir(), '.claude', 'skills');
 }
 
@@ -32,20 +32,35 @@ function parseDescription(content: string): string {
   return descMatch ? descMatch[1].trim() : '';
 }
 
-export async function listSkills(): Promise<Skill[]> {
-  const dir = getSkillsDir();
-
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+async function ensureDir(dir: string): Promise<void> {
+  try {
+    await fs.promises.access(dir);
+  } catch {
+    await fs.promises.mkdir(dir, { recursive: true });
   }
+}
 
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.promises.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listSkills(): Promise<Skill[]> {
+  const dir = skillsDir();
+
+  await ensureDir(dir);
+
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
   const skills: Skill[] = [];
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const skillFile = path.join(dir, entry.name, 'SKILL.md');
-    const content = fs.readFileSync(skillFile, 'utf-8');
+    const content = await fs.promises.readFile(skillFile, 'utf-8');
     skills.push({ name: entry.name, description: parseDescription(content) });
   }
 
@@ -53,54 +68,58 @@ export async function listSkills(): Promise<Skill[]> {
 }
 
 export async function getSkill(name: string): Promise<SkillDetail> {
-  const dir = getSkillsDir();
+  validateName(name);
+
+  const dir = skillsDir();
   const skillDir = path.join(dir, name);
 
-  if (!fs.existsSync(skillDir)) {
+  if (!(await exists(skillDir))) {
     throw new Error(`Skill not found: ${name}`);
   }
 
-  const content = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
+  const content = await fs.promises.readFile(path.join(skillDir, 'SKILL.md'), 'utf-8');
   return { name, content };
 }
 
 export async function createSkill(name: string, content: string): Promise<SkillDetail> {
   validateName(name);
 
-  const dir = getSkillsDir();
+  const dir = skillsDir();
   const skillDir = path.join(dir, name);
 
-  if (fs.existsSync(skillDir)) {
+  if (await exists(skillDir)) {
     throw new Error(`Skill already exists: ${name}`);
   }
 
-  fs.mkdirSync(skillDir, { recursive: true });
-  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+  await fs.promises.mkdir(skillDir, { recursive: true });
+  await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
 
   return { name, content };
 }
 
 export async function updateSkill(name: string, content: string): Promise<SkillDetail> {
-  const dir = getSkillsDir();
+  validateName(name);
+
+  const dir = skillsDir();
   const skillDir = path.join(dir, name);
 
-  if (!fs.existsSync(skillDir)) {
+  if (!(await exists(skillDir))) {
     throw new Error(`Skill not found: ${name}`);
   }
 
-  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+  await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
   return { name, content };
 }
 
 export async function deleteSkill(name: string): Promise<void> {
   validateName(name);
 
-  const dir = getSkillsDir();
+  const dir = skillsDir();
   const skillDir = path.join(dir, name);
 
-  if (!fs.existsSync(skillDir)) {
+  if (!(await exists(skillDir))) {
     throw new Error(`Skill not found: ${name}`);
   }
 
-  fs.rmSync(skillDir, { recursive: true, force: true });
+  await fs.promises.rm(skillDir, { recursive: true });
 }

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export interface Skill {
+  name: string;
+  description: string;
+}
+
+export interface SkillDetail {
+  name: string;
+  content: string;
+}
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function getSkillsDir(): string {
+  return path.join(os.homedir(), '.claude', 'skills');
+}
+
+function validateName(name: string): void {
+  if (name === '..' || name.includes('..') || !NAME_RE.test(name)) {
+    throw new Error(`Invalid skill name: ${name}`);
+  }
+}
+
+function parseDescription(content: string): string {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return '';
+  const frontmatter = match[1];
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+  return descMatch ? descMatch[1].trim() : '';
+}
+
+export async function listSkills(): Promise<Skill[]> {
+  const dir = getSkillsDir();
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const skills: Skill[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillFile = path.join(dir, entry.name, 'SKILL.md');
+    const content = fs.readFileSync(skillFile, 'utf-8');
+    skills.push({ name: entry.name, description: parseDescription(content) });
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getSkill(name: string): Promise<SkillDetail> {
+  const dir = getSkillsDir();
+  const skillDir = path.join(dir, name);
+
+  if (!fs.existsSync(skillDir)) {
+    throw new Error(`Skill not found: ${name}`);
+  }
+
+  const content = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8');
+  return { name, content };
+}
+
+export async function createSkill(name: string, content: string): Promise<SkillDetail> {
+  validateName(name);
+
+  const dir = getSkillsDir();
+  const skillDir = path.join(dir, name);
+
+  if (fs.existsSync(skillDir)) {
+    throw new Error(`Skill already exists: ${name}`);
+  }
+
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+
+  return { name, content };
+}
+
+export async function updateSkill(name: string, content: string): Promise<SkillDetail> {
+  const dir = getSkillsDir();
+  const skillDir = path.join(dir, name);
+
+  if (!fs.existsSync(skillDir)) {
+    throw new Error(`Skill not found: ${name}`);
+  }
+
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return { name, content };
+}
+
+export async function deleteSkill(name: string): Promise<void> {
+  validateName(name);
+
+  const dir = getSkillsDir();
+  const skillDir = path.join(dir, name);
+
+  if (!fs.existsSync(skillDir)) {
+    throw new Error(`Skill not found: ${name}`);
+  }
+
+  fs.rmSync(skillDir, { recursive: true, force: true });
+}

--- a/server/startup.test.ts
+++ b/server/startup.test.ts
@@ -163,7 +163,7 @@ describe('checkNeovimVersion', () => {
     { version: 'NVIM v0.11.0', desc: '0.11.0' },
     { version: 'NVIM v1.0.0', desc: '1.0.0' },
   ])('passes for version $desc', ({ version }) => {
-    mockExecFileSync.mockReturnValue(version as unknown as Buffer);
+    mockExecFileSync.mockReturnValue(version);
     checkNeovimVersion();
     expect(mockExit).not.toHaveBeenCalled();
   });
@@ -172,13 +172,13 @@ describe('checkNeovimVersion', () => {
     { version: 'NVIM v0.9.5', desc: '0.9.5' },
     { version: 'NVIM v0.8.0', desc: '0.8.0' },
   ])('exits for version $desc (too old)', ({ version }) => {
-    mockExecFileSync.mockReturnValue(version as unknown as Buffer);
+    mockExecFileSync.mockReturnValue(version);
     expect(() => checkNeovimVersion()).toThrow('process.exit');
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('exits when version cannot be determined', () => {
-    mockExecFileSync.mockReturnValue('unknown output' as unknown as Buffer);
+    mockExecFileSync.mockReturnValue('unknown output');
     expect(() => checkNeovimVersion()).toThrow('process.exit');
     expect(mockExit).toHaveBeenCalledWith(1);
   });

--- a/skills/octomux-create-pr/SKILL.md
+++ b/skills/octomux-create-pr/SKILL.md
@@ -92,7 +92,7 @@ Create a GitHub pull request directly using `gh pr create`. The octomux dashboar
      --repo <repo_path>
    ```
 
-6. **Report** — Print the PR URL. The octomux dashboard at localhost:7777 will auto-detect and link it to the task within ~30 seconds via the PR poller.
+6. **Report** — Print the PR URL. The octomux dashboard will auto-detect and link it to the task within ~30 seconds via the PR poller.
 
 ## Notes
 

--- a/skills/octomux-create-task/SKILL.md
+++ b/skills/octomux-create-task/SKILL.md
@@ -14,16 +14,16 @@ Dispatch an autonomous Claude Code agent to work on a feature, bugfix, or code c
    - If given a Jira ticket URL, fetch the ticket details to extract title, description, and acceptance criteria
 
 2. **Resolve the repo:**
-   - Query the octomux API for recent repos:
+   - Query recent repos via CLI:
      ```bash
-     curl -s http://localhost:7777/api/recent-repos | jq .
+     octomux recent-repos
      ```
    - If the repo is ambiguous, ask the user
 
 3. **Detect base branch:**
 
    ```bash
-   curl -s 'http://localhost:7777/api/default-branch?repo_path=<resolved_path>' | jq -r .branch
+   octomux default-branch --repo-path <resolved_path>
    ```
 
 4. **Generate the branch name:**
@@ -85,15 +85,15 @@ Dispatch an autonomous Claude Code agent to work on a feature, bugfix, or code c
 
 7. **Report:**
    - Print the task ID returned by the CLI
-   - Tell the user to monitor at the dashboard: http://localhost:7777
+   - Tell the user to monitor via `octomux list-tasks` or the dashboard
    - Or via CLI: `octomux list-tasks`
 
 ## Notes
 
-- The octomux server must be running at localhost:7777
+- The octomux server must be running (start with `octomux start`)
 - Tasks start immediately by default — agents begin working right away
 - Each task gets its own git worktree and tmux session for isolation
 - Keep titles short (under 60 chars) and descriptive
 - Initial prompts should be specific and actionable
-- The user can monitor tasks at the dashboard or via the CLI
+- Monitor tasks via `octomux list-tasks` or the dashboard
 - To create PRs for completed tasks, use the `octomux-create-pr` skill

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { UniversalSidebar } from './components/UniversalSidebar';
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 const OrchestratorPage = lazy(() => import('./pages/OrchestratorPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
+const SkillEditor = lazy(() => import('./pages/SkillEditor'));
 
 /** Runs at app root so notifications fire on every page. */
 function GlobalNotifications() {
@@ -85,6 +86,7 @@ export default function App() {
                 <Route path="/tasks/:id" element={<TaskDetail />} />
                 <Route path="/orchestrator" element={<OrchestratorPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
+                <Route path="/skills/:name" element={<SkillEditor />} />
               </Routes>
             </Suspense>
           </main>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -61,6 +61,16 @@ export interface RecentRepo {
   last_used: string;
 }
 
+export interface Skill {
+  name: string;
+  description: string;
+}
+
+export interface SkillDetail {
+  name: string;
+  content: string;
+}
+
 export const api = {
   browse: (path?: string) =>
     request<BrowseResult>(`/browse${path ? `?path=${encodeURIComponent(path)}` : ''}`),
@@ -104,4 +114,17 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ message }),
     }),
+
+  // Skills
+  listSkills: () => request<Skill[]>('/skills'),
+  getSkill: (name: string) => request<SkillDetail>(`/skills/${encodeURIComponent(name)}`),
+  createSkill: (data: { name: string; content: string }) =>
+    request<SkillDetail>('/skills', { method: 'POST', body: JSON.stringify(data) }),
+  updateSkill: (name: string, data: { content: string }) =>
+    request<SkillDetail>(`/skills/${encodeURIComponent(name)}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  deleteSkill: (name: string) =>
+    request<void>(`/skills/${encodeURIComponent(name)}`, { method: 'DELETE' }),
 };

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Task } from '../../server/types';
+import type { Skill } from './api';
 import { api } from './api';
 import { subscribe } from './event-source';
 
@@ -114,4 +115,28 @@ export function useTask(id: string) {
   }, [refresh, id]);
 
   return { task, loading, error, refresh };
+}
+
+export function useSkills() {
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.listSkills();
+      setSkills(data);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { skills, loading, error, refresh };
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,8 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useSkills } from '../lib/hooks';
+import { api } from '../lib/api';
 
 function ToggleSwitch({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
   return (
@@ -41,6 +45,198 @@ function SettingRow({
       </div>
       {children}
     </div>
+  );
+}
+
+function SkillsSection() {
+  const { skills, loading, error, refresh } = useSkills();
+  const navigate = useNavigate();
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleCreate = useCallback(async () => {
+    if (!newName.trim()) return;
+    setCreating(true);
+    try {
+      const content = `---\nname: ${newName.trim()}\ndescription: \n---\n`;
+      await api.createSkill({ name: newName.trim(), content });
+      toast.success(`Skill "${newName.trim()}" created`);
+      setShowCreate(false);
+      setNewName('');
+      navigate(`/skills/${encodeURIComponent(newName.trim())}`);
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  }, [newName, navigate]);
+
+  const handleDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await api.deleteSkill(deleteTarget);
+      toast.success(`Skill "${deleteTarget}" deleted`);
+      setDeleteTarget(null);
+      refresh();
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteTarget, refresh]);
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center justify-between">
+        <SectionHeader label="SKILLS" />
+        <button
+          className="mb-4 text-xs text-[#3B82F6] hover:text-[#60a5fa]"
+          onClick={() => setShowCreate(true)}
+        >
+          + New Skill
+        </button>
+      </div>
+
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-12 animate-pulse rounded bg-[#141414] border border-[#2f2f2f]"
+            />
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-3 rounded border border-red-400/30 bg-red-400/5 px-4 py-3">
+          <span className="text-sm text-red-400">{error}</span>
+          <button
+            className="text-xs text-[#3B82F6] hover:text-[#60a5fa]"
+            onClick={refresh}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && skills.length === 0 && (
+        <div className="py-8 text-center text-sm text-[#6a6a6a]">
+          No skills installed.{' '}
+          <button
+            className="text-[#3B82F6] hover:text-[#60a5fa]"
+            onClick={() => setShowCreate(true)}
+          >
+            Create your first skill
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && skills.length > 0 && (
+        <div className="space-y-0">
+          {skills.map((skill) => (
+            <div
+              key={skill.name}
+              className="flex items-center justify-between border-b border-[#2f2f2f] py-3 cursor-pointer hover:bg-[#141414]"
+              onClick={() => navigate(`/skills/${encodeURIComponent(skill.name)}`)}
+            >
+              <div>
+                <span className="text-sm font-mono">{skill.name}</span>
+                {skill.description && (
+                  <p className="text-xs text-[#8a8a8a]">{skill.description}</p>
+                )}
+              </div>
+              <button
+                className="text-xs text-[#6a6a6a] hover:text-red-400"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setDeleteTarget(skill.name);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Create Dialog */}
+      {showCreate && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setShowCreate(false)}
+        >
+          <div
+            className="w-full max-w-md rounded border border-[#2f2f2f] bg-[#0A0A0A] p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-4 text-sm font-bold">Create Skill</h3>
+            <input
+              type="text"
+              placeholder="Skill name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              className="mb-4 w-full rounded border border-[#2f2f2f] bg-[#141414] px-3 py-2 font-mono text-sm text-white outline-none focus:border-[#3B82F6]"
+              autoFocus
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                className="rounded px-3 py-1.5 text-xs text-[#8a8a8a] hover:text-white"
+                onClick={() => setShowCreate(false)}
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] disabled:opacity-50"
+                onClick={handleCreate}
+                disabled={creating || !newName.trim()}
+              >
+                {creating ? 'Creating…' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-sm rounded border border-[#2f2f2f] bg-[#0A0A0A] p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-2 text-sm font-bold">Delete Skill</h3>
+            <p className="mb-4 text-xs text-[#8a8a8a]">
+              Are you sure you want to delete{' '}
+              <span className="font-mono text-white">{deleteTarget}</span>? This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="rounded px-3 py-1.5 text-xs text-[#8a8a8a] hover:text-white"
+                onClick={() => setDeleteTarget(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="rounded bg-red-600 px-3 py-1.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -98,6 +294,8 @@ export default function SettingsPage() {
             <ToggleSwitch checked={false} onChange={() => {}} />
           </SettingRow>
         </section>
+
+        <SkillsSection />
       </div>
     </div>
   );

--- a/src/pages/SkillEditor.test.tsx
+++ b/src/pages/SkillEditor.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SkillEditor from './SkillEditor';
+import { renderWithRouter, mockApi } from '../test-helpers';
+
+const apiMock = mockApi({
+  getSkill: vi.fn().mockResolvedValue({ name: 'test-skill', content: '# Test Skill' }),
+  updateSkill: vi.fn().mockResolvedValue({ name: 'test-skill', content: 'Updated' }),
+});
+
+vi.mock('@/lib/api', () => ({
+  api: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) => apiMock[prop as keyof typeof apiMock],
+    },
+  ),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+describe('SkillEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getSkill.mockResolvedValue({ name: 'test-skill', content: '# Test Skill' });
+    apiMock.updateSkill.mockResolvedValue({ name: 'test-skill', content: 'Updated' });
+  });
+
+  const renderEditor = () =>
+    renderWithRouter(<SkillEditor />, { route: '/skills/test-skill', path: '/skills/:name' });
+
+  it('renders skill content in textarea', async () => {
+    renderEditor();
+    await waitFor(() => {
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toHaveValue('# Test Skill');
+    });
+  });
+
+  it('shows skill name in header', async () => {
+    renderEditor();
+    await waitFor(() => {
+      expect(screen.getByText('test-skill')).toBeInTheDocument();
+    });
+  });
+
+  it('save button is disabled when content unchanged', async () => {
+    renderEditor();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('# Test Skill');
+    });
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('save button enables when content changes', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('# Test Skill');
+    });
+    await user.click(screen.getByRole('textbox'));
+    await user.type(screen.getByRole('textbox'), ' extra');
+    expect(screen.getByRole('button', { name: /save/i })).not.toBeDisabled();
+  });
+
+  it('shows error state when skill not found', async () => {
+    apiMock.getSkill.mockRejectedValue(new Error('Skill not found'));
+    renderEditor();
+    await waitFor(() => {
+      expect(screen.getByText('Skill not found')).toBeInTheDocument();
+    });
+  });
+
+  it('shows unsaved indicator when content changes', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('# Test Skill');
+    });
+    await user.click(screen.getByRole('textbox'));
+    await user.type(screen.getByRole('textbox'), ' changed');
+    expect(screen.getByText('unsaved')).toBeInTheDocument();
+  });
+});

--- a/src/pages/SkillEditor.tsx
+++ b/src/pages/SkillEditor.tsx
@@ -1,0 +1,121 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { api } from '../lib/api';
+
+export default function SkillEditor() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const savedContentRef = useRef('');
+  const isDirty = content !== savedContentRef.current;
+
+  useEffect(() => {
+    if (!name) return;
+    api
+      .getSkill(name)
+      .then((skill) => {
+        setContent(skill.content);
+        savedContentRef.current = skill.content;
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [name]);
+
+  const save = useCallback(async () => {
+    if (!name || !isDirty || saving) return;
+    setSaving(true);
+    try {
+      await api.updateSkill(name, { content });
+      savedContentRef.current = content;
+      toast.success('Skill saved');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save skill');
+    } finally {
+      setSaving(false);
+    }
+  }, [name, content, isDirty, saving]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        save();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [save]);
+
+  const handleBack = useCallback(() => {
+    if (isDirty) {
+      const confirmed = window.confirm('You have unsaved changes. Discard them?');
+      if (!confirmed) return;
+    }
+    navigate('/settings');
+  }, [isDirty, navigate]);
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <span className="text-[#6a6a6a]">Loading...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3">
+        <p className="text-red-400">{error}</p>
+        <button
+          onClick={() => navigate('/settings')}
+          className="text-xs text-[#3B82F6] hover:underline"
+        >
+          Back to Settings
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-[#2f2f2f] px-6 py-4">
+        <div className="flex items-center gap-3">
+          <button onClick={handleBack} className="text-sm text-[#6a6a6a] hover:text-white">
+            &larr;
+          </button>
+          <span className="font-mono text-lg font-bold">{name}</span>
+          {isDirty && <span className="text-xs text-[#FFB800]">unsaved</span>}
+        </div>
+        <button
+          onClick={save}
+          disabled={!isDirty || saving}
+          className="bg-[#3B82F6] px-4 py-2 text-xs text-white disabled:opacity-50"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+      <div className="flex-1 p-6">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="h-full min-h-[500px] w-full resize-none border border-[#2f2f2f] bg-[#0A0A0A] p-4 font-mono text-sm leading-relaxed text-white outline-none focus:border-[#3B82F6]"
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -107,6 +107,11 @@ export function mockApi(overrides: Record<string, unknown> = {}) {
     orchestratorStop: vi.fn().mockResolvedValue({ running: false }),
     orchestratorSend: vi.fn().mockResolvedValue({ ok: true, running: true }),
     orchestratorType: vi.fn().mockResolvedValue({ ok: true, running: true }),
+    listSkills: vi.fn().mockResolvedValue([]),
+    getSkill: vi.fn().mockResolvedValue({ name: 'test-skill', content: '# Test' }),
+    createSkill: vi.fn().mockResolvedValue({ name: 'test-skill', content: '# Test' }),
+    updateSkill: vi.fn().mockResolvedValue({ name: 'test-skill', content: '# Updated' }),
+    deleteSkill: vi.fn().mockResolvedValue(undefined),
   };
   return { ...defaults, ...overrides };
 }


### PR DESCRIPTION
## What
- Add Skills section to Settings page with list, create, and delete functionality
- Add dedicated `/skills/:name` editor page with save, dirty tracking, and Cmd+S shortcut
- Add 5 REST API endpoints for skills CRUD (`GET/POST/PUT/DELETE /api/skills`)
- Add 6 CLI commands: `list-skills`, `get-skill`, `create-skill`, `delete-skill`, `recent-repos`, `default-branch`
- Replace hardcoded `curl` API calls in bundled skills with CLI commands

## Why
Skills could only be managed by manually editing files on disk. This adds a full CRUD interface so users can browse, create, edit, and delete Claude Code skills without leaving the octomux dashboard or CLI.

## Testing
- 28 new server tests (skills filesystem module + API routes)
- 6 new frontend component tests (SkillEditor)
- All 630 tests passing, typecheck clean, 0 lint errors