### PR TITLE
feat(toasts): restyle notifications with custom accent bar design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,13 +61,7 @@ export default function App() {
             theme="dark"
             position="bottom-right"
             toastOptions={{
-              style: {
-                background: '#0A0A0A',
-                border: '1px solid #2f2f2f',
-                borderRadius: 0,
-                color: '#FFFFFF',
-                fontFamily: "'JetBrains Mono Variable', monospace",
-              },
+              unstyled: true,
             }}
           />
           <GlobalNotifications />

--- a/src/components/CustomToast.tsx
+++ b/src/components/CustomToast.tsx
@@ -1,0 +1,128 @@
+import { toast as sonnerToast } from 'sonner';
+import { X } from 'lucide-react';
+
+type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+const ACCENT_COLORS: Record<ToastType, string> = {
+  success: '#22C55E',
+  error: '#EF4444',
+  warning: '#FFB800',
+  info: '#3B82F6',
+};
+
+interface CustomToastProps {
+  id: string | number;
+  type: ToastType;
+  title: string;
+  description: string;
+  action?: { label: string; onClick: () => void };
+}
+
+export function CustomToast({ id, type, title, description, action }: CustomToastProps) {
+  return (
+    <div
+      style={{
+        width: 360,
+        background: '#0A0A0A',
+        border: '1px solid #2f2f2f',
+        padding: '14px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        fontFamily: "'JetBrains Mono Variable', monospace",
+      }}
+    >
+      {/* Accent bar */}
+      <div
+        style={{
+          width: 3,
+          height: 32,
+          flexShrink: 0,
+          backgroundColor: ACCENT_COLORS[type],
+          borderRadius: 0,
+        }}
+      />
+
+      {/* Text content */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: '#FFFFFF',
+            textTransform: 'uppercase',
+            lineHeight: 1.3,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 400,
+            color: '#8a8a8a',
+            lineHeight: 1.3,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {description}
+        </div>
+      </div>
+
+      {/* Action button */}
+      {action && (
+        <button
+          onClick={() => {
+            action.onClick();
+            sonnerToast.dismiss(id);
+          }}
+          style={{
+            flexShrink: 0,
+            fontSize: 11,
+            fontWeight: 700,
+            color: ACCENT_COLORS[type],
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px 8px',
+            fontFamily: "'JetBrains Mono Variable', monospace",
+            textTransform: 'uppercase',
+          }}
+        >
+          {action.label}
+        </button>
+      )}
+
+      {/* Close button */}
+      <button
+        onClick={() => sonnerToast.dismiss(id)}
+        style={{
+          flexShrink: 0,
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <X size={12} color="#6a6a6a" />
+      </button>
+    </div>
+  );
+}
+
+/** Helper to fire a styled custom toast. */
+export function showToast(
+  type: ToastType,
+  title: string,
+  description: string,
+  action?: { label: string; onClick: () => void },
+) {
+  return sonnerToast.custom((id) => (
+    <CustomToast id={id} type={type} title={title} description={description} action={action} />
+  ));
+}

--- a/src/lib/use-notifications.ts
+++ b/src/lib/use-notifications.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { toast } from 'sonner';
 import type { Task, Agent } from '../../server/types';
+import { showToast } from '../components/CustomToast';
 import { getNotificationsEnabled } from './notification-settings';
 
 interface AgentSnapshot {
@@ -61,24 +61,18 @@ export function useNotifications(tasks: Task[], navigate: (path: string) => void
         // Agent stopped transition
         if (prev.status !== 'stopped' && agent.status === 'stopped') {
           const taskId = task.id;
-          toast(agentTag(task, agent), {
-            description: 'Agent stopped',
-            action: {
-              label: 'View',
-              onClick: () => navigate(`/tasks/${taskId}`),
-            },
+          showToast('info', agentTag(task, agent), 'Agent stopped', {
+            label: 'View',
+            onClick: () => navigate(`/tasks/${taskId}`),
           });
         }
 
         // Agent finished (went idle after being active)
         if (prev.hookActivity === 'active' && agent.hook_activity === 'idle') {
           const taskId = task.id;
-          toast.success(agentTag(task, agent), {
-            description: 'Agent finished',
-            action: {
-              label: 'View',
-              onClick: () => navigate(`/tasks/${taskId}`),
-            },
+          showToast('success', agentTag(task, agent), 'Agent finished', {
+            label: 'View',
+            onClick: () => navigate(`/tasks/${taskId}`),
           });
         }
       }
@@ -92,12 +86,9 @@ export function useNotifications(tasks: Task[], navigate: (path: string) => void
             const agentId = prompt.agent_id;
             const promptAgent = task.agents?.find((a) => a.id === prompt.agent_id);
             const promptTag = promptAgent ? agentTag(task, promptAgent) : `${task.title} #?`;
-            toast.warning(promptTag, {
-              description: `Needs permission: ${prompt.tool_name}`,
-              action: {
-                label: 'View',
-                onClick: () => navigate(`/tasks/${taskId}?agent=${agentId}`),
-              },
+            showToast('warning', promptTag, `Needs permission: ${prompt.tool_name}`, {
+              label: 'View',
+              onClick: () => navigate(`/tasks/${taskId}?agent=${agentId}`),
             });
           }
         }
@@ -117,20 +108,14 @@ export function useNotifications(tasks: Task[], navigate: (path: string) => void
           if (hadActiveAgents) {
             const taskId = task.id;
             if (task.status === 'error') {
-              toast.error(task.title, {
-                description: 'Task errored',
-                action: {
-                  label: 'View',
-                  onClick: () => navigate(`/tasks/${taskId}`),
-                },
+              showToast('error', task.title, 'Task errored', {
+                label: 'View',
+                onClick: () => navigate(`/tasks/${taskId}`),
               });
             } else {
-              toast.success(task.title, {
-                description: 'Task closed',
-                action: {
-                  label: 'View',
-                  onClick: () => navigate(`/tasks/${taskId}`),
-                },
+              showToast('success', task.title, 'Task closed', {
+                label: 'View',
+                onClick: () => navigate(`/tasks/${taskId}`),
               });
             }
           }


### PR DESCRIPTION
## What
- Replace default Sonner toast styling with a custom `CustomToast` component using `toast.custom()`
- Each toast type gets a colored left accent bar (green/red/yellow/blue), JetBrains Mono typography, ALL CAPS titles, and muted descriptions
- New `showToast()` helper centralizes toast rendering with consistent styling
- Toaster config set to `unstyled: true` to prevent Sonner defaults from conflicting

## Why
The default Sonner styling felt generic and inconsistent with the terminal-inspired dashboard aesthetic. The new design matches the octomux.pen specs with 3×32px accent bars, monospace font, and proper color coding per toast type.

## Testing
- All 615 unit tests pass (`bun run test`)
- No new type errors from `bun run typecheck`
- Lint and format clean