### PR TITLE
feat(tasks): add opt-in no-worktree mode for task creation

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -38,6 +38,7 @@ export interface OctomuxClient {
     branch?: string;
     base_branch?: string;
     draft?: boolean;
+    no_worktree?: boolean;
   }): Promise<Task>;
   listTasks(params?: { repo_path?: string }): Promise<Task[]>;
   getTask(id: string): Promise<Task>;

--- a/cli/src/commands/create-task.ts
+++ b/cli/src/commands/create-task.ts
@@ -13,6 +13,7 @@ export function registerCreateTask(program: Command): void {
     .option('-b, --branch <name>', 'branch name')
     .option('--base-branch <name>', 'base branch name')
     .option('--draft', 'create as draft without starting')
+    .option('--no-worktree', 'run agent in the repo directory without creating a worktree')
     .action(async (opts, cmd) => {
       const globals = cmd.optsWithGlobals();
       const client: OctomuxClient = globals._client;
@@ -25,6 +26,7 @@ export function registerCreateTask(program: Command): void {
         branch: opts.branch,
         base_branch: opts.baseBranch,
         draft: opts.draft,
+        no_worktree: opts.noWorktree,
       });
 
       if (isJsonMode(globals.json)) {

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -389,6 +389,24 @@ describe('POST /api/tasks', () => {
     const task = getTask(db, res.body.id);
     expect(task?.initial_prompt).toBe('Fix the bug in orders.ts');
   });
+
+  it('stores no_worktree when provided', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({ ...validPayload, no_worktree: true });
+
+    expect(res.status).toBe(201);
+    const task = getTask(db, res.body.id);
+    expect(task?.no_worktree).toBe(1);
+  });
+
+  it('defaults no_worktree to 0 when not provided', async () => {
+    const res = await request(app).post('/api/tasks').send(validPayload);
+
+    expect(res.status).toBe(201);
+    const task = getTask(db, res.body.id);
+    expect(task?.no_worktree).toBe(0);
+  });
 });
 
 // ─── POST /api/tasks/:id/start ──────────────────────────────────────────────
@@ -496,6 +514,19 @@ describe('PATCH /api/tasks/:id', () => {
     expect(resumeTask).toHaveBeenCalledOnce();
   });
 
+  it.each(resumableStatuses)(
+    'allows resume of no_worktree %s task without worktree check',
+    async (status) => {
+      vi.mocked(fs.existsSync).mockReturnValue(false); // no worktree on disk
+      insertTask(db, { ...DEFAULTS.runningTask, status, no_worktree: 1 });
+      const res = await request(app)
+        .patch(`/api/tasks/${DEFAULTS.task.id}`)
+        .send({ status: 'running' });
+      expect(res.status).toBe(200);
+      expect(resumeTask).toHaveBeenCalledOnce();
+    },
+  );
+
   // ─── Draft field updates ──────────────────────────────────────────────────
 
   it('updates draft task fields', async () => {
@@ -552,6 +583,16 @@ describe('PATCH /api/tasks/:id', () => {
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
       .send({ title: 'New title' });
     expect(res.body.updated_at).not.toBe('2020-01-01 00:00:00');
+  });
+
+  it('updates no_worktree on draft task', async () => {
+    insertTask(db);
+    const res = await request(app)
+      .patch(`/api/tasks/${DEFAULTS.task.id}`)
+      .send({ no_worktree: true });
+    expect(res.status).toBe(200);
+    const task = getTask(db, res.body.id);
+    expect(task?.no_worktree).toBe(1);
   });
 });
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -316,7 +316,7 @@ export function setupRoutes(app: Express): void {
     const isDraft = !!body.draft;
 
     db.prepare(
-      'INSERT INTO tasks (id, title, description, repo_path, status, branch, base_branch, initial_prompt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      'INSERT INTO tasks (id, title, description, repo_path, status, branch, base_branch, initial_prompt, no_worktree) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
     ).run(
       id,
       body.title,
@@ -326,6 +326,7 @@ export function setupRoutes(app: Express): void {
       body.branch ?? null,
       body.base_branch ?? null,
       body.initial_prompt ?? null,
+      body.no_worktree ? 1 : 0,
     );
 
     const created = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Task;
@@ -369,6 +370,7 @@ export function setupRoutes(app: Express): void {
       'branch',
       'base_branch',
       'initial_prompt',
+      'no_worktree',
     ].some((k) => (body as Record<string, unknown>)[k] !== undefined);
 
     if (hasDraftFields) {
@@ -404,10 +406,11 @@ export function setupRoutes(app: Express): void {
         'branch',
         'base_branch',
         'initial_prompt',
+        'no_worktree',
       ] as const) {
         if (body[key] !== undefined) {
           fields.push(`${key} = ?`);
-          values.push(body[key] ?? null);
+          values.push(key === 'no_worktree' ? (body[key] ? 1 : 0) : (body[key] ?? null));
         }
       }
       if (fields.length > 0) {
@@ -421,7 +424,7 @@ export function setupRoutes(app: Express): void {
         res.status(400).json({ error: 'Can only resume tasks in closed or error state' });
         return;
       }
-      if (!task.worktree || !fs.existsSync(task.worktree)) {
+      if (!task.no_worktree && (!task.worktree || !fs.existsSync(task.worktree))) {
         res.status(400).json({ error: 'Worktree no longer exists on disk' });
         return;
       }

--- a/server/db.ts
+++ b/server/db.ts
@@ -128,6 +128,9 @@ export function initDb(instance: Database.Database): void {
   if (!colNames.includes('user_window_index')) {
     instance.exec('ALTER TABLE tasks ADD COLUMN user_window_index INTEGER');
   }
+  if (!colNames.includes('no_worktree')) {
+    instance.exec('ALTER TABLE tasks ADD COLUMN no_worktree INTEGER NOT NULL DEFAULT 0');
+  }
 
   // Add hook_activity columns to agents table (for existing DBs)
   const agentCols2 = instance.pragma('table_info(agents)') as Array<{ name: string }>;

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -291,6 +291,64 @@ describe('startTask', () => {
     expect(updated.status).toBe('error');
     expect(updated.error).toContain(errorContains);
   });
+
+  // ─── No-worktree mode ─────────────────────────────────────────────────
+
+  describe('no_worktree mode', () => {
+    const noWorktreeTask = { ...DEFAULTS.task, no_worktree: 1 } as Task;
+
+    beforeEach(async () => {
+      insertTask(db, { no_worktree: 1 });
+      await startTask(noWorktreeTask);
+    });
+
+    it('sets worktree to repo_path', () => {
+      const updated = getTask(db, DEFAULTS.task.id)!;
+      expect(updated.worktree).toBe(DEFAULTS.task.repo_path);
+    });
+
+    it('sets branch to null', () => {
+      const updated = getTask(db, DEFAULTS.task.id)!;
+      expect(updated.branch).toBeNull();
+    });
+
+    it('sets status to running', () => {
+      const updated = getTask(db, DEFAULTS.task.id)!;
+      expect(updated.status).toBe('running');
+    });
+
+    it('does not create a git worktree', () => {
+      expect(
+        findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'add'] }),
+      ).toBeUndefined();
+    });
+
+    it('does not create .worktrees directory', () => {
+      expect(vi.mocked(fs.mkdirSync)).not.toHaveBeenCalledWith(
+        expect.stringContaining('.worktrees'),
+        expect.anything(),
+      );
+    });
+
+    it('creates tmux session with repo_path as cwd', () => {
+      const call = findExecCall(vi.mocked(execFile), {
+        cmd: 'tmux',
+        argsInclude: ['new-session'],
+      });
+      expect(call).toBeDefined();
+      expect(call![1]).toContain(DEFAULTS.task.repo_path);
+    });
+
+    it('still creates an agent', () => {
+      const agents = getAgents(db, DEFAULTS.task.id);
+      expect(agents).toHaveLength(1);
+      expect(agents[0].label).toBe('Agent 1');
+    });
+
+    it('installs hook settings in repo_path', () => {
+      expect(installHookSettings).toHaveBeenCalledWith(DEFAULTS.task.repo_path);
+    });
+  });
 });
 
 // ─── addAgent ─────────────────────────────────────────────────────────────────

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -605,6 +605,39 @@ describe('deleteTask', () => {
     await deleteTask(task);
     expect(findExecCall(vi.mocked(execFile), shouldNotCall)).toBeUndefined();
   });
+
+  describe('no_worktree mode', () => {
+    const noWorktreeRunningTask = {
+      ...DEFAULTS.runningTask,
+      no_worktree: 1,
+      worktree: DEFAULTS.runningTask.repo_path,
+      branch: null,
+    } as Task;
+
+    it('kills tmux session', async () => {
+      insertTask(db, noWorktreeRunningTask);
+      await deleteTask(noWorktreeRunningTask);
+      expect(
+        findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['kill-session'] }),
+      ).toBeDefined();
+    });
+
+    it('does not remove worktree', async () => {
+      insertTask(db, noWorktreeRunningTask);
+      await deleteTask(noWorktreeRunningTask);
+      expect(
+        findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'remove'] }),
+      ).toBeUndefined();
+    });
+
+    it('does not delete branch', async () => {
+      insertTask(db, noWorktreeRunningTask);
+      await deleteTask(noWorktreeRunningTask);
+      expect(
+        findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['branch', '-D'] }),
+      ).toBeUndefined();
+    });
+  });
 });
 
 // ─── stopAgent ────────────────────────────────────────────────────────────────
@@ -772,6 +805,65 @@ describe('resumeTask', () => {
 
     const updated = getTask(db, DEFAULTS.task.id)!;
     expect(updated.user_window_index).toBeNull();
+  });
+
+  describe('no_worktree mode', () => {
+    const noWorktreeClosedTask = {
+      ...DEFAULTS.runningTask,
+      status: 'closed' as const,
+      no_worktree: 1,
+      worktree: DEFAULTS.runningTask.repo_path,
+      branch: null,
+    } as Task;
+
+    beforeEach(() => {
+      vi.mocked(execFile).mockImplementation(((_cmd: string, args: string[], cb: Function) => {
+        if (args.includes('display-message')) {
+          cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+        } else if (args.includes('list-windows')) {
+          cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+        } else if (args.includes('new-window')) {
+          nextWindowIndex++;
+          cb(null, { stdout: '', stderr: '' });
+        } else {
+          cb(null, { stdout: 'true', stderr: '' });
+        }
+      }) as any);
+    });
+
+    it('resumes to running status', async () => {
+      insertTask(db, { ...noWorktreeClosedTask });
+      insertAgent(db, { status: 'stopped' });
+
+      await resumeTask(noWorktreeClosedTask);
+
+      const updated = getTask(db, DEFAULTS.task.id)!;
+      expect(updated.status).toBe('running');
+    });
+
+    it('creates tmux session with repo_path as cwd', async () => {
+      insertTask(db, { ...noWorktreeClosedTask });
+      insertAgent(db, { status: 'stopped' });
+
+      await resumeTask(noWorktreeClosedTask);
+
+      const call = findExecCall(vi.mocked(execFile), {
+        cmd: 'tmux',
+        argsInclude: ['new-session'],
+      });
+      expect(call).toBeDefined();
+      expect(call![1]).toContain(DEFAULTS.task.repo_path);
+    });
+
+    it('marks stopped agents as running', async () => {
+      insertTask(db, { ...noWorktreeClosedTask });
+      insertAgent(db, { status: 'stopped' });
+
+      await resumeTask(noWorktreeClosedTask);
+
+      const agents = getAgents(db, DEFAULTS.task.id);
+      expect(agents[0].status).toBe('running');
+    });
   });
 });
 

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -321,6 +321,9 @@ export async function deleteTask(task: Task): Promise<void> {
     await execFile('tmux', ['kill-session', '-t', task.tmux_session]).catch(() => {});
   }
 
+  // Skip worktree and branch cleanup for no-worktree tasks
+  if (task.no_worktree) return;
+
   // Remove worktree
   if (task.worktree) {
     await execFile('git', [

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -127,46 +127,58 @@ export async function startTask(task: Task): Promise<void> {
   const db = getDb();
   const id = task.id;
   const session = `octomux-agent-${id}`;
-  const slug = slugifyTitle(task.title, id);
-  const branch = task.branch || `agents/${slug}`;
-  const worktreeDir = task.branch || slug;
-  const worktreePath = path.join(task.repo_path, '.worktrees', worktreeDir);
+  const isNoWorktree = !!task.no_worktree;
 
   try {
-    // 1. Update status to setting_up
-    db.prepare(
-      `UPDATE tasks SET status = ?, tmux_session = ?, branch = ?, worktree = ?, updated_at = datetime('now') WHERE id = ?`,
-    ).run('setting_up', session, branch, worktreePath, id);
-
-    // 2. Validate repo path
+    // 1. Validate repo path
     if (!fs.existsSync(task.repo_path)) {
       throw new Error(`Repository path does not exist: ${task.repo_path}`);
     }
     await execFile('git', ['-C', task.repo_path, 'rev-parse', '--is-inside-work-tree']);
 
-    // 3. Ensure .worktrees directory exists
-    const worktreeBaseDir = path.join(task.repo_path, '.worktrees');
-    fs.mkdirSync(worktreeBaseDir, { recursive: true });
+    let worktreePath: string;
 
-    // 4. Create worktree (optionally from a base branch)
-    const worktreeArgs = ['-C', task.repo_path, 'worktree', 'add', worktreePath, '-b', branch];
-    if (task.base_branch) {
-      worktreeArgs.push(task.base_branch);
+    if (isNoWorktree) {
+      // No-worktree mode: run directly in repo
+      worktreePath = task.repo_path;
+      db.prepare(
+        `UPDATE tasks SET status = ?, tmux_session = ?, branch = NULL, worktree = ?, updated_at = datetime('now') WHERE id = ?`,
+      ).run('setting_up', session, worktreePath, id);
+    } else {
+      // Standard mode: create worktree and branch
+      const slug = slugifyTitle(task.title, id);
+      const branch = task.branch || `agents/${slug}`;
+      const worktreeDir = task.branch || slug;
+      worktreePath = path.join(task.repo_path, '.worktrees', worktreeDir);
+
+      db.prepare(
+        `UPDATE tasks SET status = ?, tmux_session = ?, branch = ?, worktree = ?, updated_at = datetime('now') WHERE id = ?`,
+      ).run('setting_up', session, branch, worktreePath, id);
+
+      // Ensure .worktrees directory exists
+      const worktreeBaseDir = path.join(task.repo_path, '.worktrees');
+      fs.mkdirSync(worktreeBaseDir, { recursive: true });
+
+      // Create worktree (optionally from a base branch)
+      const worktreeArgs = ['-C', task.repo_path, 'worktree', 'add', worktreePath, '-b', branch];
+      if (task.base_branch) {
+        worktreeArgs.push(task.base_branch);
+      }
+      await execFile('git', worktreeArgs);
+
+      // Copy .claude/settings.local.json if it exists
+      const settingsSrc = path.join(task.repo_path, '.claude', 'settings.local.json');
+      const settingsDst = path.join(worktreePath, '.claude', 'settings.local.json');
+      if (fs.existsSync(settingsSrc)) {
+        fs.mkdirSync(path.dirname(settingsDst), { recursive: true });
+        fs.copyFileSync(settingsSrc, settingsDst);
+      }
     }
-    await execFile('git', worktreeArgs);
 
-    // 5. Copy .claude/settings.local.json if it exists
-    const settingsSrc = path.join(task.repo_path, '.claude', 'settings.local.json');
-    const settingsDst = path.join(worktreePath, '.claude', 'settings.local.json');
-    if (fs.existsSync(settingsSrc)) {
-      fs.mkdirSync(path.dirname(settingsDst), { recursive: true });
-      fs.copyFileSync(settingsSrc, settingsDst);
-    }
-
-    // 5b. Install hook settings for permission tracking
+    // Install hook settings
     installHookSettings(worktreePath);
 
-    // 6. Create tmux session
+    // Create tmux session
     await execFile('tmux', ['new-session', '-d', '-s', session, '-c', worktreePath]);
     // Prevent grouped viewer sessions from constraining window size
     await execFile('tmux', ['set-option', '-t', session, 'aggressive-resize', 'on']);

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -20,6 +20,7 @@ export const DEFAULTS = {
     pr_number: null,
     user_window_index: null,
     initial_prompt: null,
+    no_worktree: 0,
     error: null,
     created_at: '2026-01-01 00:00:00',
     updated_at: '2026-01-01 00:00:00',
@@ -39,6 +40,7 @@ export const DEFAULTS = {
     pr_number: null,
     user_window_index: null,
     initial_prompt: null,
+    no_worktree: 0,
     error: null,
     created_at: '2026-01-01 00:00:00',
     updated_at: '2026-01-01 00:00:00',
@@ -101,8 +103,8 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
   } as Task;
 
   db.prepare(
-    `INSERT INTO tasks (id, title, description, repo_path, status, branch, base_branch, worktree, tmux_session, pr_url, pr_number, user_window_index, initial_prompt, error, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO tasks (id, title, description, repo_path, status, branch, base_branch, worktree, tmux_session, pr_url, pr_number, user_window_index, initial_prompt, no_worktree, error, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     task.id,
     task.title,
@@ -117,6 +119,7 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
     task.pr_number,
     task.user_window_index,
     task.initial_prompt,
+    task.no_worktree ?? 0,
     task.error,
     task.created_at,
     task.updated_at,
@@ -287,6 +290,7 @@ export const TASKS_TABLE_COLUMNS = [
   'pr_number',
   'user_window_index',
   'initial_prompt',
+  'no_worktree',
   'error',
   'created_at',
   'updated_at',

--- a/server/types.ts
+++ b/server/types.ts
@@ -17,6 +17,7 @@ export interface Task {
   pr_number: number | null;
   user_window_index: number | null;
   initial_prompt: string | null;
+  no_worktree: number;
   error: string | null;
   created_at: string;
   updated_at: string;
@@ -70,6 +71,7 @@ export interface CreateTaskRequest {
   base_branch?: string;
   initial_prompt?: string;
   draft?: boolean;
+  no_worktree?: boolean;
 }
 
 export interface OrchestratorStatus {
@@ -89,4 +91,5 @@ export interface UpdateTaskRequest {
   branch?: string;
   base_branch?: string;
   initial_prompt?: string;
+  no_worktree?: boolean;
 }

--- a/src/components/CreateTaskDialog.test.tsx
+++ b/src/components/CreateTaskDialog.test.tsx
@@ -235,6 +235,51 @@ describe('CreateTaskDialog', () => {
     });
   });
 
+  // ─── No-worktree mode ──────────────────────────────────────────────────────
+
+  describe('no-worktree mode', () => {
+    it('renders NO WORKTREE checkbox', async () => {
+      await openDialog();
+      expect(screen.getByLabelText(/NO WORKTREE/)).toBeInTheDocument();
+    });
+
+    it('hides branch and base branch fields when checked', async () => {
+      await openDialog();
+      // Branch fields visible by default
+      expect(screen.getByLabelText(/^Branch Name/)).toBeInTheDocument();
+      // Check no-worktree
+      await user.click(screen.getByLabelText(/NO WORKTREE/));
+      // Branch fields hidden
+      expect(screen.queryByLabelText(/^Branch Name/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Base Branch/)).not.toBeInTheDocument();
+    });
+
+    it('passes no_worktree to API when checked', async () => {
+      await openDialog();
+      await fillForm({ title: 'Fix bug', description: 'Desc', repoPath: '/tmp/repo' });
+      await user.click(screen.getByLabelText(/NO WORKTREE/));
+      await user.click(screen.getByText('DISPATCH'));
+
+      await waitFor(() => {
+        expect(apiMock.createTask).toHaveBeenCalledWith(
+          expect.objectContaining({ no_worktree: true }),
+        );
+      });
+    });
+
+    it('does not pass no_worktree when unchecked', async () => {
+      await openDialog();
+      await fillForm({ title: 'Fix bug', description: 'Desc', repoPath: '/tmp/repo' });
+      await user.click(screen.getByText('DISPATCH'));
+
+      await waitFor(() => {
+        expect(apiMock.createTask).toHaveBeenCalledWith(
+          expect.not.objectContaining({ no_worktree: true }),
+        );
+      });
+    });
+  });
+
   // ─── Cancel ───────────────────────────────────────────────────────────────
 
   it('closes dialog on cancel without calling API', async () => {

--- a/src/components/CreateTaskDialog.tsx
+++ b/src/components/CreateTaskDialog.tsx
@@ -46,6 +46,7 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
   const [branch, setBranch] = useState('');
   const [baseBranch, setBaseBranch] = useState('');
   const [showPrompt, setShowPrompt] = useState(false);
+  const [noWorktree, setNoWorktree] = useState(false);
   const [draft, setDraft] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -95,6 +96,7 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
         branch: branch.trim() || undefined,
         base_branch: baseBranch.trim() || undefined,
         initial_prompt: initialPrompt.trim() || undefined,
+        no_worktree: noWorktree || undefined,
         draft: draft || undefined,
       });
       setTitle('');
@@ -104,6 +106,7 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
       setBaseBranch('');
       setInitialPrompt('');
       setShowPrompt(false);
+      setNoWorktree(false);
       setDraft(false);
       setTouched({});
       setRepoValidation('idle');
@@ -191,41 +194,45 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
             )}
           </div>
 
-          {/* Branch name */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <Label htmlFor="branch">Branch Name</Label>
-              {branchIsAuto && branch && (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                  auto
-                </span>
-              )}
-            </div>
-            <Input
-              id="branch"
-              placeholder="feat/my-feature"
-              className="font-mono text-sm"
-              value={branch}
-              onChange={(e) => {
-                setBranch(e.target.value);
-                setBranchIsAuto(false);
-              }}
-            />
-          </div>
+          {!noWorktree && (
+            <>
+              {/* Branch name */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="branch">Branch Name</Label>
+                  {branchIsAuto && branch && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      auto
+                    </span>
+                  )}
+                </div>
+                <Input
+                  id="branch"
+                  placeholder="feat/my-feature"
+                  className="font-mono text-sm"
+                  value={branch}
+                  onChange={(e) => {
+                    setBranch(e.target.value);
+                    setBranchIsAuto(false);
+                  }}
+                />
+              </div>
 
-          {/* Base branch */}
-          <div className="flex flex-col gap-2">
-            <Label>Base Branch</Label>
-            <BranchPickerField
-              repoPath={repoPath}
-              value={baseBranch}
-              onChange={setBaseBranch}
-              onBranchesLoaded={(_branches, defaultBranch) => {
-                setBaseBranch(defaultBranch);
-              }}
-              disabled={!repoPath.trim()}
-            />
-          </div>
+              {/* Base branch */}
+              <div className="flex flex-col gap-2">
+                <Label>Base Branch</Label>
+                <BranchPickerField
+                  repoPath={repoPath}
+                  value={baseBranch}
+                  onChange={setBaseBranch}
+                  onBranchesLoaded={(_branches, defaultBranch) => {
+                    setBaseBranch(defaultBranch);
+                  }}
+                  disabled={!repoPath.trim()}
+                />
+              </div>
+            </>
+          )}
 
           {/* Initial Prompt (optional) */}
           <div className="flex flex-col gap-2">
@@ -248,6 +255,17 @@ export function CreateTaskDialog({ onCreated }: CreateTaskDialogProps) {
               />
             )}
           </div>
+
+          {/* No-worktree mode */}
+          <label className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-[#8a8a8a] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={noWorktree}
+              onChange={(e) => setNoWorktree(e.target.checked)}
+              className="h-4 w-4 rounded-none border border-[#3f3f3f] bg-transparent accent-[#3B82F6] cursor-pointer"
+            />
+            NO WORKTREE
+          </label>
 
           {/* Draft mode */}
           <label className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-[#8a8a8a] cursor-pointer">

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -35,6 +35,7 @@ export const TASK_DEFAULTS: Task = {
   pr_number: null,
   user_window_index: null,
   initial_prompt: null,
+  no_worktree: 0,
   error: null,
   created_at: '2026-01-01 00:00:00',
   updated_at: '2026-01-01 00:00:00',


### PR DESCRIPTION
## What
Add a `no_worktree` flag to task creation that lets agents run directly in the main repo directory, skipping git worktree and branch creation. When enabled:
- `task.worktree` is set to `repo_path` (so all downstream code works unchanged)
- No git branch is created — commits go to whatever branch the repo is on
- `deleteTask` skips worktree/branch cleanup
- Resume works without worktree existence check

Changes span the full stack: DB schema, task runner, REST API, CLI (`--no-worktree`), and dashboard UI (checkbox).

## Why
Worktree isolation adds setup time and complexity. For quick fixes, exploratory work, or simple tasks, users want agents to work directly on their current working directory without the overhead.

## Testing
- 683 tests pass (`bun run test`)
- Typecheck clean (`bun run typecheck`)
- No lint errors
- New tests cover: startTask no-worktree mode (8 tests), deleteTask no-worktree mode (3 tests), resumeTask no-worktree mode (3 tests), API creation/resume/draft-update (4 tests), UI checkbox behavior (4 tests)