### PR TITLE
feat(lazygit): inline commit guidelines and auto-install config on startup

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,36 @@
+os:
+  editPreset: "nvim"
+git:
+  pagers:
+    - colorArg: always
+      pager: delta --dark --paging=never --line-numbers
+customCommands:
+  - key: "C"
+    context: "files"
+    command: "(echo '---RECENT COMMITS (do NOT repeat these)---' && git log --oneline -5 2>/dev/null && echo '---DIFF---' && git diff --cached) | claude --model sonnet -p 'You are a commit message generator. Guidelines: use conventional commits format type(scope): message. Types: feat, fix, chore, refactor, style, test, docs. Use kebab-case scopes. Max 100 chars for the header line. Use imperative mood. Do NOT include Co-Authored-By lines. The RECENT COMMITS section shows what was already committed — your message MUST be different and describe only what is new in this diff. Cover ALL changes but keep the message short. Output ONLY the commit message, nothing else.' > /tmp/claude-commit-msg && git commit -e -F /tmp/claude-commit-msg"
+    description: "Commit with Claude-generated message"
+    output: terminal
+gui:
+  nerdFontsVersion: "3"
+  sidePanelWidth: 0.25
+  enlargedSideViewLocation: top
+  theme:
+    activeBorderColor:
+      - "#89b4fa"
+      - bold
+    inactiveBorderColor:
+      - "#a6adc8"
+    optionsTextColor:
+      - "#89b4fa"
+    selectedLineBgColor:
+      - "#313244"
+    cherryPickedCommitBgColor:
+      - "#45475a"
+    cherryPickedCommitFgColor:
+      - "#89b4fa"
+    unstagedChangesColor:
+      - "#f38ba8"
+    defaultFgColor:
+      - "#cdd6f4"
+    searchingActiveBorderColor:
+      - "#f9e2af"

--- a/bin/octomux.js
+++ b/bin/octomux.js
@@ -43,8 +43,9 @@ async function runStart(startArgs) {
   // Welcome banner
   console.log(`\n\uD83D\uDC19 octomux v${version}\n`);
 
-  // Install bundled skills
+  // Install bundled skills and configs
   installSkills();
+  installLazygitConfig();
 
   // Ensure cli/ dependencies are installed
   ensureCliDeps();
@@ -146,6 +147,23 @@ function fixNodePtyPermissions() {
 }
 
 // ─── skill installer ─────────────────────────────────────────────────────────
+
+function installLazygitConfig() {
+  const source = path.join(__dirname, '..', '.config', 'lazygit', 'config.yml');
+  if (!existsSync(source)) return;
+
+  const configDir =
+    process.platform === 'darwin'
+      ? path.join(os.homedir(), 'Library', 'Application Support', 'lazygit')
+      : path.join(os.homedir(), '.config', 'lazygit');
+  const target = path.join(configDir, 'config.yml');
+
+  if (existsSync(target)) return;
+
+  mkdirSync(configDir, { recursive: true });
+  cpSync(source, target);
+  console.log('Installed lazygit config');
+}
 
 function installSkills() {
   const skillsSource = path.join(__dirname, '..', 'skills');


### PR DESCRIPTION
## What
- Add lazygit config at `.config/lazygit/config.yml` with shift-C keybinding that pipes staged diffs to Claude for commit message generation, with conventional commit guidelines inlined in the prompt
- Add `installLazygitConfig()` to `bin/octomux.js` startup that copies the config to the user's lazygit config directory if not already present (macOS `~/Library/Application Support/lazygit/`, Linux `~/.config/lazygit/`)

## Why
The previous shift-C command tried to `cat ~/Documents/Projects/octomux/GITHUB_GUIDELINES.md` which doesn't exist. Inlining the guidelines removes the external file dependency, and auto-installing on startup ensures all octomux users get the config.

## Testing
- Verified the config file is valid YAML
- Confirmed `installLazygitConfig()` follows the same pattern as `installSkills()` (skip if target exists)