### PR TITLE
refactor(ui): remove free-text input from orchestrator command bar

### DIFF
--- a/src/components/OrchestratorCommandBar.test.tsx
+++ b/src/components/OrchestratorCommandBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OrchestratorCommandBar } from './OrchestratorCommandBar';
 import { renderWithRouter } from '../test-helpers';
@@ -7,6 +7,7 @@ import { renderWithRouter } from '../test-helpers';
 const mockRefresh = vi.fn();
 let mockRunning = true;
 const mockSend = vi.fn().mockResolvedValue({ ok: true, running: true });
+const mockType = vi.fn().mockResolvedValue({ ok: true, running: true });
 
 vi.mock('@/lib/orchestrator-context', () => ({
   useOrchestratorContext: () => ({
@@ -22,6 +23,7 @@ vi.mock('@/lib/orchestrator-context', () => ({
 vi.mock('@/lib/api', () => ({
   api: {
     orchestratorSend: (...args: any[]) => mockSend(...args),
+    orchestratorType: (...args: any[]) => mockType(...args),
     recentRepos: vi.fn().mockResolvedValue([]),
     browse: vi.fn().mockResolvedValue({ current: '/tmp', parent: '/', entries: [] }),
     listBranches: vi.fn().mockResolvedValue([]),
@@ -36,149 +38,77 @@ beforeEach(() => {
 });
 
 describe('OrchestratorCommandBar', () => {
-  it('renders input with placeholder', () => {
+  it('renders all command chips from COMMANDS', () => {
     renderWithRouter(<OrchestratorCommandBar />);
-    expect(screen.getByPlaceholderText(/ask the orchestrator/i)).toBeInTheDocument();
+    expect(screen.getByText('+ Create Task')).toBeInTheDocument();
+    expect(screen.getByText('List Tasks')).toBeInTheDocument();
+    expect(screen.getByText('Task Status')).toBeInTheDocument();
+    expect(screen.getByText('Create PR')).toBeInTheDocument();
   });
 
-  it('renders send button disabled when input is empty', () => {
+  it('does not render a free-text input', () => {
     renderWithRouter(<OrchestratorCommandBar />);
-    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
-  });
-
-  it('enables send button when input has text', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'hello');
-    expect(screen.getByRole('button', { name: /send/i })).toBeEnabled();
-  });
-
-  it('sends message and refreshes on submit', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'Show me tasks');
-    await userEvent.click(screen.getByRole('button', { name: /send/i }));
-
-    expect(mockSend).toHaveBeenCalledWith('Show me tasks');
-    await waitFor(() => {
-      expect(mockRefresh).toHaveBeenCalled();
-    });
-  });
-
-  it('clears input after successful send', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'Show me tasks');
-    await userEvent.click(screen.getByRole('button', { name: /send/i }));
-
-    await waitFor(() => {
-      expect(input).toHaveValue('');
-    });
-  });
-
-  it('sends on Enter key', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'hello{Enter}');
-
-    expect(mockSend).toHaveBeenCalledWith('hello');
-  });
-
-  it('clears input on Escape', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'hello');
-    fireEvent.keyDown(input, { key: 'Escape' });
-    expect(input).toHaveValue('');
+    expect(screen.queryByPlaceholderText(/ask the orchestrator/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 });
 
-describe('slash command autocomplete', () => {
-  it('shows dropdown when input starts with /', async () => {
+describe('fieldless commands', () => {
+  it('sends immediately via orchestratorSend when clicking a fieldless chip', async () => {
     renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, '/');
-    expect(screen.getByText('/create-task')).toBeInTheDocument();
-    expect(screen.getByText('/list-tasks')).toBeInTheDocument();
-    expect(screen.getByText('/status')).toBeInTheDocument();
-    expect(screen.getByText('/create-pr')).toBeInTheDocument();
-  });
-
-  it('filters commands as user types', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, '/cr');
-    expect(screen.getByText('/create-task')).toBeInTheDocument();
-    expect(screen.getByText('/create-pr')).toBeInTheDocument();
-    expect(screen.queryByText('/list-tasks')).not.toBeInTheDocument();
-    expect(screen.queryByText('/status')).not.toBeInTheDocument();
-  });
-
-  it('hides dropdown when no commands match', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, '/xyz');
-    expect(screen.queryByText('/create-task')).not.toBeInTheDocument();
-  });
-
-  it('navigates with arrow keys and selects with Enter', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, '/');
-    // Arrow down to second item (/list-tasks — no fields, sends immediately)
-    fireEvent.keyDown(input, { key: 'ArrowDown' });
-    fireEvent.keyDown(input, { key: 'Enter' });
+    await userEvent.click(screen.getByText('List Tasks'));
     await waitFor(() => {
       expect(mockSend).toHaveBeenCalledWith('Show me all running tasks');
     });
+    expect(mockRefresh).toHaveBeenCalled();
   });
 
-  it('closes dropdown on Escape without clearing input', async () => {
+  it('does not show a form for fieldless commands', async () => {
     renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, '/cr');
-    expect(screen.getByText('/create-task')).toBeInTheDocument();
-    fireEvent.keyDown(input, { key: 'Escape' });
-    expect(screen.queryByText('/create-task')).not.toBeInTheDocument();
-    expect(input).toHaveValue('/cr');
+    await userEvent.click(screen.getByText('List Tasks'));
+    await waitFor(() => {
+      expect(mockSend).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
   });
 
-  it('does not show dropdown for / in middle of text', async () => {
+  it('disables chips while a fieldless send is in flight', async () => {
+    let resolveSend: (v: { ok: boolean; running: boolean }) => void = () => {};
+    mockSend.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: boolean; running: boolean }>((r) => {
+          resolveSend = r;
+        }),
+    );
     renderWithRouter(<OrchestratorCommandBar />);
-    const input = screen.getByPlaceholderText(/ask the orchestrator/i);
-    await userEvent.type(input, 'hello /create');
-    expect(screen.queryByText('/create-task')).not.toBeInTheDocument();
+    const listChip = screen.getByText('List Tasks') as HTMLButtonElement;
+    await userEvent.click(listChip);
+    expect(listChip).toBeDisabled();
+    resolveSend({ ok: true, running: true });
+    await waitFor(() => {
+      expect(listChip).not.toBeDisabled();
+    });
   });
 });
 
 describe('field-based commands', () => {
   it('shows form when clicking a chip with fields', async () => {
     renderWithRouter(<OrchestratorCommandBar />);
-    // Click the Create Task chip button (not the form header which also has the same text)
     const chips = screen.getAllByText('+ Create Task');
     await userEvent.click(chips[0]);
-    // Should show the form — textarea input should be gone, close button visible
     expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/ask the orchestrator/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
   });
 
-  it('sends immediately for commands without fields', async () => {
-    renderWithRouter(<OrchestratorCommandBar />);
-    await userEvent.click(screen.getByText('List Tasks'));
-    await waitFor(() => {
-      expect(mockSend).toHaveBeenCalledWith('Show me all running tasks');
-    });
-    // Should NOT show a form
-    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
-  });
-
-  it('closes form and returns to input on close button', async () => {
+  it('closes form and returns to chips on close button', async () => {
     renderWithRouter(<OrchestratorCommandBar />);
     await userEvent.click(screen.getAllByText('+ Create Task')[0]);
-    expect(screen.queryByPlaceholderText(/ask the orchestrator/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /close/i }));
-    expect(screen.getByPlaceholderText(/ask the orchestrator/i)).toBeInTheDocument();
+    expect(screen.queryByText('Title')).not.toBeInTheDocument();
+    // Chips row still rendered
+    expect(screen.getByText('List Tasks')).toBeInTheDocument();
   });
 
   it('replaces form when clicking a different chip with fields', async () => {
@@ -186,7 +116,6 @@ describe('field-based commands', () => {
     await userEvent.click(screen.getByText('+ Create Task'));
     expect(screen.getByText('Title')).toBeInTheDocument();
 
-    // Click a different field-based command
     await userEvent.click(screen.getByText('Task Status'));
     expect(screen.queryByText('Title')).not.toBeInTheDocument();
     expect(screen.getByText('Task')).toBeInTheDocument();
@@ -195,13 +124,13 @@ describe('field-based commands', () => {
   it('sends immediately and collapses form when clicking fieldless chip while form is open', async () => {
     renderWithRouter(<OrchestratorCommandBar />);
     await userEvent.click(screen.getByText('+ Create Task'));
-    expect(screen.queryByPlaceholderText(/ask the orchestrator/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('List Tasks'));
     await waitFor(() => {
       expect(mockSend).toHaveBeenCalledWith('Show me all running tasks');
     });
-    // Form should be closed, input should be back
-    expect(screen.getByPlaceholderText(/ask the orchestrator/i)).toBeInTheDocument();
+    // Form should be closed
+    expect(screen.queryByText('Title')).not.toBeInTheDocument();
   });
 });

--- a/src/components/OrchestratorCommandBar.tsx
+++ b/src/components/OrchestratorCommandBar.tsx
@@ -1,28 +1,20 @@
-import { useState, useRef } from 'react';
-import { Button } from '@/components/ui/button';
+import { useState } from 'react';
 import { useOrchestratorContext } from '@/lib/orchestrator-context';
 import { api } from '@/lib/api';
-import { COMMANDS, filterCommands } from '@/lib/orchestrator-commands';
+import { COMMANDS } from '@/lib/orchestrator-commands';
 import type { OrchestratorCommand } from '@/lib/orchestrator-commands';
 import { CommandFieldForm } from './CommandFieldForm';
 
 export function OrchestratorCommandBar() {
-  const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
-  const [showSlashMenu, setShowSlashMenu] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const [activeCommand, setActiveCommand] = useState<OrchestratorCommand | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { refresh } = useOrchestratorContext();
-
-  const filteredCommands = input.startsWith('/') ? filterCommands(input.slice(1)) : [];
 
   const sendMessage = async (message: string) => {
     if (!message.trim() || sending) return;
     setSending(true);
     try {
       await api.orchestratorSend(message);
-      setInput('');
       refresh();
     } catch (err) {
       console.error('Failed to send to orchestrator:', err);
@@ -31,74 +23,13 @@ export function OrchestratorCommandBar() {
     }
   };
 
-  const handleSend = () => sendMessage(input.trim());
-
-  const slashMenuOpen = showSlashMenu && input.startsWith('/') && filteredCommands.length > 0;
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (slashMenuOpen) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % filteredCommands.length);
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length);
-        return;
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        handleChipClick(filteredCommands[selectedIndex]);
-        setShowSlashMenu(false);
-        return;
-      }
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        setShowSlashMenu(false);
-        return;
-      }
-    }
-
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-    if (e.key === 'Escape') {
-      e.stopPropagation();
-      if (activeCommand) {
-        setActiveCommand(null);
-      } else {
-        setInput('');
-      }
-    }
-  };
-
   const handleChipClick = (command: OrchestratorCommand) => {
     if (command.fields) {
       setActiveCommand(command);
-      setShowSlashMenu(false);
-      setInput(''); // Clear free-text input when switching to structured form
       return;
     }
-    // No fields — send immediately
     setActiveCommand(null);
     sendMessage(command.buildMessage({}));
-  };
-
-  // Auto-resize textarea
-  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
-    setInput(value);
-    if (value.startsWith('/')) {
-      setShowSlashMenu(true);
-      setSelectedIndex(0);
-    } else {
-      setShowSlashMenu(false);
-    }
-    const ta = e.target;
-    ta.style.height = 'auto';
-    ta.style.height = `${Math.min(ta.scrollHeight, 80)}px`;
   };
 
   return (
@@ -121,98 +52,19 @@ export function OrchestratorCommandBar() {
           onClose={() => setActiveCommand(null)}
           sending={sending}
         />
-      ) : (
-        <div className="flex items-end gap-2 p-3">
-          <span className="shrink-0 select-none font-mono text-sm text-[#8a8a8a]">&gt;</span>
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={handleInput}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask the orchestrator anything..."
-            rows={1}
-            className="flex-1 resize-none bg-transparent font-mono text-sm outline-none placeholder:text-[#6a6a6a]"
-          />
-          <Button
-            size="sm"
-            disabled={!input.trim() || sending}
-            onClick={handleSend}
-            aria-label="Send"
-            className="shrink-0"
-          >
-            {sending ? (
-              <LoadingIcon className="h-4 w-4 animate-spin" />
-            ) : (
-              <SendIcon className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-      )}
-      <div className="flex flex-wrap gap-1.5 border-t border-[#2f2f2f] px-3 py-2">
+      ) : null}
+      <div className="flex flex-wrap gap-1.5 border-t border-[#2f2f2f] px-3 py-2 first:border-t-0">
         {COMMANDS.map((cmd) => (
           <button
             key={cmd.slash}
             onClick={() => handleChipClick(cmd)}
-            className="border border-[#2f2f2f] bg-transparent px-2.5 py-1 text-xs text-[#8a8a8a] transition-colors hover:border-[#4a4a4a] hover:text-white"
+            disabled={sending}
+            className="border border-[#2f2f2f] bg-transparent px-2.5 py-1 text-xs text-[#8a8a8a] transition-colors hover:border-[#4a4a4a] hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cmd.chipLabel}
           </button>
         ))}
       </div>
-      {slashMenuOpen && (
-        <div className="absolute top-full left-0 z-50 mt-1 w-72 border border-[#2f2f2f] bg-[#0A0A0A] p-1 shadow-md">
-          {filteredCommands.map((cmd, i) => (
-            <button
-              key={cmd.slash}
-              onClick={() => {
-                handleChipClick(cmd);
-                setShowSlashMenu(false);
-              }}
-              className={`flex w-full flex-col items-start px-3 py-2 text-left text-sm ${
-                i === selectedIndex ? 'bg-[#1a1a1a]' : ''
-              }`}
-            >
-              <span className="font-mono font-semibold text-white">{cmd.slash}</span>
-              <span className="text-xs text-[#8a8a8a]">{cmd.description}</span>
-            </button>
-          ))}
-        </div>
-      )}
     </div>
-  );
-}
-
-function SendIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
-      <path d="m21.854 2.147-10.94 10.939" />
-    </svg>
-  );
-}
-
-function LoadingIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-    </svg>
   );
 }


### PR DESCRIPTION
## Summary

Simplify `OrchestratorCommandBar` so that command chips are the only input path — removes the textarea, send button, and slash-command autocomplete menu.

- Fieldless chips (e.g. `List Tasks`) fire immediately via `api.orchestratorSend`.
- Chips with fields (`+ Create Task`, `Task Status`, `Create PR`) open the existing `CommandFieldForm`, which continues to submit via `api.orchestratorType`.
- Chips are disabled while a send is in flight.
- Removes unused state (`input`, `showSlashMenu`, `selectedIndex`, `textareaRef`, `filteredCommands`), associated handlers, and the `SendIcon` / `LoadingIcon` helpers.

Net: -268 / +49 lines across component + tests.

## UI change

Before: chip row + free-text textarea + send button; typing `/` popped a fuzzy-filtered command menu.
After: chip row only. Clicking a chip either (a) sends its canned message immediately, or (b) reveals the field form above the chip row.

## API footprint

- `api.orchestratorSend` is still used by fieldless chips → stays.
- `api.orchestratorType` is still used by the field form → stays.
- No server changes.

## Dead code removed

- `SendIcon` component (only consumer was the removed send button).
- `LoadingIcon` component (only consumer was the removed send button — `CommandFieldForm` renders its own SEND button text, so it did not depend on it).
- `filterCommands` import (still exported from `src/lib/orchestrator-commands.ts` for completeness; only consumer was the removed slash menu).

## Test plan

- [x] `bun run test` — 718 tests pass; `OrchestratorCommandBar.test.tsx` rewritten to cover: renders all chips, no textarea, fieldless chip triggers `orchestratorSend`, field chip shows form, close returns to chips, switching chips swaps/closes the form, chips disable during in-flight send.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — no new warnings (pre-existing warnings only).
- [ ] Manual browser verification — not run in this environment; component behavior is fully covered by the updated component tests.

## Coordination

Concurrent `src/` audit task `3dDt5N0arahf` may also touch component files — flag for merge order.