### PR TITLE
feat(ui): persist per-file expand-all state in DiffViewer

### DIFF
--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRef } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { diffExpandedKey } from '@/lib/diff-state';
 
 const { apiMock, apiProxy } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupApiMock(),
@@ -8,14 +10,32 @@ const { apiMock, apiProxy } = await vi.hoisted(async () =>
 vi.mock('@/lib/api', () => ({ api: apiProxy }));
 
 // Monaco's DiffEditor does real DOM work; replace with a stub that exposes
-// the original/modified content as testids.
+// the original/modified content, options, and a per-mount id so tests can
+// verify remounts on key change.
+let mountCounter = 0;
 vi.mock('@monaco-editor/react', () => ({
-  DiffEditor: ({ original, modified }: { original: string; modified: string }) => (
-    <div data-testid="monaco-diff">
-      <pre data-testid="orig">{original}</pre>
-      <pre data-testid="mod">{modified}</pre>
-    </div>
-  ),
+  DiffEditor: ({
+    original,
+    modified,
+    options,
+  }: {
+    original: string;
+    modified: string;
+    options?: unknown;
+  }) => {
+    const idRef = useRef<number | null>(null);
+    if (idRef.current === null) idRef.current = ++mountCounter;
+    return (
+      <div
+        data-testid="monaco-diff"
+        data-mount-id={String(idRef.current)}
+        data-options={JSON.stringify(options ?? {})}
+      >
+        <pre data-testid="orig">{original}</pre>
+        <pre data-testid="mod">{modified}</pre>
+      </div>
+    );
+  },
 }));
 
 import { DiffViewer } from './DiffViewer';
@@ -30,6 +50,8 @@ beforeEach(() => {
     tooLarge: false,
     binary: false,
   });
+  localStorage.clear();
+  mountCounter = 0;
 });
 
 describe('DiffViewer', () => {
@@ -140,5 +162,91 @@ describe('DiffViewer', () => {
     await vi.advanceTimersByTimeAsync(2500);
     await waitFor(() => expect(screen.getByTestId('mod')).toHaveTextContent('b-new'));
     vi.useRealTimers();
+  });
+
+  it('remounts MonacoDiff (new mount-id) when the selected file changes', async () => {
+    const user = userEvent.setup();
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [
+        { path: 'a.ts', status: 'M', additions: 1, deletions: 0 },
+        { path: 'b.ts', status: 'A', additions: 5, deletions: 0 },
+      ],
+    });
+    apiMock.getTaskDiffFile
+      .mockResolvedValueOnce({
+        oldContent: 'a-old',
+        newContent: 'a-new',
+        status: 'M',
+        tooLarge: false,
+        binary: false,
+      })
+      .mockResolvedValueOnce({
+        oldContent: '',
+        newContent: 'b-new',
+        status: 'A',
+        tooLarge: false,
+        binary: false,
+      });
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+    await waitFor(() => expect(screen.getByTestId('mod')).toHaveTextContent('a-new'));
+    const firstId = screen.getByTestId('monaco-diff').getAttribute('data-mount-id');
+    expect(firstId).not.toBeNull();
+
+    await user.click(screen.getByText('b.ts'));
+    await waitFor(() => expect(screen.getByTestId('mod')).toHaveTextContent('b-new'));
+    const secondId = screen.getByTestId('monaco-diff').getAttribute('data-mount-id');
+    expect(secondId).not.toBeNull();
+    expect(secondId).not.toBe(firstId);
+  });
+
+  it('toolbar flips label and persists expandedAll to localStorage', async () => {
+    const user = userEvent.setup();
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [{ path: 'src/a.ts', status: 'M', additions: 2, deletions: 1 }],
+    });
+    apiMock.getTaskDiffFile.mockResolvedValue({
+      oldContent: 'old',
+      newContent: 'new',
+      status: 'M',
+      tooLarge: false,
+      binary: false,
+    });
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+    const btn = await screen.findByRole('button', { name: 'Expand all' });
+    expect(localStorage.getItem(diffExpandedKey('t1', 'src/a.ts'))).toBeNull();
+
+    await user.click(btn);
+
+    await screen.findByRole('button', { name: 'Collapse all' });
+    expect(localStorage.getItem(diffExpandedKey('t1', 'src/a.ts'))).toBe('true');
+
+    await waitFor(() => {
+      const opts = JSON.parse(
+        screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}',
+      );
+      expect(opts.hideUnchangedRegions.enabled).toBe(false);
+    });
+  });
+
+  it('reads stored expandedAll on mount and passes hideUnchangedRegions=false', async () => {
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [{ path: 'src/a.ts', status: 'M', additions: 2, deletions: 1 }],
+    });
+    apiMock.getTaskDiffFile.mockResolvedValue({
+      oldContent: 'old',
+      newContent: 'new',
+      status: 'M',
+      tooLarge: false,
+      binary: false,
+    });
+    localStorage.setItem(diffExpandedKey('t1', 'src/a.ts'), 'true');
+
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+
+    await screen.findByRole('button', { name: 'Collapse all' });
+    const opts = JSON.parse(
+      screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}',
+    );
+    expect(opts.hideUnchangedRegions.enabled).toBe(false);
   });
 });

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,5 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { api, type DiffFileEntry, type FileDiffResponse } from '@/lib/api';
+import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
+import { Button } from '@/components/ui/button';
 import { DiffFileTree } from './DiffFileTree';
 
 const MonacoDiff = lazy(() =>
@@ -42,6 +44,8 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [fileLoading, setFileLoading] = useState(false);
+  const [expandedAll, setExpandedAll] = useState(false);
+  const expandedFallback = useRef<Record<string, boolean>>({});
 
   const selectedRef = useRef<string | null>(null);
   useEffect(() => {
@@ -75,8 +79,17 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   useEffect(() => {
     if (!selected) {
       setFileDiff(null);
+      setExpandedAll(false);
       return;
     }
+    const stored = (() => {
+      try {
+        return getDiffExpanded(taskId, selected);
+      } catch {
+        return expandedFallback.current[selected] ?? false;
+      }
+    })();
+    setExpandedAll(stored);
     let cancelled = false;
     setFileLoading(true);
     setError(null); // clear stale error on new selection
@@ -96,6 +109,21 @@ export function DiffViewer({ taskId, isRunning }: Props) {
     };
   }, [taskId, selected]);
 
+  const toggleExpandedAll = useCallback(() => {
+    if (!selected) return;
+    const next = !expandedAll;
+    setExpandedAll(next);
+    try {
+      setDiffExpanded(taskId, selected, next);
+    } catch {
+      expandedFallback.current[selected] = next;
+    }
+  }, [taskId, selected, expandedAll]);
+
+  const showToolbar = Boolean(
+    selected && fileDiff && !fileDiff.tooLarge && !fileDiff.binary && !error,
+  );
+
   if (error && !files.length) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-destructive">
@@ -113,7 +141,21 @@ export function DiffViewer({ taskId, isRunning }: Props) {
           <DiffFileTree files={files} selected={selected} onSelect={setSelected} />
         )}
       </aside>
-      <main className="min-w-0 flex-1">
+      <main className="flex min-w-0 flex-1 flex-col">
+        {showToolbar && selected ? (
+          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+            <span className="truncate text-xs text-muted-foreground">{selected}</span>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={toggleExpandedAll}
+              aria-label={expandedAll ? 'Collapse all' : 'Expand all'}
+            >
+              {expandedAll ? 'Collapse all' : 'Expand all'}
+            </Button>
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1">
         {error && selected ? (
           <div className="flex h-full items-center justify-center text-sm text-destructive">
             {error}
@@ -143,6 +185,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
             }
           >
             <MonacoDiff
+              key={`${selected}:${expandedAll ? 'expanded' : 'collapsed'}`}
               height="100%"
               original={fileDiff.oldContent}
               modified={fileDiff.newContent}
@@ -152,12 +195,13 @@ export function DiffViewer({ taskId, isRunning }: Props) {
                 readOnly: true,
                 renderSideBySide: true,
                 minimap: { enabled: true },
-                hideUnchangedRegions: { enabled: true },
+                hideUnchangedRegions: { enabled: !expandedAll },
                 scrollBeyondLastLine: false,
               }}
             />
           </Suspense>
         ) : null}
+        </div>
       </main>
     </div>
   );

--- a/src/lib/diff-state.ts
+++ b/src/lib/diff-state.ts
@@ -1,0 +1,19 @@
+export function diffExpandedKey(taskId: string, filePath: string): string {
+  return `octomux:diff-expanded:${taskId}:${filePath}`;
+}
+
+export function getDiffExpanded(taskId: string, filePath: string): boolean {
+  try {
+    return localStorage.getItem(diffExpandedKey(taskId, filePath)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setDiffExpanded(taskId: string, filePath: string, value: boolean): void {
+  try {
+    localStorage.setItem(diffExpandedKey(taskId, filePath), String(value));
+  } catch {
+    // localStorage unavailable (SSR, privacy mode) — degrade silently
+  }
+}


### PR DESCRIPTION
## What

- Force Monaco `DiffEditor` to remount on file switch via a stable
  `key={${selected}:${expandedAll ? 'expanded' : 'collapsed'}}`, so
  `hideUnchangedRegions` is honored deterministically on every file
  change.
- Persist a single `expandedAll` bool per `(taskId, filePath)` in
  localStorage under `octomux:diff-expanded:<taskId>:<filePath>`,
  with an in-memory `useRef` fallback if localStorage throws.
- Add a small header toolbar inside the `<main>` pane of `DiffViewer`
  with a ghost-variant "Expand all" / "Collapse all" toggle, hidden
  when no file is selected or the file is binary / tooLarge / errored.
- Extract the localStorage key + read/write into `src/lib/diff-state.ts`
  so tests can assert the key scheme.

## Why

Switching files used to leave unchanged regions rendered expanded until
Monaco recomputed, and sometimes they never collapsed, because
`@monaco-editor/react` swaps models on the same editor instance instead
of remounting. The remount key fixes that. The persisted `expandedAll`
gives reviewers a predictable "show everything" toggle per file without
having to click each hidden-region widget — per-region persistence is
explicitly out of scope (Monaco has no clean API for it).

## Testing

- `bun run typecheck` — clean.
- `bun run test` — 772 passing (4 new cases in
  `src/components/DiffViewer.test.tsx`: new mount-id on file switch,
  toolbar toggle flips label + writes `'true'` to localStorage, stored
  `'true'` on mount renders "Collapse all" and sets
  `hideUnchangedRegions.enabled=false`).
- `bun run lint` — 0 errors (only preexisting warnings).
- E2E not run (per task instructions).