### PR TITLE
feat(settings): add UI control for claude launch flags

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -114,10 +114,17 @@ vi.mock('./skills.js', () => ({
 }));
 
 vi.mock('./settings.js', () => ({
-  getSettings: vi.fn(async () => ({ editor: 'nvim', useOrchestratorAgent: false })),
+  getSettings: vi.fn(async () => ({
+    editor: 'nvim',
+    useOrchestratorAgent: false,
+    dangerouslySkipPermissions: false,
+    claudeFlags: '',
+  })),
   updateSettings: vi.fn(async (patch: Record<string, unknown>) => ({
     editor: 'nvim',
     useOrchestratorAgent: false,
+    dangerouslySkipPermissions: false,
+    claudeFlags: '',
     ...patch,
   })),
 }));
@@ -1427,10 +1434,27 @@ describe('Skills API', () => {
 // ─── Settings ─────────────────────────────────────────────────────────────────
 
 describe('GET /api/settings', () => {
-  it('returns default settings', async () => {
+  afterEach(() => {
+    delete process.env.OCTOMUX_CLAUDE_FLAGS;
+  });
+
+  it('returns default settings with envOverrides', async () => {
     const res = await request(app).get('/api/settings');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ editor: 'nvim', useOrchestratorAgent: false });
+    expect(res.body).toEqual({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+      envOverrides: { claudeFlags: null },
+    });
+  });
+
+  it('surfaces OCTOMUX_CLAUDE_FLAGS in envOverrides when set', async () => {
+    process.env.OCTOMUX_CLAUDE_FLAGS = '--model opus';
+    const res = await request(app).get('/api/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.envOverrides).toEqual({ claudeFlags: '--model opus' });
   });
 });
 
@@ -1439,6 +1463,8 @@ describe('PATCH /api/settings', () => {
     vi.mocked(updateSettings).mockResolvedValue({
       editor: 'cursor',
       useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
     });
     const res = await request(app).patch('/api/settings').send({ editor: 'cursor' });
     expect(res.status).toBe(200);
@@ -1449,5 +1475,14 @@ describe('PATCH /api/settings', () => {
     vi.mocked(updateSettings).mockRejectedValue(new Error('Invalid editor: emacs'));
     const res = await request(app).patch('/api/settings').send({ editor: 'emacs' });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when claudeFlags validation fails', async () => {
+    vi.mocked(updateSettings).mockRejectedValue(
+      new Error('Invalid claudeFlags: backticks are not allowed'),
+    );
+    const res = await request(app).patch('/api/settings').send({ claudeFlags: '`whoami`' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid claudeFlags');
   });
 });

--- a/server/api.ts
+++ b/server/api.ts
@@ -735,7 +735,13 @@ export function setupRoutes(app: Express): void {
   app.get('/api/settings', async (_req: Request, res: Response) => {
     try {
       const settings = await getSettings();
-      res.json(settings);
+      const envClaudeFlags = process.env.OCTOMUX_CLAUDE_FLAGS?.trim();
+      res.json({
+        ...settings,
+        envOverrides: {
+          claudeFlags: envClaudeFlags ? envClaudeFlags : null,
+        },
+      });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
@@ -747,7 +753,7 @@ export function setupRoutes(app: Express): void {
       res.json(settings);
     } catch (err) {
       const message = (err as Error).message;
-      if (message.startsWith('Invalid editor')) {
+      if (message.startsWith('Invalid editor') || message.startsWith('Invalid claudeFlags')) {
         res.status(400).json({ error: message });
       } else {
         res.status(500).json({ error: message });

--- a/server/orchestrator.test.ts
+++ b/server/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('child_process', () => ({
   execFile: vi.fn((_cmd: string, _args: string[], cb: Function) => {
@@ -25,9 +25,18 @@ vi.mock('./agents.js', () => ({
   syncAgents: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('./settings.js', () => ({
-  getSettings: vi.fn().mockResolvedValue({ editor: 'nvim', useOrchestratorAgent: false }),
-}));
+vi.mock('./settings.js', async () => {
+  const actual = await vi.importActual<typeof import('./settings.js')>('./settings.js');
+  return {
+    ...actual,
+    getSettings: vi.fn().mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    }),
+  };
+});
 
 const {
   isOrchestratorRunning,
@@ -219,6 +228,8 @@ describe('startOrchestrator', () => {
     vi.mocked(settings.getSettings).mockResolvedValue({
       editor: 'nvim',
       useOrchestratorAgent: true,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
     });
 
     await startOrchestrator('/test/cwd');
@@ -264,6 +275,71 @@ describe('startOrchestrator', () => {
 
     const newSessionCall = vi.mocked(execFile).mock.calls[1];
     expect(newSessionCall[1]).toContain('/my/project');
+  });
+
+  describe('claude launch flags', () => {
+    afterEach(() => {
+      delete process.env.OCTOMUX_CLAUDE_FLAGS;
+    });
+
+    it('appends OCTOMUX_CLAUDE_FLAGS env var, ignoring settings', async () => {
+      process.env.OCTOMUX_CLAUDE_FLAGS = '--from-env';
+      mockSessionNotRunning();
+      vi.mocked(settings.getSettings).mockResolvedValue({
+        editor: 'nvim',
+        useOrchestratorAgent: false,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--from-settings',
+      });
+
+      await startOrchestrator('/test/cwd');
+
+      expect(getClaudeCmd()).toBe('claude --from-env');
+    });
+
+    it('appends --dangerously-skip-permissions from settings', async () => {
+      mockSessionNotRunning();
+      vi.mocked(settings.getSettings).mockResolvedValue({
+        editor: 'nvim',
+        useOrchestratorAgent: false,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '',
+      });
+
+      await startOrchestrator('/test/cwd');
+
+      expect(getClaudeCmd()).toBe('claude --dangerously-skip-permissions');
+    });
+
+    it('appends claudeFlags from settings', async () => {
+      mockSessionNotRunning();
+      vi.mocked(settings.getSettings).mockResolvedValue({
+        editor: 'nvim',
+        useOrchestratorAgent: false,
+        dangerouslySkipPermissions: false,
+        claudeFlags: '--model opus',
+      });
+
+      await startOrchestrator('/test/cwd');
+
+      expect(getClaudeCmd()).toBe('claude --model opus');
+    });
+
+    it('composes flags after --agent orchestrator when agent enabled', async () => {
+      mockSessionNotRunning();
+      vi.mocked(settings.getSettings).mockResolvedValue({
+        editor: 'nvim',
+        useOrchestratorAgent: true,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--model opus',
+      });
+
+      await startOrchestrator('/test/cwd');
+
+      expect(getClaudeCmd()).toBe(
+        'claude --agent orchestrator --dangerously-skip-permissions --model opus',
+      );
+    });
   });
 });
 

--- a/server/orchestrator.ts
+++ b/server/orchestrator.ts
@@ -1,7 +1,7 @@
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { getAgent, saveAgent, resetAgent, syncAgents } from './agents.js';
-import { getSettings } from './settings.js';
+import { getSettings, resolveClaudeFlags } from './settings.js';
 import { childLogger } from './logger.js';
 
 const execFile = promisify(execFileCb);
@@ -82,6 +82,9 @@ export async function startOrchestrator(cwd?: string, initialMessage?: string): 
       // Plain claude with no agent
       claudeCmd = 'claude';
     }
+
+    // Append user-configured launch flags (env var > settings).
+    claudeCmd += resolveClaudeFlags(settings);
 
     // Use single quotes for the user message to prevent shell interpretation of $, `, etc.
     const messagePart = initialMessage ? ` '${initialMessage.replace(/'/g, "'\"'\"'")}'` : '';

--- a/server/settings.test.ts
+++ b/server/settings.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getSettings, updateSettings, DEFAULT_SETTINGS } from './settings.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getSettings, updateSettings, resolveClaudeFlags, DEFAULT_SETTINGS } from './settings.js';
 import type { OctomuxSettings } from './settings.js';
 
 // Mock fs
@@ -32,6 +32,13 @@ describe('settings', () => {
     vi.clearAllMocks();
   });
 
+  describe('DEFAULT_SETTINGS', () => {
+    it('has expected defaults for new flag-related fields', () => {
+      expect(DEFAULT_SETTINGS.dangerouslySkipPermissions).toBe(false);
+      expect(DEFAULT_SETTINGS.claudeFlags).toBe('');
+    });
+  });
+
   describe('getSettings', () => {
     it('returns default settings when file does not exist', async () => {
       mockFs.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
@@ -40,7 +47,12 @@ describe('settings', () => {
     });
 
     it('returns saved settings when file exists', async () => {
-      const saved: OctomuxSettings = { editor: 'cursor', useOrchestratorAgent: false };
+      const saved: OctomuxSettings = {
+        editor: 'cursor',
+        useOrchestratorAgent: false,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--model opus',
+      };
       mockFs.readFile.mockResolvedValue(JSON.stringify(saved));
       const settings = await getSettings();
       expect(settings).toEqual({ ...DEFAULT_SETTINGS, ...saved });
@@ -54,16 +66,18 @@ describe('settings', () => {
   });
 
   describe('updateSettings', () => {
-    it('merges new settings with existing', async () => {
-      mockFs.readFile.mockResolvedValue(JSON.stringify({ editor: 'nvim' }));
+    beforeEach(() => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify(DEFAULT_SETTINGS));
       mockFs.mkdir.mockResolvedValue(undefined);
       mockFs.writeFile.mockResolvedValue(undefined);
+    });
 
+    it('merges new settings with existing', async () => {
       const result = await updateSettings({ editor: 'vscode' });
       expect(result.editor).toBe('vscode');
       expect(mockFs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('settings.json'),
-        JSON.stringify({ editor: 'vscode', useOrchestratorAgent: false }, null, 2),
+        JSON.stringify({ ...DEFAULT_SETTINGS, editor: 'vscode' }, null, 2),
         'utf-8',
       );
     });
@@ -71,5 +85,93 @@ describe('settings', () => {
     it('rejects invalid editor values', async () => {
       await expect(updateSettings({ editor: 'emacs' as any })).rejects.toThrow('Invalid editor');
     });
+
+    it('persists dangerouslySkipPermissions toggle', async () => {
+      const result = await updateSettings({ dangerouslySkipPermissions: true });
+      expect(result.dangerouslySkipPermissions).toBe(true);
+    });
+
+    it('trims claudeFlags on save', async () => {
+      const result = await updateSettings({ claudeFlags: '  --model opus   ' });
+      expect(result.claudeFlags).toBe('--model opus');
+    });
+
+    const invalidFlagCases = [
+      { name: 'backticks', value: '--foo `whoami`' },
+      { name: 'command substitution', value: '--foo $(rm -rf /)' },
+      { name: 'unbalanced single quote', value: "--foo 'bar" },
+      { name: 'unbalanced double quote', value: '--foo "bar' },
+      { name: 'not a string', value: 42 as any },
+    ];
+
+    it.each(invalidFlagCases)('rejects claudeFlags with $name', async ({ value }) => {
+      await expect(updateSettings({ claudeFlags: value })).rejects.toThrow('Invalid claudeFlags');
+    });
+
+    it('roundtrips settings through write+read', async () => {
+      const result = await updateSettings({
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--model opus',
+      });
+      expect(result).toEqual({
+        ...DEFAULT_SETTINGS,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--model opus',
+      });
+      const writtenJson = mockFs.writeFile.mock.calls[0][1] as string;
+      expect(JSON.parse(writtenJson)).toEqual(result);
+    });
+  });
+});
+
+describe('resolveClaudeFlags', () => {
+  const baseSettings: OctomuxSettings = { ...DEFAULT_SETTINGS };
+
+  afterEach(() => {
+    delete process.env.OCTOMUX_CLAUDE_FLAGS;
+  });
+
+  it('returns empty string when nothing configured', () => {
+    expect(resolveClaudeFlags(baseSettings)).toBe('');
+  });
+
+  it('prefixes with a single space when flags present', () => {
+    expect(resolveClaudeFlags({ ...baseSettings, dangerouslySkipPermissions: true })).toBe(
+      ' --dangerously-skip-permissions',
+    );
+  });
+
+  it('composes dangerouslySkipPermissions before claudeFlags', () => {
+    expect(
+      resolveClaudeFlags({
+        ...baseSettings,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--model opus',
+      }),
+    ).toBe(' --dangerously-skip-permissions --model opus');
+  });
+
+  it('appends only claudeFlags when dangerouslySkipPermissions is false', () => {
+    expect(resolveClaudeFlags({ ...baseSettings, claudeFlags: '--model opus' })).toBe(
+      ' --model opus',
+    );
+  });
+
+  it('uses OCTOMUX_CLAUDE_FLAGS env var verbatim when set', () => {
+    process.env.OCTOMUX_CLAUDE_FLAGS = '--env-only';
+    expect(
+      resolveClaudeFlags({
+        ...baseSettings,
+        dangerouslySkipPermissions: true,
+        claudeFlags: '--from-settings',
+      }),
+    ).toBe(' --env-only');
+  });
+
+  it('treats whitespace-only env var as unset', () => {
+    process.env.OCTOMUX_CLAUDE_FLAGS = '   ';
+    expect(resolveClaudeFlags({ ...baseSettings, claudeFlags: '--from-settings' })).toBe(
+      ' --from-settings',
+    );
   });
 });

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -7,17 +7,40 @@ export type EditorChoice = 'nvim' | 'vscode' | 'cursor';
 export interface OctomuxSettings {
   editor: EditorChoice;
   useOrchestratorAgent: boolean;
+  dangerouslySkipPermissions: boolean;
+  claudeFlags: string;
 }
 
 export const DEFAULT_SETTINGS: OctomuxSettings = {
   editor: 'nvim',
   useOrchestratorAgent: false,
+  dangerouslySkipPermissions: false,
+  claudeFlags: '',
 };
 
 const VALID_EDITORS: EditorChoice[] = ['nvim', 'vscode', 'cursor'];
 
 function settingsPath(): string {
   return path.join(os.homedir(), '.octomux', 'settings.json');
+}
+
+function validateClaudeFlags(flags: unknown): string {
+  if (typeof flags !== 'string') {
+    throw new Error('Invalid claudeFlags: must be a string');
+  }
+  const trimmed = flags.trim();
+  if (trimmed.includes('`')) {
+    throw new Error('Invalid claudeFlags: backticks are not allowed');
+  }
+  if (trimmed.includes('$(')) {
+    throw new Error('Invalid claudeFlags: $(...) command substitution is not allowed');
+  }
+  const singleQuotes = (trimmed.match(/'/g) || []).length;
+  const doubleQuotes = (trimmed.match(/"/g) || []).length;
+  if (singleQuotes % 2 !== 0 || doubleQuotes % 2 !== 0) {
+    throw new Error('Invalid claudeFlags: unbalanced quotes');
+  }
+  return trimmed;
 }
 
 export async function getSettings(): Promise<OctomuxSettings> {
@@ -36,12 +59,40 @@ export async function updateSettings(patch: Partial<OctomuxSettings>): Promise<O
     throw new Error(`Invalid editor: ${patch.editor}. Must be one of: ${VALID_EDITORS.join(', ')}`);
   }
 
+  let normalizedFlags: string | undefined;
+  if (patch.claudeFlags !== undefined) {
+    normalizedFlags = validateClaudeFlags(patch.claudeFlags);
+  }
+
   const current = await getSettings();
-  const merged = { ...current, ...patch };
+  const merged: OctomuxSettings = {
+    ...current,
+    ...patch,
+    ...(normalizedFlags !== undefined ? { claudeFlags: normalizedFlags } : {}),
+  };
 
   const filePath = settingsPath();
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
   await fs.promises.writeFile(filePath, JSON.stringify(merged, null, 2), 'utf-8');
 
   return merged;
+}
+
+/**
+ * Compose the claude launch flag string. Precedence:
+ *   1. `OCTOMUX_CLAUDE_FLAGS` env var (verbatim), if set.
+ *   2. Settings composition: dangerouslySkipPermissions toggle + trimmed claudeFlags.
+ *
+ * Returns a string with a leading space, or '' when no flags apply. The leading
+ * space lets callers append the result directly to the base claude command.
+ */
+export function resolveClaudeFlags(settings: OctomuxSettings): string {
+  const envFlags = process.env.OCTOMUX_CLAUDE_FLAGS?.trim();
+  if (envFlags) return ` ${envFlags}`;
+
+  const parts: string[] = [];
+  if (settings.dangerouslySkipPermissions) parts.push('--dangerously-skip-permissions');
+  const trimmed = settings.claudeFlags.trim();
+  if (trimmed) parts.push(trimmed);
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -39,9 +39,18 @@ vi.mock('./hook-settings.js', () => ({
   installHookSettings: vi.fn(),
 }));
 
-vi.mock('./settings.js', () => ({
-  getSettings: vi.fn().mockResolvedValue({ editor: 'nvim', useOrchestratorAgent: false }),
-}));
+vi.mock('./settings.js', async () => {
+  const actual = await vi.importActual<typeof import('./settings.js')>('./settings.js');
+  return {
+    ...actual,
+    getSettings: vi.fn().mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    }),
+  };
+});
 
 vi.mock('./repo-config.js', () => ({
   getOrCreateRepoConfig: vi.fn().mockResolvedValue({
@@ -906,6 +915,155 @@ describe('resumeTask', () => {
   });
 });
 
+// ─── claude launch flags ─────────────────────────────────────────────────────
+
+describe('claude launch flags', () => {
+  function findClaudeCmd(): string | undefined {
+    const sendKeysCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['send-keys', 'Enter'],
+    });
+    if (!sendKeysCall) return undefined;
+    return (sendKeysCall[1] as string[]).find((a: string) => a.includes('claude'));
+  }
+
+  beforeEach(() => {
+    // Earlier tests may have left execFile with a throwing or send-keys-failing
+    // implementation. Restore the default working mock. Support both the 3-arg
+    // (cmd, args, cb) and 4-arg (cmd, args, opts, cb) calling conventions used
+    // by promisified execFile.
+    vi.mocked(execFile).mockImplementation(((
+      _cmd: string,
+      args: string[],
+      optsOrCb: Function | object,
+      maybeCb?: Function,
+    ) => {
+      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb!;
+      if (args.includes('display-message')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('list-windows')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('new-window')) {
+        nextWindowIndex++;
+        cb(null, { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: 'true', stderr: '' });
+      }
+    }) as any);
+  });
+
+  afterEach(() => {
+    delete process.env.OCTOMUX_CLAUDE_FLAGS;
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    });
+  });
+
+  it('appends OCTOMUX_CLAUDE_FLAGS env var verbatim, ignoring settings', async () => {
+    process.env.OCTOMUX_CLAUDE_FLAGS = '--from-env';
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: true,
+      claudeFlags: '--from-settings',
+    });
+    insertTask(db);
+    await startTask({ ...DEFAULTS.task } as Task);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--from-env');
+    expect(claudeCmd).not.toContain('--from-settings');
+    expect(claudeCmd).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('appends --dangerously-skip-permissions when setting is enabled', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: true,
+      claudeFlags: '',
+    });
+    insertTask(db);
+    await startTask({ ...DEFAULTS.task } as Task);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--dangerously-skip-permissions');
+  });
+
+  it('appends claudeFlags from settings when env var unset', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '--model opus',
+    });
+    insertTask(db);
+    await startTask({ ...DEFAULTS.task } as Task);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toMatch(/claude --session-id [^ ]+ --model opus/);
+  });
+
+  it('composes dangerouslySkipPermissions before claudeFlags', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: true,
+      claudeFlags: '--model opus',
+    });
+    insertTask(db);
+    await startTask({ ...DEFAULTS.task } as Task);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--dangerously-skip-permissions --model opus');
+  });
+
+  it('applies flags in resumeTask --resume branch', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: true,
+      claudeFlags: '',
+    });
+    const closedTask = { ...DEFAULTS.runningTask, status: 'closed' as const } as Task;
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped', claude_session_id: 'abc-123' });
+    await resumeTask(closedTask);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--resume abc-123 --dangerously-skip-permissions');
+  });
+
+  it('applies flags in resumeTask --continue branch', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '--model opus',
+    });
+    const closedTask = { ...DEFAULTS.runningTask, status: 'closed' as const } as Task;
+    insertTask(db, { ...closedTask });
+    insertAgent(db, { status: 'stopped', claude_session_id: null });
+    await resumeTask(closedTask);
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--continue --session-id');
+    expect(claudeCmd).toContain('--model opus');
+  });
+
+  it('applies flags in addAgent', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: true,
+      claudeFlags: '--model opus',
+    });
+    insertTask(db, { ...DEFAULTS.runningTask });
+    await addAgent({ ...DEFAULTS.runningTask } as Task);
+    // Flush fire-and-forget launch
+    await new Promise((r) => setTimeout(r, 0));
+    const claudeCmd = findClaudeCmd();
+    expect(claudeCmd).toContain('--dangerously-skip-permissions --model opus');
+  });
+});
+
 // ─── createUserTerminal ──────────────────────────────────────────────────────
 
 describe('createUserTerminal', () => {
@@ -970,7 +1128,12 @@ describe('createUserTerminal', () => {
   });
 
   it('opens vscode when editor setting is vscode', async () => {
-    vi.mocked(getSettings).mockResolvedValue({ editor: 'vscode', useOrchestratorAgent: false });
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'vscode',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    });
     insertTask(db, { ...DEFAULTS.runningTask });
     const task = { ...runningTask, worktree: '/repo/.worktrees/test' } as Task;
     const result = await createUserTerminal(task);
@@ -981,7 +1144,12 @@ describe('createUserTerminal', () => {
   });
 
   it('opens cursor when editor setting is cursor', async () => {
-    vi.mocked(getSettings).mockResolvedValue({ editor: 'cursor', useOrchestratorAgent: false });
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'cursor',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    });
     insertTask(db, { ...DEFAULTS.runningTask });
     const task = { ...runningTask, worktree: '/repo/.worktrees/test' } as Task;
     const result = await createUserTerminal(task);
@@ -992,7 +1160,12 @@ describe('createUserTerminal', () => {
   });
 
   it('creates tmux window with nvim when editor setting is nvim', async () => {
-    vi.mocked(getSettings).mockResolvedValue({ editor: 'nvim', useOrchestratorAgent: false });
+    vi.mocked(getSettings).mockResolvedValue({
+      editor: 'nvim',
+      useOrchestratorAgent: false,
+      dangerouslySkipPermissions: false,
+      claudeFlags: '',
+    });
     insertTask(db, { ...DEFAULTS.runningTask });
     const result = await createUserTerminal(runningTask);
     expect(result).toEqual({ editor: 'nvim', windowIndex: expect.any(Number) });

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
 import { installHookSettings } from './hook-settings.js';
-import { getSettings } from './settings.js';
+import { getSettings, resolveClaudeFlags } from './settings.js';
 import { getOrCreateRepoConfig } from './repo-config.js';
 import { childLogger } from './logger.js';
 import type { RepoConfig } from './repo-config.js';
@@ -20,6 +20,14 @@ export interface UserTerminalResult {
 }
 
 const execFile = promisify(execFileCb);
+
+/**
+ * Resolve extra claude CLI flags from env var (if set) or settings.
+ * Returns a string with a leading space, or '' when empty.
+ */
+async function getClaudeFlags(): Promise<string> {
+  return resolveClaudeFlags(await getSettings());
+}
 
 /** Get the active window index of a tmux session. */
 async function getActiveWindowIndex(session: string): Promise<number> {
@@ -305,9 +313,10 @@ export async function startTask(task: Task): Promise<void> {
 
     // Launch claude in the window. Prompt (if any) goes via a tempfile to avoid
     // shell-escape hazards in the user-supplied prompt content.
+    const flags = await getClaudeFlags();
     await sendClaudeCommand({
       target: `${session}:${windowIndex}`,
-      baseCmd: `claude --session-id ${claudeSessionId}`,
+      baseCmd: `claude --session-id ${claudeSessionId}${flags}`,
       prompt: task.initial_prompt,
       worktreePath,
       agentId,
@@ -370,11 +379,12 @@ export async function addAgent(task: Task, prompt?: string): Promise<Agent> {
 
   // Launch claude asynchronously — do not block the HTTP response
   const addTarget = `${task.tmux_session}:${windowIndex}`;
+  const flags = await getClaudeFlags();
   (async () => {
     try {
       await sendClaudeCommand({
         target: addTarget,
-        baseCmd: `claude --session-id ${claudeSessionId}`,
+        baseCmd: `claude --session-id ${claudeSessionId}${flags}`,
         prompt,
         worktreePath: task.worktree!,
         agentId,
@@ -702,14 +712,15 @@ export async function resumeTask(task: Task): Promise<void> {
     }
 
     // Phase 2: Launch claude in all windows concurrently (slow part — waitForShellReady)
+    const flags = await getClaudeFlags();
     await Promise.all(
       agentTargets.map(async ({ agent, windowIndex, target }) => {
         let baseCmd: string;
         if (agent.claude_session_id) {
-          baseCmd = `claude --resume ${agent.claude_session_id}`;
+          baseCmd = `claude --resume ${agent.claude_session_id}${flags}`;
         } else {
           const newSessionId = crypto.randomUUID();
-          baseCmd = `claude --continue --session-id ${newSessionId}`;
+          baseCmd = `claude --continue --session-id ${newSessionId}${flags}`;
           db.prepare('UPDATE agents SET claude_session_id = ? WHERE id = ?').run(
             newSessionId,
             agent.id,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,6 +93,11 @@ export interface AgentDetail {
 export interface OctomuxSettings {
   editor: 'nvim' | 'vscode' | 'cursor';
   useOrchestratorAgent: boolean;
+  dangerouslySkipPermissions: boolean;
+  claudeFlags: string;
+  envOverrides?: {
+    claudeFlags: string | null;
+  };
 }
 
 export interface RepoConfig {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -532,6 +532,129 @@ function EditorSection() {
   );
 }
 
+function ClaudeLaunchFlagsSection() {
+  const [dangerouslySkip, setDangerouslySkip] = useState(false);
+  const [savedFlags, setSavedFlags] = useState('');
+  const [flagsBuffer, setFlagsBuffer] = useState('');
+  const [envOverride, setEnvOverride] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getSettings()
+      .then((s) => {
+        if (cancelled) return;
+        setDangerouslySkip(s.dangerouslySkipPermissions);
+        setSavedFlags(s.claudeFlags);
+        setFlagsBuffer(s.claudeFlags);
+        setEnvOverride(s.envOverrides?.claudeFlags ?? null);
+      })
+      .catch((err) => {
+        if (!cancelled) showToast('error', 'ERROR', err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = async (value: boolean) => {
+    const prev = dangerouslySkip;
+    setDangerouslySkip(value);
+    try {
+      await api.updateSettings({ dangerouslySkipPermissions: value });
+      showToast(
+        'success',
+        'LAUNCH FLAGS',
+        value
+          ? '--dangerously-skip-permissions enabled'
+          : '--dangerously-skip-permissions disabled',
+      );
+    } catch (err) {
+      setDangerouslySkip(prev);
+      showToast('error', 'ERROR', err instanceof Error ? err.message : 'Failed to update');
+    }
+  };
+
+  const isDirty = flagsBuffer !== savedFlags;
+  const saveFlags = useCallback(async () => {
+    if (!isDirty || saving) return;
+    setSaving(true);
+    try {
+      const result = await api.updateSettings({ claudeFlags: flagsBuffer });
+      setSavedFlags(result.claudeFlags);
+      setFlagsBuffer(result.claudeFlags);
+      showToast('success', 'LAUNCH FLAGS', 'Advanced flags saved');
+    } catch (err) {
+      showToast('error', 'ERROR', err instanceof Error ? err.message : 'Failed to save flags');
+    } finally {
+      setSaving(false);
+    }
+  }, [flagsBuffer, isDirty, saving]);
+
+  if (loading) return null;
+
+  return (
+    <section className="mb-8">
+      <SectionHeader label="AGENT LAUNCH FLAGS" />
+
+      {envOverride !== null && (
+        <div className="mb-3 border border-[#FFB800]/40 bg-[#FFB800]/5 px-3 py-2 text-xs text-[#FFB800]">
+          Overridden by OCTOMUX_CLAUDE_FLAGS env var:{' '}
+          <span className="font-mono text-[#FFB800]">{envOverride}</span>
+        </div>
+      )}
+
+      <SettingRow
+        label="--dangerously-skip-permissions"
+        description="Launch claude without permission prompts. Agents can run arbitrary shell commands without asking."
+      >
+        <ToggleSwitch checked={dangerouslySkip} onChange={handleToggle} />
+      </SettingRow>
+
+      {dangerouslySkip && (
+        <div className="mb-3 mt-3 border border-red-400/40 bg-red-400/5 px-3 py-2 text-xs text-red-400">
+          ⚠ DANGER: agents will execute shell commands without confirmation. Only enable in trusted
+          environments.
+        </div>
+      )}
+
+      <div className="border-b border-[#2f2f2f] py-3">
+        <div className="mb-2 flex items-center justify-between">
+          <div>
+            <span className="text-sm">Advanced flags</span>
+            <p className="text-xs text-[#6a6a6a]">
+              Extra flags appended to the claude launch command
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {isDirty && <span className="text-xs text-[#FFB800]">unsaved</span>}
+            <button
+              onClick={saveFlags}
+              disabled={!isDirty || saving}
+              className="bg-[#3B82F6] px-3 py-1 text-xs text-white disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </div>
+        <input
+          type="text"
+          value={flagsBuffer}
+          onChange={(e) => setFlagsBuffer(e.target.value)}
+          placeholder="--model opus --verbose"
+          className="w-full border border-[#2f2f2f] bg-[#0A0A0A] px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
+          spellCheck={false}
+        />
+      </div>
+    </section>
+  );
+}
+
 function OrchestratorAgentToggle() {
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -716,6 +839,7 @@ export default function SettingsPage() {
         </section>
 
         <EditorSection />
+        <ClaudeLaunchFlagsSection />
         <RepoConfigsSection />
 
         <section className="mb-8">


### PR DESCRIPTION
## What

Adds a first-class settings UI for flags appended to every `claude` launch.

- New `OctomuxSettings` fields: `dangerouslySkipPermissions` (bool) and `claudeFlags` (string).
- New `resolveClaudeFlags()` helper: `OCTOMUX_CLAUDE_FLAGS` env var wins verbatim when set; otherwise composes `--dangerously-skip-permissions` (if toggled) + trimmed `claudeFlags`.
- `task-runner.ts` awaits `getClaudeFlags()` at all four launch sites (startTask, addAgent, resumeTask `--resume`, resumeTask `--continue`). Orchestrator mirrors the same logic.
- `PATCH /api/settings` validates `claudeFlags` and rejects backticks, `\$(...)`, and unbalanced quotes with 400.
- `GET /api/settings` surfaces a non-persisted `envOverrides.claudeFlags` so the UI can show an override notice.
- New "AGENT LAUNCH FLAGS" section in `SettingsPage.tsx` with a toggle (plus red danger blurb when on), a monospace advanced-flags input, and a yellow "Overridden by OCTOMUX_CLAUDE_FLAGS" notice when the env var is set.

## Why

The `--dangerously-skip-permissions` flag and other advanced claude CLI options were previously baked into `package.json`'s `dev:server` via `OCTOMUX_CLAUDE_FLAGS`. Moving the source of truth into settings makes it user-controllable at runtime without touching the repo, while keeping the env var as an override escape hatch.

## Testing

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 797/797 pass (40/40 files). New cases cover roundtrip, every validation rejection, env-var precedence, toggle-only composition, claudeFlags-only composition, combined ordering, and all four launch sites (task-runner + orchestrator).
- [x] `bun run lint` — 0 errors (only pre-existing warnings).
- [x] `bun run format:check` — clean