### PR TITLE
feat(ui): persist per-region expand state across file switches in DiffViewer

### DIFF
--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,4 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
+import type { DiffOnMount } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
 import { api, type DiffFileEntry, type FileDiffResponse } from '@/lib/api';
 import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
 import { Button } from '@/components/ui/button';
@@ -46,6 +48,47 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   const [fileLoading, setFileLoading] = useState(false);
   const [expandedAll, setExpandedAll] = useState(false);
   const expandedFallback = useRef<Record<string, boolean>>({});
+
+  const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
+  const editorKeyRef = useRef<string | null>(null);
+  const viewStates = useRef<Map<string, editor.IDiffEditorViewState>>(new Map());
+
+  const viewStateKey = useCallback(
+    (path: string, expanded: boolean) => `${taskId}::${path}::${expanded ? 'e' : 'c'}`,
+    [taskId],
+  );
+
+  const saveActiveViewState = useCallback(() => {
+    const ed = editorRef.current;
+    const k = editorKeyRef.current;
+    if (!ed || !k) return;
+    const s = ed.saveViewState();
+    if (s) viewStates.current.set(k, s);
+  }, []);
+
+  const handleSelect = useCallback(
+    (path: string) => {
+      saveActiveViewState();
+      setSelected(path);
+    },
+    [saveActiveViewState],
+  );
+
+  const handleEditorMount = useCallback<DiffOnMount>(
+    (ed) => {
+      editorRef.current = ed;
+      const k = selected ? viewStateKey(selected, expandedAll) : null;
+      editorKeyRef.current = k;
+      if (!k) return;
+      const saved = viewStates.current.get(k);
+      if (!saved) return;
+      const disposable = ed.onDidUpdateDiff(() => {
+        ed.restoreViewState(saved);
+        disposable.dispose();
+      });
+    },
+    [selected, expandedAll, viewStateKey],
+  );
 
   const selectedRef = useRef<string | null>(null);
   useEffect(() => {
@@ -138,7 +181,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
         {summaryLoading && files.length === 0 ? (
           <div className="p-4 text-xs text-muted-foreground">Loading diff...</div>
         ) : (
-          <DiffFileTree files={files} selected={selected} onSelect={setSelected} />
+          <DiffFileTree files={files} selected={selected} onSelect={handleSelect} />
         )}
       </aside>
       <main className="flex min-w-0 flex-1 flex-col">
@@ -191,6 +234,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
               modified={fileDiff.newContent}
               language={extToLanguage(selected)}
               theme="vs-dark"
+              onMount={handleEditorMount}
               options={{
                 readOnly: true,
                 renderSideBySide: true,


### PR DESCRIPTION
## Summary

- Adds per-(taskId, filePath, expandedMode) persistence for Monaco's manually-expanded unchanged-region state inside the DiffViewer. Switching files and returning keeps the \"Show N hidden lines\" regions you clicked open.
- Implementation round-trips Monaco's public \`IStandaloneDiffEditor.saveViewState()\` / \`restoreViewState()\` through an in-memory \`Map\`. \`modelState\` in the view-state object is produced by Monaco's own \`DiffEditorViewModel.serializeState()\` — we never read it, only hand it back.
- Saves synchronously inside the sidebar \`onSelect\` handler (before React remounts the editor via the existing \`key=\` pattern from #89) so the outgoing editor ref is still valid. Restores once inside \`onDidUpdateDiff\` on the next file, after Monaco has recomputed regions for the new content.

## Layering on #89

#89 shipped a per-file \`expandedAll\` bool that toggles \`hideUnchangedRegions\` wholesale and persists via localStorage. This PR is additive: the \`expandedAll\` mode is part of the view-state key (\`::e\` vs \`::c\`), so per-region state is scoped within a mode and toggling \"Expand all\" / \"Collapse all\" still resets regions as before. No behavioral conflict with #89.

## Why this approach

Investigated alternatives — private \`_diffModel\` access, \`setHiddenAreas\` on inner editors, DOM-tapping the widget, swapping Monaco entirely. All are strictly worse: higher fragility, worse TS ergonomics, or fight Monaco's own region pipeline. The public \`saveViewState\`/\`restoreViewState\` path is typed end-to-end (\`monaco.d.ts\` 2643 / 6428 / 6432), stable across Monaco minors, and handles background content drift gracefully — \`restoreSerializedState\` intersects saved ranges with freshly-computed regions and drops entries that no longer match.

Persistence is in-memory for now (dies with the DiffViewer unmount on tab/task nav). Cross-reload persistence via localStorage is a follow-up — \`modelState\` is typed \`unknown\` so we'd need a version tag and a schema contract before hardening that.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — no new errors
- [x] \`bun run test src/components/DiffViewer\` — 8/8 pass
- [ ] Manual: open a task with a multi-file diff, click \"Show N hidden lines\" on one region of file A, switch to file B, switch back — region stays expanded.
- [ ] Manual: toggle \"Expand all\" / \"Collapse all\" → regions reset as before (confirming no regression of #89).
- [ ] Manual: let the agent modify file A in the background while you're viewing file B; switch back — saved region state still applies where ranges still intersect current regions, degrades gracefully otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)