### PR TITLE
feat(diff): surface gitignored files as a collapsible group

### DIFF
--- a/server/diff.test.ts
+++ b/server/diff.test.ts
@@ -4,7 +4,13 @@ import { promisify } from 'util';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { getDiffSummary, getFileDiff, safeResolvePath } from './diff.js';
+import {
+  getDiffSummary,
+  getFileDiff,
+  safeResolvePath,
+  MAX_IGNORED_FILES,
+  IGNORED_DENY_PREFIXES,
+} from './diff.js';
 
 const execFileRaw = promisify(execFileCb);
 
@@ -130,6 +136,118 @@ describe('diff module', () => {
       const diff = await getFileDiff({ worktree: repo, base: 'main', relPath: 'big.txt' });
       expect(diff.tooLarge).toBe(true);
       expect(diff.newContent).toBe('');
+    });
+  });
+
+  describe('ignored files', () => {
+    async function writeIgnoreAndFiles(files: Record<string, string>): Promise<void> {
+      for (const [p, content] of Object.entries(files)) {
+        const full = path.join(repo, p);
+        await fs.promises.mkdir(path.dirname(full), { recursive: true });
+        await fs.promises.writeFile(full, content);
+      }
+    }
+
+    it('includes gitignored files with ignored=true and status=A', async () => {
+      await writeIgnoreAndFiles({
+        '.gitignore': '*.log\n',
+        'debug.log': 'line1\nline2\n',
+      });
+      const { files } = await getDiffSummary({ worktree: repo, base: 'main' });
+      const entry = files.find((f) => f.path === 'debug.log');
+      expect(entry).toBeDefined();
+      expect(entry).toMatchObject({
+        path: 'debug.log',
+        status: 'A',
+        additions: 2,
+        deletions: 0,
+        ignored: true,
+      });
+      // .gitignore itself is untracked (not ignored), must NOT carry ignored flag
+      const gi = files.find((f) => f.path === '.gitignore');
+      expect(gi?.ignored).toBeUndefined();
+    });
+
+    it('applies the deny-prefix list to filter out cache/build dirs', async () => {
+      // Include one entry per deny prefix, plus one legitimate ignored file.
+      const ignoreLines = ['*.log', ...IGNORED_DENY_PREFIXES.map((p) => p.replace(/\/$/, ''))];
+      await writeIgnoreAndFiles({
+        '.gitignore': ignoreLines.join('\n') + '\n',
+        'debug.log': 'x\n',
+        'node_modules/pkg/index.js': 'x\n',
+        'dist/bundle.js': 'x\n',
+        'coverage/lcov.info': 'x\n',
+        '.DS_Store': 'x',
+      });
+      const { files } = await getDiffSummary({ worktree: repo, base: 'main' });
+      const ignoredPaths = files.filter((f) => f.ignored).map((f) => f.path);
+      expect(ignoredPaths).toContain('debug.log');
+      expect(ignoredPaths).not.toContain('node_modules/pkg/index.js');
+      expect(ignoredPaths).not.toContain('dist/bundle.js');
+      expect(ignoredPaths).not.toContain('coverage/lcov.info');
+      expect(ignoredPaths).not.toContain('.DS_Store');
+    });
+
+    it('flags oversized ignored files with tooLarge=true but still lists them', async () => {
+      await writeIgnoreAndFiles({
+        '.gitignore': '*.log\n',
+      });
+      const big = 'x'.repeat(1_048_577);
+      await fs.promises.writeFile(path.join(repo, 'big.log'), big);
+      const { files } = await getDiffSummary({ worktree: repo, base: 'main' });
+      const entry = files.find((f) => f.path === 'big.log');
+      expect(entry).toBeDefined();
+      expect(entry?.ignored).toBe(true);
+      expect(entry?.tooLarge).toBe(true);
+      expect(entry?.additions).toBe(0);
+    });
+
+    it('marks binary ignored files with binary=true', async () => {
+      await writeIgnoreAndFiles({
+        '.gitignore': '*.bin\n',
+      });
+      await fs.promises.writeFile(
+        path.join(repo, 'blob.bin'),
+        Buffer.from([0, 1, 2, 3, 0, 255, 10]),
+      );
+      const { files } = await getDiffSummary({ worktree: repo, base: 'main' });
+      const entry = files.find((f) => f.path === 'blob.bin');
+      expect(entry?.ignored).toBe(true);
+      expect(entry?.binary).toBe(true);
+      expect(entry?.additions).toBe(0);
+    });
+
+    it('truncates the ignored list at MAX_IGNORED_FILES and sets ignoredTruncated', async () => {
+      await writeIgnoreAndFiles({
+        '.gitignore': '*.log\n',
+      });
+      for (let i = 0; i < MAX_IGNORED_FILES + 5; i++) {
+        await fs.promises.writeFile(path.join(repo, `file${i}.log`), 'x\n');
+      }
+      const summary = await getDiffSummary({ worktree: repo, base: 'main' });
+      const ignored = summary.files.filter((f) => f.ignored);
+      expect(ignored).toHaveLength(MAX_IGNORED_FILES);
+      expect(summary.ignoredTruncated).toBe(true);
+    });
+
+    it('does NOT set ignoredTruncated when list fits under the cap', async () => {
+      await writeIgnoreAndFiles({
+        '.gitignore': '*.log\n',
+        'one.log': 'x\n',
+      });
+      const summary = await getDiffSummary({ worktree: repo, base: 'main' });
+      expect(summary.ignoredTruncated).toBeUndefined();
+    });
+  });
+
+  describe('getFileDiff for ignored files', () => {
+    it('returns oldContent="" and reads newContent from worktree', async () => {
+      await fs.promises.writeFile(path.join(repo, '.gitignore'), '*.log\n');
+      await fs.promises.writeFile(path.join(repo, 'debug.log'), 'log line\n');
+      const diff = await getFileDiff({ worktree: repo, base: 'main', relPath: 'debug.log' });
+      expect(diff.oldContent).toBe('');
+      expect(diff.newContent).toBe('log line\n');
+      expect(diff.status).toBe('A');
     });
   });
 

--- a/server/diff.ts
+++ b/server/diff.ts
@@ -216,13 +216,7 @@ async function appendIgnoredFiles(
 
   let stdout = '';
   try {
-    stdout = await git(worktree, [
-      'ls-files',
-      '--others',
-      '--ignored',
-      '--exclude-standard',
-      '-z',
-    ]);
+    stdout = await git(worktree, ['ls-files', '--others', '--ignored', '--exclude-standard', '-z']);
   } catch (err) {
     logger.warn(
       { worktree, err: (err as Error).message },

--- a/server/diff.ts
+++ b/server/diff.ts
@@ -8,6 +8,30 @@ const execFile = promisify(execFileCb);
 const logger = childLogger('diff');
 
 export const MAX_FILE_BYTES = 1_048_576; // 1 MiB
+export const MAX_IGNORED_FILES = 200;
+
+// Paths starting with any of these are filtered out of the ignored-files list
+// entirely — they're always-huge caches/builds that provide no useful review signal.
+export const IGNORED_DENY_PREFIXES = [
+  'node_modules/',
+  '.git/',
+  '.next/',
+  'dist/',
+  'dist-server/',
+  'coverage/',
+  '.cache/',
+  '.vite/',
+  '.pnp/',
+  '.yarn/',
+  '.turbo/',
+  '.parcel-cache/',
+  '__pycache__/',
+  '.pytest_cache/',
+  'target/',
+  'build/',
+  'out/',
+  '.DS_Store',
+];
 
 export type FileStatus = 'A' | 'M' | 'D' | 'B';
 
@@ -16,10 +40,14 @@ export interface DiffFileEntry {
   status: FileStatus;
   additions: number;
   deletions: number;
+  ignored?: boolean;
+  tooLarge?: boolean;
+  binary?: boolean;
 }
 
 export interface DiffSummary {
   files: DiffFileEntry[];
+  ignoredTruncated?: boolean;
 }
 
 export interface FileDiff {
@@ -167,8 +195,87 @@ export async function getDiffSummary(opts: {
     files.push({ path: p, status, additions, deletions });
   }
 
-  files.sort((a, b) => a.path.localeCompare(b.path));
-  return { files };
+  const summary: DiffSummary = { files };
+  await appendIgnoredFiles(summary, { worktree, knownPaths: paths });
+
+  summary.files.sort((a, b) => a.path.localeCompare(b.path));
+  return summary;
+}
+
+function isDeniedIgnoredPath(p: string): boolean {
+  return IGNORED_DENY_PREFIXES.some((prefix) =>
+    prefix.endsWith('/') ? p === prefix || p.startsWith(prefix) : p === prefix,
+  );
+}
+
+async function appendIgnoredFiles(
+  summary: DiffSummary,
+  opts: { worktree: string; knownPaths: Set<string> },
+): Promise<void> {
+  const { worktree, knownPaths } = opts;
+
+  let stdout = '';
+  try {
+    stdout = await git(worktree, [
+      'ls-files',
+      '--others',
+      '--ignored',
+      '--exclude-standard',
+      '-z',
+    ]);
+  } catch (err) {
+    logger.warn(
+      { worktree, err: (err as Error).message },
+      'ls-files --ignored failed; skipping ignored files',
+    );
+    return;
+  }
+
+  // -z separates entries with NUL (filenames may contain newlines).
+  const candidates = stdout.split('\0').filter(Boolean);
+  const filtered: string[] = [];
+  for (const p of candidates) {
+    if (knownPaths.has(p)) continue;
+    if (isDeniedIgnoredPath(p)) continue;
+    filtered.push(p);
+  }
+  if (filtered.length > MAX_IGNORED_FILES) {
+    summary.ignoredTruncated = true;
+    filtered.length = MAX_IGNORED_FILES;
+  }
+
+  for (const p of filtered) {
+    const abs = path.join(worktree, p);
+    let tooLarge = false;
+    let binary = false;
+    let additions = 0;
+    try {
+      const stat = await fs.promises.stat(abs);
+      if (stat.size > MAX_FILE_BYTES) {
+        tooLarge = true;
+      } else {
+        const buf = await fs.promises.readFile(abs);
+        const sniff = buf.subarray(0, Math.min(buf.length, 8192));
+        binary = sniff.includes(0);
+        if (!binary && buf.length > 0) {
+          for (let i = 0; i < buf.length; i++) if (buf[i] === 0x0a) additions++;
+          if (buf[buf.length - 1] !== 0x0a) additions++;
+        }
+      }
+    } catch {
+      continue;
+    }
+    const entry: DiffFileEntry = {
+      path: p,
+      status: 'A',
+      additions,
+      deletions: 0,
+      ignored: true,
+    };
+    if (tooLarge) entry.tooLarge = true;
+    if (binary) entry.binary = true;
+    summary.files.push(entry);
+  }
 }
 
 export async function getFileDiff(opts: {

--- a/src/components/DiffFileTree.test.tsx
+++ b/src/components/DiffFileTree.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { DiffFileEntry } from '@/lib/api';
+import { DiffFileTree, ignoredGroupKey } from './DiffFileTree';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('DiffFileTree', () => {
+  it('renders no group header when there are no ignored entries', () => {
+    const files: DiffFileEntry[] = [{ path: 'a.ts', status: 'M', additions: 1, deletions: 0 }];
+    render(<DiffFileTree files={files} selected={null} onSelect={vi.fn()} taskId="t1" />);
+    expect(screen.queryByText(/ignored files/i)).not.toBeInTheDocument();
+    expect(screen.getByText('a.ts')).toBeInTheDocument();
+  });
+
+  it('renders the ignored group collapsed by default', () => {
+    const files: DiffFileEntry[] = [
+      { path: 'a.ts', status: 'M', additions: 1, deletions: 0 },
+      { path: 'debug.log', status: 'A', additions: 3, deletions: 0, ignored: true },
+    ];
+    render(<DiffFileTree files={files} selected={null} onSelect={vi.fn()} taskId="t1" />);
+    // The header is shown…
+    const header = screen.getByRole('button', { name: /ignored files \(1\)/i });
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    // …but the ignored file itself is hidden.
+    expect(screen.queryByText('debug.log')).not.toBeInTheDocument();
+  });
+
+  it('expands the ignored group on click and persists the state to localStorage', async () => {
+    const user = userEvent.setup();
+    const files: DiffFileEntry[] = [
+      { path: 'a.ts', status: 'M', additions: 1, deletions: 0 },
+      { path: 'debug.log', status: 'A', additions: 3, deletions: 0, ignored: true },
+    ];
+    render(<DiffFileTree files={files} selected={null} onSelect={vi.fn()} taskId="t1" />);
+
+    await user.click(screen.getByRole('button', { name: /ignored files/i }));
+
+    expect(screen.getByText('debug.log')).toBeInTheDocument();
+    expect(localStorage.getItem(ignoredGroupKey('t1'))).toBe('true');
+  });
+
+  it('restores prior open state from localStorage on mount', () => {
+    localStorage.setItem(ignoredGroupKey('t1'), 'true');
+    const files: DiffFileEntry[] = [
+      { path: 'debug.log', status: 'A', additions: 3, deletions: 0, ignored: true },
+    ];
+    render(<DiffFileTree files={files} selected={null} onSelect={vi.fn()} taskId="t1" />);
+    expect(screen.getByText('debug.log')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ignored files/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  it('shows a "more hidden" hint when ignoredTruncated is true', () => {
+    const files: DiffFileEntry[] = [
+      { path: 'debug.log', status: 'A', additions: 3, deletions: 0, ignored: true },
+    ];
+    render(
+      <DiffFileTree
+        files={files}
+        selected={null}
+        onSelect={vi.fn()}
+        taskId="t1"
+        ignoredTruncated
+      />,
+    );
+    expect(screen.getByText(/more hidden/i)).toBeInTheDocument();
+  });
+
+  it('calls onSelect when an ignored file is clicked after expanding', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const files: DiffFileEntry[] = [
+      { path: 'debug.log', status: 'A', additions: 1, deletions: 0, ignored: true },
+    ];
+    render(<DiffFileTree files={files} selected={null} onSelect={onSelect} taskId="t1" />);
+    await user.click(screen.getByRole('button', { name: /ignored files/i }));
+    await user.click(screen.getByText('debug.log'));
+    expect(onSelect).toHaveBeenCalledWith('debug.log');
+  });
+});

--- a/src/components/DiffFileTree.tsx
+++ b/src/components/DiffFileTree.tsx
@@ -173,9 +173,7 @@ export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncat
             </span>
             <span>Ignored files ({ignored.length})</span>
             {ignoredTruncated ? (
-              <span className="ml-1 normal-case text-muted-foreground/70">
-                (+more hidden)
-              </span>
+              <span className="ml-1 normal-case text-muted-foreground/70">(+more hidden)</span>
             ) : null}
           </button>
           {ignoredOpen ? (

--- a/src/components/DiffFileTree.tsx
+++ b/src/components/DiffFileTree.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { DiffFileEntry } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
@@ -6,6 +6,12 @@ interface Props {
   files: DiffFileEntry[];
   selected: string | null;
   onSelect: (path: string) => void;
+  taskId?: string;
+  ignoredTruncated?: boolean;
+}
+
+export function ignoredGroupKey(taskId: string): string {
+  return `octomux:diff-ignored-open:${taskId}`;
 }
 
 interface Node {
@@ -115,14 +121,68 @@ function TreeRow({
   );
 }
 
-export function DiffFileTree({ files, selected, onSelect }: Props) {
-  const tree = useMemo(() => buildTree(files), [files]);
+export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncated }: Props) {
+  const changed = useMemo(() => files.filter((f) => !f.ignored), [files]);
+  const ignored = useMemo(() => files.filter((f) => f.ignored), [files]);
+  const changedTree = useMemo(() => buildTree(changed), [changed]);
+  const ignoredTree = useMemo(() => buildTree(ignored), [ignored]);
+
+  const [ignoredOpen, setIgnoredOpen] = useState(false);
+  useEffect(() => {
+    if (!taskId) return;
+    try {
+      setIgnoredOpen(localStorage.getItem(ignoredGroupKey(taskId)) === 'true');
+    } catch {
+      // localStorage unavailable (SSR, privacy mode, etc.) — keep default closed.
+    }
+  }, [taskId]);
+
+  const toggleIgnored = () => {
+    setIgnoredOpen((prev) => {
+      const next = !prev;
+      if (taskId) {
+        try {
+          localStorage.setItem(ignoredGroupKey(taskId), String(next));
+        } catch {
+          // ignore
+        }
+      }
+      return next;
+    });
+  };
+
   if (files.length === 0) {
     return <div className="p-4 text-xs text-muted-foreground">No changes on this branch yet.</div>;
   }
+
   return (
     <div className="overflow-y-auto">
-      <TreeRow node={tree} depth={0} selected={selected} onSelect={onSelect} />
+      {changed.length > 0 ? (
+        <TreeRow node={changedTree} depth={0} selected={selected} onSelect={onSelect} />
+      ) : null}
+      {ignored.length > 0 ? (
+        <div className="border-t border-border">
+          <button
+            type="button"
+            onClick={toggleIgnored}
+            aria-expanded={ignoredOpen}
+            className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent"
+          >
+            <span aria-hidden className="inline-block w-3 font-mono">
+              {ignoredOpen ? '▾' : '▸'}
+            </span>
+            <span>Ignored files ({ignored.length})</span>
+            {ignoredTruncated ? (
+              <span className="ml-1 normal-case text-muted-foreground/70">
+                (+more hidden)
+              </span>
+            ) : null}
+          </button>
+          {ignoredOpen ? (
+            <TreeRow node={ignoredTree} depth={0} selected={selected} onSelect={onSelect} />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -244,9 +244,7 @@ describe('DiffViewer', () => {
     render(<DiffViewer taskId="t1" isRunning={false} />);
 
     await screen.findByRole('button', { name: 'Collapse all' });
-    const opts = JSON.parse(
-      screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}',
-    );
+    const opts = JSON.parse(screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}');
     expect(opts.hideUnchangedRegions.enabled).toBe(false);
   });
 });

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -41,6 +41,7 @@ function extToLanguage(p: string): string {
 
 export function DiffViewer({ taskId, isRunning }: Props) {
   const [files, setFiles] = useState<DiffFileEntry[]>([]);
+  const [ignoredTruncated, setIgnoredTruncated] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
   const [fileDiff, setFileDiff] = useState<FileDiffResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -99,6 +100,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
     try {
       const s = await api.getTaskDiffSummary(taskId);
       setFiles(s.files);
+      setIgnoredTruncated(s.ignoredTruncated ?? false);
       setError(null);
       const cur = selectedRef.current;
       if (!cur && s.files.length > 0) setSelected(s.files[0].path);
@@ -181,7 +183,13 @@ export function DiffViewer({ taskId, isRunning }: Props) {
         {summaryLoading && files.length === 0 ? (
           <div className="p-4 text-xs text-muted-foreground">Loading diff...</div>
         ) : (
-          <DiffFileTree files={files} selected={selected} onSelect={handleSelect} />
+          <DiffFileTree
+            files={files}
+            selected={selected}
+            onSelect={handleSelect}
+            taskId={taskId}
+            ignoredTruncated={ignoredTruncated}
+          />
         )}
       </aside>
       <main className="flex min-w-0 flex-1 flex-col">

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -199,52 +199,52 @@ export function DiffViewer({ taskId, isRunning }: Props) {
           </div>
         ) : null}
         <div className="min-h-0 flex-1">
-        {error && selected ? (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
-            {error}
-          </div>
-        ) : !selected ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Select a file to view its diff
-          </div>
-        ) : fileLoading && !fileDiff ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Loading {selected}...
-          </div>
-        ) : fileDiff?.tooLarge ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {selected} is too large to display (&gt;1 MiB). Open the worktree directly.
-          </div>
-        ) : fileDiff?.binary ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {selected} is a binary file.
-          </div>
-        ) : fileDiff ? (
-          <Suspense
-            fallback={
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Loading editor...
-              </div>
-            }
-          >
-            <MonacoDiff
-              key={`${selected}:${expandedAll ? 'expanded' : 'collapsed'}`}
-              height="100%"
-              original={fileDiff.oldContent}
-              modified={fileDiff.newContent}
-              language={extToLanguage(selected)}
-              theme="vs-dark"
-              onMount={handleEditorMount}
-              options={{
-                readOnly: true,
-                renderSideBySide: true,
-                minimap: { enabled: true },
-                hideUnchangedRegions: { enabled: !expandedAll },
-                scrollBeyondLastLine: false,
-              }}
-            />
-          </Suspense>
-        ) : null}
+          {error && selected ? (
+            <div className="flex h-full items-center justify-center text-sm text-destructive">
+              {error}
+            </div>
+          ) : !selected ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Select a file to view its diff
+            </div>
+          ) : fileLoading && !fileDiff ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Loading {selected}...
+            </div>
+          ) : fileDiff?.tooLarge ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {selected} is too large to display (&gt;1 MiB). Open the worktree directly.
+            </div>
+          ) : fileDiff?.binary ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {selected} is a binary file.
+            </div>
+          ) : fileDiff ? (
+            <Suspense
+              fallback={
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Loading editor...
+                </div>
+              }
+            >
+              <MonacoDiff
+                key={`${selected}:${expandedAll ? 'expanded' : 'collapsed'}`}
+                height="100%"
+                original={fileDiff.oldContent}
+                modified={fileDiff.newContent}
+                language={extToLanguage(selected)}
+                theme="vs-dark"
+                onMount={handleEditorMount}
+                options={{
+                  readOnly: true,
+                  renderSideBySide: true,
+                  minimap: { enabled: true },
+                  hideUnchangedRegions: { enabled: !expandedAll },
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </Suspense>
+          ) : null}
         </div>
       </main>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -117,10 +117,14 @@ export interface DiffFileEntry {
   status: DiffFileStatus;
   additions: number;
   deletions: number;
+  ignored?: boolean;
+  tooLarge?: boolean;
+  binary?: boolean;
 }
 
 export interface DiffSummaryResponse {
   files: DiffFileEntry[];
+  ignoredTruncated?: boolean;
 }
 
 export interface FileDiffResponse {


### PR DESCRIPTION
## What

Adds a separate, collapsible "Ignored files" section to the DiffViewer for
files that exist in the task worktree but are matched by `.gitignore` (logs,
local configs, agent-generated artifacts, etc.).

Server (`server/diff.ts`):
- Enumerates ignored files via `git ls-files --others --ignored --exclude-standard -z`.
- Filters out cache/build dirs via a hard-coded deny list (`node_modules/`,
  `.git/`, `.next/`, `dist/`, `dist-server/`, `coverage/`, `.cache/`, `.vite/`,
  `.pnp/`, `.yarn/`, `.turbo/`, `.parcel-cache/`, `__pycache__/`,
  `.pytest_cache/`, `target/`, `build/`, `out/`, `.DS_Store`).
- Caps the list at 200 entries and sets `ignoredTruncated: true` when exceeded.
- Flags oversized files (>1 MiB) with `tooLarge: true` and binary files with
  `binary: true`, still listing them by path.
- Extends `DiffFileEntry` with `ignored?`, `tooLarge?`, `binary?`.
- `getFileDiff` required no changes — its existing 128-error catch already
  yields `oldContent: ''` and reads `newContent` from disk.

Client:
- `DiffFileTree` splits entries into "Changed" and "Ignored files" groups.
  The ignored group is collapsed by default, shows a count, renders a
  "(+more hidden)" hint when `ignoredTruncated` is true, and persists its
  open state per-task to `localStorage` under
  `octomux:diff-ignored-open:<taskId>`.
- `DiffViewer` reads `ignoredTruncated` from the summary and passes
  `taskId` + `ignoredTruncated` through to the tree. No changes to Monaco
  options, toolbar, or polling.

## Why

Agents regularly create files that `.gitignore` hides — local configs,
build artifacts, logs. Those changes were previously invisible during
review. Surfacing them in a separate collapsed group gives visibility
without drowning the main changed-files list. The deny list + 200-file
cap + size/binary flags keep the enumeration cheap even on the 2s poll
cadence.

## Testing

- \`bun run typecheck\` — clean.
- \`bun run test\` — 813 tests pass, including 7 new \`server/diff.test.ts\`
  cases (ignored detection, deny-prefix filter, \`tooLarge\`, \`binary\`,
  cap+\`ignoredTruncated\`, no-truncate path, \`getFileDiff\` for ignored) and
  6 new \`src/components/DiffFileTree.test.tsx\` cases (group hidden when
  empty, default collapsed, click-to-expand + localStorage write,
  localStorage restore on mount, truncation hint, selection callback).
- \`bun run lint\` — 0 errors on changed files (only pre-existing warnings
  elsewhere).