### PR TITLE
feat(cli): --fork-from on create-task and new add-agent subcommand

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -16,6 +16,8 @@ export interface Task {
   agents?: Agent[];
   pending_prompts?: unknown[];
   derived_status?: string | null;
+  run_mode?: string | null;
+  no_worktree?: number | boolean;
 }
 
 export interface Agent {
@@ -44,7 +46,10 @@ export interface OctomuxClient {
   getTask(id: string): Promise<Task>;
   updateTask(id: string, data: { status: string }): Promise<Task>;
   deleteTask(id: string): Promise<void>;
-  addAgent(taskId: string, data?: { prompt?: string }): Promise<Agent>;
+  addAgent(
+    taskId: string,
+    data?: { prompt?: string; agent?: string; label?: string },
+  ): Promise<Agent>;
   stopAgent(taskId: string, agentId: string): Promise<void>;
   sendMessage(taskId: string, agentId: string, message: string): Promise<{ success: boolean }>;
   listSkills(): Promise<{ name: string; description: string }[]>;

--- a/cli/src/commands/add-agent.test.ts
+++ b/cli/src/commands/add-agent.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerAddAgent } from './add-agent.js';
+import type { OctomuxClient, Agent } from '../client.js';
+
+function makeAgent(partial: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-1',
+    task_id: 'task-1',
+    window_index: 1,
+    label: 'Agent 2',
+    status: 'running',
+    claude_session_id: null,
+    hook_activity: '',
+    created_at: '2026-01-01T00:00:00Z',
+    ...partial,
+  };
+}
+
+function makeClient(addAgent: OctomuxClient['addAgent']): OctomuxClient {
+  const notImpl = () => {
+    throw new Error('not implemented in test');
+  };
+  return {
+    createTask: notImpl as never,
+    listTasks: notImpl as never,
+    getTask: notImpl as never,
+    updateTask: notImpl as never,
+    deleteTask: notImpl as never,
+    addAgent,
+    stopAgent: notImpl as never,
+    sendMessage: notImpl as never,
+    listSkills: notImpl as never,
+    getSkill: notImpl as never,
+    createSkill: notImpl as never,
+    deleteSkill: notImpl as never,
+    recentRepos: notImpl as never,
+    defaultBranch: notImpl as never,
+    getRepoConfig: notImpl as never,
+  } as OctomuxClient;
+}
+
+function buildProgram(client: OctomuxClient): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  program.option('--json');
+  program.hook('preAction', (thisCommand) => {
+    thisCommand.setOptionValue('_client', client);
+  });
+  registerAddAgent(program);
+  return program;
+}
+
+describe('add-agent command', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('requires --task and --prompt', async () => {
+    const addAgent = vi.fn(async () => makeAgent());
+    const program = buildProgram(makeClient(addAgent));
+
+    await expect(
+      program.parseAsync(['add-agent'], { from: 'user' }),
+    ).rejects.toThrow(/required option/);
+  });
+
+  it('sends prompt only when --agent and --label are not passed', async () => {
+    const addAgent = vi.fn(async () => makeAgent());
+    const program = buildProgram(makeClient(addAgent));
+
+    await program.parseAsync(
+      ['add-agent', '--task', 'task-1', '--prompt', 'do the thing'],
+      { from: 'user' },
+    );
+
+    expect(addAgent).toHaveBeenCalledWith('task-1', { prompt: 'do the thing' });
+  });
+
+  it('forwards --agent and --label when provided', async () => {
+    const addAgent = vi.fn(async () => makeAgent({ label: 'Reviewer' }));
+    const program = buildProgram(makeClient(addAgent));
+
+    await program.parseAsync(
+      [
+        'add-agent',
+        '--task',
+        'task-1',
+        '--prompt',
+        'review the diff',
+        '--agent',
+        'code-reviewer',
+        '--label',
+        'Reviewer',
+      ],
+      { from: 'user' },
+    );
+
+    expect(addAgent).toHaveBeenCalledWith('task-1', {
+      prompt: 'review the diff',
+      agent: 'code-reviewer',
+      label: 'Reviewer',
+    });
+  });
+});

--- a/cli/src/commands/add-agent.ts
+++ b/cli/src/commands/add-agent.ts
@@ -4,23 +4,29 @@ import { outputJson, success, label } from '../format.js';
 
 export function registerAddAgent(program: Command): void {
   program
-    .command('add-agent <task-id>')
-    .description('Add a new agent to a running task')
-    .option('-p, --prompt <prompt>', 'initial prompt for the agent')
-    .action(async (taskId: string, opts, cmd) => {
+    .command('add-agent')
+    .description('Add a new agent (tmux window) to an existing running task')
+    .requiredOption('-t, --task <task-id>', 'task ID to add the agent to')
+    .requiredOption('-p, --prompt <prompt>', 'initial prompt for the new agent')
+    .option('-a, --agent <agent-type>', 'Claude Code agent type (e.g. code-reviewer)')
+    .option('-l, --label <label>', 'label for the new agent (default: server-assigned "Agent N")')
+    .action(async (opts, cmd) => {
       const { client, json } = getContext(cmd);
 
-      const agent = await client.addAgent(
-        taskId,
-        opts.prompt ? { prompt: opts.prompt } : undefined,
-      );
+      const payload: { prompt: string; agent?: string; label?: string } = {
+        prompt: opts.prompt,
+      };
+      if (opts.agent) payload.agent = opts.agent;
+      if (opts.label) payload.label = opts.label;
+
+      const agent = await client.addAgent(opts.task, payload);
 
       if (json) {
         outputJson(agent);
         return;
       }
 
-      success(`Added agent to task ${taskId}`);
+      success(`Added agent to task ${opts.task}`);
       console.log(label('Agent ID', agent.id));
       console.log(label('Label', agent.label));
       console.log(label('Window', String(agent.window_index)));

--- a/cli/src/commands/create-task.test.ts
+++ b/cli/src/commands/create-task.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { resolveForkFrom, registerCreateTask } from './create-task.js';
+import type { OctomuxClient, Task } from '../client.js';
+
+function makeTask(partial: Partial<Task> = {}): Task {
+  return {
+    id: 'abc123',
+    title: 'source',
+    description: 'desc',
+    status: 'running',
+    repo_path: '/repo/src',
+    branch: 'agents/abc123',
+    base_branch: 'main',
+    worktree: '/repo/src/.worktrees/abc123',
+    pr_url: null,
+    pr_number: null,
+    initial_prompt: null,
+    error: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...partial,
+  };
+}
+
+function makeClient(overrides: Partial<OctomuxClient> = {}): OctomuxClient {
+  const notImpl = () => {
+    throw new Error('not implemented in test');
+  };
+  return {
+    createTask: vi.fn(async () => makeTask({ id: 'new-id' })),
+    listTasks: notImpl as never,
+    getTask: vi.fn(async () => makeTask()),
+    updateTask: notImpl as never,
+    deleteTask: notImpl as never,
+    addAgent: notImpl as never,
+    stopAgent: notImpl as never,
+    sendMessage: notImpl as never,
+    listSkills: notImpl as never,
+    getSkill: notImpl as never,
+    createSkill: notImpl as never,
+    deleteSkill: notImpl as never,
+    recentRepos: notImpl as never,
+    defaultBranch: notImpl as never,
+    getRepoConfig: vi.fn(async () => ({
+      repo_path: '/repo/src',
+      base_branch: null,
+      test_command: '',
+      format_command: '',
+      lint_command: '',
+    })),
+    ...overrides,
+  } as OctomuxClient;
+}
+
+describe('resolveForkFrom', () => {
+  it('expands fork-from to agents/<id> and inherits repo_path from source', async () => {
+    const source = makeTask();
+    const client = makeClient({ getTask: vi.fn(async () => source) });
+    const git = vi.fn(async () => ({ stdout: '' }));
+
+    const res = await resolveForkFrom(client, 'abc123', undefined, git);
+
+    expect(res.baseBranch).toBe('agents/abc123');
+    expect(res.repoPath).toBe('/repo/src');
+    expect(res.warnings).toEqual([]);
+  });
+
+  it('prefers explicit repo_path over source.repo_path', async () => {
+    const client = makeClient({ getTask: vi.fn(async () => makeTask()) });
+    const git = vi.fn(async () => ({ stdout: '' }));
+
+    const res = await resolveForkFrom(client, 'abc123', '/other/repo', git);
+
+    expect(res.repoPath).toBe('/other/repo');
+  });
+
+  it.each([
+    ['draft status', { status: 'draft' }],
+    ['scratch run_mode', { run_mode: 'scratch' }],
+    ['none run_mode', { run_mode: 'none' }],
+    ['no_worktree legacy flag', { no_worktree: 1 }],
+  ])('refuses to fork from %s', async (_name, overrides) => {
+    const client = makeClient({ getTask: vi.fn(async () => makeTask(overrides as Partial<Task>)) });
+    const git = vi.fn(async () => ({ stdout: '' }));
+
+    await expect(resolveForkFrom(client, 'abc123', undefined, git)).rejects.toThrow(
+      /cannot fork from abc123: source has no branch/,
+    );
+  });
+
+  it('refuses when source task not found', async () => {
+    const client = makeClient({
+      getTask: vi.fn(async () => {
+        throw new Error('Task not found');
+      }),
+    });
+    const git = vi.fn(async () => ({ stdout: '' }));
+
+    await expect(resolveForkFrom(client, 'missing', undefined, git)).rejects.toThrow(
+      /cannot fork from missing: source not found/,
+    );
+  });
+
+  it('emits a warning when source worktree is dirty', async () => {
+    const client = makeClient({ getTask: vi.fn(async () => makeTask()) });
+    const git = vi.fn(async (args: string[]) => {
+      if (args[0] === 'status') return { stdout: ' M server/api.ts\n' };
+      if (args[0] === 'rev-parse') return { stdout: '1a2b3c4\n' };
+      return { stdout: '' };
+    });
+
+    const res = await resolveForkFrom(client, 'abc123', undefined, git);
+
+    expect(res.warnings).toHaveLength(1);
+    expect(res.warnings[0]).toContain('abc123');
+    expect(res.warnings[0]).toContain('1a2b3c4');
+    expect(res.warnings[0]).toContain('uncommitted changes');
+  });
+
+  it('emits no warning when source worktree is clean', async () => {
+    const client = makeClient({ getTask: vi.fn(async () => makeTask()) });
+    const git = vi.fn(async () => ({ stdout: '' }));
+
+    const res = await resolveForkFrom(client, 'abc123', undefined, git);
+
+    expect(res.warnings).toEqual([]);
+  });
+});
+
+// ─── Integration: exercising registerCreateTask via commander ─────────────────
+
+function buildProgram(client: OctomuxClient): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  program.option('--json');
+  program.hook('preAction', (thisCommand) => {
+    thisCommand.setOptionValue('_client', client);
+  });
+  registerCreateTask(program);
+  return program;
+}
+
+describe('create-task command', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('errors when --fork-from and --base-branch are both supplied', async () => {
+    const client = makeClient();
+    const program = buildProgram(client);
+
+    await expect(
+      program.parseAsync(
+        [
+          'create-task',
+          '--title',
+          't',
+          '--description',
+          'd',
+          '--fork-from',
+          'abc123',
+          '--base-branch',
+          'main',
+        ],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it('passes base_branch=agents/<id> and inherited repo_path when forking', async () => {
+    const source = makeTask();
+    const createTask = vi.fn(async () => makeTask({ id: 'new-id' }));
+    const client = makeClient({
+      getTask: vi.fn(async () => source),
+      createTask,
+    });
+    const program = buildProgram(client);
+
+    await program.parseAsync(
+      ['create-task', '--title', 't', '--description', 'd', '--fork-from', 'abc123'],
+      { from: 'user' },
+    );
+
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base_branch: 'agents/abc123',
+        repo_path: '/repo/src',
+      }),
+    );
+  });
+});

--- a/cli/src/commands/create-task.ts
+++ b/cli/src/commands/create-task.ts
@@ -1,6 +1,77 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import chalk from 'chalk';
 import { Command } from 'commander';
 import { getContext } from '../action.js';
+import type { OctomuxClient, Task } from '../client.js';
 import { outputJson, label, success, colorStatus } from '../format.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface ForkResolution {
+  baseBranch: string;
+  repoPath: string;
+  warnings: string[];
+}
+
+export async function resolveForkFrom(
+  client: OctomuxClient,
+  forkFromId: string,
+  explicitRepoPath: string | undefined,
+  git: (args: string[], cwd: string) => Promise<{ stdout: string }> = defaultGit,
+): Promise<ForkResolution> {
+  let source: Task;
+  try {
+    source = await client.getTask(forkFromId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`cannot fork from ${forkFromId}: source not found (${msg})`);
+  }
+
+  const status = source.status;
+  const runMode = source.run_mode ?? (source.no_worktree ? 'scratch' : 'new');
+
+  if (runMode === 'scratch' || runMode === 'none') {
+    throw new Error(
+      `cannot fork from ${forkFromId}: source has no branch (status=${status}, run_mode=${runMode})`,
+    );
+  }
+  if (status === 'draft') {
+    throw new Error(
+      `cannot fork from ${forkFromId}: source has no branch (status=${status}, run_mode=${runMode})`,
+    );
+  }
+
+  const baseBranch = `agents/${forkFromId}`;
+  const repoPath = explicitRepoPath ?? source.repo_path;
+
+  const warnings: string[] = [];
+  if (source.worktree) {
+    try {
+      const { stdout: dirty } = await git(['status', '--porcelain'], source.worktree);
+      if (dirty.trim().length > 0) {
+        let shortSha = '';
+        try {
+          const { stdout: sha } = await git(['rev-parse', '--short', 'HEAD'], source.worktree);
+          shortSha = sha.trim();
+        } catch {
+          shortSha = 'unknown';
+        }
+        warnings.push(
+          `Source task ${forkFromId} has uncommitted changes; fork starts from last commit ${shortSha}. Those changes will not be in the fork.`,
+        );
+      }
+    } catch {
+      // Worktree unreadable; skip cleanliness check silently.
+    }
+  }
+
+  return { baseBranch, repoPath, warnings };
+}
+
+async function defaultGit(args: string[], cwd: string): Promise<{ stdout: string }> {
+  return execFileAsync('git', ['-C', cwd, ...args]);
+}
 
 export function registerCreateTask(program: Command): void {
   program
@@ -8,14 +79,32 @@ export function registerCreateTask(program: Command): void {
     .description('Create a new agent task')
     .requiredOption('-t, --title <title>', 'task title')
     .requiredOption('-d, --description <desc>', 'task description')
-    .requiredOption('-r, --repo-path <path>', 'repository path')
+    .option('-r, --repo-path <path>', 'repository path (inherited from source when using --fork-from)')
     .option('-p, --initial-prompt <prompt>', 'initial prompt for the agent')
     .option('-b, --branch <name>', 'branch name')
     .option('--base-branch <name>', 'base branch name')
+    .option('--fork-from <task-id>', 'fork from an existing task (sets base branch to agents/<id>)')
     .option('--draft', 'create as draft without starting')
     .option('--no-worktree', 'run agent in the repo directory without creating a worktree')
     .action(async (opts, cmd) => {
       const { client, json } = getContext(cmd);
+
+      if (opts.forkFrom && opts.baseBranch) {
+        throw new Error('--fork-from and --base-branch are mutually exclusive');
+      }
+
+      if (opts.forkFrom) {
+        const fork = await resolveForkFrom(client, opts.forkFrom, opts.repoPath);
+        opts.baseBranch = fork.baseBranch;
+        opts.repoPath = fork.repoPath;
+        for (const w of fork.warnings) {
+          console.error(chalk.yellow('Warning:') + ' ' + w);
+        }
+      }
+
+      if (!opts.repoPath) {
+        throw new Error("required option '-r, --repo-path <path>' not specified");
+      }
 
       // Auto-fill base branch from repo config if not specified
       if (!opts.baseBranch) {

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -9,5 +9,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/skills/add-agent/SKILL.md
+++ b/skills/add-agent/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: add-agent
+description: Use when you need to attach a new Claude Code agent (new tmux window) to an existing running octomux task, sharing the task's worktree and cwd
+---
+
+# Add an agent to an octomux task
+
+Attach a new Claude Code agent to an existing running task via `octomux add-agent`. The new agent is a fresh tmux window inside the task's tmux session, sharing the task's worktree/cwd. Each task can hold multiple agents working in parallel in the same worktree.
+
+## Distinction from `send-agent-message`
+
+- **`add-agent`** — creates a NEW agent (new tmux window, new Claude Code process) attached to an existing task. Use this to spin up an additional helper agent (e.g. a reviewer) alongside the original agent.
+- **`send-agent-message`** — sends a message to an ALREADY-RUNNING agent via tmux `send-keys`. Use this to nudge or redirect an agent that is already working.
+
+If you want another voice in the task, use `add-agent`. If you want to talk to the voice already there, use `send-agent-message`.
+
+## When to use
+
+- Adding a reviewer / QA agent alongside an implementing agent
+- Spawning an additional helper to work on a subtask in the same worktree
+- Continuing an interrupted task with a fresh prompt without losing the original context in the running agent
+
+## Steps
+
+1. **Identify the task:**
+   - If the user provides a task ID, use it directly
+   - Otherwise look it up via `octomux list-tasks --json` and find the task by title/description
+   - The task must be in `running` status — `add-agent` will fail otherwise
+
+2. **Craft a focused initial prompt** for the new agent. Keep it specific: the new agent lands in the same worktree but knows nothing about what the first agent has been doing.
+
+3. **Run the command:**
+
+   ```bash
+   octomux add-agent \
+     --task <task-id> \
+     --prompt '<initial prompt for the new agent>'
+   ```
+
+   Optional flags:
+
+   - `--agent <agent-type>` — use a Claude Code agent type (e.g. `code-reviewer`). Default: plain `claude` with no specific agent type.
+   - `--label <label>` — custom label for the new agent. Default: server-assigned `"Agent N"`.
+
+4. **Report:** the command prints the new agent's ID, label, and tmux window index on success. Pass the agent ID back to the user so they can `send-agent-message` to it later.
+
+## Examples
+
+**Add a reviewer to a running implementation task:**
+
+```bash
+octomux add-agent \
+  --task ABC123XYZ \
+  --agent code-reviewer \
+  --label 'Reviewer' \
+  --prompt 'Review the diff on this branch against main. Focus on correctness and edge cases, flag anything risky.'
+```
+
+**Add a second implementer to parallelize a subtask:**
+
+```bash
+octomux add-agent \
+  --task ABC123XYZ \
+  --prompt 'While Agent 1 finishes the API work, scaffold the frontend table in src/pages/tasks/. Do not touch server/ files.'
+```
+
+## Notes
+
+- The octomux server must be running (`octomux start`)
+- The task must be in `running` status; `add-agent` fails on `draft`, `setting_up`, `closed`, or `error` tasks
+- The new agent shares the task's worktree — both agents operate on the same files, so coordinate explicitly via prompts to avoid conflicts
+- Monitor the new agent via `octomux get-task <task-id>` or the dashboard

--- a/skills/create-task/SKILL.md
+++ b/skills/create-task/SKILL.md
@@ -109,6 +109,42 @@ Dispatch an autonomous Claude Code agent to work on a feature, bugfix, or code c
    - Tell the user to monitor via `octomux list-tasks` or the dashboard
    - Or via CLI: `octomux list-tasks`
 
+## Forking an existing task
+
+Use `--fork-from <task-id>` to start a new task from the branch of an existing task. The new task gets its own worktree and its own branch; the source task is left untouched.
+
+```bash
+octomux create-task \
+  --fork-from ABC123XYZ \
+  --title 'Try a different approach' \
+  --description 'Explore alternative implementation on top of ABC123XYZ' \
+  --branch 'feat/try-alt-approach' \
+  --initial-prompt 'Continue from the current state. Consider a simpler approach to ...'
+```
+
+**What it does:**
+
+- Sets `--base-branch` to `agents/<task-id>` — you MUST NOT pass `--base-branch` yourself (the two flags are mutually exclusive and the CLI will error).
+- Inherits `--repo-path` from the source task if you don't pass one.
+- All other flags (`--title`, `--description`, `--branch`, `--initial-prompt`, etc.) behave exactly as usual.
+
+**Dirty source warning:**
+
+If the source task's worktree has uncommitted changes, the CLI prints a warning to stderr like:
+
+```
+Warning: Source task ABC123XYZ has uncommitted changes; fork starts from last commit 1a2b3c4. Those changes will not be in the fork.
+```
+
+The fork proceeds anyway — but expect to re-apply any uncommitted work manually if you need it in the fork. If you want those changes in the fork, commit them in the source first.
+
+**Refusal cases (the CLI exits non-zero):**
+
+- Source task does not exist.
+- Source's `status` is `draft` (task was never started, so there's no branch yet).
+- Source's `run_mode` is `scratch` or `none` (task runs in the repo directory with no branch to fork from).
+- Both `--fork-from` and `--base-branch` are passed (mutually exclusive).
+
 ## Notes
 
 - The octomux server must be running (start with `octomux start`)

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -244,9 +244,7 @@ describe('DiffViewer', () => {
     render(<DiffViewer taskId="t1" isRunning={false} />);
 
     await screen.findByRole('button', { name: 'Collapse all' });
-    const opts = JSON.parse(
-      screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}',
-    );
+    const opts = JSON.parse(screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}');
     expect(opts.hideUnchangedRegions.enabled).toBe(false);
   });
 });

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -199,52 +199,52 @@ export function DiffViewer({ taskId, isRunning }: Props) {
           </div>
         ) : null}
         <div className="min-h-0 flex-1">
-        {error && selected ? (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
-            {error}
-          </div>
-        ) : !selected ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Select a file to view its diff
-          </div>
-        ) : fileLoading && !fileDiff ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Loading {selected}...
-          </div>
-        ) : fileDiff?.tooLarge ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {selected} is too large to display (&gt;1 MiB). Open the worktree directly.
-          </div>
-        ) : fileDiff?.binary ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            {selected} is a binary file.
-          </div>
-        ) : fileDiff ? (
-          <Suspense
-            fallback={
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                Loading editor...
-              </div>
-            }
-          >
-            <MonacoDiff
-              key={`${selected}:${expandedAll ? 'expanded' : 'collapsed'}`}
-              height="100%"
-              original={fileDiff.oldContent}
-              modified={fileDiff.newContent}
-              language={extToLanguage(selected)}
-              theme="vs-dark"
-              onMount={handleEditorMount}
-              options={{
-                readOnly: true,
-                renderSideBySide: true,
-                minimap: { enabled: true },
-                hideUnchangedRegions: { enabled: !expandedAll },
-                scrollBeyondLastLine: false,
-              }}
-            />
-          </Suspense>
-        ) : null}
+          {error && selected ? (
+            <div className="flex h-full items-center justify-center text-sm text-destructive">
+              {error}
+            </div>
+          ) : !selected ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Select a file to view its diff
+            </div>
+          ) : fileLoading && !fileDiff ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Loading {selected}...
+            </div>
+          ) : fileDiff?.tooLarge ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {selected} is too large to display (&gt;1 MiB). Open the worktree directly.
+            </div>
+          ) : fileDiff?.binary ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {selected} is a binary file.
+            </div>
+          ) : fileDiff ? (
+            <Suspense
+              fallback={
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Loading editor...
+                </div>
+              }
+            >
+              <MonacoDiff
+                key={`${selected}:${expandedAll ? 'expanded' : 'collapsed'}`}
+                height="100%"
+                original={fileDiff.oldContent}
+                modified={fileDiff.newContent}
+                language={extToLanguage(selected)}
+                theme="vs-dark"
+                onMount={handleEditorMount}
+                options={{
+                  readOnly: true,
+                  renderSideBySide: true,
+                  minimap: { enabled: true },
+                  hideUnchangedRegions: { enabled: !expandedAll },
+                  scrollBeyondLastLine: false,
+                }}
+              />
+            </Suspense>
+          ) : null}
         </div>
       </main>
     </div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,14 @@ export default defineConfig({
           setupFiles: ['src/test-setup.ts'],
         },
       },
+      {
+        test: {
+          name: 'cli',
+          globals: true,
+          environment: 'node',
+          include: ['cli/src/**/*.test.ts'],
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## What

Adds two CLI features, both scoped to `cli/` and `skills/`:

- **`create-task --fork-from <task-id>`** — sugar flag that resolves a source task, validates it has a usable branch (not draft, not `scratch`/`none` run_mode), expands to `--base-branch agents/<id>`, and inherits `--repo-path` from the source when unspecified. Emits a stderr warning (non-blocking) when the source worktree is dirty. Errors if `--fork-from` and `--base-branch` are both passed.
- **`octomux add-agent`** — rewritten subcommand that wraps `POST /api/tasks/:id/agents`. New flag shape: `--task` (required), `--prompt` (required), `--agent` (optional Claude Code agent type), `--label` (optional). Replaces the prior positional-task-id form.

Also:
- New skill `skills/add-agent/SKILL.md`.
- New "Forking an existing task" section in `skills/create-task/SKILL.md`.
- New `cli` vitest project + 14 unit tests covering fork resolution, mutual exclusion, dirty-source warning, and add-agent payload shaping.
- Branch also carries `chore: fix pre-existing formatting` from upstream — unrelated to this feature, already on the branch when the work started.

## Why

Two recurring workflows needed first-class CLI support: forking from a running task to try an alternate approach without disturbing it, and attaching an additional agent (e.g. a reviewer) to an existing task. Previously both required manual branch plumbing or were unreachable from the CLI. This PR surfaces them.

Note on \`--agent\`/\`--label\`: the endpoint's current \`AddAgentRequest\` only declares \`prompt?\`, so those flags are forwarded but a no-op until a sibling backend task lands that extends the handler. The CLI is intentionally ready ahead of that.

## Testing

- \`bun run test\` — 42 files, 814 tests passing (includes 14 new CLI tests in the new \`cli\` project).
- \`bun run lint\` — 0 errors.
- \`bun run typecheck\` — clean.
- \`bun run cli:build\` — clean.
- Manual \`--help\` verification for both commands (outputs confirmed in the task hand-off).