### PR TITLE
feat(ui): make TaskDetail mode-aware for all four run modes

### DIFF
--- a/cli/src/commands/add-agent.test.ts
+++ b/cli/src/commands/add-agent.test.ts
@@ -70,19 +70,18 @@ describe('add-agent command', () => {
     const addAgent = vi.fn(async () => makeAgent());
     const program = buildProgram(makeClient(addAgent));
 
-    await expect(
-      program.parseAsync(['add-agent'], { from: 'user' }),
-    ).rejects.toThrow(/required option/);
+    await expect(program.parseAsync(['add-agent'], { from: 'user' })).rejects.toThrow(
+      /required option/,
+    );
   });
 
   it('sends prompt only when --agent and --label are not passed', async () => {
     const addAgent = vi.fn(async () => makeAgent());
     const program = buildProgram(makeClient(addAgent));
 
-    await program.parseAsync(
-      ['add-agent', '--task', 'task-1', '--prompt', 'do the thing'],
-      { from: 'user' },
-    );
+    await program.parseAsync(['add-agent', '--task', 'task-1', '--prompt', 'do the thing'], {
+      from: 'user',
+    });
 
     expect(addAgent).toHaveBeenCalledWith('task-1', { prompt: 'do the thing' });
   });

--- a/cli/src/commands/create-task.ts
+++ b/cli/src/commands/create-task.ts
@@ -85,13 +85,12 @@ export function registerCreateTask(program: Command): void {
     .option('-p, --initial-prompt <prompt>', 'initial prompt for the agent')
     .option('-b, --branch <name>', 'branch name (new mode only)')
     .option('--base-branch <name>', 'base branch name (new mode only)')
-    .option(
-      '--mode <mode>',
-      `run mode: ${VALID_MODES.join(' | ')} (default: new)`,
-      'new',
-    )
+    .option('--mode <mode>', `run mode: ${VALID_MODES.join(' | ')} (default: new)`, 'new')
     .option('--worktree-path <path>', 'existing worktree path (required for existing mode)')
-    .option('--fork-from <task-id>', 'fork from an existing new-mode task (sets base_branch to agents/<id>)')
+    .option(
+      '--fork-from <task-id>',
+      'fork from an existing new-mode task (sets base_branch to agents/<id>)',
+    )
     .option('--draft', 'create as draft without starting')
     .action(async (opts, cmd) => {
       const { client, json } = getContext(cmd);

--- a/server/api.ts
+++ b/server/api.ts
@@ -396,7 +396,8 @@ export function setupRoutes(app: Express): void {
     if (runMode === 'scratch') {
       if (body.repo_path || body.base_branch || body.branch || body.worktree_path) {
         res.status(400).json({
-          error: 'repo_path, base_branch, branch, worktree_path are not allowed for run_mode=scratch',
+          error:
+            'repo_path, base_branch, branch, worktree_path are not allowed for run_mode=scratch',
         });
         return;
       }

--- a/server/run-mode.test.ts
+++ b/server/run-mode.test.ts
@@ -256,19 +256,19 @@ describe('startTask per-mode setup', () => {
     { mode: 'scratch' as const, callsWorktreeAdd: 0 },
   ];
 
-  it.each(modes)('$mode mode calls worktree add $callsWorktreeAdd times', async ({
-    mode,
-    callsWorktreeAdd,
-  }) => {
-    const task: Task = { ...DEFAULTS.task, run_mode: mode } as Task;
-    if (mode === 'scratch') task.repo_path = '';
-    insertTask(db, { ...task });
-    await startTask(task);
+  it.each(modes)(
+    '$mode mode calls worktree add $callsWorktreeAdd times',
+    async ({ mode, callsWorktreeAdd }) => {
+      const task: Task = { ...DEFAULTS.task, run_mode: mode } as Task;
+      if (mode === 'scratch') task.repo_path = '';
+      insertTask(db, { ...task });
+      await startTask(task);
 
-    expect(
-      countExecCalls(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'add'] }),
-    ).toBe(callsWorktreeAdd);
-  });
+      expect(
+        countExecCalls(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'add'] }),
+      ).toBe(callsWorktreeAdd);
+    },
+  );
 
   it('existing mode does not call worktree add and captures base_sha from HEAD', async () => {
     const task: Task = {

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -367,7 +367,13 @@ async function setupExisting(task: Task): Promise<SetupResult> {
 
   let branch: string | null = null;
   try {
-    const { stdout } = await execFile('git', ['-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD']);
+    const { stdout } = await execFile('git', [
+      '-C',
+      worktreePath,
+      'rev-parse',
+      '--abbrev-ref',
+      'HEAD',
+    ]);
     const name = stdout.trim();
     branch = name === 'HEAD' ? null : name;
   } catch {
@@ -407,9 +413,7 @@ async function setupNone(task: Task): Promise<SetupResult> {
   if (dirty.length > 0) {
     const preview = dirty.slice(0, 5).join(', ');
     const extra = dirty.length > 5 ? ` (+${dirty.length - 5} more)` : '';
-    throw new Error(
-      `none mode refuses dirty checkout at ${task.repo_path}: ${preview}${extra}`,
-    );
+    throw new Error(`none mode refuses dirty checkout at ${task.repo_path}: ${preview}${extra}`);
   }
 
   const baseSha = await revParseHead(task.repo_path);

--- a/skills/add-agent/SKILL.md
+++ b/skills/add-agent/SKILL.md
@@ -38,7 +38,6 @@ If you want another voice in the task, use `add-agent`. If you want to talk to t
    ```
 
    Optional flags:
-
    - `--agent <agent-type>` — use a Claude Code agent type (e.g. `code-reviewer`). Default: plain `claude` with no specific agent type.
    - `--label <label>` — custom label for the new agent. Default: server-assigned `"Agent N"`.
 

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -55,6 +55,14 @@ beforeEach(() => {
 });
 
 describe('DiffViewer', () => {
+  it('shows base_sha-unavailable empty state when server returns that error', async () => {
+    apiMock.getTaskDiffSummary.mockRejectedValue(new Error('base_sha not available for this task'));
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+    await waitFor(() => expect(screen.getByText(/base_sha not captured/i)).toBeInTheDocument());
+    // Error path should NOT render the destructive error style.
+    expect(screen.queryByText(/base_sha not available for this task/i)).not.toBeInTheDocument();
+  });
+
   it('shows empty state when no files changed', async () => {
     apiMock.getTaskDiffSummary.mockResolvedValue({ files: [] });
     render(<DiffViewer taskId="t1" isRunning={false} />);

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -45,6 +45,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   const [selected, setSelected] = useState<string | null>(null);
   const [fileDiff, setFileDiff] = useState<FileDiffResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [baseShaUnavailable, setBaseShaUnavailable] = useState(false);
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [fileLoading, setFileLoading] = useState(false);
   const [expandedAll, setExpandedAll] = useState(false);
@@ -102,13 +103,21 @@ export function DiffViewer({ taskId, isRunning }: Props) {
       setFiles(s.files);
       setIgnoredTruncated(s.ignoredTruncated ?? false);
       setError(null);
+      setBaseShaUnavailable(false);
       const cur = selectedRef.current;
       if (!cur && s.files.length > 0) setSelected(s.files[0].path);
       else if (cur && !s.files.find((f) => f.path === cur)) {
         setSelected(s.files[0]?.path ?? null);
       }
     } catch (err) {
-      setError((err as Error).message);
+      const msg = (err as Error).message;
+      if (msg.includes('base_sha not available')) {
+        setFiles([]);
+        setBaseShaUnavailable(true);
+        setError(null);
+      } else {
+        setError(msg);
+      }
     } finally {
       setSummaryLoading(false);
     }
@@ -168,6 +177,14 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   const showToolbar = Boolean(
     selected && fileDiff && !fileDiff.tooLarge && !fileDiff.binary && !error,
   );
+
+  if (baseShaUnavailable) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Diff unavailable (base_sha not captured)
+      </div>
+    );
+  }
 
   if (error && !files.length) {
     return (

--- a/src/components/DraftEditForm.test.tsx
+++ b/src/components/DraftEditForm.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+// RepoPickerField / BranchPickerField pull from the filesystem-ish APIs and
+// include combobox UIs we don't need here.
+vi.mock('./fields/RepoPickerField', () => ({
+  RepoPickerField: ({ value }: { value: string }) => (
+    <input aria-label="Repository Path" readOnly value={value} />
+  ),
+}));
+vi.mock('./fields/BranchPickerField', () => ({
+  BranchPickerField: ({ value }: { value: string }) => (
+    <input aria-label="Base Branch" readOnly value={value} />
+  ),
+}));
+
+import { DraftEditForm } from './DraftEditForm';
+import { makeTask } from '../test-helpers';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.updateTask.mockResolvedValue(makeTask());
+});
+
+describe('DraftEditForm', () => {
+  it('shows branch/repo/base fields for non-scratch modes', () => {
+    render(
+      <DraftEditForm
+        task={makeTask({ status: 'draft', run_mode: 'new' })}
+        onSaved={() => {}}
+        onStart={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('Repository Path')).toBeInTheDocument();
+    expect(screen.getByLabelText('Branch Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Base Branch')).toBeInTheDocument();
+  });
+
+  it('hides branch/repo/base fields for scratch mode', () => {
+    render(
+      <DraftEditForm
+        task={makeTask({ status: 'draft', run_mode: 'scratch', repo_path: '', branch: null })}
+        onSaved={() => {}}
+        onStart={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText('Repository Path')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Branch Name')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Base Branch')).not.toBeInTheDocument();
+  });
+
+  it('scratch draft can be saved without repo_path', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    render(
+      <DraftEditForm
+        task={makeTask({
+          status: 'draft',
+          run_mode: 'scratch',
+          repo_path: '',
+          branch: null,
+          title: 'Scratch task',
+          description: 'No repo',
+        })}
+        onSaved={onSaved}
+        onStart={() => {}}
+      />,
+    );
+    const save = screen.getByRole('button', { name: /save/i });
+    expect(save).not.toBeDisabled();
+    await user.click(save);
+    await waitFor(() => expect(apiMock.updateTask).toHaveBeenCalled());
+    const [, payload] = apiMock.updateTask.mock.calls[0];
+    expect(payload.repo_path).toBeUndefined();
+    expect(payload.branch).toBeUndefined();
+    expect(payload.base_branch).toBeUndefined();
+  });
+});

--- a/src/components/DraftEditForm.tsx
+++ b/src/components/DraftEditForm.tsx
@@ -27,8 +27,11 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
+  const isScratch = task.run_mode === 'scratch';
+
   async function handleSave() {
-    if (!title.trim() || !description.trim() || !repoPath.trim()) return;
+    if (!title.trim() || !description.trim()) return;
+    if (!isScratch && !repoPath.trim()) return;
     setSaving(true);
     setError(null);
     setSaved(false);
@@ -36,9 +39,9 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
       await api.updateTask(task.id, {
         title: title.trim(),
         description: description.trim(),
-        repo_path: repoPath.trim(),
-        branch: branch.trim() || undefined,
-        base_branch: baseBranch.trim() || undefined,
+        repo_path: isScratch ? undefined : repoPath.trim(),
+        branch: isScratch ? undefined : branch.trim() || undefined,
+        base_branch: isScratch ? undefined : baseBranch.trim() || undefined,
         initial_prompt: initialPrompt.trim() || undefined,
       });
       setSaved(true);
@@ -51,7 +54,11 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
     }
   }
 
-  const canSave = title.trim() && description.trim() && repoPath.trim() && !saving;
+  const canSave =
+    title.trim().length > 0 &&
+    description.trim().length > 0 &&
+    (isScratch || repoPath.trim().length > 0) &&
+    !saving;
 
   return (
     <div className="mx-auto max-w-2xl p-6">
@@ -77,35 +84,39 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
           />
         </div>
 
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="repo-path">Repository Path</Label>
-          <RepoPickerField value={repoPath} onChange={setRepoPath} />
-        </div>
+        {!isScratch && (
+          <>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="repo-path">Repository Path</Label>
+              <RepoPickerField value={repoPath} onChange={setRepoPath} />
+            </div>
 
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="edit-branch">Branch Name</Label>
-          <Input
-            id="edit-branch"
-            className="font-mono text-sm"
-            value={branch}
-            onChange={(e) => setBranch(e.target.value)}
-            placeholder="feat/my-feature"
-          />
-        </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="edit-branch">Branch Name</Label>
+              <Input
+                id="edit-branch"
+                className="font-mono text-sm"
+                value={branch}
+                onChange={(e) => setBranch(e.target.value)}
+                placeholder="feat/my-feature"
+              />
+            </div>
 
-        <div className="flex flex-col gap-2">
-          <Label>Base Branch</Label>
-          <BranchPickerField
-            repoPath={repoPath}
-            value={baseBranch}
-            onChange={setBaseBranch}
-            onBranchesLoaded={(_branches, defaultBranch) => {
-              // Only auto-fill when empty so we don't clobber a saved draft.
-              setBaseBranch((current) => current || defaultBranch);
-            }}
-            disabled={!repoPath.trim()}
-          />
-        </div>
+            <div className="flex flex-col gap-2">
+              <Label>Base Branch</Label>
+              <BranchPickerField
+                repoPath={repoPath}
+                value={baseBranch}
+                onChange={setBaseBranch}
+                onBranchesLoaded={(_branches, defaultBranch) => {
+                  // Only auto-fill when empty so we don't clobber a saved draft.
+                  setBaseBranch((current) => current || defaultBranch);
+                }}
+                disabled={!repoPath.trim()}
+              />
+            </div>
+          </>
+        )}
 
         <div className="flex flex-col gap-2">
           <button

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -524,6 +524,131 @@ describe('TaskDetail', () => {
     });
   });
 
+  // ─── Run mode rendering ───────────────────────────────────────────────────
+
+  describe('run mode', () => {
+    const modeCases = [
+      {
+        mode: 'new' as const,
+        badge: 'N',
+        tooltip: 'new worktree',
+        showsDiff: true,
+        showsBranchInfo: true,
+      },
+      {
+        mode: 'existing' as const,
+        badge: 'E',
+        tooltip: 'attached existing',
+        showsDiff: true,
+        showsBranchInfo: true,
+      },
+      {
+        mode: 'none' as const,
+        badge: 'Ø',
+        tooltip: 'in-place (no worktree)',
+        showsDiff: true,
+        showsBranchInfo: true,
+      },
+      {
+        mode: 'scratch' as const,
+        badge: 'S',
+        tooltip: 'scratch',
+        showsDiff: false,
+        showsBranchInfo: false,
+      },
+    ];
+
+    it.each(modeCases)(
+      '$mode mode: badge=$badge, showsDiff=$showsDiff, showsBranchInfo=$showsBranchInfo',
+      async ({ mode, badge, tooltip, showsDiff, showsBranchInfo }) => {
+        apiMock.getTask.mockResolvedValue(
+          makeTask({
+            run_mode: mode,
+            status: 'running',
+            agents: [makeAgent({ id: 'a1' })],
+            branch: mode === 'scratch' ? null : 'agents/test-task-01',
+            repo_path: mode === 'scratch' ? '' : '/Users/dev/projects/my-repo',
+          }),
+        );
+        renderDetail();
+        await waitFor(() => {
+          const b = screen.getByTestId('mode-badge');
+          expect(b).toHaveTextContent(badge);
+          expect(b).toHaveAttribute('title', tooltip);
+        });
+
+        const diffBtn = screen.queryByRole('button', { name: /^diff$/i });
+        if (showsDiff) expect(diffBtn).toBeInTheDocument();
+        else expect(diffBtn).not.toBeInTheDocument();
+
+        const repoLabel = screen.queryByText('REPO');
+        if (showsBranchInfo) expect(repoLabel).toBeInTheDocument();
+        else expect(repoLabel).not.toBeInTheDocument();
+      },
+    );
+
+    it('none mode renders branch with "(working tree)" suffix', async () => {
+      apiMock.getTask.mockResolvedValue(
+        makeTask({
+          run_mode: 'none',
+          status: 'running',
+          branch: 'feat/inplace',
+          agents: [makeAgent({ id: 'a1' })],
+        }),
+      );
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByText('feat/inplace (working tree)')).toBeInTheDocument();
+      });
+    });
+
+    it('existing mode uses "WORKTREE HEAD" label', async () => {
+      apiMock.getTask.mockResolvedValue(
+        makeTask({
+          run_mode: 'existing',
+          status: 'running',
+          branch: 'feat/existing',
+          agents: [makeAgent({ id: 'a1' })],
+        }),
+      );
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByText('WORKTREE HEAD')).toBeInTheDocument();
+      });
+    });
+
+    it('scratch mode hides PR link even when pr_url is set', async () => {
+      apiMock.getTask.mockResolvedValue(
+        makeTask({
+          run_mode: 'scratch',
+          status: 'running',
+          agents: [makeAgent({ id: 'a1' })],
+          pr_url: 'https://github.com/org/repo/pull/99',
+          pr_number: 99,
+        }),
+      );
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByTestId('mode-badge')).toHaveTextContent('S');
+      });
+      expect(screen.queryByText('#99')).not.toBeInTheDocument();
+    });
+
+    it('falls back to "new" badge when run_mode is undefined', async () => {
+      apiMock.getTask.mockResolvedValue(
+        makeTask({
+          run_mode: undefined as unknown as 'new',
+          status: 'running',
+          agents: [makeAgent({ id: 'a1' })],
+        }),
+      );
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByTestId('mode-badge')).toHaveTextContent('N');
+      });
+    });
+  });
+
   // ─── Diff toggle ──────────────────────────────────────────────────────────
 
   describe('diff toggle', () => {

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -12,6 +12,21 @@ import { useTask } from '@/lib/hooks';
 import { api } from '@/lib/api';
 import { repoName } from '@/lib/utils';
 import { TerminalRectIcon } from '@/components/icons';
+import type { RunMode } from '../../server/types';
+
+const MODE_LABEL: Record<RunMode, string> = {
+  new: 'N',
+  existing: 'E',
+  none: 'Ø',
+  scratch: 'S',
+};
+
+const MODE_TOOLTIP: Record<RunMode, string> = {
+  new: 'new worktree',
+  existing: 'attached existing',
+  none: 'in-place (no worktree)',
+  scratch: 'scratch',
+};
 
 // Per-task UI state preserved across task switches (session-only, not persisted to disk).
 interface PerTaskUiState {
@@ -248,6 +263,9 @@ export default function TaskDetail() {
   const isRunning = task.status === 'running';
   const isDraft = task.status === 'draft';
   const canResume = (task.status === 'closed' || task.status === 'error') && !!task.worktree;
+  const runMode: RunMode = task.run_mode ?? 'new';
+  const isScratch = runMode === 'scratch';
+  const canShowDiff = !isScratch && task.status !== 'draft';
 
   const isTerminalAlive = task.status === 'running' || task.status === 'setting_up';
   const hasTerminal =
@@ -261,6 +279,14 @@ export default function TaskDetail() {
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <h1 className="truncate text-base font-semibold sm:text-lg">{task.title}</h1>
+              <span
+                data-testid="mode-badge"
+                title={MODE_TOOLTIP[runMode]}
+                aria-label={`run mode: ${MODE_TOOLTIP[runMode]}`}
+                className="inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-[#2f2f2f] bg-[#1a1a1a] px-1.5 font-mono text-[10px] font-bold text-[#8a8a8a]"
+              >
+                {MODE_LABEL[runMode]}
+              </span>
               <StatusBadge status={task.derived_status || task.status} />
             </div>
             <p className="hidden max-w-xl truncate text-xs text-muted-foreground sm:block">
@@ -285,7 +311,7 @@ export default function TaskDetail() {
               &lt;&gt; EDITOR
             </Button>
           )}
-          {task.worktree && task.base_branch && (
+          {canShowDiff && (
             <Button
               variant="outline"
               size="sm"
@@ -324,41 +350,55 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Metadata bar — always visible */}
-      <div className="flex items-center gap-5 border-b border-border bg-[#141414] px-6 py-2">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">REPO</span>
-        <span className="text-[11px] text-[#8a8a8a]">{repoName(task.repo_path)}</span>
-        <span className="text-[11px] text-[#2f2f2f]">|</span>
-        <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
-          BRANCH
-        </span>
-        <span className="text-[11px] font-medium text-[#3B82F6]">{task.branch}</span>
-        {task.base_branch && (
-          <>
-            <span className="text-[11px] text-[#2f2f2f]">|</span>
-            <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
-              BASE
-            </span>
-            <span className="text-[11px] text-[#8a8a8a]">{task.base_branch}</span>
-          </>
-        )}
-        {task.pr_url && (
-          <>
-            <span className="text-[11px] text-[#2f2f2f]">|</span>
-            <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
-              PR
-            </span>
-            <a
-              href={task.pr_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[11px] font-medium text-[#3B82F6] hover:underline"
-            >
-              #{task.pr_number}
-            </a>
-          </>
-        )}
-      </div>
+      {/* Metadata bar — hidden for scratch tasks which have no repo/branch */}
+      {!isScratch && (
+        <div className="flex items-center gap-5 border-b border-border bg-[#141414] px-6 py-2">
+          {task.repo_path && (
+            <>
+              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+                REPO
+              </span>
+              <span className="text-[11px] text-[#8a8a8a]">{repoName(task.repo_path)}</span>
+            </>
+          )}
+          {task.branch && (
+            <>
+              {task.repo_path && <span className="text-[11px] text-[#2f2f2f]">|</span>}
+              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+                {runMode === 'existing' ? 'WORKTREE HEAD' : 'BRANCH'}
+              </span>
+              <span className="text-[11px] font-medium text-[#3B82F6]">
+                {runMode === 'none' ? `${task.branch} (working tree)` : task.branch}
+              </span>
+            </>
+          )}
+          {task.base_branch && (
+            <>
+              <span className="text-[11px] text-[#2f2f2f]">|</span>
+              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+                BASE
+              </span>
+              <span className="text-[11px] text-[#8a8a8a]">{task.base_branch}</span>
+            </>
+          )}
+          {task.pr_url && (
+            <>
+              <span className="text-[11px] text-[#2f2f2f]">|</span>
+              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+                PR
+              </span>
+              <a
+                href={task.pr_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[11px] font-medium text-[#3B82F6] hover:underline"
+              >
+                #{task.pr_number}
+              </a>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Agent view — shown in agents mode */}
       {hasTerminal ? (
@@ -424,7 +464,7 @@ export default function TaskDetail() {
       )}
 
       {/* Diff view */}
-      {mode === 'diff' && task.worktree && task.base_branch && (
+      {mode === 'diff' && canShowDiff && (
         <div className="flex min-h-0 flex-1 flex-col">
           <DiffViewer taskId={task.id} isRunning={task.status === 'running'} />
         </div>


### PR DESCRIPTION
## What

Adapts `TaskDetail` to render correctly for all four `run_mode` values
(`new`, `existing`, `none`, `scratch`).

- Adds a compact run-mode badge (`N` / `E` / `Ø` / `S`) with a tooltip
  (full mode name) next to the title.
- Gates the DIFF button and diff panel on `run_mode !== 'scratch'`
  (and not a draft), replacing the old `worktree && base_branch` check so
  `none`-mode tasks now get diff visibility via the `base_sha`-driven
  server endpoint.
- Metadata bar: hidden entirely for scratch; labels the branch line as
  `WORKTREE HEAD` for `existing` and appends `(working tree)` to the
  branch value for `none`.
- Hides the PR link in scratch mode.
- `DiffViewer` detects the server's `"base_sha not available"` 400 and
  renders an inline "Diff unavailable (base_sha not captured)" empty
  state instead of a destructive error.
- `DraftEditForm` hides repo/branch/base fields for scratch drafts and
  skips them in both validation and the update payload.
- Defensive fallback: treats `run_mode === undefined` as `new`.

Also bundles a pre-existing `chore: fix pre-existing formatting` commit
that was already on the branch base.

## Why

`run_mode` and `base_sha` landed in the backend on main, but the UI was
still shaped around the single "new worktree" assumption. Scratch tasks
showed dead affordances (diff, PR link, branch metadata) and `none`
tasks hid diff behind a `task.worktree` check that never became true
for in-place runs. This brings the detail page in line with the
backend contract so each mode renders only the affordances that are
meaningful for it.

Known punt: the spec asked for hiding the PR link for
`existing`/`none` when `task.branch === repo default`. The task row
doesn't yet carry a `default_branch`, so the PR link is shown for all
non-scratch modes when `pr_url` is set. Follow-up: expose
`default_branch` on the task row (or fetch via `/api/default-branch`
client-side) and gate accordingly.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean on touched files (only pre-existing warnings
  elsewhere)
- `bun run format:check` — clean
- `bun run test` — 868 tests across 46 files, all passing

New test coverage:
- `TaskDetail.test.tsx` — per-mode table-driven assertions for badge
  text/tooltip, DIFF button visibility, and metadata bar visibility;
  checks that `none` mode appends `(working tree)` to the branch label,
  that `existing` mode uses the `WORKTREE HEAD` label, that scratch
  hides the PR link even when `pr_url` is set, and that undefined
  `run_mode` falls back to `new`.
- `DiffViewer.test.tsx` — new test asserting the friendly empty state
  renders when the summary endpoint rejects with \`base_sha not
  available\`, and that the raw error text is not surfaced.
- `DraftEditForm.test.tsx` (new file) — fields visible for `new`,
  hidden for `scratch`, and a scratch draft can be saved without a
  repo path (payload omits `repo_path` / `branch` / `base_branch`).