### PR TITLE
feat(ui): sidebar + IA skeleton for chat-first UX (Phase 1)

### DIFF
--- a/cli/src/commands/add-agent.test.ts
+++ b/cli/src/commands/add-agent.test.ts
@@ -70,19 +70,18 @@ describe('add-agent command', () => {
     const addAgent = vi.fn(async () => makeAgent());
     const program = buildProgram(makeClient(addAgent));
 
-    await expect(
-      program.parseAsync(['add-agent'], { from: 'user' }),
-    ).rejects.toThrow(/required option/);
+    await expect(program.parseAsync(['add-agent'], { from: 'user' })).rejects.toThrow(
+      /required option/,
+    );
   });
 
   it('sends prompt only when --agent and --label are not passed', async () => {
     const addAgent = vi.fn(async () => makeAgent());
     const program = buildProgram(makeClient(addAgent));
 
-    await program.parseAsync(
-      ['add-agent', '--task', 'task-1', '--prompt', 'do the thing'],
-      { from: 'user' },
-    );
+    await program.parseAsync(['add-agent', '--task', 'task-1', '--prompt', 'do the thing'], {
+      from: 'user',
+    });
 
     expect(addAgent).toHaveBeenCalledWith('task-1', { prompt: 'do the thing' });
   });

--- a/cli/src/commands/create-task.ts
+++ b/cli/src/commands/create-task.ts
@@ -85,13 +85,12 @@ export function registerCreateTask(program: Command): void {
     .option('-p, --initial-prompt <prompt>', 'initial prompt for the agent')
     .option('-b, --branch <name>', 'branch name (new mode only)')
     .option('--base-branch <name>', 'base branch name (new mode only)')
-    .option(
-      '--mode <mode>',
-      `run mode: ${VALID_MODES.join(' | ')} (default: new)`,
-      'new',
-    )
+    .option('--mode <mode>', `run mode: ${VALID_MODES.join(' | ')} (default: new)`, 'new')
     .option('--worktree-path <path>', 'existing worktree path (required for existing mode)')
-    .option('--fork-from <task-id>', 'fork from an existing new-mode task (sets base_branch to agents/<id>)')
+    .option(
+      '--fork-from <task-id>',
+      'fork from an existing new-mode task (sets base_branch to agents/<id>)',
+    )
     .option('--draft', 'create as draft without starting')
     .action(async (opts, cmd) => {
       const { client, json } = getContext(cmd);

--- a/server/api.ts
+++ b/server/api.ts
@@ -396,7 +396,8 @@ export function setupRoutes(app: Express): void {
     if (runMode === 'scratch') {
       if (body.repo_path || body.base_branch || body.branch || body.worktree_path) {
         res.status(400).json({
-          error: 'repo_path, base_branch, branch, worktree_path are not allowed for run_mode=scratch',
+          error:
+            'repo_path, base_branch, branch, worktree_path are not allowed for run_mode=scratch',
         });
         return;
       }

--- a/server/run-mode.test.ts
+++ b/server/run-mode.test.ts
@@ -256,19 +256,19 @@ describe('startTask per-mode setup', () => {
     { mode: 'scratch' as const, callsWorktreeAdd: 0 },
   ];
 
-  it.each(modes)('$mode mode calls worktree add $callsWorktreeAdd times', async ({
-    mode,
-    callsWorktreeAdd,
-  }) => {
-    const task: Task = { ...DEFAULTS.task, run_mode: mode } as Task;
-    if (mode === 'scratch') task.repo_path = '';
-    insertTask(db, { ...task });
-    await startTask(task);
+  it.each(modes)(
+    '$mode mode calls worktree add $callsWorktreeAdd times',
+    async ({ mode, callsWorktreeAdd }) => {
+      const task: Task = { ...DEFAULTS.task, run_mode: mode } as Task;
+      if (mode === 'scratch') task.repo_path = '';
+      insertTask(db, { ...task });
+      await startTask(task);
 
-    expect(
-      countExecCalls(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'add'] }),
-    ).toBe(callsWorktreeAdd);
-  });
+      expect(
+        countExecCalls(vi.mocked(execFile), { cmd: 'git', argsInclude: ['worktree', 'add'] }),
+      ).toBe(callsWorktreeAdd);
+    },
+  );
 
   it('existing mode does not call worktree add and captures base_sha from HEAD', async () => {
     const task: Task = {

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -367,7 +367,13 @@ async function setupExisting(task: Task): Promise<SetupResult> {
 
   let branch: string | null = null;
   try {
-    const { stdout } = await execFile('git', ['-C', worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD']);
+    const { stdout } = await execFile('git', [
+      '-C',
+      worktreePath,
+      'rev-parse',
+      '--abbrev-ref',
+      'HEAD',
+    ]);
     const name = stdout.trim();
     branch = name === 'HEAD' ? null : name;
   } catch {
@@ -407,9 +413,7 @@ async function setupNone(task: Task): Promise<SetupResult> {
   if (dirty.length > 0) {
     const preview = dirty.slice(0, 5).join(', ');
     const extra = dirty.length > 5 ? ` (+${dirty.length - 5} more)` : '';
-    throw new Error(
-      `none mode refuses dirty checkout at ${task.repo_path}: ${preview}${extra}`,
-    );
+    throw new Error(`none mode refuses dirty checkout at ${task.repo_path}: ${preview}${extra}`);
   }
 
   const baseSha = await revParseHead(task.repo_path);

--- a/skills/add-agent/SKILL.md
+++ b/skills/add-agent/SKILL.md
@@ -38,7 +38,6 @@ If you want another voice in the task, use `add-agent`. If you want to talk to t
    ```
 
    Optional flags:
-
    - `--agent <agent-type>` — use a Claude Code agent type (e.g. `code-reviewer`). Default: plain `claude` with no specific agent type.
    - `--label <label>` — custom label for the new agent. Default: server-assigned `"Agent N"`.
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
+import HomePage from './pages/HomePage';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('./test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('@/lib/orchestrator-context', () => ({
+  useOrchestratorContext: () => ({
+    running: false,
+    loading: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    error: null,
+    refresh: vi.fn(),
+  }),
+  OrchestratorProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const TasksPage = lazy(() => import('./pages/TasksPage'));
+
+function renderAt(route: string) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/tasks" element={<TasksPage />} />
+        </Routes>
+      </Suspense>
+    </MemoryRouter>,
+  );
+}
+
+describe('App routing', () => {
+  it('renders HomePage at /', async () => {
+    apiMock.listTasks.mockResolvedValue([]);
+    renderAt('/');
+    await waitFor(() => {
+      expect(screen.getByText(/welcome back/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('COMMAND CENTER')).not.toBeInTheDocument();
+  });
+
+  it('renders TasksPage (former Dashboard) at /tasks', async () => {
+    apiMock.listTasks.mockResolvedValue([]);
+    // Mount TasksProvider-free: TasksPage imports useTasksContext, so we need the provider.
+    const { TasksProvider } = await import('./lib/tasks-context');
+    render(
+      <MemoryRouter initialEntries={['/tasks']}>
+        <TasksProvider>
+          <Suspense fallback={<div>Loading...</div>}>
+            <Routes>
+              <Route path="/tasks" element={<TasksPage />} />
+            </Routes>
+          </Suspense>
+        </TasksProvider>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('COMMAND CENTER')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,12 @@ import { Routes, Route, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { useAttentionIndicator } from './lib/use-attention-indicator';
 import { useNotifications } from './lib/use-notifications';
-import Dashboard from './pages/Dashboard';
+import HomePage from './pages/HomePage';
 import { OrchestratorProvider } from './lib/orchestrator-context';
 import { TasksProvider, useTasksContext } from './lib/tasks-context';
 import { UniversalSidebar } from './components/UniversalSidebar';
 
+const TasksPage = lazy(() => import('./pages/TasksPage'));
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
 const OrchestratorPage = lazy(() => import('./pages/OrchestratorPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
@@ -87,7 +88,8 @@ function AppShell() {
           }
         >
           <Routes>
-            <Route path="/" element={<Dashboard />} />
+            <Route path="/" element={<HomePage />} />
+            <Route path="/tasks" element={<TasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetail />} />
             <Route path="/orchestrator" element={<OrchestratorPage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UniversalSidebar, forkDisabledReason } from './UniversalSidebar';
+import { renderWithRouter, makeTask } from '../test-helpers';
+import { TasksProvider } from '../lib/tasks-context';
+import type { RunMode } from '../../server/types';
+import type { SidebarItem } from '@/lib/sidebar-utils';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('@/lib/orchestrator-context', () => ({
+  useOrchestratorContext: () => ({
+    running: false,
+    loading: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function renderSidebar(route: string = '/') {
+  return renderWithRouter(
+    <TasksProvider>
+      <UniversalSidebar />
+    </TasksProvider>,
+    { route },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  apiMock.listTasks.mockResolvedValue([]);
+});
+
+describe('UniversalSidebar nav', () => {
+  it('renders Home, Tasks, Orchestrator, Settings nav items', async () => {
+    renderSidebar('/');
+    await waitFor(() => expect(screen.getByText('HOME')).toBeInTheDocument());
+    expect(screen.getByText('TASKS')).toBeInTheDocument();
+    expect(screen.getByText('ORCHESTRATOR')).toBeInTheDocument();
+    expect(screen.getByText('SETTINGS')).toBeInTheDocument();
+  });
+
+  it('points Tasks to /tasks and Home to /', async () => {
+    renderSidebar('/');
+    await waitFor(() => expect(screen.getByText('HOME')).toBeInTheDocument());
+    expect(screen.getByText('HOME').closest('a')).toHaveAttribute('href', '/');
+    expect(screen.getByText('TASKS').closest('a')).toHaveAttribute('href', '/tasks');
+  });
+});
+
+describe('UniversalSidebar grouping', () => {
+  it('groups sessions by repo basename', async () => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/nucleus', title: 'Alpha' }),
+      makeTask({ id: 't2', status: 'running', repo_path: '/dev/octomux', title: 'Beta' }),
+      makeTask({ id: 't3', status: 'running', repo_path: '/dev/nucleus', title: 'Gamma' }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+    expect(
+      screen.getByRole('button', { expanded: true, name: /nucleus/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { expanded: true, name: /^octomux$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders an Other group for scratch / repo-less tasks', async () => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
+      makeTask({
+        id: 'scratch-1',
+        status: 'running',
+        repo_path: '',
+        run_mode: 'scratch',
+        title: 'Scratchwork',
+      }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(screen.getByText('Scratchwork')).toBeInTheDocument());
+    expect(screen.getByText('OTHER')).toBeInTheDocument();
+  });
+
+  it('does not render a + button on the Other group', async () => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: 'scratch-1',
+        status: 'running',
+        repo_path: '',
+        run_mode: 'scratch',
+        title: 'Scratchwork',
+      }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(screen.getByText('OTHER')).toBeInTheDocument());
+    expect(screen.queryByTestId('sidebar-group-add-__other__')).toBeNull();
+  });
+
+  it('navigates to the composer with repo + mode on + click', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/nucleus' }),
+    ]);
+    renderSidebar();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-group-add-/dev/nucleus')).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId('sidebar-group-add-/dev/nucleus'));
+    expect(mockNavigate).toHaveBeenCalledWith('/?repo=%2Fdev%2Fnucleus&mode=new');
+  });
+});
+
+describe('UniversalSidebar status glyph + run-mode badge', () => {
+  const rowFor = (id: string) => screen.getByTestId(`sidebar-row-${id}`);
+
+  it.each<{ mode: RunMode; letter: string }>([
+    { mode: 'new', letter: 'N' },
+    { mode: 'existing', letter: 'E' },
+    { mode: 'none', letter: 'Ø' },
+    { mode: 'scratch', letter: 'S' },
+  ])('renders the $letter badge for run_mode=$mode', async ({ mode, letter }) => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: `t-${mode}`,
+        status: 'running',
+        run_mode: mode,
+        repo_path: mode === 'scratch' ? '' : '/dev/alpha',
+      }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(rowFor(`t-${mode}`)).toBeInTheDocument());
+    const row = rowFor(`t-${mode}`);
+    const badge = row.querySelector('[data-run-mode]') as HTMLElement;
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe(letter);
+  });
+
+  it.each([
+    { name: 'running', status: 'running' as const, derived: null, glyph: 'running' },
+    {
+      name: 'needs_attention',
+      status: 'running' as const,
+      derived: 'needs_attention' as const,
+      glyph: 'needs-you',
+    },
+    { name: 'error', status: 'error' as const, derived: null, glyph: 'error' },
+    {
+      name: 'setting_up',
+      status: 'setting_up' as const,
+      derived: null,
+      glyph: 'setting_up',
+    },
+  ])('maps $name → glyph=$glyph', async ({ status, derived, glyph }) => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status, derived_status: derived, repo_path: '/dev/alpha' }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(rowFor('t1')).toBeInTheDocument());
+    expect(rowFor('t1').querySelector(`[data-status-glyph="${glyph}"]`)).toBeTruthy();
+  });
+});
+
+describe('UniversalSidebar group collapse persistence', () => {
+  it('persists collapsed state per-group and rehydrates on re-render', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/nucleus', title: 'Alpha' }),
+    ]);
+    const { unmount } = renderSidebar();
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+
+    // The group header button exposes aria-expanded; target it specifically.
+    await user.click(screen.getByRole('button', { expanded: true, name: /nucleus/i }));
+    await waitFor(() => expect(screen.queryByText('Alpha')).not.toBeInTheDocument());
+
+    expect(localStorage.getItem('octomux:sidebar:collapsed:/dev/nucleus')).toBe('true');
+
+    unmount();
+
+    renderSidebar();
+    // After rehydrate, the group should still be collapsed
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { expanded: false, name: /nucleus/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+  });
+});
+
+describe('UniversalSidebar row menu', () => {
+  async function openMenu(user: ReturnType<typeof userEvent.setup>, id: string) {
+    await waitFor(() =>
+      expect(screen.getByTestId(`task-row-menu-trigger-${id}`)).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId(`task-row-menu-trigger-${id}`));
+    await waitFor(() =>
+      expect(screen.getByTestId(`task-row-menu-${id}`)).toBeInTheDocument(),
+    );
+    return screen.getByTestId(`task-row-menu-${id}`);
+  }
+
+  it('Open navigates to /tasks/<id>', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Open'));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks/t1');
+  });
+
+  it('Fork navigates to Home with repo/base_branch/mode/fork_of', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: 't1',
+        status: 'running',
+        run_mode: 'new',
+        repo_path: '/dev/nucleus',
+      }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Fork into new task'));
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const url = mockNavigate.mock.calls[0][0] as string;
+    expect(url).toContain('/?');
+    expect(url).toContain('repo=%2Fdev%2Fnucleus');
+    expect(url).toContain('base_branch=agents%2Ft1');
+    expect(url).toContain('mode=new');
+    expect(url).toContain('fork_of=t1');
+  });
+
+  it('Add agent navigates to Home with add_agent=<id>', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Add agent…'));
+    expect(mockNavigate).toHaveBeenCalledWith('/?add_agent=t1');
+  });
+
+  it('Close calls updateTask({status:closed})', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Close'));
+    await waitFor(() =>
+      expect(apiMock.updateTask).toHaveBeenCalledWith('t1', { status: 'closed' }),
+    );
+  });
+
+  it('Delete calls deleteTask', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Delete'));
+    await waitFor(() => expect(apiMock.deleteTask).toHaveBeenCalledWith('t1'));
+  });
+
+  it('Rename shows an input and calls updateTask({title}) on submit', async () => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: 't1',
+        status: 'running',
+        repo_path: '/dev/alpha',
+        title: 'Old Title',
+      }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    await user.click(within(menu).getByText('Rename'));
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-rename-input')).toBeInTheDocument(),
+    );
+    const input = screen.getByTestId('sidebar-rename-input') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'New Title');
+    await user.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(apiMock.updateTask).toHaveBeenCalledWith('t1', { title: 'New Title' }),
+    );
+  });
+});
+
+describe('forkDisabledReason', () => {
+  function item(overrides: Partial<SidebarItem> = {}): SidebarItem {
+    return {
+      id: 'x',
+      title: 'T',
+      status: 'running',
+      derivedStatus: null,
+      runMode: 'new',
+      repoPath: '/r',
+      ...overrides,
+    };
+  }
+
+  it.each<{ name: string; item: Partial<SidebarItem>; expected: string | null }>([
+    { name: 'allows new', item: { runMode: 'new' }, expected: null },
+    { name: 'allows existing', item: { runMode: 'existing' }, expected: null },
+    { name: 'disallows scratch', item: { runMode: 'scratch' }, expected: 'scratch' },
+    { name: 'disallows none', item: { runMode: 'none' }, expected: 'working tree' },
+    { name: 'disallows draft', item: { status: 'draft' }, expected: 'draft' },
+  ])('$name', ({ item: overrides, expected }) => {
+    const reason = forkDisabledReason(item(overrides));
+    if (expected === null) expect(reason).toBeNull();
+    else expect(reason).toMatch(new RegExp(expected, 'i'));
+  });
+});
+
+describe('UniversalSidebar row menu — Fork refusal', () => {
+  async function openMenu(user: ReturnType<typeof userEvent.setup>, id: string) {
+    await waitFor(() =>
+      expect(screen.getByTestId(`task-row-menu-trigger-${id}`)).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId(`task-row-menu-trigger-${id}`));
+    return screen.getByTestId(`task-row-menu-${id}`);
+  }
+
+  it.each<{ name: string; runMode: RunMode; repoPath: string }>([
+    { name: 'scratch', runMode: 'scratch', repoPath: '' },
+    { name: 'none', runMode: 'none', repoPath: '/dev/alpha' },
+  ])('disables Fork for run_mode=$name', async ({ runMode, repoPath }) => {
+    const user = userEvent.setup();
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({ id: 't1', status: 'running', run_mode: runMode, repo_path: repoPath }),
+    ]);
+    renderSidebar();
+    const menu = await openMenu(user, 't1');
+    const forkItem = within(menu).getByText('Fork into new task');
+    expect(forkItem.closest('button')).toBeDisabled();
+    // Click should not navigate
+    mockNavigate.mockClear();
+    await user.click(forkItem);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -1,10 +1,25 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useCallback,
+  useRef,
+  type KeyboardEvent,
+} from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTasksContext } from '@/lib/tasks-context';
-import { groupTasksForSidebar, type SidebarItem } from '@/lib/sidebar-utils';
+import {
+  groupTasksForSidebar,
+  OTHER_GROUP_KEY,
+  type SidebarItem,
+  type SidebarGroup,
+} from '@/lib/sidebar-utils';
 import { useOrchestratorContext } from '@/lib/orchestrator-context';
+import { api } from '@/lib/api';
+import type { RunMode, TaskStatus } from '../../server/types';
 
 const STORAGE_KEY = 'octomux-sidebar-collapsed';
+const GROUP_COLLAPSE_PREFIX = 'octomux:sidebar:collapsed:';
 
 function getInitialCollapsed(): boolean {
   try {
@@ -14,7 +29,15 @@ function getInitialCollapsed(): boolean {
   }
 }
 
-// ─── Status Icons (16x16 inline SVGs) ──────────────────────────────────────
+function getInitialGroupCollapsed(groupKey: string): boolean {
+  try {
+    return localStorage.getItem(GROUP_COLLAPSE_PREFIX + groupKey) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// ─── Status Icons (both color AND shape — colorblind safe) ─────────────────
 
 function StatusIcon({ item }: { item: SidebarItem }) {
   const effectiveStatus = item.derivedStatus ?? item.status;
@@ -27,6 +50,7 @@ function StatusIcon({ item }: { item: SidebarItem }) {
           className="inline-block h-2 w-2 shrink-0 animate-pulse bg-[#22C55E]"
           style={{ borderRadius: '50%' }}
           aria-hidden="true"
+          data-status-glyph="running"
         />
       );
     case 'setting_up':
@@ -35,11 +59,18 @@ function StatusIcon({ item }: { item: SidebarItem }) {
           className="inline-block h-2 w-2 shrink-0 animate-pulse"
           style={{ borderRadius: '50%', backgroundColor: '#FFB800' }}
           aria-hidden="true"
+          data-status-glyph="setting_up"
         />
       );
     case 'needs_attention':
       return (
-        <svg className="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <svg
+          className="h-4 w-4 shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+          data-status-glyph="needs-you"
+        >
           <path
             d="M8 1.5l6.5 12H1.5L8 1.5z"
             stroke="#FFB800"
@@ -60,26 +91,89 @@ function StatusIcon({ item }: { item: SidebarItem }) {
       );
     case 'error':
       return (
-        <span
-          className="inline-block h-2 w-2 shrink-0"
-          style={{ borderRadius: '50%', backgroundColor: '#EF4444' }}
+        <svg
+          className="h-4 w-4 shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
           aria-hidden="true"
-        />
+          data-status-glyph="error"
+        >
+          <line
+            x1="4"
+            y1="4"
+            x2="12"
+            y2="12"
+            stroke="#EF4444"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+          />
+          <line
+            x1="12"
+            y1="4"
+            x2="4"
+            y2="12"
+            stroke="#EF4444"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+          />
+        </svg>
       );
     default:
       return (
         <span
           className="inline-block h-2 w-2 shrink-0"
-          style={{ borderRadius: '50%', backgroundColor: '#6a6a6a' }}
+          style={{
+            borderRadius: '50%',
+            border: '1px solid #6a6a6a',
+            backgroundColor: 'transparent',
+          }}
           aria-hidden="true"
+          data-status-glyph="idle"
         />
       );
   }
 }
 
+// ─── Run mode badge ────────────────────────────────────────────────────────
+
+const RUN_MODE_LETTER: Record<RunMode, string> = {
+  new: 'N',
+  existing: 'E',
+  none: 'Ø',
+  scratch: 'S',
+};
+
+const RUN_MODE_TOOLTIP: Record<RunMode, string> = {
+  new: 'New worktree',
+  existing: 'Existing worktree',
+  none: 'No worktree (working tree)',
+  scratch: 'Scratch (no repo)',
+};
+
+function RunModeBadge({ mode }: { mode: RunMode }) {
+  return (
+    <span
+      className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm"
+      style={{
+        fontSize: 9,
+        fontWeight: 700,
+        fontFamily: 'ui-monospace, SFMono-Regular, monospace',
+        color: '#8a8a8a',
+        backgroundColor: '#1a1a1a',
+        border: '1px solid #2f2f2f',
+      }}
+      title={RUN_MODE_TOOLTIP[mode]}
+      aria-label={RUN_MODE_TOOLTIP[mode]}
+      data-run-mode={mode}
+    >
+      {RUN_MODE_LETTER[mode]}
+    </span>
+  );
+}
+
 // ─── Nav icons (inline SVGs, 16px) ──────────────────────────────────────────
 
-function DashboardIcon({ color }: { color: string }) {
+function HomeIcon({ color }: { color: string }) {
   return (
     <svg
       width="16"
@@ -93,10 +187,32 @@ function DashboardIcon({ color }: { color: string }) {
       className="shrink-0"
       aria-hidden="true"
     >
-      <rect x="3" y="3" width="7" height="9" rx="1" />
-      <rect x="14" y="3" width="7" height="5" rx="1" />
-      <rect x="14" y="12" width="7" height="9" rx="1" />
-      <rect x="3" y="16" width="7" height="5" rx="1" />
+      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </svg>
+  );
+}
+
+function TasksIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <line x1="8" y1="6" x2="21" y2="6" />
+      <line x1="8" y1="12" x2="21" y2="12" />
+      <line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" />
+      <line x1="3" y1="12" x2="3.01" y2="12" />
+      <line x1="3" y1="18" x2="3.01" y2="18" />
     </svg>
   );
 }
@@ -144,18 +260,185 @@ function SettingsIcon({ color }: { color: string }) {
 // ─── Static config ──────────────────────────────────────────────────────────
 
 const NAV_ITEMS = [
-  { key: 'dashboard', label: 'DASHBOARD', to: '/', Icon: DashboardIcon },
+  { key: 'home', label: 'HOME', to: '/', Icon: HomeIcon },
+  { key: 'tasks', label: 'TASKS', to: '/tasks', Icon: TasksIcon },
   { key: 'orchestrator', label: 'ORCHESTRATOR', to: '/orchestrator', Icon: TerminalIcon },
   { key: 'settings', label: 'SETTINGS', to: '/settings', Icon: SettingsIcon },
 ] as const;
+
+// ─── Fork refusal helper ────────────────────────────────────────────────────
+
+export function forkDisabledReason(item: SidebarItem): string | null {
+  if (item.runMode === 'scratch') return 'Cannot fork a scratch task (no repo).';
+  if (item.runMode === 'none') return 'Cannot fork a task that runs on the working tree (no branch).';
+  if (item.status === 'draft') return 'Cannot fork a draft task (no branch yet).';
+  return null;
+}
+
+// ─── URL builders ───────────────────────────────────────────────────────────
+
+function buildGroupAddUrl(repoPath: string): string {
+  const params = new URLSearchParams({ repo: repoPath, mode: 'new' });
+  return `/?${params.toString()}`;
+}
+
+function buildForkUrl(item: SidebarItem): string {
+  const params = new URLSearchParams({
+    repo: item.repoPath ?? '',
+    base_branch: `agents/${item.id}`,
+    mode: 'new',
+    fork_of: item.id,
+  });
+  return `/?${params.toString()}`;
+}
+
+function buildAddAgentUrl(taskId: string): string {
+  return `/?add_agent=${encodeURIComponent(taskId)}`;
+}
+
+// ─── Row menu ───────────────────────────────────────────────────────────────
+
+interface RowMenuProps {
+  item: SidebarItem;
+  onOpen: () => void;
+  onFork: () => void;
+  onAddAgent: () => void;
+  onRename: () => void;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+function RowMenu({ item, onOpen, onFork, onAddAgent, onRename, onClose, onDelete }: RowMenuProps) {
+  const forkDisabled = forkDisabledReason(item);
+  const closeDisabled = (['closed', 'draft'] as TaskStatus[]).includes(item.status);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside click or Escape
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: globalThis.MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  function choose(action?: () => void) {
+    if (!action) return;
+    setOpen(false);
+    action();
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        aria-label="Task actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Task actions"
+        data-testid={`task-row-menu-trigger-${item.id}`}
+        className={
+          'flex h-5 w-5 items-center justify-center text-[#8a8a8a] hover:text-white ' +
+          (open ? 'opacity-100' : 'opacity-0 group-hover/row:opacity-100')
+        }
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="12" cy="19" r="1.5" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          data-testid={`task-row-menu-${item.id}`}
+          className="absolute right-0 top-full z-50 mt-1 min-w-44 bg-[#141414] border border-border py-1 text-sm outline-hidden"
+        >
+          <MenuItemRow onClick={() => choose(onOpen)} label="Open" />
+          <MenuItemRow
+            onClick={() => choose(onFork)}
+            disabled={!!forkDisabled}
+            title={forkDisabled ?? undefined}
+            label="Fork into new task"
+          />
+          <MenuItemRow onClick={() => choose(onAddAgent)} label="Add agent…" />
+          <div className="my-1 h-px bg-[#2f2f2f]" />
+          <MenuItemRow onClick={() => choose(onRename)} label="Rename" />
+          <MenuItemRow
+            onClick={() => choose(onClose)}
+            disabled={closeDisabled}
+            label="Close"
+          />
+          <MenuItemRow onClick={() => choose(onDelete)} label="Delete" destructive />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItemRow({
+  onClick,
+  label,
+  disabled = false,
+  destructive = false,
+  title,
+}: {
+  onClick: () => void;
+  label: string;
+  disabled?: boolean;
+  destructive?: boolean;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      title={title}
+      className={
+        'block w-full px-3 py-1.5 text-left text-xs ' +
+        (disabled
+          ? 'cursor-not-allowed text-[#555]'
+          : destructive
+            ? 'text-[#EF4444] hover:bg-[#1a1a1a]'
+            : 'text-[#d0d0d0] hover:bg-[#1a1a1a]')
+      }
+    >
+      {label}
+    </button>
+  );
+}
 
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export function UniversalSidebar() {
   const [collapsed, setCollapsed] = useState(getInitialCollapsed);
-  const { tasks } = useTasksContext();
+  const { tasks, refresh } = useTasksContext();
   const location = useLocation();
+  const navigate = useNavigate();
   const { running: orchestratorRunning } = useOrchestratorContext();
+
+  // Track renaming state per task id
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+
+  // Track per-group collapse state
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
 
   // Extract task ID from URL — useParams doesn't work here since we're outside <Routes>
   const activeTaskId = useMemo(() => {
@@ -164,6 +447,21 @@ export function UniversalSidebar() {
   }, [location.pathname]);
 
   const groups = useMemo(() => groupTasksForSidebar(tasks), [tasks]);
+
+  // Hydrate collapsed state for new groups that appear
+  useEffect(() => {
+    setCollapsedGroups((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const group of groups) {
+        if (!(group.key in next)) {
+          next[group.key] = getInitialGroupCollapsed(group.key);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [groups]);
 
   const toggleCollapsed = useCallback(() => {
     setCollapsed((prev) => {
@@ -177,6 +475,18 @@ export function UniversalSidebar() {
     });
   }, []);
 
+  const toggleGroupCollapsed = useCallback((groupKey: string) => {
+    setCollapsedGroups((prev) => {
+      const next = !prev[groupKey];
+      try {
+        localStorage.setItem(GROUP_COLLAPSE_PREFIX + groupKey, String(next));
+      } catch {
+        // ignore
+      }
+      return { ...prev, [groupKey]: next };
+    });
+  }, []);
+
   // Cmd/Ctrl+B keyboard shortcut
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -185,17 +495,68 @@ export function UniversalSidebar() {
         toggleCollapsed();
       }
     }
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener(
+      'keydown',
+      handleKeyDown as unknown as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        'keydown',
+        handleKeyDown as unknown as EventListener,
+      );
   }, [toggleCollapsed]);
 
-  // Active nav detection — no nav highlighted when viewing a task
+  // Active nav detection
   const activeNav = useMemo(() => {
     if (location.pathname === '/orchestrator') return 'orchestrator';
     if (location.pathname === '/settings') return 'settings';
-    if (activeTaskId) return null; // on /tasks/:id — task item highlights instead
-    return 'dashboard';
+    if (location.pathname === '/tasks' || location.pathname.startsWith('/tasks/'))
+      return 'tasks';
+    if (activeTaskId) return null;
+    if (location.pathname === '/') return 'home';
+    return null;
   }, [location.pathname, activeTaskId]);
+
+  // ─── Row actions ──────────────────────────────────────────────────────────
+
+  const handleClose = useCallback(
+    async (id: string) => {
+      try {
+        await api.updateTask(id, { status: 'closed' });
+        refresh();
+      } catch (err) {
+        console.error('Failed to close task:', err);
+      }
+    },
+    [refresh],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await api.deleteTask(id);
+        refresh();
+      } catch (err) {
+        console.error('Failed to delete task:', err);
+      }
+    },
+    [refresh],
+  );
+
+  const handleRenameSubmit = useCallback(
+    async (id: string, title: string) => {
+      const trimmed = title.trim();
+      setRenamingId(null);
+      if (!trimmed) return;
+      try {
+        await api.updateTask(id, { title: trimmed });
+        refresh();
+      } catch (err) {
+        console.error('Failed to rename task:', err);
+      }
+    },
+    [refresh],
+  );
 
   return (
     <nav
@@ -328,53 +689,293 @@ export function UniversalSidebar() {
       {/* Task groups */}
       <div className="flex-1">
         {groups.map((group) => (
-          <div key={group.repo} style={{ paddingBottom: 16 }}>
-            {!collapsed && (
-              <div
-                className="font-bold uppercase tracking-wider"
-                style={{
-                  fontSize: 10,
-                  color: '#6a6a6a',
-                  padding: '0 20px 8px',
-                }}
-              >
-                {'// ' + group.repo.toUpperCase()}
-              </div>
-            )}
-            {group.items.map((item) => {
-              const isActive = item.id === activeTaskId;
-              return (
-                <Link
-                  key={item.id}
-                  to={`/tasks/${item.id}`}
-                  aria-current={isActive ? 'page' : undefined}
-                  title={collapsed ? item.title : undefined}
-                  className="flex items-center"
-                  style={{
-                    padding: collapsed ? '10px 0' : '10px 20px',
-                    gap: 10,
-                    backgroundColor: isActive ? '#3B82F620' : 'transparent',
-                    justifyContent: collapsed ? 'center' : undefined,
-                  }}
-                >
-                  <StatusIcon item={item} />
-                  {!collapsed && (
-                    <span
-                      className="truncate font-medium"
-                      style={{
-                        fontSize: 11,
-                        color: isActive ? '#3B82F6' : '#8a8a8a',
-                      }}
-                    >
-                      {item.title}
-                    </span>
-                  )}
-                </Link>
-              );
-            })}
-          </div>
+          <SidebarGroupView
+            key={group.key}
+            group={group}
+            collapsed={collapsed}
+            groupCollapsed={collapsedGroups[group.key] ?? false}
+            activeTaskId={activeTaskId}
+            renamingId={renamingId}
+            onToggleGroup={() => toggleGroupCollapsed(group.key)}
+            onAddTask={() => {
+              if (group.key === OTHER_GROUP_KEY) return;
+              navigate(buildGroupAddUrl(group.key));
+            }}
+            onOpenRow={(id) => navigate(`/tasks/${id}`)}
+            onFork={(item) => navigate(buildForkUrl(item))}
+            onAddAgent={(id) => navigate(buildAddAgentUrl(id))}
+            onStartRename={(id) => setRenamingId(id)}
+            onCancelRename={() => setRenamingId(null)}
+            onSubmitRename={handleRenameSubmit}
+            onClose={handleClose}
+            onDelete={handleDelete}
+          />
         ))}
       </div>
     </nav>
+  );
+}
+
+// ─── Group View ─────────────────────────────────────────────────────────────
+
+interface SidebarGroupViewProps {
+  group: SidebarGroup;
+  collapsed: boolean;
+  groupCollapsed: boolean;
+  activeTaskId: string | null;
+  renamingId: string | null;
+  onToggleGroup: () => void;
+  onAddTask: () => void;
+  onOpenRow: (id: string) => void;
+  onFork: (item: SidebarItem) => void;
+  onAddAgent: (id: string) => void;
+  onStartRename: (id: string) => void;
+  onCancelRename: () => void;
+  onSubmitRename: (id: string, title: string) => void;
+  onClose: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function SidebarGroupView({
+  group,
+  collapsed,
+  groupCollapsed,
+  activeTaskId,
+  renamingId,
+  onToggleGroup,
+  onAddTask,
+  onOpenRow,
+  onFork,
+  onAddAgent,
+  onStartRename,
+  onCancelRename,
+  onSubmitRename,
+  onClose,
+  onDelete,
+}: SidebarGroupViewProps) {
+  const isOther = group.key === OTHER_GROUP_KEY;
+
+  return (
+    <div style={{ paddingBottom: 16 }}>
+      {!collapsed && (
+        <div
+          className="group/header flex items-center justify-between"
+          style={{ padding: '0 20px 8px' }}
+        >
+          <button
+            type="button"
+            onClick={onToggleGroup}
+            className="flex items-center gap-1.5 font-bold uppercase tracking-wider hover:text-white"
+            style={{ fontSize: 10, color: '#6a6a6a' }}
+            aria-expanded={!groupCollapsed}
+            aria-controls={`sidebar-group-${group.key}`}
+          >
+            <svg
+              width="8"
+              height="8"
+              viewBox="0 0 8 8"
+              fill="none"
+              aria-hidden="true"
+              style={{
+                transform: groupCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+                transition: 'transform 120ms',
+              }}
+            >
+              <path
+                d="M1.5 2.5 4 5l2.5-2.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span>{group.repo.toUpperCase()}</span>
+          </button>
+          {!isOther && (
+            <button
+              type="button"
+              onClick={onAddTask}
+              aria-label={`New task in ${group.repo}`}
+              title={`New task in ${group.repo}`}
+              data-testid={`sidebar-group-add-${group.key}`}
+              className="flex h-4 w-4 items-center justify-center text-[#6a6a6a] opacity-0 hover:text-white group-hover/header:opacity-100"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+                <line
+                  x1="5"
+                  y1="1"
+                  x2="5"
+                  y2="9"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+                <line
+                  x1="1"
+                  y1="5"
+                  x2="9"
+                  y2="5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
+      {!groupCollapsed && (
+        <div id={`sidebar-group-${group.key}`}>
+          {group.items.map((item) => (
+            <SessionRow
+              key={item.id}
+              item={item}
+              collapsed={collapsed}
+              isActive={item.id === activeTaskId}
+              isRenaming={renamingId === item.id}
+              onOpen={() => onOpenRow(item.id)}
+              onFork={() => onFork(item)}
+              onAddAgent={() => onAddAgent(item.id)}
+              onStartRename={() => onStartRename(item.id)}
+              onCancelRename={onCancelRename}
+              onSubmitRename={(title) => onSubmitRename(item.id, title)}
+              onClose={() => onClose(item.id)}
+              onDelete={() => onDelete(item.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Session Row ───────────────────────────────────────────────────────────
+
+interface SessionRowProps {
+  item: SidebarItem;
+  collapsed: boolean;
+  isActive: boolean;
+  isRenaming: boolean;
+  onOpen: () => void;
+  onFork: () => void;
+  onAddAgent: () => void;
+  onStartRename: () => void;
+  onCancelRename: () => void;
+  onSubmitRename: (title: string) => void;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+function SessionRow({
+  item,
+  collapsed,
+  isActive,
+  isRenaming,
+  onOpen,
+  onFork,
+  onAddAgent,
+  onStartRename,
+  onCancelRename,
+  onSubmitRename,
+  onClose,
+  onDelete,
+}: SessionRowProps) {
+  if (collapsed) {
+    return (
+      <Link
+        to={`/tasks/${item.id}`}
+        aria-current={isActive ? 'page' : undefined}
+        title={item.title}
+        className="flex items-center"
+        style={{
+          padding: '10px 0',
+          gap: 10,
+          backgroundColor: isActive ? '#3B82F620' : 'transparent',
+          justifyContent: 'center',
+        }}
+      >
+        <StatusIcon item={item} />
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      className="group/row flex items-center"
+      data-testid={`sidebar-row-${item.id}`}
+      data-run-mode={item.runMode}
+      style={{
+        padding: '6px 20px',
+        gap: 8,
+        backgroundColor: isActive ? '#3B82F620' : 'transparent',
+      }}
+    >
+      <StatusIcon item={item} />
+      <RunModeBadge mode={item.runMode} />
+      {isRenaming ? (
+        <RenameInput
+          initial={item.title}
+          onSubmit={onSubmitRename}
+          onCancel={onCancelRename}
+        />
+      ) : (
+        <Link
+          to={`/tasks/${item.id}`}
+          aria-current={isActive ? 'page' : undefined}
+          className="min-w-0 flex-1 truncate font-medium"
+          style={{
+            fontSize: 11,
+            color: isActive ? '#3B82F6' : '#8a8a8a',
+          }}
+        >
+          {item.title}
+        </Link>
+      )}
+      {!isRenaming && (
+        <RowMenu
+          item={item}
+          onOpen={onOpen}
+          onFork={onFork}
+          onAddAgent={onAddAgent}
+          onRename={onStartRename}
+          onClose={onClose}
+          onDelete={onDelete}
+        />
+      )}
+    </div>
+  );
+}
+
+function RenameInput({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  onSubmit: (title: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+
+  return (
+    <input
+      autoFocus
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => onSubmit(value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          onSubmit(value);
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+      className="min-w-0 flex-1 bg-[#141414] px-1.5 py-0.5 font-medium text-white outline-none"
+      style={{ fontSize: 11, border: '1px solid #3B82F6' }}
+      aria-label="Rename task"
+      data-testid="sidebar-rename-input"
+    />
   );
 }

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -96,6 +96,8 @@ describe('groupTasksForSidebar', () => {
       title: 'My Task',
       status: 'running',
       derivedStatus: 'needs_attention',
+      runMode: 'new',
+      repoPath: '/home/dev/repo',
     });
   });
 
@@ -116,8 +118,47 @@ describe('groupTasksForSidebar', () => {
       title: 'T',
       status: 'running',
       derivedStatus: null,
+      runMode: 'new',
+      repoPath: '/r',
     };
-    const group: SidebarGroup = { repo: 'r', items: [item] };
+    const group: SidebarGroup = { key: '/r', repo: 'r', items: [item] };
     expect(group.repo).toBe('r');
+  });
+
+  it('places scratch-mode tasks in the Other group (sorted last)', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', repo_path: '/home/dev/alpha' }),
+      makeTask({
+        id: '2',
+        status: 'running',
+        repo_path: '',
+        run_mode: 'scratch',
+        title: 'Scratch work',
+      }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups.map((g) => g.repo)).toEqual(['alpha', 'Other']);
+    expect(groups[1].key).toBe('__other__');
+    expect(groups[1].items).toHaveLength(1);
+    expect(groups[1].items[0].id).toBe('2');
+  });
+
+  it('places repo-less non-scratch tasks in the Other group', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', repo_path: '', run_mode: 'new' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('__other__');
+  });
+
+  it('surfaces runMode on each item', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', run_mode: 'existing' }),
+      makeTask({ id: '2', status: 'running', run_mode: 'none' }),
+    ];
+    const items = groupTasksForSidebar(tasks).flatMap((g) => g.items);
+    const modes = Object.fromEntries(items.map((i) => [i.id, i.runMode]));
+    expect(modes).toEqual({ '1': 'existing', '2': 'none' });
   });
 });

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -1,14 +1,22 @@
-import type { Task, TaskStatus, DerivedTaskStatus } from '../../server/types';
+import type { Task, TaskStatus, DerivedTaskStatus, RunMode } from '../../server/types';
 import { repoName } from './utils';
+
+export const OTHER_GROUP_KEY = '__other__';
+export const OTHER_GROUP_LABEL = 'Other';
 
 export interface SidebarItem {
   id: string;
   title: string;
   status: TaskStatus;
   derivedStatus: DerivedTaskStatus | null;
+  runMode: RunMode;
+  repoPath: string | null;
 }
 
 export interface SidebarGroup {
+  /** Stable key — either the task's `repo_path` or `OTHER_GROUP_KEY` for scratch/repo-less tasks. */
+  key: string;
+  /** Display label for the group header. */
   repo: string;
   items: SidebarItem[];
 }
@@ -23,38 +31,60 @@ function sortPriority(item: SidebarItem): number {
   return 3;
 }
 
+function itemFromTask(task: Task): SidebarItem {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    derivedStatus: task.derived_status ?? null,
+    runMode: task.run_mode,
+    repoPath: task.repo_path || null,
+  };
+}
+
+function groupKeyFor(task: Task): { key: string; label: string } {
+  if (task.run_mode === 'scratch' || !task.repo_path) {
+    return { key: OTHER_GROUP_KEY, label: OTHER_GROUP_LABEL };
+  }
+  return { key: task.repo_path, label: repoName(task.repo_path) };
+}
+
 export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
   const active = tasks.filter((t) => ACTIVE_STATUSES.includes(t.status));
 
-  const grouped = new Map<string, { items: SidebarItem[]; tasks: Task[] }>();
+  const grouped = new Map<
+    string,
+    { label: string; items: SidebarItem[]; tasks: Task[] }
+  >();
+
   for (const task of active) {
-    const repo = repoName(task.repo_path);
-    const item: SidebarItem = {
-      id: task.id,
-      title: task.title,
-      status: task.status,
-      derivedStatus: task.derived_status ?? null,
-    };
-    const existing = grouped.get(repo);
+    const { key, label } = groupKeyFor(task);
+    const item = itemFromTask(task);
+    const existing = grouped.get(key);
     if (existing) {
       existing.items.push(item);
       existing.tasks.push(task);
     } else {
-      grouped.set(repo, { items: [item], tasks: [task] });
+      grouped.set(key, { label, items: [item], tasks: [task] });
     }
   }
 
   const groups: SidebarGroup[] = [];
-  for (const [repo, { items, tasks: groupTasks }] of grouped) {
+  for (const [key, { label, items, tasks: groupTasks }] of grouped) {
     const createdAt = new Map(groupTasks.map((t) => [t.id, t.created_at]));
     items.sort((a, b) => {
       const priorityDiff = sortPriority(a) - sortPriority(b);
       if (priorityDiff !== 0) return priorityDiff;
       return (createdAt.get(b.id) ?? '').localeCompare(createdAt.get(a.id) ?? '');
     });
-    groups.push({ repo, items });
+    groups.push({ key, repo: label, items });
   }
 
-  groups.sort((a, b) => a.repo.localeCompare(b.repo));
+  groups.sort((a, b) => {
+    // "Other" always sorts last.
+    if (a.key === OTHER_GROUP_KEY) return 1;
+    if (b.key === OTHER_GROUP_KEY) return -1;
+    return a.repo.localeCompare(b.repo);
+  });
   return groups;
 }

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import HomePage from './HomePage';
+import { renderWithRouter } from '../test-helpers';
+
+describe('HomePage', () => {
+  it('renders welcome heading', () => {
+    renderWithRouter(<HomePage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/welcome back/i);
+  });
+
+  it('renders the coming-soon subtext', () => {
+    renderWithRouter(<HomePage />);
+    expect(screen.getByText(/composer and sessions inbox coming soon/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,22 @@
+import { useSearchParams } from 'react-router-dom';
+
+export default function HomePage() {
+  // Pre-fill params for the future chip composer. Sibling task will wire the composer up.
+  useSearchParams();
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto max-w-4xl px-8 py-12">
+        <h1
+          className="font-display text-[42px] font-bold leading-none tracking-tight"
+          style={{ letterSpacing: '-1px' }}
+        >
+          ✦ WELCOME BACK
+        </h1>
+        <p className="mt-4 text-sm text-[#8a8a8a]">
+          Composer and sessions inbox coming soon.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -108,11 +108,11 @@ describe('TaskDetail', () => {
     });
   });
 
-  it('shows back to dashboard button on error', async () => {
+  it('shows back to tasks button on error', async () => {
     apiMock.getTask.mockRejectedValue(new Error('fail'));
     renderDetail();
     await waitFor(() => {
-      expect(screen.getByText('Back to Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Back to Tasks')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -237,8 +237,8 @@ export default function TaskDetail() {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4">
         <p className="text-destructive">{error || 'Task not found'}</p>
-        <Button variant="outline" onClick={() => navigate('/')}>
-          Back to Dashboard
+        <Button variant="outline" onClick={() => navigate('/tasks')}>
+          Back to Tasks
         </Button>
       </div>
     );

--- a/src/pages/TasksPage.test.tsx
+++ b/src/pages/TasksPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Dashboard from './Dashboard';
+import TasksPage from './TasksPage';
 import { renderWithRouter, makeTask } from '../test-helpers';
 import { TasksProvider } from '../lib/tasks-context';
 
@@ -34,12 +34,12 @@ vi.mock('react-router-dom', routerMockFactory);
 function renderDashboard() {
   return renderWithRouter(
     <TasksProvider>
-      <Dashboard />
+      <TasksPage />
     </TasksProvider>,
   );
 }
 
-describe('Dashboard', () => {
+describe('TasksPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -18,7 +18,7 @@ function NewTaskButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-export default function Dashboard() {
+export default function TasksPage() {
   const { tasks, loading, error, refresh } = useTasksContext();
   const { filters, setFilter, filtered, counts, repos } = useTaskFilters(tasks);
   const [createOpen, setCreateOpen] = useState(false);


### PR DESCRIPTION
## What

Phase 1 of the chat-first UX: navigation + routing + sidebar skeleton. Does NOT include the chip composer or sessions inbox (sibling tasks).

- Move the Dashboard page from `/` to `/tasks`. Rename `Dashboard` → `TasksPage`; behavior unchanged.
- Add a minimal `HomePage` stub at `/` (`✦ Welcome back` + "coming soon" line). `useSearchParams` is wired for the future composer to read `repo`, `mode`, `base_branch`, `fork_of`, `add_agent`.
- Rework `UniversalSidebar`:
  - Nav: `Home / Tasks / Orchestrator / Settings`.
  - Active sessions grouped by `repo_path` basename, alpha-sorted, with a trailing **Other** group for `run_mode='scratch'` or repo-less tasks.
  - Group headers collapse (chevron button); per-group state persists in `localStorage` at `octomux:sidebar:collapsed:<repo_path>`.
  - Non-Other group headers expose a hover `+` that navigates to `/?repo=<path>&mode=new`.
  - Each row shows a colorblind-safe 4-state status glyph (running dot / needs-you triangle / error X / idle hollow circle), a one-letter **run-mode badge** (N/E/Ø/S) with tooltip, and a hover `⋮` menu.
  - Row menu: Open, Fork into new task, Add agent…, Rename (inline), Close, Delete. **Fork** is disabled (with a `title` explaining why) when the source's `run_mode` is `scratch` or `none`, or status is `draft`.
- Redirect `TaskDetail`'s "Back to Dashboard" link to `/tasks` ("Back to Tasks").

## Why

The chat-first UX treats Home as the primary jumping-off point (composer + sessions inbox) and the sidebar as the persistent index of live work. This PR lays the routing + sidebar skeleton so the composer + inbox work (sibling tasks) can land without also shipping navigation churn.

Grouping sessions by repo matches how users already think about their work, and the `+` / Fork / Add-agent affordances pre-seed the composer via URL params so the composer owns one entry flow rather than many.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean (no new warnings; 18 pre-existing warnings unchanged)
- `bun run test` — 891 passed / 48 files (up from 859 / 45). New tests:
  - `src/App.test.tsx` — `/` renders HomePage, `/tasks` renders TasksPage
  - `src/pages/HomePage.test.tsx` — stub renders heading + subtext
  - `src/components/UniversalSidebar.test.tsx` (28 tests) — nav, grouping, Other group, collapse persistence across re-renders, run-mode badge for all four modes, status-glyph mapping, row menu navigation + API calls, Fork disabled for scratch/none/draft, inline rename submits
  - `src/lib/sidebar-utils.test.tsx` — Other group placement, runMode surfacing on items
- Manual verification: not run (headless environment). UI browser testing is left to the user.