### PR TITLE
fix(task-runner): disable noisy per-project plugins in agent worktrees

### DIFF
--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -298,6 +298,56 @@ describe('startTask', () => {
     expect(vi.mocked(fs.copyFileSync)).not.toHaveBeenCalled();
   });
 
+  // ─── Agent-local settings ──────────────────────────────────────────────
+
+  describe('agent-local settings', () => {
+    it('writes settings.local.json disabling noisy plugins when none exists', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        // Repo path exists; settings.local.json (source or destination) does not
+        return !String(p).includes('settings.local.json');
+      });
+
+      insertTask(db);
+      await startTask({ ...DEFAULTS.task } as Task);
+
+      const writeCall = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]).endsWith('/.claude/settings.local.json'));
+      expect(writeCall).toBeDefined();
+      expect(String(writeCall![0])).toBe(
+        `${DEFAULTS.task.repo_path}/.worktrees/fix-order-validation-test-t/.claude/settings.local.json`,
+      );
+      const parsed = JSON.parse(String(writeCall![1]));
+      expect(parsed.plugins['remember@claude-plugins-official']).toBe(false);
+    });
+
+    it('does not write settings.local.json in run_mode=none', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return !String(p).includes('settings.local.json');
+      });
+
+      insertTask(db, { run_mode: 'none' });
+      await startTask({ ...DEFAULTS.task, run_mode: 'none' as const } as Task);
+
+      const writeCall = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]).endsWith('/.claude/settings.local.json'));
+      expect(writeCall).toBeUndefined();
+    });
+
+    it('leaves an existing settings.local.json alone', async () => {
+      // Default existsSync returns true for all paths, so the destination is
+      // treated as already present.
+      insertTask(db);
+      await startTask({ ...DEFAULTS.task } as Task);
+
+      const writeCall = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]).endsWith('/.claude/settings.local.json'));
+      expect(writeCall).toBeUndefined();
+    });
+  });
+
   // ─── Error cases (table-driven) ────────────────────────────────────────
 
   const errorCases = [

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -68,8 +68,20 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const PROMPT_FILE_CLEANUP_MS = 5000;
 
+const DISABLED_PLUGINS_IN_WORKTREES = ['remember@claude-plugins-official'] as const;
+
 function shellQuoteSingle(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function writeAgentLocalSettings(worktreePath: string): void {
+  const claudeDir = path.join(worktreePath, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  const settingsPath = path.join(claudeDir, 'settings.local.json');
+  if (fs.existsSync(settingsPath)) return;
+  const plugins: Record<string, boolean> = {};
+  for (const p of DISABLED_PLUGINS_IN_WORKTREES) plugins[p] = false;
+  fs.writeFileSync(settingsPath, JSON.stringify({ plugins }, null, 2));
 }
 
 /**
@@ -342,6 +354,17 @@ async function setupNew(task: Task): Promise<SetupResult> {
     fs.mkdirSync(path.dirname(settingsDst), { recursive: true });
     fs.copyFileSync(settingsSrc, settingsDst);
   }
+
+  writeAgentLocalSettings(worktreePath);
+  logger.info(
+    {
+      task_id: task.id,
+      operation: 'createTask',
+      settings_path: settingsDst,
+      disabled_plugins: DISABLED_PLUGINS_IN_WORKTREES.length,
+    },
+    'createTask: wrote agent-local settings',
+  );
 
   return {
     worktreePath,

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -70,12 +70,8 @@ describe('UniversalSidebar grouping', () => {
     ]);
     renderSidebar();
     await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
-    expect(
-      screen.getByRole('button', { expanded: true, name: /nucleus/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { expanded: true, name: /^octomux$/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { expanded: true, name: /nucleus/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { expanded: true, name: /^octomux$/i })).toBeInTheDocument();
   });
 
   it('renders an Other group for scratch / repo-less tasks', async () => {
@@ -193,9 +189,7 @@ describe('UniversalSidebar group collapse persistence', () => {
     renderSidebar();
     // After rehydrate, the group should still be collapsed
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { expanded: false, name: /nucleus/i }),
-      ).toBeInTheDocument(),
+      expect(screen.getByRole('button', { expanded: false, name: /nucleus/i })).toBeInTheDocument(),
     );
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
   });
@@ -207,9 +201,7 @@ describe('UniversalSidebar row menu', () => {
       expect(screen.getByTestId(`task-row-menu-trigger-${id}`)).toBeInTheDocument(),
     );
     await user.click(screen.getByTestId(`task-row-menu-trigger-${id}`));
-    await waitFor(() =>
-      expect(screen.getByTestId(`task-row-menu-${id}`)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByTestId(`task-row-menu-${id}`)).toBeInTheDocument());
     return screen.getByTestId(`task-row-menu-${id}`);
   }
 
@@ -294,9 +286,7 @@ describe('UniversalSidebar row menu', () => {
     renderSidebar();
     const menu = await openMenu(user, 't1');
     await user.click(within(menu).getByText('Rename'));
-    await waitFor(() =>
-      expect(screen.getByTestId('sidebar-rename-input')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByTestId('sidebar-rename-input')).toBeInTheDocument());
     const input = screen.getByTestId('sidebar-rename-input') as HTMLInputElement;
     await user.clear(input);
     await user.type(input, 'New Title');

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -1,11 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useEffect,
-  useCallback,
-  useRef,
-  type KeyboardEvent,
-} from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef, type KeyboardEvent } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTasksContext } from '@/lib/tasks-context';
 import {
@@ -270,7 +263,8 @@ const NAV_ITEMS = [
 
 export function forkDisabledReason(item: SidebarItem): string | null {
   if (item.runMode === 'scratch') return 'Cannot fork a scratch task (no repo).';
-  if (item.runMode === 'none') return 'Cannot fork a task that runs on the working tree (no branch).';
+  if (item.runMode === 'none')
+    return 'Cannot fork a task that runs on the working tree (no branch).';
   if (item.status === 'draft') return 'Cannot fork a draft task (no branch yet).';
   return null;
 }
@@ -379,11 +373,7 @@ function RowMenu({ item, onOpen, onFork, onAddAgent, onRename, onClose, onDelete
           <MenuItemRow onClick={() => choose(onAddAgent)} label="Add agent…" />
           <div className="my-1 h-px bg-[#2f2f2f]" />
           <MenuItemRow onClick={() => choose(onRename)} label="Rename" />
-          <MenuItemRow
-            onClick={() => choose(onClose)}
-            disabled={closeDisabled}
-            label="Close"
-          />
+          <MenuItemRow onClick={() => choose(onClose)} disabled={closeDisabled} label="Close" />
           <MenuItemRow onClick={() => choose(onDelete)} label="Delete" destructive />
         </div>
       )}
@@ -495,23 +485,15 @@ export function UniversalSidebar() {
         toggleCollapsed();
       }
     }
-    window.addEventListener(
-      'keydown',
-      handleKeyDown as unknown as EventListener,
-    );
-    return () =>
-      window.removeEventListener(
-        'keydown',
-        handleKeyDown as unknown as EventListener,
-      );
+    window.addEventListener('keydown', handleKeyDown as unknown as EventListener);
+    return () => window.removeEventListener('keydown', handleKeyDown as unknown as EventListener);
   }, [toggleCollapsed]);
 
   // Active nav detection
   const activeNav = useMemo(() => {
     if (location.pathname === '/orchestrator') return 'orchestrator';
     if (location.pathname === '/settings') return 'settings';
-    if (location.pathname === '/tasks' || location.pathname.startsWith('/tasks/'))
-      return 'tasks';
+    if (location.pathname === '/tasks' || location.pathname.startsWith('/tasks/')) return 'tasks';
     if (activeTaskId) return null;
     if (location.pathname === '/') return 'home';
     return null;
@@ -913,11 +895,7 @@ function SessionRow({
       <StatusIcon item={item} />
       <RunModeBadge mode={item.runMode} />
       {isRenaming ? (
-        <RenameInput
-          initial={item.title}
-          onSubmit={onSubmitRename}
-          onCancel={onCancelRename}
-        />
+        <RenameInput initial={item.title} onSubmit={onSubmitRename} onCancel={onCancelRename} />
       ) : (
         <Link
           to={`/tasks/${item.id}`}

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -144,9 +144,7 @@ describe('groupTasksForSidebar', () => {
   });
 
   it('places repo-less non-scratch tasks in the Other group', () => {
-    const tasks = [
-      makeTask({ id: '1', status: 'running', repo_path: '', run_mode: 'new' }),
-    ];
+    const tasks = [makeTask({ id: '1', status: 'running', repo_path: '', run_mode: 'new' })];
     const groups = groupTasksForSidebar(tasks);
     expect(groups).toHaveLength(1);
     expect(groups[0].key).toBe('__other__');

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -52,10 +52,7 @@ function groupKeyFor(task: Task): { key: string; label: string } {
 export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
   const active = tasks.filter((t) => ACTIVE_STATUSES.includes(t.status));
 
-  const grouped = new Map<
-    string,
-    { label: string; items: SidebarItem[]; tasks: Task[] }
-  >();
+  const grouped = new Map<string, { label: string; items: SidebarItem[]; tasks: Task[] }>();
 
   for (const task of active) {
     const { key, label } = groupKeyFor(task);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,9 +13,7 @@ export default function HomePage() {
         >
           ✦ WELCOME BACK
         </h1>
-        <p className="mt-4 text-sm text-[#8a8a8a]">
-          Composer and sessions inbox coming soon.
-        </p>
+        <p className="mt-4 text-sm text-[#8a8a8a]">Composer and sessions inbox coming soon.</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

- Add a `DISABLED_PLUGINS_IN_WORKTREES` constant and `writeAgentLocalSettings` helper in `server/task-runner.ts` that drops a minimal `.claude/settings.local.json` into each new agent worktree with `{ plugins: { 'remember@claude-plugins-official': false } }`.
- Wire the helper into `setupNew` (the `run_mode='new'` path) right after the existing `.claude/settings.local.json` copy. Does not clobber a pre-existing settings file and only runs for new worktrees — `run_mode` of `none`/`existing`/`scratch` is untouched.
- Add three tests covering the happy path, `run_mode=none` skip, and the existing-file respect case.

## Why

The third-party `remember@claude-plugins-official` plugin registers SessionStart and PostToolUse hooks that write to `\$CLAUDE_PROJECT_DIR/.remember/logs/…`. Octomux agents run in git worktrees that don't inherit the gitignored `.remember/` directory from the main checkout, so every tool call in an agent session emits `/bin/sh: .../hook-err…: No such file or directory` and a "Failed with non-blocking status code" warning in the Claude Code UI. Disabling the plugin per-worktree silences the noise without touching the user's main-repo sessions where `.remember/` exists.

## Testing

- `bun run typecheck` — pass
- `bun run test` — 906 pass
- `bun run lint` — no new warnings