### PR TITLE
feat(ui): global keyboard shortcuts (⌘K palette, sidebar nav)

### DIFF
--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from './App';
+import { makeTask } from './test-helpers';
+import { TasksProvider } from './lib/tasks-context';
+import type { Task } from '../server/types';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('./test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+vi.mock('./lib/api', () => ({ api: apiProxy }));
+vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('./lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('./lib/orchestrator-context', () => ({
+  useOrchestratorContext: () => ({
+    running: false,
+    loading: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    error: null,
+    refresh: vi.fn(),
+  }),
+  OrchestratorProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockTasksRef = { current: [] as Task[] };
+vi.mock('./lib/hooks', () => ({
+  useTasks: () => ({
+    tasks: mockTasksRef.current,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+  useTask: () => ({ task: null, loading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock('@/lib/hooks', () => ({
+  useTasks: () => ({
+    tasks: mockTasksRef.current,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+  useTask: () => ({ task: null, loading: false, error: null, refresh: vi.fn() }),
+}));
+
+// We observe navigation rather than performing it, to keep tests simple.
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('./test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+// Keep attention/notification hooks quiet.
+vi.mock('./lib/use-attention-indicator', () => ({ useAttentionIndicator: vi.fn() }));
+vi.mock('./lib/use-notifications', () => ({ useNotifications: vi.fn() }));
+
+function renderShell(route = '/', tasks: Task[] = []) {
+  mockTasksRef.current = tasks;
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <TasksProvider>
+        <AppShell />
+      </TasksProvider>
+    </MemoryRouter>,
+  );
+}
+
+function cmdKey(key: string, extra: KeyboardEventInit = {}) {
+  return new KeyboardEvent('keydown', { key, metaKey: true, ...extra });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNavigate.mockReset();
+  mockTasksRef.current = [];
+  localStorage.clear();
+  apiMock.listTasks.mockResolvedValue([]);
+  Object.defineProperty(window.navigator, 'platform', {
+    value: 'MacIntel',
+    configurable: true,
+  });
+});
+
+describe('App global shortcuts', () => {
+  it('⌘K opens command palette', async () => {
+    renderShell('/');
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(cmdKey('k'));
+    });
+    await waitFor(() => expect(screen.getByTestId('command-palette')).toBeInTheDocument());
+  });
+
+  it('⌘K preempts terminal-focused input', async () => {
+    renderShell('/');
+    // Simulate a terminal by focusing an input. Dispatch keydown from that target.
+    const fakeTerm = document.createElement('textarea');
+    fakeTerm.setAttribute('data-testid', 'fake-terminal');
+    document.body.appendChild(fakeTerm);
+    fakeTerm.focus();
+    act(() => {
+      fakeTerm.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true, cancelable: true }),
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('command-palette')).toBeInTheDocument());
+    document.body.removeChild(fakeTerm);
+  });
+
+  it('⌘⇧N navigates to / (replace) and dispatches focus-composer', async () => {
+    renderShell('/tasks/x');
+    const focusSpy = vi.fn();
+    window.addEventListener('focus-composer', focusSpy);
+    act(() => {
+      window.dispatchEvent(cmdKey('n', { shiftKey: true }));
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(focusSpy).toHaveBeenCalled();
+    window.removeEventListener('focus-composer', focusSpy);
+  });
+
+  it('⌘Enter on / dispatches submit-composer event', () => {
+    renderShell('/');
+    const submitSpy = vi.fn();
+    window.addEventListener('submit-composer', submitSpy);
+    act(() => {
+      window.dispatchEvent(cmdKey('Enter'));
+    });
+    expect(submitSpy).toHaveBeenCalled();
+    window.removeEventListener('submit-composer', submitSpy);
+  });
+
+  it('⌘Enter on /tasks/:id does NOT dispatch submit-composer', () => {
+    renderShell('/tasks/xyz');
+    const submitSpy = vi.fn();
+    window.addEventListener('submit-composer', submitSpy);
+    act(() => {
+      window.dispatchEvent(cmdKey('Enter'));
+    });
+    expect(submitSpy).not.toHaveBeenCalled();
+    window.removeEventListener('submit-composer', submitSpy);
+  });
+
+  it('⌘↓ navigates to next visible session (wrap from last → first)', () => {
+    const tasks = [
+      makeTask({ id: 's1', status: 'running', repo_path: '/r/octo' }),
+      makeTask({ id: 's2', status: 'running', repo_path: '/r/octo' }),
+    ];
+    renderShell('/tasks/s2', tasks);
+    act(() => {
+      window.dispatchEvent(cmdKey('ArrowDown'));
+    });
+    // s2 is sorted by created_at (same) so stable-ish order. Accept any navigation
+    // as long as it cycles to a valid session id.
+    expect(mockNavigate).toHaveBeenCalled();
+    const dest = mockNavigate.mock.calls[0][0] as string;
+    expect(dest).toMatch(/^\/tasks\/(s1|s2)$/);
+  });
+
+  it('⌘↑ from non-task route goes to last visible session', () => {
+    const tasks = [
+      makeTask({ id: 'a', status: 'running', repo_path: '/r/octo' }),
+      makeTask({ id: 'b', status: 'running', repo_path: '/r/octo' }),
+    ];
+    renderShell('/', tasks);
+    act(() => {
+      window.dispatchEvent(cmdKey('ArrowUp'));
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const dest = mockNavigate.mock.calls[0][0] as string;
+    expect(dest).toMatch(/^\/tasks\//);
+  });
+
+  it('⌘↓ does nothing when no visible sessions', () => {
+    renderShell('/');
+    act(() => {
+      window.dispatchEvent(cmdKey('ArrowDown'));
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('palette ⌘K + typing + Enter (from within palette) navigates', async () => {
+    const tasks = [makeTask({ id: 'target', title: 'Alpha', status: 'running' })];
+    renderShell('/', tasks);
+    act(() => {
+      window.dispatchEvent(cmdKey('k'));
+    });
+    const input = await screen.findByTestId('command-palette-input');
+    // Avoid using userEvent here — the shortcut listener is still registered and
+    // could swallow keys. fireEvent is precise.
+    fireEvent.change(input, { target: { value: 'Alpha' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks/target');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { Component, lazy, Suspense, type ReactNode } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Component, lazy, Suspense, useMemo, useState, type ReactNode } from 'react';
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { useAttentionIndicator } from './lib/use-attention-indicator';
 import { useNotifications } from './lib/use-notifications';
@@ -7,6 +7,15 @@ import HomePage from './pages/HomePage';
 import { OrchestratorProvider } from './lib/orchestrator-context';
 import { TasksProvider, useTasksContext } from './lib/tasks-context';
 import { UniversalSidebar } from './components/UniversalSidebar';
+import { CommandPalette } from './components/CommandPalette';
+import { useGlobalShortcut } from './lib/shortcuts';
+import { groupTasksForSidebar } from './lib/sidebar-utils';
+import {
+  currentTaskIdFromPath,
+  getNextSessionId,
+  readCollapsedGroups,
+  visibleSessionIds,
+} from './lib/sidebar-nav';
 
 const TasksPage = lazy(() => import('./pages/TasksPage'));
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
@@ -67,7 +76,53 @@ export default function App() {
   );
 }
 
-function AppShell() {
+export function AppShell() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { tasks } = useTasksContext();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const groups = useMemo(() => groupTasksForSidebar(tasks), [tasks]);
+
+  useGlobalShortcut({ key: 'k', mod: true }, (e) => {
+    e.preventDefault();
+    setPaletteOpen(true);
+  });
+
+  useGlobalShortcut({ key: 'n', mod: true, shift: true }, (e) => {
+    if (paletteOpen) return;
+    e.preventDefault();
+    navigate('/', { replace: true });
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('focus-composer'));
+    });
+  });
+
+  useGlobalShortcut({ key: 'ArrowDown', mod: true }, (e) => {
+    if (paletteOpen) return;
+    const visible = visibleSessionIds(groups, readCollapsedGroups(groups));
+    if (visible.length === 0) return;
+    e.preventDefault();
+    const next = getNextSessionId(visible, currentTaskIdFromPath(location.pathname), 'next');
+    if (next) navigate(`/tasks/${next}`);
+  });
+
+  useGlobalShortcut({ key: 'ArrowUp', mod: true }, (e) => {
+    if (paletteOpen) return;
+    const visible = visibleSessionIds(groups, readCollapsedGroups(groups));
+    if (visible.length === 0) return;
+    e.preventDefault();
+    const next = getNextSessionId(visible, currentTaskIdFromPath(location.pathname), 'prev');
+    if (next) navigate(`/tasks/${next}`);
+  });
+
+  useGlobalShortcut({ key: 'Enter', mod: true }, (e) => {
+    if (paletteOpen) return;
+    if (location.pathname !== '/') return;
+    e.preventDefault();
+    window.dispatchEvent(new CustomEvent('submit-composer'));
+  });
+
   return (
     <div className="flex h-screen bg-background text-foreground">
       <Toaster
@@ -98,6 +153,7 @@ function AppShell() {
           </Routes>
         </Suspense>
       </main>
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
     </div>
   );
 }

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { TasksProvider } from '@/lib/tasks-context';
+import { CommandPalette } from './CommandPalette';
+import { makeTask } from '../test-helpers';
+import type { Task } from '../../server/types';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+const mockTasksRef = { current: [] as Task[] };
+vi.mock('@/lib/hooks', () => ({
+  useTasks: () => ({
+    tasks: mockTasksRef.current,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function renderPalette(tasks: Task[], props: { open?: boolean } = {}) {
+  mockTasksRef.current = tasks;
+  const onClose = vi.fn();
+  const utils = render(
+    <MemoryRouter>
+      <TasksProvider>
+        <CommandPalette open={props.open ?? true} onClose={onClose} />
+      </TasksProvider>
+    </MemoryRouter>,
+  );
+  return { ...utils, onClose };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNavigate.mockReset();
+  mockTasksRef.current = [];
+  apiMock.listTasks.mockResolvedValue([]);
+});
+
+describe('CommandPalette', () => {
+  const tasks: Task[] = [
+    makeTask({ id: 't1', title: 'Authentication rewrite', repo_path: '/u/dev/octo' }),
+    makeTask({ id: 't2', title: 'Billing fix', repo_path: '/u/dev/pay' }),
+    makeTask({
+      id: 't3',
+      title: 'Auth telemetry',
+      repo_path: '/u/dev/octo',
+      status: 'setting_up',
+    }),
+    makeTask({ id: 't-closed', title: 'Closed one', status: 'closed' }),
+  ];
+
+  it('renders role="dialog" with aria-modal when open', () => {
+    renderPalette(tasks);
+    const dialog = screen.getByRole('dialog', { name: /command palette/i });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('renders all open sessions (excludes closed/draft) when query is empty', () => {
+    renderPalette(tasks);
+    expect(screen.getByTestId('command-palette-result-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('command-palette-result-t2')).toBeInTheDocument();
+    expect(screen.getByTestId('command-palette-result-t3')).toBeInTheDocument();
+    expect(screen.queryByTestId('command-palette-result-t-closed')).not.toBeInTheDocument();
+  });
+
+  it('typing filters results', async () => {
+    const user = userEvent.setup();
+    renderPalette(tasks);
+    await user.type(screen.getByTestId('command-palette-input'), 'auth');
+    expect(screen.getByTestId('command-palette-result-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('command-palette-result-t3')).toBeInTheDocument();
+    expect(screen.queryByTestId('command-palette-result-t2')).not.toBeInTheDocument();
+  });
+
+  it('Arrow keys navigate and Enter selects → navigate + focus-terminal event', async () => {
+    const user = userEvent.setup();
+    const focusSpy = vi.fn();
+    window.addEventListener('focus-terminal', focusSpy);
+    const { onClose } = renderPalette(tasks);
+    const input = screen.getByTestId('command-palette-input');
+    input.focus();
+    // default active = 0 (first result). Move down once then select.
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    // navigate fires with /tasks/<second-result-id>
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate.mock.calls[0][0]).toMatch(/^\/tasks\//);
+    expect(onClose).toHaveBeenCalled();
+
+    // focus-terminal dispatched on rAF — flush it
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(focusSpy).toHaveBeenCalled();
+    window.removeEventListener('focus-terminal', focusSpy);
+  });
+
+  it('Escape closes without selecting', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderPalette(tasks);
+    screen.getByTestId('command-palette-input').focus();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('clicking backdrop closes', () => {
+    const { onClose } = renderPalette(tasks);
+    fireEvent.click(screen.getByTestId('command-palette-backdrop'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clicking inside dialog does not close', () => {
+    const { onClose } = renderPalette(tasks);
+    fireEvent.click(screen.getByTestId('command-palette'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when closed', () => {
+    renderPalette(tasks, { open: false });
+    expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTasksContext } from '@/lib/tasks-context';
+import { repoName } from '@/lib/utils';
+import type { Task } from '../../server/types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface Scored {
+  task: Task;
+  score: number;
+}
+
+function scoreMatch(haystack: string, needle: string): number {
+  if (!needle) return 1;
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase();
+  const idx = h.indexOf(n);
+  if (idx !== -1) return 1 - idx / (haystack.length + 1);
+  // Subsequence fallback (characters appear in order, not adjacent).
+  let i = 0;
+  for (const ch of h) {
+    if (ch === n[i]) i++;
+    if (i === n.length) return 0.1;
+  }
+  return -1;
+}
+
+const OPEN_STATUSES = new Set(['running', 'setting_up', 'error']);
+
+export function CommandPalette({ open, onClose }: Props) {
+  const navigate = useNavigate();
+  const { tasks } = useTasksContext();
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setActive(0);
+    // Focus after render so input exists in the DOM.
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  const results = useMemo<Scored[]>(() => {
+    const openTasks = tasks.filter((t) => OPEN_STATUSES.has(t.status));
+    if (!query) return openTasks.slice(0, 50).map((t) => ({ task: t, score: 1 }));
+    const scored: Scored[] = [];
+    for (const t of openTasks) {
+      const hay = `${t.title} ${t.repo_path ? repoName(t.repo_path) : ''}`;
+      const s = scoreMatch(hay, query);
+      if (s >= 0) scored.push({ task: t, score: s });
+    }
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, 50);
+  }, [tasks, query]);
+
+  useEffect(() => {
+    if (active >= results.length) setActive(Math.max(0, results.length - 1));
+  }, [results.length, active]);
+
+  if (!open) return null;
+
+  const select = (task: Task) => {
+    onClose();
+    navigate(`/tasks/${task.id}`);
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('focus-terminal'));
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((a) => Math.min(Math.max(results.length - 1, 0), a + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((a) => Math.max(0, a - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const r = results[active];
+      if (r) select(r.task);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      role="presentation"
+      data-testid="command-palette-backdrop"
+      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/50 pt-[10vh]"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        data-testid="command-palette"
+        className="w-full max-w-xl border border-border bg-background shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActive(0);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="Jump to session…"
+          aria-label="Search sessions"
+          data-testid="command-palette-input"
+          className="w-full border-b border-border bg-transparent px-4 py-3 text-sm outline-none"
+        />
+        <ul
+          role="listbox"
+          aria-label="Sessions"
+          data-testid="command-palette-results"
+          className="max-h-[60vh] overflow-y-auto"
+        >
+          {results.length === 0 && (
+            <li className="px-4 py-3 text-xs text-muted-foreground" aria-live="polite">
+              No sessions match
+            </li>
+          )}
+          {results.map(({ task }, i) => (
+            <li
+              key={task.id}
+              role="option"
+              aria-selected={i === active}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(task);
+              }}
+              onMouseEnter={() => setActive(i)}
+              data-testid={`command-palette-result-${task.id}`}
+              className={`cursor-pointer px-4 py-2 text-sm ${
+                i === active ? 'bg-muted text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <StatusGlyph status={task.status} />
+                <span className="min-w-0 flex-1 truncate font-medium">{task.title}</span>
+                {task.repo_path && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {repoName(task.repo_path)}
+                  </span>
+                )}
+                <span className="rounded-sm border border-border px-1 text-[10px] font-mono uppercase">
+                  {task.run_mode}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function StatusGlyph({ status }: { status: string }) {
+  const color = status === 'running' ? '#22C55E' : status === 'error' ? '#EF4444' : '#FFB800';
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block h-2 w-2 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+  );
+}

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -295,6 +295,44 @@ describe('Composer / chip interactions', () => {
   });
 });
 
+// ─── Global shortcut bridges ─────────────────────────────────────────────
+
+describe('Composer / global shortcut bridges', () => {
+  it('auto-focuses the textarea on mount', () => {
+    renderComposer('/');
+    expect(document.activeElement).toBe(screen.getByTestId('composer-prompt'));
+  });
+
+  it('`focus-composer` window event refocuses textarea', () => {
+    renderComposer('/');
+    const textarea = screen.getByTestId('composer-prompt') as HTMLTextAreaElement;
+    // Move focus away, then dispatch focus-composer.
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(document.activeElement).not.toBe(textarea);
+    window.dispatchEvent(new CustomEvent('focus-composer'));
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it('`submit-composer` window event submits when state is valid', async () => {
+    apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'global-submit' }));
+    const user = userEvent.setup();
+    renderComposer('/?mode=scratch');
+    await user.type(screen.getByTestId('composer-prompt'), 'via global shortcut');
+    window.dispatchEvent(new CustomEvent('submit-composer'));
+    await waitFor(() => {
+      expect(apiMock.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'via global shortcut' }),
+      );
+    });
+  });
+
+  it('`submit-composer` is a no-op when prompt is empty', () => {
+    renderComposer('/?mode=scratch');
+    window.dispatchEvent(new CustomEvent('submit-composer'));
+    expect(apiMock.createTask).not.toHaveBeenCalled();
+  });
+});
+
 // ─── URL mirror ──────────────────────────────────────────────────────────
 
 describe('Composer / URL mirror', () => {

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -57,6 +57,7 @@ export function Composer({ onSubmitted }: Props = {}) {
     message: string;
     conflictTaskId?: string | null;
   } | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Re-hydrate when the URL is changed externally (e.g. sidebar click navigating
   // to a new `?repo=...` URL while the Composer is already mounted).
@@ -194,6 +195,28 @@ export function Composer({ onSubmitted }: Props = {}) {
     [handleSubmit],
   );
 
+  // Auto-focus on mount so the composer is immediately typeable — also gives
+  // ⌘⇧N (navigate to /) a predictable focus target on remount.
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Listen for global shortcut bridges (⌘⇧N → focus, ⌘Enter → submit).
+  const submitRef = useRef(handleSubmit);
+  submitRef.current = handleSubmit;
+  useEffect(() => {
+    const onFocus = () => textareaRef.current?.focus();
+    const onSubmit = () => {
+      void submitRef.current();
+    };
+    window.addEventListener('focus-composer', onFocus);
+    window.addEventListener('submit-composer', onSubmit);
+    return () => {
+      window.removeEventListener('focus-composer', onFocus);
+      window.removeEventListener('submit-composer', onSubmit);
+    };
+  }, []);
+
   // ─── Render helpers ──────────────────────────────────────────────────
 
   const derivedLabel = useDerivedModeLabel(state, sourceTask);
@@ -283,6 +306,7 @@ export function Composer({ onSubmitted }: Props = {}) {
       {/* ─── Prompt + submit ─────────────────────────────────────────── */}
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <textarea
+          ref={textareaRef}
           data-testid="composer-prompt"
           className="min-h-[72px] resize-y border border-input bg-transparent px-3 py-2 text-sm font-mono outline-none focus:border-ring"
           placeholder={promptPlaceholder(state)}

--- a/src/lib/shortcuts.test.tsx
+++ b/src/lib/shortcuts.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { matchShortcut, useGlobalShortcut } from './shortcuts';
+
+function setPlatform(platform: string) {
+  Object.defineProperty(window.navigator, 'platform', { value: platform, configurable: true });
+}
+
+afterEach(() => {
+  setPlatform('MacIntel');
+});
+
+describe('matchShortcut', () => {
+  it.each([
+    {
+      name: 'mac: meta+k matches',
+      platform: 'MacIntel',
+      event: { key: 'k', metaKey: true },
+      spec: { key: 'k', mod: true },
+      expected: true,
+    },
+    {
+      name: 'mac: ctrl+k does NOT match mod',
+      platform: 'MacIntel',
+      event: { key: 'k', ctrlKey: true },
+      spec: { key: 'k', mod: true },
+      expected: false,
+    },
+    {
+      name: 'linux: ctrl+k matches mod',
+      platform: 'Linux x86_64',
+      event: { key: 'k', ctrlKey: true },
+      spec: { key: 'k', mod: true },
+      expected: true,
+    },
+    {
+      name: 'linux: meta+k does NOT match mod',
+      platform: 'Win32',
+      event: { key: 'k', metaKey: true },
+      spec: { key: 'k', mod: true },
+      expected: false,
+    },
+    {
+      name: 'case-insensitive key (Shift+K)',
+      platform: 'MacIntel',
+      event: { key: 'K', metaKey: true, shiftKey: true },
+      spec: { key: 'n', mod: true, shift: true }, // different key → false
+      expected: false,
+    },
+    {
+      name: 'case-insensitive key (K matches k)',
+      platform: 'MacIntel',
+      event: { key: 'K', metaKey: true, shiftKey: true },
+      spec: { key: 'k', mod: true, shift: true },
+      expected: true,
+    },
+    {
+      name: 'shift required but not pressed',
+      platform: 'MacIntel',
+      event: { key: 'n', metaKey: true },
+      spec: { key: 'n', mod: true, shift: true },
+      expected: false,
+    },
+    {
+      name: 'shift pressed but not required → reject (strict match)',
+      platform: 'MacIntel',
+      event: { key: 'k', metaKey: true, shiftKey: true },
+      spec: { key: 'k', mod: true },
+      expected: false,
+    },
+    {
+      name: 'alt required',
+      platform: 'MacIntel',
+      event: { key: 'a', metaKey: true, altKey: true },
+      spec: { key: 'a', mod: true, alt: true },
+      expected: true,
+    },
+    {
+      name: 'no mod required, plain Enter',
+      platform: 'MacIntel',
+      event: { key: 'Enter' },
+      spec: { key: 'Enter' },
+      expected: true,
+    },
+    {
+      name: 'ArrowDown with cmd on mac',
+      platform: 'MacIntel',
+      event: { key: 'ArrowDown', metaKey: true },
+      spec: { key: 'ArrowDown', mod: true },
+      expected: true,
+    },
+  ])('$name', ({ platform, event, spec, expected }) => {
+    setPlatform(platform);
+    const ke = new KeyboardEvent('keydown', {
+      key: event.key,
+      metaKey: event.metaKey ?? false,
+      ctrlKey: event.ctrlKey ?? false,
+      shiftKey: event.shiftKey ?? false,
+      altKey: event.altKey ?? false,
+    });
+    expect(matchShortcut(ke, spec)).toBe(expected);
+  });
+});
+
+describe('useGlobalShortcut', () => {
+  beforeEach(() => setPlatform('MacIntel'));
+
+  function Harness({ onFire }: { onFire: (e: KeyboardEvent) => void }) {
+    useGlobalShortcut({ key: 'k', mod: true }, onFire);
+    return null;
+  }
+
+  function dispatchCmdK() {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+  }
+
+  it('installs on mount and fires handler', () => {
+    const fn = vi.fn();
+    render(<Harness onFire={fn} />);
+    dispatchCmdK();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes listener on unmount — handler not called after unmount', () => {
+    const fn = vi.fn();
+    const { unmount } = render(<Harness onFire={fn} />);
+    unmount();
+    dispatchCmdK();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-matching events', () => {
+    const fn = vi.fn();
+    render(<Harness onFire={fn} />);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'j', metaKey: true }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k' })); // no mod
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest handler without rebinding', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    function H({ h }: { h: (e: KeyboardEvent) => void }) {
+      useGlobalShortcut({ key: 'k', mod: true }, h);
+      return null;
+    }
+    const { rerender } = render(<H h={a} />);
+    dispatchCmdK();
+    rerender(<H h={b} />);
+    dispatchCmdK();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+
+export interface ShortcutKeys {
+  /** KeyboardEvent.key value — matched case-insensitively. */
+  key: string;
+  /** ⌘ on Mac, Ctrl elsewhere. */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /mac/i.test(navigator.platform) || /Mac/i.test(navigator.userAgent);
+}
+
+export function matchShortcut(e: KeyboardEvent, keys: ShortcutKeys): boolean {
+  const modPressed = isMac() ? e.metaKey : e.ctrlKey;
+  const otherModPressed = isMac() ? e.ctrlKey : e.metaKey;
+  const modRequired = !!keys.mod;
+  if (modRequired !== modPressed) return false;
+  if (modRequired && otherModPressed) return false;
+  if ((keys.shift ?? false) !== e.shiftKey) return false;
+  if ((keys.alt ?? false) !== e.altKey) return false;
+
+  return e.key.toLowerCase() === keys.key.toLowerCase();
+}
+
+export function useGlobalShortcut(
+  keys: ShortcutKeys,
+  handler: (e: KeyboardEvent) => void,
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const { key, mod, shift, alt } = keys;
+  useEffect(() => {
+    const spec = { key, mod, shift, alt };
+    const listener = (e: KeyboardEvent) => {
+      if (matchShortcut(e, spec)) {
+        handlerRef.current(e);
+      }
+    };
+    window.addEventListener('keydown', listener, { capture: true });
+    return () => window.removeEventListener('keydown', listener, { capture: true });
+  }, [key, mod, shift, alt]);
+}

--- a/src/lib/sidebar-nav.test.tsx
+++ b/src/lib/sidebar-nav.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  currentTaskIdFromPath,
+  getNextSessionId,
+  readCollapsedGroups,
+  visibleSessionIds,
+  GROUP_COLLAPSE_PREFIX,
+} from './sidebar-nav';
+import type { SidebarGroup } from './sidebar-utils';
+
+const group = (key: string, ids: string[]): SidebarGroup => ({
+  key,
+  repo: key,
+  items: ids.map((id) => ({
+    id,
+    title: id,
+    status: 'running',
+    derivedStatus: null,
+    runMode: 'new',
+    repoPath: key,
+  })),
+});
+
+describe('currentTaskIdFromPath', () => {
+  it.each([
+    { path: '/tasks/abc', expected: 'abc' },
+    { path: '/tasks/abc/something', expected: 'abc' },
+    { path: '/', expected: null },
+    { path: '/tasks', expected: null },
+    { path: '/orchestrator', expected: null },
+  ])('$path → $expected', ({ path, expected }) => {
+    expect(currentTaskIdFromPath(path)).toBe(expected);
+  });
+});
+
+describe('visibleSessionIds', () => {
+  it('returns every id when no group collapsed', () => {
+    const groups = [group('r1', ['a', 'b']), group('r2', ['c'])];
+    expect(visibleSessionIds(groups, {})).toEqual(['a', 'b', 'c']);
+  });
+
+  it('skips items in collapsed groups', () => {
+    const groups = [group('r1', ['a', 'b']), group('r2', ['c'])];
+    expect(visibleSessionIds(groups, { r1: true })).toEqual(['c']);
+  });
+
+  it('returns empty when every group collapsed', () => {
+    const groups = [group('r1', ['a']), group('r2', ['b'])];
+    expect(visibleSessionIds(groups, { r1: true, r2: true })).toEqual([]);
+  });
+});
+
+describe('getNextSessionId', () => {
+  const ids = ['a', 'b', 'c'];
+
+  it.each([
+    { name: 'next from a', current: 'a', dir: 'next', expected: 'b' },
+    { name: 'next from c wraps to a', current: 'c', dir: 'next', expected: 'a' },
+    { name: 'prev from a wraps to c', current: 'a', dir: 'prev', expected: 'c' },
+    { name: 'prev from b → a', current: 'b', dir: 'prev', expected: 'a' },
+    { name: 'no current + next → first', current: null, dir: 'next', expected: 'a' },
+    { name: 'no current + prev → last', current: null, dir: 'prev', expected: 'c' },
+    { name: 'unknown current + next → first', current: 'ghost', dir: 'next', expected: 'a' },
+    { name: 'unknown current + prev → last', current: 'ghost', dir: 'prev', expected: 'c' },
+  ] as const)('$name', ({ current, dir, expected }) => {
+    expect(getNextSessionId(ids, current, dir)).toBe(expected);
+  });
+
+  it('returns null when list is empty', () => {
+    expect(getNextSessionId([], 'x', 'next')).toBeNull();
+    expect(getNextSessionId([], null, 'prev')).toBeNull();
+  });
+});
+
+describe('readCollapsedGroups', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('reads per-group flag from localStorage', () => {
+    localStorage.setItem(GROUP_COLLAPSE_PREFIX + 'r1', 'true');
+    const groups = [group('r1', ['a']), group('r2', ['b'])];
+    expect(readCollapsedGroups(groups)).toEqual({ r1: true, r2: false });
+  });
+});

--- a/src/lib/sidebar-nav.ts
+++ b/src/lib/sidebar-nav.ts
@@ -1,0 +1,51 @@
+import type { SidebarGroup } from './sidebar-utils';
+
+export const GROUP_COLLAPSE_PREFIX = 'octomux:sidebar:collapsed:';
+
+/** Read per-group collapsed state from localStorage. Mirrors UniversalSidebar. */
+export function isGroupCollapsed(groupKey: string): boolean {
+  try {
+    return localStorage.getItem(GROUP_COLLAPSE_PREFIX + groupKey) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Build a `{groupKey -> collapsed}` map for all groups from localStorage. */
+export function readCollapsedGroups(groups: SidebarGroup[]): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const g of groups) out[g.key] = isGroupCollapsed(g.key);
+  return out;
+}
+
+/** Flattened list of session IDs that are currently visible (ignores collapsed groups). */
+export function visibleSessionIds(
+  groups: SidebarGroup[],
+  collapsedGroups: Record<string, boolean>,
+): string[] {
+  const ids: string[] = [];
+  for (const group of groups) {
+    if (collapsedGroups[group.key]) continue;
+    for (const item of group.items) ids.push(item.id);
+  }
+  return ids;
+}
+
+export function getNextSessionId(
+  ids: string[],
+  currentId: string | null,
+  direction: 'next' | 'prev',
+): string | null {
+  if (ids.length === 0) return null;
+  const idx = currentId ? ids.indexOf(currentId) : -1;
+  if (idx === -1) {
+    return direction === 'next' ? ids[0] : ids[ids.length - 1];
+  }
+  if (direction === 'next') return ids[(idx + 1) % ids.length];
+  return ids[(idx - 1 + ids.length) % ids.length];
+}
+
+export function currentTaskIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/tasks\/([^/]+)/);
+  return match?.[1] ?? null;
+}


### PR DESCRIPTION
## What

- Platform-normalized shortcut matcher + `useGlobalShortcut` hook
  (`src/lib/shortcuts.ts`) — ⌘ on Mac, Ctrl elsewhere; rejects
  wrong-OS modifier.
- `⌘K` command palette with fuzzy session search, arrow/Enter/Esc
  navigation, backdrop-close (`src/components/CommandPalette.tsx`).
- `⌘↑ / ⌘↓` cycles visible sidebar rows, respecting per-group
  collapsed state in localStorage (`src/lib/sidebar-nav.ts`). Wraps
  at both ends; falls back to first/last from non-task routes.
- `⌘⇧N` replace-navigates to `/` and dispatches `focus-composer` so
  the textarea re-focuses on a fresh empty composer.
- `⌘Enter` on `/` dispatches `submit-composer` which Composer
  forwards to its existing submit flow. No-ops on other routes and
  while the palette is open.
- All global listeners install at window \`{capture: true}\` so xterm
  inside a focused terminal doesn't swallow the keypress.

## Why

No keyboard-first navigation existed. This lands the first system-wide
wiring — a palette for jump-to-session, hotkeys for sidebar traversal,
and a "fresh compose" path that bypasses mouse-driven URL wiping.
`⌘1..⌘9` slot bindings are deliberately deferred until sidebar
ordering is stable.

## Testing

- 50 new unit tests:
  - `shortcuts.test.tsx` — matcher across Mac/Linux/Windows, modifier
    combos, case-insensitive key, hook mount/unmount/rebind.
  - `sidebar-nav.test.tsx` — visible-rows selector, next/prev wrapping,
    current-row detection from pathname, collapsed-group reading.
  - `CommandPalette.test.tsx` — role=dialog + aria-modal, filter,
    arrow/Enter/Esc/backdrop behavior, focus-terminal dispatch.
  - `App.shortcuts.test.tsx` — integration: ⌘K opens + preempts
    terminal-focused input, ⌘⇧N fires focus-composer, ⌘Enter gated
    on \`/\`, ⌘↑/⌘↓ navigate.
  - `Composer.test.tsx` — mount-focus, focus-composer + submit-composer
    bridges.
- \`bun run lint\` → 0 errors (pre-existing warnings only).
- \`bun run typecheck\` → clean.
- \`bun run test\` → 1111 tests pass (54 files).