### PR TITLE
feat(ui): sessions inbox on Home — needs-you + activity buckets

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -284,6 +284,67 @@ describe('GET /api/tasks', () => {
   });
 });
 
+// ─── Inbox ──────────────────────────────────────────────────────────────────
+
+describe('GET /api/tasks/inbox', () => {
+  it('returns both buckets', async () => {
+    const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+    insertTask(db, { id: 'err', status: 'error', last_viewed_at: null, updated_at: now });
+    insertTask(db, { id: 'closed', status: 'closed', last_viewed_at: null, updated_at: now });
+
+    const res = await request(app).get('/api/tasks/inbox');
+    expect(res.status).toBe(200);
+    expect(res.body.needs_you.map((t: Task) => t.id)).toEqual(['err']);
+    expect(res.body.activity.map((t: Task) => t.id)).toEqual(['closed']);
+  });
+
+  it('returns empty arrays when no tasks match', async () => {
+    const res = await request(app).get('/api/tasks/inbox');
+    expect(res.body).toEqual({ needs_you: [], activity: [] });
+  });
+});
+
+describe('PATCH /api/tasks/:id/viewed', () => {
+  it('sets last_viewed_at on the task', async () => {
+    insertTask(db);
+    const before = getTask(db, DEFAULTS.task.id);
+    expect(before?.last_viewed_at).toBeNull();
+
+    const res = await request(app).patch(`/api/tasks/${DEFAULTS.task.id}/viewed`);
+    expect(res.status).toBe(200);
+    expect(res.body.last_viewed_at).toBeTruthy();
+
+    const after = getTask(db, DEFAULTS.task.id);
+    expect(after?.last_viewed_at).toBeTruthy();
+  });
+
+  it('returns 404 for missing task', async () => {
+    const res = await request(app).patch('/api/tasks/nope/viewed');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/tasks/viewed-all', () => {
+  it('marks every task as viewed and reports count', async () => {
+    insertTask(db, { id: 'a' });
+    insertTask(db, { id: 'b' });
+    insertTask(db, { id: 'c' });
+
+    const res = await request(app).post('/api/tasks/viewed-all');
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(3);
+
+    for (const id of ['a', 'b', 'c']) {
+      expect(getTask(db, id)?.last_viewed_at).toBeTruthy();
+    }
+  });
+
+  it('returns 0 when no tasks', async () => {
+    const res = await request(app).post('/api/tasks/viewed-all');
+    expect(res.body.updated).toBe(0);
+  });
+});
+
 // ─── GET /api/tasks/:id ──────────────────────────────────────────────────────
 
 describe('GET /api/tasks/:id', () => {

--- a/server/api.ts
+++ b/server/api.ts
@@ -6,6 +6,8 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { getDb } from './db.js';
+import { childLogger } from './logger.js';
+import { getNeedsYou, getActivity } from './inbox.js';
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import {
@@ -61,6 +63,7 @@ import type {
 import { RUN_MODES } from './types.js';
 
 const execFile = promisify(execFileCb);
+const apiLogger = childLogger('api');
 
 const TERMINALS_BY_TASK_SQL =
   'SELECT * FROM user_terminals WHERE task_id = ? ORDER BY window_index';
@@ -321,6 +324,33 @@ export function setupRoutes(app: Express): void {
     });
 
     res.json(result);
+  });
+
+  // Inbox: tasks needing attention + recent activity
+  app.get('/api/tasks/inbox', (_req: Request, res: Response) => {
+    res.json({ needs_you: getNeedsYou(), activity: getActivity() });
+  });
+
+  // Mark all tasks viewed
+  app.post('/api/tasks/viewed-all', (_req: Request, res: Response) => {
+    const db = getDb();
+    const info = db.prepare(`UPDATE tasks SET last_viewed_at = datetime('now')`).run();
+    apiLogger.info(
+      { operation: 'marked_all_viewed', updated: info.changes },
+      'marked all tasks viewed',
+    );
+    res.json({ updated: info.changes });
+  });
+
+  // Mark a single task viewed
+  app.patch('/api/tasks/:id/viewed', (req: Request, res: Response) => {
+    const task = loadTaskOrFail(req, res);
+    if (!task) return;
+    const db = getDb();
+    db.prepare(`UPDATE tasks SET last_viewed_at = datetime('now') WHERE id = ?`).run(task.id);
+    apiLogger.info({ task_id: task.id, operation: 'marked_viewed' }, 'marked task viewed');
+    const updated = db.prepare('SELECT * FROM tasks WHERE id = ?').get(task.id) as Task;
+    res.json(updated);
   });
 
   // Get single task with agents

--- a/server/inbox.test.ts
+++ b/server/inbox.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTestDb, insertTask, insertPermissionPrompt, DEFAULTS } from './test-helpers.js';
+import { getNeedsYou, getActivity } from './inbox.js';
+
+describe('inbox queries', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('getNeedsYou', () => {
+    it('returns task with a pending permission prompt', () => {
+      insertTask(db, { id: 'task-pp', status: 'running' });
+      insertPermissionPrompt(db, {
+        id: 'pp1',
+        task_id: 'task-pp',
+        agent_id: null,
+        status: 'pending',
+      });
+
+      const rows = getNeedsYou();
+      expect(rows.map((t) => t.id)).toContain('task-pp');
+    });
+
+    it('returns errored + unviewed task', () => {
+      insertTask(db, {
+        id: 'task-err',
+        status: 'error',
+        last_viewed_at: null,
+        updated_at: '2026-04-23 10:00:00',
+      });
+
+      const rows = getNeedsYou();
+      expect(rows.map((t) => t.id)).toContain('task-err');
+    });
+
+    it('returns errored task whose view is stale (viewed before latest update)', () => {
+      insertTask(db, {
+        id: 'task-err-stale',
+        status: 'error',
+        last_viewed_at: '2026-04-20 10:00:00',
+        updated_at: '2026-04-23 10:00:00',
+      });
+
+      const rows = getNeedsYou();
+      expect(rows.map((t) => t.id)).toContain('task-err-stale');
+    });
+
+    it('omits errored task that has been viewed since update', () => {
+      insertTask(db, {
+        id: 'task-err-viewed',
+        status: 'error',
+        last_viewed_at: '2026-04-23 11:00:00',
+        updated_at: '2026-04-23 10:00:00',
+      });
+
+      const rows = getNeedsYou();
+      expect(rows.map((t) => t.id)).not.toContain('task-err-viewed');
+    });
+
+    it('omits running task with no pending prompts and no error', () => {
+      insertTask(db, { id: 'task-run', status: 'running' });
+      const rows = getNeedsYou();
+      expect(rows.map((t) => t.id)).not.toContain('task-run');
+    });
+
+    it('does not double-count when a task has multiple pending prompts', () => {
+      insertTask(db, { id: 'task-many-pp', status: 'running' });
+      insertPermissionPrompt(db, {
+        id: 'pp-a',
+        task_id: 'task-many-pp',
+        agent_id: null,
+        status: 'pending',
+      });
+      insertPermissionPrompt(db, {
+        id: 'pp-b',
+        task_id: 'task-many-pp',
+        agent_id: null,
+        status: 'pending',
+      });
+      const rows = getNeedsYou();
+      expect(rows.filter((t) => t.id === 'task-many-pp')).toHaveLength(1);
+    });
+
+    it('orders by updated_at DESC', () => {
+      insertTask(db, {
+        id: 'task-old',
+        status: 'error',
+        updated_at: '2026-04-20 00:00:00',
+      });
+      insertTask(db, {
+        id: 'task-new',
+        status: 'error',
+        updated_at: '2026-04-23 00:00:00',
+      });
+      const rows = getNeedsYou();
+      expect(rows[0].id).toBe('task-new');
+      expect(rows[1].id).toBe('task-old');
+    });
+  });
+
+  describe('getActivity', () => {
+    it('returns closed + unviewed task within 7 days', () => {
+      insertTask(db, {
+        id: 'task-closed',
+        status: 'closed',
+        last_viewed_at: null,
+        updated_at: new Date().toISOString().slice(0, 19).replace('T', ' '),
+      });
+      const rows = getActivity();
+      expect(rows.map((t) => t.id)).toContain('task-closed');
+    });
+
+    it('omits closed task older than 7 days', () => {
+      insertTask(db, {
+        id: 'task-stale',
+        status: 'closed',
+        last_viewed_at: null,
+        updated_at: '2026-04-01 00:00:00',
+      });
+      const rows = getActivity();
+      expect(rows.map((t) => t.id)).not.toContain('task-stale');
+    });
+
+    it('omits closed task that has been viewed since update', () => {
+      const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+      insertTask(db, {
+        id: 'task-seen',
+        status: 'closed',
+        updated_at: now,
+        last_viewed_at: '2099-01-01 00:00:00',
+      });
+      const rows = getActivity();
+      expect(rows.map((t) => t.id)).not.toContain('task-seen');
+    });
+
+    it('omits running tasks', () => {
+      const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+      insertTask(db, {
+        id: 'task-run',
+        status: 'running',
+        updated_at: now,
+        last_viewed_at: null,
+      });
+      const rows = getActivity();
+      expect(rows.map((t) => t.id)).not.toContain('task-run');
+    });
+
+    it('omits errored tasks (they belong in needs-you)', () => {
+      const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+      insertTask(db, {
+        id: 'task-err',
+        status: 'error',
+        updated_at: now,
+        last_viewed_at: null,
+      });
+      const rows = getActivity();
+      expect(rows.map((t) => t.id)).not.toContain('task-err');
+    });
+
+    it('omits task that also has pending permission prompt (needs-you wins)', () => {
+      const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+      insertTask(db, {
+        id: 'task-both',
+        status: 'closed',
+        updated_at: now,
+        last_viewed_at: null,
+      });
+      insertPermissionPrompt(db, {
+        id: 'pp-x',
+        task_id: 'task-both',
+        agent_id: null,
+        status: 'pending',
+      });
+
+      expect(getNeedsYou().map((t) => t.id)).toContain('task-both');
+      expect(getActivity().map((t) => t.id)).not.toContain('task-both');
+    });
+
+    it('caps at 50 rows', () => {
+      const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+      for (let i = 0; i < 60; i++) {
+        insertTask(db, {
+          id: `task-${i}`,
+          status: 'closed',
+          updated_at: now,
+          last_viewed_at: null,
+        });
+      }
+      const rows = getActivity();
+      expect(rows).toHaveLength(50);
+    });
+
+    it('uses default fixture shape', () => {
+      // Sanity: DEFAULTS exposes last_viewed_at as null
+      expect(DEFAULTS.task.last_viewed_at).toBeNull();
+    });
+  });
+});

--- a/server/inbox.ts
+++ b/server/inbox.ts
@@ -1,0 +1,47 @@
+import { getDb } from './db.js';
+import type { Task } from './types.js';
+
+/**
+ * Tasks that need the user's attention right now: pending permission prompts,
+ * or errored tasks whose error hasn't been viewed.
+ */
+export function getNeedsYou(): Task[] {
+  return getDb()
+    .prepare(
+      `SELECT DISTINCT t.*
+       FROM tasks t
+       WHERE (
+         EXISTS (
+           SELECT 1 FROM permission_prompts pp
+           WHERE pp.task_id = t.id AND pp.status = 'pending'
+         )
+       ) OR (
+         t.status = 'error'
+         AND (t.last_viewed_at IS NULL OR t.last_viewed_at < t.updated_at)
+       )
+       ORDER BY t.updated_at DESC`,
+    )
+    .all() as Task[];
+}
+
+/**
+ * Closed tasks from the last 7 days that the user hasn't seen since they were
+ * updated. Excludes anything already in the needs-you bucket.
+ */
+export function getActivity(): Task[] {
+  return getDb()
+    .prepare(
+      `SELECT t.*
+       FROM tasks t
+       WHERE t.status = 'closed'
+         AND (t.last_viewed_at IS NULL OR t.last_viewed_at < t.updated_at)
+         AND t.updated_at > datetime('now', '-7 days')
+         AND NOT EXISTS (
+           SELECT 1 FROM permission_prompts pp
+           WHERE pp.task_id = t.id AND pp.status = 'pending'
+         )
+       ORDER BY t.updated_at DESC
+       LIMIT 50`,
+    )
+    .all() as Task[];
+}

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -171,7 +171,9 @@ export function getAgents(db: Database.Database, taskId: string): Agent[] {
 
 export function insertPermissionPrompt(
   db: Database.Database,
-  overrides: Partial<typeof DEFAULTS.permissionPrompt> = {},
+  overrides: Partial<Omit<typeof DEFAULTS.permissionPrompt, 'agent_id'>> & {
+    agent_id?: string | null;
+  } = {},
 ) {
   const pp = { ...DEFAULTS.permissionPrompt, ...overrides };
   db.prepare(

--- a/src/components/SessionsInbox.test.tsx
+++ b/src/components/SessionsInbox.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { SessionsInbox } from './SessionsInbox';
+import { _resetInboxStore } from '@/lib/inbox';
+import { makeTask } from '../test-helpers';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+const eventCallbacks: Set<(event: any) => void> = new Set();
+const unsubscribe = vi.fn();
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn((cb: (event: any) => void) => {
+    eventCallbacks.add(cb);
+    return () => {
+      eventCallbacks.delete(cb);
+      unsubscribe();
+    };
+  }),
+}));
+
+function fireEvent(event: any): void {
+  for (const cb of eventCallbacks) cb(event);
+}
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function renderInbox() {
+  return render(
+    <MemoryRouter>
+      <SessionsInbox />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetInboxStore();
+  eventCallbacks.clear();
+  mockNavigate.mockReset();
+  apiMock.getInbox.mockResolvedValue({ needs_you: [], activity: [] });
+});
+
+afterEach(() => {
+  _resetInboxStore();
+});
+
+describe('SessionsInbox', () => {
+  it('renders "caught up" when both sections empty', async () => {
+    renderInbox();
+    await waitFor(() => expect(screen.getByTestId('inbox-empty')).toBeInTheDocument());
+    expect(screen.queryByTestId('inbox-section-needs_you')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-section-activity')).not.toBeInTheDocument();
+  });
+
+  it('renders Needs you and Activity sections with rows', async () => {
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [makeTask({ id: 'n1', title: 'Auth Rewrite', status: 'error' })],
+      activity: [makeTask({ id: 'a1', title: 'Feature XYZ', status: 'closed' })],
+    });
+
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByTestId('inbox-row-n1')).toBeInTheDocument());
+    expect(screen.getByTestId('inbox-row-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-section-needs_you')).toHaveTextContent(/needs you/i);
+    expect(screen.getByTestId('inbox-section-activity')).toHaveTextContent(/activity/i);
+    expect(screen.queryByTestId('inbox-empty')).not.toBeInTheDocument();
+  });
+
+  it('hides a section when it is empty but shows the other', async () => {
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [],
+      activity: [makeTask({ id: 'a1', status: 'closed' })],
+    });
+
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByTestId('inbox-section-activity')).toBeInTheDocument());
+    expect(screen.queryByTestId('inbox-section-needs_you')).not.toBeInTheDocument();
+  });
+
+  it('clicking a row navigates to the task', async () => {
+    const user = userEvent.setup();
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [makeTask({ id: 'n1' })],
+      activity: [],
+    });
+
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByTestId('inbox-row-n1')).toBeInTheDocument());
+    await user.click(screen.getByTestId('inbox-row-n1'));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks/n1');
+  });
+
+  it('mark-all-read calls API and refetches', async () => {
+    const user = userEvent.setup();
+    apiMock.getInbox
+      .mockResolvedValueOnce({ needs_you: [makeTask({ id: 'n1' })], activity: [] })
+      .mockResolvedValueOnce({ needs_you: [], activity: [] });
+
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByTestId('inbox-mark-all-read')).toBeInTheDocument());
+    await user.click(screen.getByTestId('inbox-mark-all-read'));
+
+    expect(apiMock.markAllTasksViewed).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('inbox-empty')).toBeInTheDocument());
+  });
+
+  it('refetches when a task:* WebSocket event fires (debounced)', async () => {
+    vi.useFakeTimers();
+    try {
+      apiMock.getInbox.mockResolvedValue({ needs_you: [], activity: [] });
+      renderInbox();
+
+      await vi.waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(1));
+
+      // Fire several events rapidly
+      act(() => {
+        fireEvent({ type: 'task:updated', payload: { taskId: 't1' } });
+        fireEvent({ type: 'task:updated', payload: { taskId: 't2' } });
+        fireEvent({ type: 'task:created', payload: { taskId: 't3' } });
+      });
+
+      // Still only the initial call until the debounce expires
+      expect(apiMock.getInbox).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -1,0 +1,125 @@
+import { useNavigate } from 'react-router-dom';
+import type { Task } from '../../server/types';
+import { useInbox } from '@/lib/inbox';
+import { timeAgo } from '@/lib/time';
+import { repoName } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+
+type RowKind = 'needs_you' | 'activity';
+
+function pendingPromptCount(task: Task): number {
+  return (task.pending_prompts?.length ?? 0) as number;
+}
+
+function subtitleFor(task: Task, kind: RowKind): string {
+  if (kind === 'activity') return 'closed';
+  if (task.status === 'error') return task.error ? `errored · ${task.error}` : 'errored';
+  const prompts = pendingPromptCount(task);
+  if (prompts > 0)
+    return prompts === 1 ? 'permission prompt open' : `${prompts} permission prompts`;
+  return 'needs attention';
+}
+
+function Glyph({ kind, task }: { kind: RowKind; task: Task }) {
+  if (kind === 'needs_you') {
+    const isError = task.status === 'error';
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          'inline-flex h-4 w-4 items-center justify-center text-sm',
+          isError ? 'text-[#EF4444]' : 'text-[#FFB800]',
+        )}
+      >
+        {isError ? '✕' : '⚠'}
+      </span>
+    );
+  }
+  return (
+    <span aria-hidden className="inline-flex h-4 w-4 items-center justify-center text-[#22C55E]">
+      ✓
+    </span>
+  );
+}
+
+function InboxRow({ task, kind }: { task: Task; kind: RowKind }) {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      data-testid={`inbox-row-${task.id}`}
+      onClick={() => navigate(`/tasks/${task.id}`)}
+      className="group flex w-full items-center gap-3 rounded border border-transparent px-3 py-2 text-left transition-colors hover:border-[#2f2f2f] hover:bg-[#141414]"
+    >
+      <Glyph kind={kind} task={task} />
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="truncate text-sm font-medium text-foreground">{task.title}</span>
+        <span className="truncate text-xs text-muted-foreground">{subtitleFor(task, kind)}</span>
+      </span>
+      <span className="shrink-0 text-[11px] text-[#6a6a6a]">
+        {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
+      </span>
+    </button>
+  );
+}
+
+function Section({ title, tasks, kind }: { title: string; tasks: Task[]; kind: RowKind }) {
+  if (tasks.length === 0) return null;
+  return (
+    <section data-testid={`inbox-section-${kind}`} className="flex flex-col gap-1">
+      <h3 className="px-3 text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+        {title}
+      </h3>
+      <div className="flex flex-col">
+        {tasks.map((t) => (
+          <InboxRow key={t.id} task={t} kind={kind} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function SessionsInbox() {
+  const { needsYou, activity, loading, error, markAllRead } = useInbox();
+  const isEmpty = !loading && needsYou.length === 0 && activity.length === 0;
+
+  return (
+    <div data-testid="sessions-inbox" className="flex flex-col gap-6">
+      <div className="flex items-baseline justify-between px-3">
+        <h2 className="font-display text-sm font-bold uppercase tracking-wider text-[#6a6a6a]">
+          Sessions
+        </h2>
+        {(needsYou.length > 0 || activity.length > 0) && (
+          <button
+            type="button"
+            data-testid="inbox-mark-all-read"
+            onClick={() => void markAllRead()}
+            className="text-[11px] font-medium text-[#8a8a8a] hover:text-foreground"
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <p data-testid="inbox-error" className="px-3 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+
+      {isEmpty ? (
+        <p
+          data-testid="inbox-empty"
+          className="px-3 py-8 text-center text-sm text-muted-foreground"
+        >
+          You&rsquo;re all caught up
+        </p>
+      ) : (
+        <>
+          <Section title="Needs you" tasks={needsYou} kind="needs_you" />
+          <Section title="Activity" tasks={activity} kind="activity" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -135,10 +135,18 @@ export interface FileDiffResponse {
   binary: boolean;
 }
 
+export interface InboxResponse {
+  needs_you: Task[];
+  activity: Task[];
+}
+
 export const api = {
   browse: (path?: string) =>
     request<BrowseResult>(`/browse${path ? `?path=${encodeURIComponent(path)}` : ''}`),
   recentRepos: () => request<RecentRepo[]>('/recent-repos'),
+  getInbox: () => request<InboxResponse>('/tasks/inbox'),
+  markTaskViewed: (id: string) => request<Task>(`/tasks/${id}/viewed`, { method: 'PATCH' }),
+  markAllTasksViewed: () => request<{ updated: number }>('/tasks/viewed-all', { method: 'POST' }),
   listBranches: (repoPath: string) =>
     request<string[]>(`/branches?repo_path=${encodeURIComponent(repoPath)}`),
   getDefaultBranch: (repoPath: string) =>

--- a/src/lib/inbox.test.tsx
+++ b/src/lib/inbox.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act, render } from '@testing-library/react';
+import { useInbox, _resetInboxStore } from './inbox';
+import { TasksProvider } from './tasks-context';
+import { makeTask } from '../test-helpers';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('./api', () => ({ api: apiProxy }));
+
+const eventCallbacks: Set<(event: any) => void> = new Set();
+const unsubscribe = vi.fn();
+vi.mock('./event-source', () => ({
+  subscribe: vi.fn((cb: (event: any) => void) => {
+    eventCallbacks.add(cb);
+    return () => {
+      eventCallbacks.delete(cb);
+      unsubscribe();
+    };
+  }),
+}));
+
+function fireEvent(event: any): void {
+  for (const cb of eventCallbacks) cb(event);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetInboxStore();
+  eventCallbacks.clear();
+  apiMock.getInbox.mockResolvedValue({ needs_you: [], activity: [] });
+});
+
+afterEach(() => {
+  _resetInboxStore();
+});
+
+describe('useInbox', () => {
+  it('fetches inbox on mount', async () => {
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [makeTask({ id: 'n1' })],
+      activity: [],
+    });
+
+    const { result } = renderHook(() => useInbox());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.needsYou).toHaveLength(1);
+    expect(result.current.needsYou[0].id).toBe('n1');
+  });
+
+  it('sets error on fetch failure', async () => {
+    apiMock.getInbox.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useInbox());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('boom');
+  });
+
+  it('debounces rapid WebSocket events into a single refetch', async () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useInbox());
+
+      await vi.waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        fireEvent({ type: 'task:updated', payload: { taskId: 't1' } });
+        fireEvent({ type: 'task:updated', payload: { taskId: 't2' } });
+        fireEvent({ type: 'task:deleted', payload: { taskId: 't3' } });
+      });
+
+      expect(apiMock.getInbox).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('markAllRead hits the API and triggers a refetch', async () => {
+    const { result } = renderHook(() => useInbox());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    apiMock.getInbox.mockClear();
+
+    await act(async () => {
+      await result.current.markAllRead();
+    });
+
+    expect(apiMock.markAllTasksViewed).toHaveBeenCalledTimes(1);
+    expect(apiMock.getInbox).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-render unrelated TasksProvider consumers on inbox updates', async () => {
+    // An unrelated component that reads TasksProvider state.
+    let unrelatedRenderCount = 0;
+    function Unrelated() {
+      unrelatedRenderCount++;
+      return <div data-testid="unrelated">unrelated</div>;
+    }
+
+    let inboxRenderCount = 0;
+    function InboxConsumer() {
+      useInbox();
+      inboxRenderCount++;
+      return <div data-testid="inbox-consumer">inbox</div>;
+    }
+
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [makeTask({ id: 'n1' })],
+      activity: [],
+    });
+
+    render(
+      <TasksProvider>
+        <Unrelated />
+        <InboxConsumer />
+      </TasksProvider>,
+    );
+
+    // Wait until the initial inbox fetch has settled and rendered
+    await waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(inboxRenderCount).toBeGreaterThanOrEqual(2));
+
+    const unrelatedBaseline = unrelatedRenderCount;
+    const inboxBaseline = inboxRenderCount;
+
+    expect(eventCallbacks.size).toBeGreaterThan(0);
+
+    // Queue up a new payload for the next fetch
+    apiMock.getInbox.mockResolvedValueOnce({
+      needs_you: [makeTask({ id: 'n2' })],
+      activity: [],
+    });
+
+    // Fire a WS event → debounced refetch
+    act(() => {
+      fireEvent({ type: 'task:updated', payload: { taskId: 'x' } });
+    });
+
+    await waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(2), { timeout: 2000 });
+    await waitFor(() => expect(inboxRenderCount).toBeGreaterThan(inboxBaseline));
+
+    // The unrelated consumer must NOT have re-rendered due to the inbox change.
+    expect(unrelatedRenderCount).toBe(unrelatedBaseline);
+  });
+});

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import type { Task } from '../../server/types';
+import { api } from './api';
+import { subscribe as subscribeEvents } from './event-source';
+
+/**
+ * Lightweight external store for inbox data. Keeping it outside React's
+ * context tree is deliberate: `SessionsInbox` is the only consumer, so an
+ * isolated store means unrelated components (sidebar, task list) never
+ * re-render when inbox state changes — even though they share the same
+ * underlying WebSocket stream.
+ */
+
+export interface InboxState {
+  needsYou: Task[];
+  activity: Task[];
+  loading: boolean;
+  error: string | null;
+}
+
+type Listener = () => void;
+
+let state: InboxState = {
+  needsYou: [],
+  activity: [],
+  loading: true,
+  error: null,
+};
+
+const listeners = new Set<Listener>();
+
+function setState(next: Partial<InboxState>): void {
+  state = { ...state, ...next };
+  for (const cb of listeners) cb();
+}
+
+function getState(): InboxState {
+  return state;
+}
+
+function subscribe(cb: Listener): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Reset for tests. */
+export function _resetInboxStore(): void {
+  state = { needsYou: [], activity: [], loading: true, error: null };
+  listeners.clear();
+  mountCount = 0;
+  if (wsUnsub) {
+    try {
+      wsUnsub();
+    } catch {
+      // ignore
+    }
+    wsUnsub = null;
+  }
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+}
+
+/** Fetch inbox data from the server and update the shared store. */
+export async function refreshInbox(): Promise<void> {
+  try {
+    const data = await api.getInbox();
+    setState({
+      needsYou: data.needs_you,
+      activity: data.activity,
+      loading: false,
+      error: null,
+    });
+  } catch (err) {
+    setState({ loading: false, error: (err as Error).message });
+  }
+}
+
+/** Mark all tasks as viewed and refresh. */
+export async function markAllInboxRead(): Promise<void> {
+  await api.markAllTasksViewed();
+  await refreshInbox();
+}
+
+// ─── WebSocket wiring (module-scoped, shared across all hook instances) ─────
+
+const DEBOUNCE_MS = 250;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let wsUnsub: (() => void) | null = null;
+let mountCount = 0;
+
+function scheduleRefresh(): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    void refreshInbox();
+  }, DEBOUNCE_MS);
+}
+
+function attachWs(): void {
+  if (wsUnsub) return;
+  wsUnsub = subscribeEvents((event) => {
+    if (event.type.startsWith('task:')) scheduleRefresh();
+  });
+}
+
+function detachWs(): void {
+  if (!wsUnsub) return;
+  wsUnsub();
+  wsUnsub = null;
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+}
+
+/** Flush pending debounced refresh (for tests). */
+export function _flushInboxDebounce(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+    void refreshInbox();
+  }
+}
+
+export interface UseInboxResult {
+  needsYou: Task[];
+  activity: Task[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  markAllRead: () => Promise<void>;
+}
+
+export function useInbox(): UseInboxResult {
+  const snapshot = useSyncExternalStore(subscribe, getState, getState);
+
+  useEffect(() => {
+    mountCount++;
+    if (mountCount === 1) {
+      attachWs();
+      void refreshInbox();
+    }
+    return () => {
+      mountCount--;
+      if (mountCount === 0) detachWs();
+    };
+  }, []);
+
+  const refresh = useCallback(() => refreshInbox(), []);
+  const markAllRead = useCallback(() => markAllInboxRead(), []);
+
+  return {
+    needsYou: snapshot.needsYou,
+    activity: snapshot.activity,
+    loading: snapshot.loading,
+    error: snapshot.error,
+    refresh,
+    markAllRead,
+  };
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { Composer } from '@/components/Composer';
+import { SessionsInbox } from '@/components/SessionsInbox';
 
 export default function HomePage() {
   return (
@@ -11,11 +12,9 @@ export default function HomePage() {
           >
             ✦ WELCOME BACK
           </h1>
-          {/*
-           * Sessions inbox slot — filled by a sibling task. Keep the id stable so
-           * that task can portal or mount into it without touching this file.
-           */}
-          <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8" />
+          <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8">
+            <SessionsInbox />
+          </div>
         </div>
       </div>
       <Composer />

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -107,6 +107,15 @@ export default function TaskDetail() {
     }
   }, [firstAgentWindow, activeWindow, agentParam, task?.agents]);
 
+  // Mark the task as viewed once when the page opens for this task id.
+  // Fire-and-forget — no loading state, no error toast.
+  useEffect(() => {
+    if (!taskId) return;
+    api.markTaskViewed(taskId).catch((err) => {
+      console.warn('Failed to mark task viewed:', err);
+    });
+  }, [taskId]);
+
   // Auto-switch back to agents when task enters non-running state.
   // Diff mode is allowed to persist so users can keep reviewing a closed task's diff.
   useEffect(() => {

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -116,6 +116,9 @@ export function mockApi(overrides: Record<string, unknown> = {}) {
   const defaults = {
     listTasks: vi.fn().mockResolvedValue([]),
     getTask: vi.fn().mockResolvedValue(TASK_DEFAULTS),
+    getInbox: vi.fn().mockResolvedValue({ needs_you: [], activity: [] }),
+    markTaskViewed: vi.fn().mockResolvedValue(TASK_DEFAULTS),
+    markAllTasksViewed: vi.fn().mockResolvedValue({ updated: 0 }),
     createTask: vi.fn().mockResolvedValue(TASK_DEFAULTS),
     updateTask: vi.fn().mockResolvedValue(TASK_DEFAULTS),
     startTask: vi.fn().mockResolvedValue(TASK_DEFAULTS),


### PR DESCRIPTION
## What

Adds a Sessions inbox surface to HomePage, split into two sections:
- **Needs you** — tasks with pending permission prompts, and errored tasks the user hasn't viewed since the error.
- **Activity** — closed tasks from the last 7 days the user hasn't viewed since the update.

Running-and-fine tasks are intentionally excluded (the sidebar's pulsing-dot already signals them).

Three new endpoints back it:
- `GET  /api/tasks/inbox` — returns both buckets
- `PATCH /api/tasks/:id/viewed` — marks a single task viewed (fired fire-and-forget from TaskDetail on mount)
- `POST  /api/tasks/viewed-all` — powers the "Mark all read" button

Inbox state lives in a standalone external store (`useSyncExternalStore` against a module-local listener set) rather than a context, so unrelated components don't re-render when inbox data changes. WebSocket `task:*` events trigger a 250ms-debounced refetch.

## Why

Home needed a single surface showing (a) anything needing attention right now, and (b) anything that changed since the user last looked, without drowning them in running-task chatter. The rerender isolation is important because the inbox sits alongside the sidebar, which already subscribes to the same WebSocket stream — context-sharing inbox state would've cascaded re-renders into the sidebar on every task event.

## Testing

- `bun run test` — 1089/1089 passing (52 suites). New coverage:
  - `server/inbox.test.ts` — 15 table-driven query tests for `getNeedsYou`/`getActivity`
  - `server/api.test.ts` — 3 new supertest cases for the inbox + viewed endpoints
  - `src/components/SessionsInbox.test.tsx` — 6 component tests (empty state, sections, mark-all-read, navigation, debounced refetch)
  - `src/lib/inbox.test.tsx` — 5 hook tests including a render-count isolation test that asserts an unrelated `TasksProvider` consumer does NOT re-render when inbox data changes
- `bun run typecheck` — clean
- `bun run lint` — clean (warnings only, all pre-existing or consistent with the repo's existing `any`-in-test convention)