### PR TITLE
fix(ui): default composer to scratch mode when no repo is picked

### DIFF
--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -55,10 +55,10 @@ beforeEach(() => {
 // ─── URL hydration ────────────────────────────────────────────────────────
 
 describe('Composer / URL hydration', () => {
-  it('empty URL → empty state (no intent header, no chips with values)', () => {
+  it('empty URL → scratch state (scratch intent, submittable with prompt only)', () => {
     renderComposer('/');
-    expect(screen.queryByTestId('intent-header')).not.toBeInTheDocument();
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/pick a repo/i);
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
+    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
   });
 
   it('?mode=scratch → scratch intent', () => {
@@ -125,6 +125,24 @@ describe('Composer / submit', () => {
       );
     });
     expect(mockNavigate).toHaveBeenLastCalledWith('/tasks/new-1');
+  });
+
+  it('bare `/` URL → typing + Enter dispatches a scratch task (no repo_path/base_branch)', async () => {
+    apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'scratch-default', title: 'hello' }));
+    renderComposer('/');
+    const textarea = screen.getByTestId('composer-prompt');
+    await user.type(textarea, 'hello world{Enter}');
+    await waitFor(() => {
+      expect(apiMock.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          run_mode: 'scratch',
+          initial_prompt: 'hello world',
+        }),
+      );
+    });
+    const payload = apiMock.createTask.mock.calls[0][0];
+    expect(payload).not.toHaveProperty('repo_path');
+    expect(payload).not.toHaveProperty('base_branch');
   });
 
   it('new mode → POST /tasks with run_mode=new, repo_path, base_branch', async () => {
@@ -254,11 +272,11 @@ describe('Composer / submit', () => {
 describe('Composer / intent dismiss', () => {
   const user = userEvent.setup();
 
-  it('dismissing add-agent returns to empty', async () => {
-    renderComposer('/?add_agent=t1', { tasks: [makeTask({ id: 't1' })] });
-    expect(screen.getByTestId('intent-header')).toBeInTheDocument();
+  it('dismissing add-agent returns to scratch', async () => {
+    renderComposer('/?add_agent=t1', { tasks: [makeTask({ id: 't1', title: 'Parent' })] });
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/adding agent to parent/i);
     await user.click(screen.getByRole('button', { name: /dismiss intent/i }));
-    expect(screen.queryByTestId('intent-header')).not.toBeInTheDocument();
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
   });
 
   it('dismissing fork-of returns to plain new mode', async () => {

--- a/src/lib/composer-state.test.tsx
+++ b/src/lib/composer-state.test.tsx
@@ -253,8 +253,11 @@ describe('reduce / enterAddAgent', () => {
 // ─── clearIntent transitions ──────────────────────────────────────────────
 
 describe('reduce / clearIntent', () => {
-  it('add-agent → empty', () => {
-    expect(reduce(addAgent, { type: 'clearIntent' })).toEqual({ mode: 'empty' });
+  it('add-agent → scratch', () => {
+    expect(reduce(addAgent, { type: 'clearIntent' })).toEqual({
+      mode: 'scratch',
+      isDraft: false,
+    });
   });
   it('new with forkOf → new without forkOf', () => {
     const withFork: ComposerState = { ...newState, forkOf: 'src1' };
@@ -284,9 +287,13 @@ describe('reduce / toggleDraft', () => {
 
 describe('hydrateFromUrl', () => {
   const table: Array<{ name: string; qs: string; expected: ComposerState }> = [
-    { name: 'empty URL → empty state', qs: '', expected: { mode: 'empty' } },
     {
-      name: '?mode=scratch → scratch',
+      name: 'empty URL → scratch state',
+      qs: '',
+      expected: { mode: 'scratch', isDraft: false },
+    },
+    {
+      name: '?mode=scratch → scratch (same as bare URL)',
       qs: 'mode=scratch',
       expected: { mode: 'scratch', isDraft: false },
     },
@@ -361,7 +368,6 @@ describe('hydrateFromUrl', () => {
 
 describe('stateToUrlParams', () => {
   const roundtrips: ComposerState[] = [
-    { mode: 'empty' },
     { mode: 'scratch', isDraft: false },
     { mode: 'new', repo: '/r', branch: 'main', isDraft: false },
     { mode: 'new', repo: '/r', branch: 'main', isDraft: false, forkOf: 'src1' },
@@ -403,6 +409,14 @@ describe('validateForSubmit', () => {
   });
   it('allows scratch with non-empty prompt', () => {
     expect(validateForSubmit(scratch, 'hello')).toBeNull();
+  });
+  it('scratch with prompt "hello" returns no blocking reason', () => {
+    expect(validateForSubmit({ mode: 'scratch', isDraft: false }, 'hello')).toBeNull();
+  });
+  it('scratch with empty prompt blocks with a prompt-required reason', () => {
+    expect(validateForSubmit({ mode: 'scratch', isDraft: false }, '')).toMatch(
+      /prompt is required/i,
+    );
   });
   it('requires branch for new mode', () => {
     expect(validateForSubmit({ ...newState, branch: null }, 'p')).toMatch(/branch/i);

--- a/src/lib/composer-state.ts
+++ b/src/lib/composer-state.ts
@@ -142,7 +142,7 @@ export function reduce(state: ComposerState, action: ComposerAction): ComposerSt
     }
 
     case 'clearIntent': {
-      if (state.mode === 'add-agent') return { mode: 'empty' };
+      if (state.mode === 'add-agent') return { mode: 'scratch', isDraft: false };
       if (state.mode === 'new' && state.forkOf) {
         const { forkOf: _forkOf, ...rest } = state;
         return rest;
@@ -186,10 +186,7 @@ export function hydrateFromUrl(params: URLSearchParams): ComposerState {
   const existingPath = params.get('worktree_path') ?? params.get('attach');
 
   if (!repo) {
-    if (modeParam === 'scratch') {
-      return { mode: 'scratch', isDraft: false };
-    }
-    return { mode: 'empty' };
+    return { mode: 'scratch', isDraft: false };
   }
 
   if (existingPath || modeParam === 'existing') {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -26,10 +26,7 @@ export function matchShortcut(e: KeyboardEvent, keys: ShortcutKeys): boolean {
   return e.key.toLowerCase() === keys.key.toLowerCase();
 }
 
-export function useGlobalShortcut(
-  keys: ShortcutKeys,
-  handler: (e: KeyboardEvent) => void,
-): void {
+export function useGlobalShortcut(keys: ShortcutKeys, handler: (e: KeyboardEvent) => void): void {
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
 


### PR DESCRIPTION
## Summary

Loading `/` with no URL params used to land the composer in `state.mode === 'empty'`. In that state, `handleSubmit` falls through the `if (state.mode === 'add-agent') ... else if (state.mode !== 'empty') ...` guard and silently creates nothing on Enter.

This PR collapses the no-repo branch of `hydrateFromUrl` so a bare `/` now hydrates directly to scratch mode — typing a prompt + Enter creates a scratch task as expected. `clearIntent` on an `add-agent` state also routes to scratch (instead of empty), so dismissing the intent leaves the composer in a submittable state.

The `empty` union variant is kept as belt-and-suspenders for unexpected states; it's just no longer reachable through normal flows.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (only pre-existing warnings)
- [x] `bun run test` — 1145 tests pass, incl. new `bare '/' URL → typing + Enter dispatches a scratch task` case in `Composer.test.tsx`
- [ ] Manual: open `/` in the dashboard, type a prompt, hit Enter — confirm a scratch task is created