### PR TITLE
refactor(ui): label scratch mode as "chat" in user-facing UI

### DIFF
--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -55,16 +55,16 @@ beforeEach(() => {
 // ─── URL hydration ────────────────────────────────────────────────────────
 
 describe('Composer / URL hydration', () => {
-  it('empty URL → scratch state (scratch intent, submittable with prompt only)', () => {
+  it('empty URL → scratch state (chat intent, submittable with prompt only)', () => {
     renderComposer('/');
-    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/new chat/i);
+    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/chat/i);
   });
 
-  it('?mode=scratch → scratch intent', () => {
+  it('?mode=scratch → chat intent', () => {
     renderComposer('/?mode=scratch');
-    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/new chat/i);
+    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/chat/i);
   });
 
   it('?repo=/r&mode=new → New task in basename', () => {
@@ -276,7 +276,7 @@ describe('Composer / intent dismiss', () => {
     renderComposer('/?add_agent=t1', { tasks: [makeTask({ id: 't1', title: 'Parent' })] });
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/adding agent to parent/i);
     await user.click(screen.getByRole('button', { name: /dismiss intent/i }));
-    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/new chat/i);
   });
 
   it('dismissing fork-of returns to plain new mode', async () => {
@@ -309,7 +309,7 @@ describe('Composer / chip interactions', () => {
       .getByTestId('repo-chip')
       .querySelector('button[aria-label="Remove"]') as HTMLButtonElement;
     await user.click(removeBtn);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/chat/i);
   });
 });
 

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -388,7 +388,7 @@ function intentHeaderText(
     case 'empty':
       return null;
     case 'scratch':
-      return 'Scratch session';
+      return 'New chat';
     case 'new':
       if (state.forkOf) {
         return `Forking from ${sourceTask?.title ?? state.forkOf}`;
@@ -408,7 +408,7 @@ function useDerivedModeLabel(state: ComposerState, sourceTask: Task | null): str
     case 'empty':
       return '→ pick a repo or start typing';
     case 'scratch':
-      return '→ scratch ⏎';
+      return '→ chat ⏎';
     case 'new':
       return '→ new worktree ⏎';
     case 'none':

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -12,7 +12,8 @@ function pendingPromptCount(task: Task): number {
 }
 
 function subtitleFor(task: Task, kind: RowKind): string {
-  if (kind === 'activity') return 'closed';
+  const isChat = task.run_mode === 'scratch';
+  if (kind === 'activity') return isChat ? 'chat closed' : 'closed';
   if (task.status === 'error') return task.error ? `errored · ${task.error}` : 'errored';
   const prompts = pendingPromptCount(task);
   if (prompts > 0)

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -74,7 +74,7 @@ describe('UniversalSidebar grouping', () => {
     expect(screen.getByRole('button', { expanded: true, name: /^octomux$/i })).toBeInTheDocument();
   });
 
-  it('renders an Other group for scratch / repo-less tasks', async () => {
+  it('renders a Chats group for scratch tasks', async () => {
     apiMock.listTasks.mockResolvedValue([
       makeTask({ id: 't1', status: 'running', repo_path: '/dev/alpha' }),
       makeTask({
@@ -82,27 +82,61 @@ describe('UniversalSidebar grouping', () => {
         status: 'running',
         repo_path: '',
         run_mode: 'scratch',
-        title: 'Scratchwork',
+        title: 'Chatwork',
       }),
     ]);
     renderSidebar();
-    await waitFor(() => expect(screen.getByText('Scratchwork')).toBeInTheDocument());
-    expect(screen.getByText('OTHER')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Chatwork')).toBeInTheDocument());
+    expect(screen.getByText('CHATS')).toBeInTheDocument();
+    expect(screen.queryByText('OTHER')).toBeNull();
+  });
+
+  it('renders an Other group for repo-less non-scratch tasks only', async () => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: 'orphan-1',
+        status: 'running',
+        repo_path: '',
+        run_mode: 'new',
+        title: 'Orphan',
+      }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(screen.getByText('OTHER')).toBeInTheDocument());
   });
 
   it('does not render a + button on the Other group', async () => {
+    apiMock.listTasks.mockResolvedValue([
+      makeTask({
+        id: 'orphan-1',
+        status: 'running',
+        repo_path: '',
+        run_mode: 'new',
+        title: 'Orphan',
+      }),
+    ]);
+    renderSidebar();
+    await waitFor(() => expect(screen.getByText('OTHER')).toBeInTheDocument());
+    expect(screen.queryByTestId('sidebar-group-add-__other__')).toBeNull();
+  });
+
+  it('renders a + button on the Chats group that navigates to /', async () => {
+    const user = userEvent.setup();
     apiMock.listTasks.mockResolvedValue([
       makeTask({
         id: 'scratch-1',
         status: 'running',
         repo_path: '',
         run_mode: 'scratch',
-        title: 'Scratchwork',
+        title: 'Chatwork',
       }),
     ]);
     renderSidebar();
-    await waitFor(() => expect(screen.getByText('OTHER')).toBeInTheDocument());
-    expect(screen.queryByTestId('sidebar-group-add-__other__')).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-group-add-__chats__')).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId('sidebar-group-add-__chats__'));
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
   it('navigates to the composer with repo + mode on + click', async () => {
@@ -126,7 +160,7 @@ describe('UniversalSidebar status glyph + run-mode badge', () => {
     { mode: 'new', letter: 'N' },
     { mode: 'existing', letter: 'E' },
     { mode: 'none', letter: 'Ø' },
-    { mode: 'scratch', letter: 'S' },
+    { mode: 'scratch', letter: 'C' },
   ])('renders the $letter badge for run_mode=$mode', async ({ mode, letter }) => {
     apiMock.listTasks.mockResolvedValue([
       makeTask({
@@ -313,7 +347,7 @@ describe('forkDisabledReason', () => {
   it.each<{ name: string; item: Partial<SidebarItem>; expected: string | null }>([
     { name: 'allows new', item: { runMode: 'new' }, expected: null },
     { name: 'allows existing', item: { runMode: 'existing' }, expected: null },
-    { name: 'disallows scratch', item: { runMode: 'scratch' }, expected: 'scratch' },
+    { name: 'disallows scratch', item: { runMode: 'scratch' }, expected: 'chat' },
     { name: 'disallows none', item: { runMode: 'none' }, expected: 'working tree' },
     { name: 'disallows draft', item: { status: 'draft' }, expected: 'draft' },
   ])('$name', ({ item: overrides, expected }) => {

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -4,6 +4,7 @@ import { useTasksContext } from '@/lib/tasks-context';
 import {
   groupTasksForSidebar,
   OTHER_GROUP_KEY,
+  CHATS_GROUP_KEY,
   type SidebarItem,
   type SidebarGroup,
 } from '@/lib/sidebar-utils';
@@ -133,14 +134,14 @@ const RUN_MODE_LETTER: Record<RunMode, string> = {
   new: 'N',
   existing: 'E',
   none: 'Ø',
-  scratch: 'S',
+  scratch: 'C',
 };
 
 const RUN_MODE_TOOLTIP: Record<RunMode, string> = {
   new: 'New worktree',
   existing: 'Existing worktree',
   none: 'No worktree (working tree)',
-  scratch: 'Scratch (no repo)',
+  scratch: 'Chat (no repo)',
 };
 
 function RunModeBadge({ mode }: { mode: RunMode }) {
@@ -262,7 +263,7 @@ const NAV_ITEMS = [
 // ─── Fork refusal helper ────────────────────────────────────────────────────
 
 export function forkDisabledReason(item: SidebarItem): string | null {
-  if (item.runMode === 'scratch') return 'Cannot fork a scratch task (no repo).';
+  if (item.runMode === 'scratch') return 'Cannot fork a chat (no repo).';
   if (item.runMode === 'none')
     return 'Cannot fork a task that runs on the working tree (no branch).';
   if (item.status === 'draft') return 'Cannot fork a draft task (no branch yet).';
@@ -681,6 +682,10 @@ export function UniversalSidebar() {
             onToggleGroup={() => toggleGroupCollapsed(group.key)}
             onAddTask={() => {
               if (group.key === OTHER_GROUP_KEY) return;
+              if (group.key === CHATS_GROUP_KEY) {
+                navigate('/');
+                return;
+              }
               navigate(buildGroupAddUrl(group.key));
             }}
             onOpenRow={(id) => navigate(`/tasks/${id}`)}
@@ -736,6 +741,8 @@ function SidebarGroupView({
   onDelete,
 }: SidebarGroupViewProps) {
   const isOther = group.key === OTHER_GROUP_KEY;
+  const isChats = group.key === CHATS_GROUP_KEY;
+  const addLabel = isChats ? 'New chat' : `New task in ${group.repo}`;
 
   return (
     <div style={{ paddingBottom: 16 }}>
@@ -777,8 +784,8 @@ function SidebarGroupView({
             <button
               type="button"
               onClick={onAddTask}
-              aria-label={`New task in ${group.repo}`}
-              title={`New task in ${group.repo}`}
+              aria-label={addLabel}
+              title={addLabel}
               data-testid={`sidebar-group-add-${group.key}`}
               className="flex h-4 w-4 items-center justify-center text-[#6a6a6a] opacity-0 hover:text-white group-hover/header:opacity-100"
             >

--- a/src/lib/sidebar-utils.test.tsx
+++ b/src/lib/sidebar-utils.test.tsx
@@ -125,7 +125,7 @@ describe('groupTasksForSidebar', () => {
     expect(group.repo).toBe('r');
   });
 
-  it('places scratch-mode tasks in the Other group (sorted last)', () => {
+  it('places scratch-mode tasks in the Chats group (sorted first)', () => {
     const tasks = [
       makeTask({ id: '1', status: 'running', repo_path: '/home/dev/alpha' }),
       makeTask({
@@ -133,14 +133,28 @@ describe('groupTasksForSidebar', () => {
         status: 'running',
         repo_path: '',
         run_mode: 'scratch',
-        title: 'Scratch work',
+        title: 'Chat work',
       }),
     ];
     const groups = groupTasksForSidebar(tasks);
-    expect(groups.map((g) => g.repo)).toEqual(['alpha', 'Other']);
-    expect(groups[1].key).toBe('__other__');
-    expect(groups[1].items).toHaveLength(1);
-    expect(groups[1].items[0].id).toBe('2');
+    expect(groups.map((g) => g.repo)).toEqual(['Chats', 'alpha']);
+    expect(groups[0].key).toBe('__chats__');
+    expect(groups[0].items).toHaveLength(1);
+    expect(groups[0].items[0].id).toBe('2');
+  });
+
+  it('places scratch-mode tasks in Chats even when repo_path is set', () => {
+    const tasks = [
+      makeTask({
+        id: '1',
+        status: 'running',
+        repo_path: '/home/dev/alpha',
+        run_mode: 'scratch',
+      }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('__chats__');
   });
 
   it('places repo-less non-scratch tasks in the Other group', () => {
@@ -148,6 +162,17 @@ describe('groupTasksForSidebar', () => {
     const groups = groupTasksForSidebar(tasks);
     expect(groups).toHaveLength(1);
     expect(groups[0].key).toBe('__other__');
+  });
+
+  it('sorts Chats first and Other last with repo groups in between', () => {
+    const tasks = [
+      makeTask({ id: '1', status: 'running', repo_path: '', run_mode: 'new' }),
+      makeTask({ id: '2', status: 'running', repo_path: '/dev/zebra' }),
+      makeTask({ id: '3', status: 'running', repo_path: '', run_mode: 'scratch' }),
+      makeTask({ id: '4', status: 'running', repo_path: '/dev/alpha' }),
+    ];
+    const groups = groupTasksForSidebar(tasks);
+    expect(groups.map((g) => g.repo)).toEqual(['Chats', 'alpha', 'zebra', 'Other']);
   });
 
   it('surfaces runMode on each item', () => {

--- a/src/lib/sidebar-utils.ts
+++ b/src/lib/sidebar-utils.ts
@@ -3,6 +3,8 @@ import { repoName } from './utils';
 
 export const OTHER_GROUP_KEY = '__other__';
 export const OTHER_GROUP_LABEL = 'Other';
+export const CHATS_GROUP_KEY = '__chats__';
+export const CHATS_GROUP_LABEL = 'Chats';
 
 export interface SidebarItem {
   id: string;
@@ -14,7 +16,12 @@ export interface SidebarItem {
 }
 
 export interface SidebarGroup {
-  /** Stable key — either the task's `repo_path` or `OTHER_GROUP_KEY` for scratch/repo-less tasks. */
+  /**
+   * Stable key:
+   * - `CHATS_GROUP_KEY` for scratch-mode tasks (shown as "Chats")
+   * - `OTHER_GROUP_KEY` for repo-less non-scratch tasks
+   * - otherwise the task's `repo_path`.
+   */
   key: string;
   /** Display label for the group header. */
   repo: string;
@@ -43,7 +50,10 @@ function itemFromTask(task: Task): SidebarItem {
 }
 
 function groupKeyFor(task: Task): { key: string; label: string } {
-  if (task.run_mode === 'scratch' || !task.repo_path) {
+  if (task.run_mode === 'scratch') {
+    return { key: CHATS_GROUP_KEY, label: CHATS_GROUP_LABEL };
+  }
+  if (!task.repo_path) {
     return { key: OTHER_GROUP_KEY, label: OTHER_GROUP_LABEL };
   }
   return { key: task.repo_path, label: repoName(task.repo_path) };
@@ -78,7 +88,9 @@ export function groupTasksForSidebar(tasks: Task[]): SidebarGroup[] {
   }
 
   groups.sort((a, b) => {
-    // "Other" always sorts last.
+    // "Chats" always sorts first, "Other" always sorts last.
+    if (a.key === CHATS_GROUP_KEY) return -1;
+    if (b.key === CHATS_GROUP_KEY) return 1;
     if (a.key === OTHER_GROUP_KEY) return 1;
     if (b.key === OTHER_GROUP_KEY) return -1;
     return a.repo.localeCompare(b.repo);

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -551,8 +551,8 @@ describe('TaskDetail', () => {
       },
       {
         mode: 'scratch' as const,
-        badge: 'S',
-        tooltip: 'scratch',
+        badge: 'C',
+        tooltip: 'chat',
         showsDiff: false,
         showsBranchInfo: false,
       },
@@ -629,7 +629,7 @@ describe('TaskDetail', () => {
       );
       renderDetail();
       await waitFor(() => {
-        expect(screen.getByTestId('mode-badge')).toHaveTextContent('S');
+        expect(screen.getByTestId('mode-badge')).toHaveTextContent('C');
       });
       expect(screen.queryByText('#99')).not.toBeInTheDocument();
     });

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -18,14 +18,14 @@ const MODE_LABEL: Record<RunMode, string> = {
   new: 'N',
   existing: 'E',
   none: 'Ø',
-  scratch: 'S',
+  scratch: 'C',
 };
 
 const MODE_TOOLTIP: Record<RunMode, string> = {
   new: 'new worktree',
   existing: 'attached existing',
   none: 'in-place (no worktree)',
-  scratch: 'scratch',
+  scratch: 'chat',
 };
 
 // Per-task UI state preserved across task switches (session-only, not persisted to disk).


### PR DESCRIPTION
## Summary

UI-only terminology change: rename "scratch" to "chat" everywhere the user sees
it. The database, API, CLI, and internal state still use `run_mode='scratch'` —
no schema, API, or CLI changes.

- Composer intent header: `Scratch session` → `New chat`; derived label `→ scratch ⏎` → `→ chat ⏎`.
- TaskDetail mode badge: letter `S` → `C`; tooltip `scratch` → `chat`.
- UniversalSidebar: badge letter + tooltip updated. New **Chats** section pinned
  at the top of the sidebar holds every `run_mode='scratch'` task regardless of
  whether a `repo_path` is set. Clicking the group's `+` opens the blank
  composer (`/`). The existing **Other** group now only collects repo-less
  non-scratch tasks (an edge case).
- SessionsInbox: closed scratch tasks show `chat closed` instead of `closed`.
- Fork-refusal reason for scratch tasks reads "Cannot fork a chat (no repo)".

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (1149 passing)
- [ ] Spot-check in dashboard: composer shows "New chat" / "→ chat ⏎" on bare `/`
- [ ] Spot-check: sidebar has Chats section at top; scratch tasks appear there; `+` opens `/`
- [ ] Spot-check: TaskDetail for a scratch task shows `C` badge with tooltip "chat"
- [ ] Spot-check: closed scratch task in inbox reads "chat closed"