### PR TITLE
feat: phase 2b — workspaces browser + agent task-hopping

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -80,6 +80,19 @@ vi.mock('./task-runner.js', async () => {
       };
     }),
     closeShellTerminal: vi.fn(),
+    hopAgent: vi.fn(async (agent: any, toTaskId: string | null) => {
+      const { getDb } = await import('./db.js');
+      const db = getDb();
+      db.prepare(
+        `UPDATE agents SET task_id = ?, window_index = ?, tmux_session = ?, status = 'running' WHERE id = ?`,
+      ).run(
+        toTaskId,
+        toTaskId === null ? 0 : 7,
+        toTaskId === null ? `octomux-chat-${agent.id}` : null,
+        agent.id,
+      );
+      return db.prepare('SELECT * FROM agents WHERE id = ?').get(agent.id);
+    }),
   };
 });
 
@@ -1752,6 +1765,80 @@ describe('DELETE /api/worktrees/:id', () => {
       worktree_id: string | null;
     };
     expect(task.worktree_id).toBeNull();
+  });
+});
+
+describe('PATCH /api/agents/:id/task', () => {
+  it('404 when agent does not exist', async () => {
+    const res = await request(app)
+      .patch('/api/agents/missing/task')
+      .send({ task_id: null });
+    expect(res.status).toBe(404);
+  });
+
+  it('400 when body missing task_id key', async () => {
+    insertAgent(db, { id: 'aBody', task_id: null });
+    const res = await request(app).patch('/api/agents/aBody/task').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when task_id equals current task_id (no-op)', async () => {
+    insertTask(db, { id: 'tSame', status: 'running' });
+    insertAgent(db, { id: 'aSame', task_id: 'tSame' });
+    const res = await request(app)
+      .patch('/api/agents/aSame/task')
+      .send({ task_id: 'tSame' });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when target task does not exist', async () => {
+    insertAgent(db, { id: 'aOrph', task_id: null });
+    const res = await request(app)
+      .patch('/api/agents/aOrph/task')
+      .send({ task_id: 'does-not-exist' });
+    expect(res.status).toBe(404);
+  });
+
+  it('409 when target task is not active', async () => {
+    insertTask(db, { id: 'tClosed', status: 'closed' });
+    insertAgent(db, { id: 'aC', task_id: null });
+    const res = await request(app)
+      .patch('/api/agents/aC/task')
+      .send({ task_id: 'tClosed' });
+    expect(res.status).toBe(409);
+  });
+
+  it('detaches to standalone (task_id=null)', async () => {
+    insertTask(db, { id: 'tFrom', status: 'running' });
+    insertAgent(db, { id: 'aDet', task_id: 'tFrom' });
+
+    const res = await request(app)
+      .patch('/api/agents/aDet/task')
+      .send({ task_id: null });
+    expect(res.status).toBe(200);
+    expect(res.body.task_id).toBeNull();
+    expect(res.body.tmux_session).toBe('octomux-chat-aDet');
+  });
+
+  it('moves between tasks', async () => {
+    insertTask(db, { id: 'tA', status: 'running' });
+    insertTask(db, { id: 'tB', status: 'running' });
+    insertAgent(db, { id: 'aMove', task_id: 'tA' });
+
+    const res = await request(app).patch('/api/agents/aMove/task').send({ task_id: 'tB' });
+    expect(res.status).toBe(200);
+    expect(res.body.task_id).toBe('tB');
+  });
+
+  it('attaches a standalone chat agent to a task', async () => {
+    insertTask(db, { id: 'tTarget', status: 'running' });
+    insertAgent(db, { id: 'aChat', task_id: null });
+    // Standalone agents carry their own tmux_session.
+    db.prepare(`UPDATE agents SET tmux_session = 'octomux-chat-aChat' WHERE id = 'aChat'`).run();
+
+    const res = await request(app).patch('/api/agents/aChat/task').send({ task_id: 'tTarget' });
+    expect(res.status).toBe(200);
+    expect(res.body.task_id).toBe('tTarget');
   });
 });
 

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -1675,6 +1675,86 @@ describe('GET /api/worktrees', () => {
   });
 });
 
+describe('GET /api/worktrees/:id', () => {
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).get('/api/worktrees/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the worktree plus active task and history', async () => {
+    db.prepare(
+      `INSERT INTO worktrees (id, path, repo_path, mode, status)
+       VALUES ('wtD1','/tmp/wtD1','/repo','new','in_use')`,
+    ).run();
+    insertTask(db, { id: 'tActive', worktree_id: 'wtD1', status: 'running' });
+    insertTask(db, {
+      id: 'tClosed',
+      worktree_id: 'wtD1',
+      status: 'closed',
+      updated_at: '2026-01-01 00:00:00',
+    });
+
+    const res = await request(app).get('/api/worktrees/wtD1');
+    expect(res.status).toBe(200);
+    expect(res.body.worktree.id).toBe('wtD1');
+    expect(res.body.active_task?.id).toBe('tActive');
+    expect(res.body.history.map((t: Task) => t.id)).toEqual(['tClosed']);
+  });
+
+  it('returns null active_task when none active', async () => {
+    db.prepare(
+      `INSERT INTO worktrees (id, path, mode, status) VALUES ('wtD2','/tmp/wtD2','new','available')`,
+    ).run();
+    insertTask(db, { id: 'tX', worktree_id: 'wtD2', status: 'closed' });
+
+    const res = await request(app).get('/api/worktrees/wtD2');
+    expect(res.status).toBe(200);
+    expect(res.body.active_task).toBeNull();
+    expect(res.body.history).toHaveLength(1);
+  });
+});
+
+describe('DELETE /api/worktrees/:id', () => {
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).delete('/api/worktrees/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+
+  it('409 when worktree is in_use', async () => {
+    db.prepare(
+      `INSERT INTO worktrees (id, path, mode, status) VALUES ('wtU1','/tmp/wtU1','new','in_use')`,
+    ).run();
+    const res = await request(app).delete('/api/worktrees/wtU1');
+    expect(res.status).toBe(409);
+  });
+
+  it('409 when active task references it', async () => {
+    db.prepare(
+      `INSERT INTO worktrees (id, path, mode, status) VALUES ('wtA1','/tmp/wtA1','new','available')`,
+    ).run();
+    insertTask(db, { id: 'tRun', worktree_id: 'wtA1', status: 'running' });
+
+    const res = await request(app).delete('/api/worktrees/wtA1');
+    expect(res.status).toBe(409);
+  });
+
+  it('deletes row when available with no active tasks', async () => {
+    db.prepare(
+      `INSERT INTO worktrees (id, path, mode, status) VALUES ('wtOK','/tmp/wtOK','existing','available')`,
+    ).run();
+    insertTask(db, { id: 'tTerm', worktree_id: 'wtOK', status: 'closed' });
+
+    const res = await request(app).delete('/api/worktrees/wtOK');
+    expect(res.status).toBe(204);
+    const remaining = db.prepare(`SELECT id FROM worktrees WHERE id = 'wtOK'`).get();
+    expect(remaining).toBeUndefined();
+    const task = db.prepare(`SELECT worktree_id FROM tasks WHERE id = 'tTerm'`).get() as {
+      worktree_id: string | null;
+    };
+    expect(task.worktree_id).toBeNull();
+  });
+});
+
 describe('GET /api/tasks/:id — worktree_row join', () => {
   it('includes the linked worktree row under worktree_row', async () => {
     db.prepare(

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -24,9 +24,11 @@ vi.mock('./task-runner.js', async () => {
         `UPDATE tasks SET status = 'running', tmux_session = ?, updated_at = datetime('now') WHERE id = ?`,
       ).run(`octomux-agent-${task.id}`, task.id);
       if (task.worktree_id) {
-        db.prepare(
-          `UPDATE worktrees SET path = ?, branch = COALESCE(branch, ?) WHERE id = ?`,
-        ).run(`/tmp/.worktrees/${task.id}`, branch, task.worktree_id);
+        db.prepare(`UPDATE worktrees SET path = ?, branch = COALESCE(branch, ?) WHERE id = ?`).run(
+          `/tmp/.worktrees/${task.id}`,
+          branch,
+          task.worktree_id,
+        );
       }
     }),
     closeTask: vi.fn(async (task: any) => {
@@ -110,17 +112,11 @@ vi.mock('./chats.js', async () => {
     }),
     listChats: vi.fn(() => {
       const db = getDb();
-      return db
-        .prepare(`SELECT * FROM agents WHERE task_id IS NULL ORDER BY pinned DESC`)
-        .all();
+      return db.prepare(`SELECT * FROM agents WHERE task_id IS NULL ORDER BY pinned DESC`).all();
     }),
     getChat: vi.fn((id: string) => {
       const db = getDb();
-      return (
-        db
-          .prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`)
-          .get(id) ?? null
-      );
+      return db.prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`).get(id) ?? null;
     }),
   };
 });
@@ -789,9 +785,7 @@ describe('GET /api/tasks/:id/diff', () => {
     db.prepare(
       `UPDATE worktrees SET path = '' WHERE id = (SELECT worktree_id FROM tasks WHERE id = ?)`,
     ).run(DEFAULTS.runningTask.id);
-    db.prepare(`UPDATE tasks SET worktree_id = NULL WHERE id = ?`).run(
-      DEFAULTS.runningTask.id,
-    );
+    db.prepare(`UPDATE tasks SET worktree_id = NULL WHERE id = ?`).run(DEFAULTS.runningTask.id);
     const res = await request(app).get(`/api/tasks/${DEFAULTS.runningTask.id}/diff`);
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/worktree/i);

--- a/server/api.ts
+++ b/server/api.ts
@@ -20,6 +20,7 @@ import {
   createUserTerminal,
   createShellTerminal,
   closeShellTerminal,
+  hopAgent,
 } from './task-runner.js';
 import * as diffMod from './diff.js';
 import { createChat, listChats, getChat } from './chats.js';
@@ -1179,6 +1180,76 @@ export function setupRoutes(app: Express): void {
       return;
     }
     res.json(chat);
+  });
+
+  /**
+   * Move a runtime agent between task ids (or detach to a standalone chat
+   * with task_id=null). Kills the old tmux window, opens a new one at the new
+   * cwd, and resumes claude so transcript context survives.
+   */
+  app.patch('/api/agents/:id/task', async (req: Request, res: Response) => {
+    const db = getDb();
+    const agent = db.prepare('SELECT * FROM agents WHERE id = ?').get(req.params.id) as
+      | Agent
+      | undefined;
+    if (!agent) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+    const body = (req.body ?? {}) as { task_id?: string | null };
+    if (!('task_id' in body)) {
+      res.status(400).json({ error: 'task_id is required (string or null)' });
+      return;
+    }
+    const targetTaskId = body.task_id;
+    if (targetTaskId !== null && typeof targetTaskId !== 'string') {
+      res.status(400).json({ error: 'task_id must be a string or null' });
+      return;
+    }
+    if (targetTaskId === agent.task_id) {
+      res.status(400).json({ error: 'Agent is already on that task' });
+      return;
+    }
+    if (targetTaskId !== null) {
+      const targetTask = db.prepare(`${SELECT_TASK_SQL} WHERE t.id = ?`).get(targetTaskId) as
+        | Task
+        | undefined;
+      if (!targetTask) {
+        res.status(404).json({ error: `Task not found: ${targetTaskId}` });
+        return;
+      }
+      if (!(['draft', 'setting_up', 'running'] as const).includes(targetTask.status as 'running')) {
+        res.status(409).json({ error: `Target task is not active (status=${targetTask.status})` });
+        return;
+      }
+      if (!targetTask.worktree_id) {
+        res.status(409).json({ error: 'Target task has no worktree' });
+        return;
+      }
+    }
+
+    try {
+      const updated = await hopAgent(agent, targetTaskId);
+      broadcast({ type: 'task:updated', payload: { taskId: agent.task_id ?? targetTaskId ?? '' } });
+      res.json(updated);
+    } catch (err) {
+      const msg = (err as Error).message;
+      apiLogger.error(
+        {
+          agent_id: agent.id,
+          from_task_id: agent.task_id,
+          to_task_id: targetTaskId,
+          operation: 'task_hop',
+          err,
+        },
+        'task_hop: failed',
+      );
+      if (msg.includes('not found') || msg.includes('does not exist')) {
+        res.status(409).json({ error: msg });
+      } else {
+        res.status(500).json({ error: msg });
+      }
+    }
   });
 
   app.post('/api/chats', async (req: Request, res: Response) => {

--- a/server/api.ts
+++ b/server/api.ts
@@ -268,9 +268,7 @@ export function setupRoutes(app: Express): void {
         .prepare(`${SELECT_TASK_SQL} WHERE w.repo_path = ? ORDER BY t.created_at DESC`)
         .all(repoPath) as Task[];
     } else {
-      tasks = db
-        .prepare(`${SELECT_TASK_SQL} ORDER BY t.created_at DESC`)
-        .all() as Task[];
+      tasks = db.prepare(`${SELECT_TASK_SQL} ORDER BY t.created_at DESC`).all() as Task[];
     }
 
     if (tasks.length === 0) {
@@ -390,9 +388,9 @@ export function setupRoutes(app: Express): void {
     }));
     const userTerminals = db.prepare(TERMINALS_BY_TASK_SQL).all(task.id) as UserTerminal[];
     const worktreeRow = task.worktree_id
-      ? (db.prepare('SELECT * FROM worktrees WHERE id = ?').get(task.worktree_id) as
+      ? ((db.prepare('SELECT * FROM worktrees WHERE id = ?').get(task.worktree_id) as
           | Worktree
-          | undefined) ?? null
+          | undefined) ?? null)
       : null;
     res.json({
       ...task,
@@ -631,9 +629,9 @@ export function setupRoutes(app: Express): void {
           db.prepare(`UPDATE tasks SET worktree_id = ? WHERE id = ?`).run(wtId, task.id);
         }
         worktreeValues.push(wtId);
-        db.prepare(
-          `UPDATE worktrees SET ${worktreeFields.join(', ')} WHERE id = ?`,
-        ).run(...worktreeValues);
+        db.prepare(`UPDATE worktrees SET ${worktreeFields.join(', ')} WHERE id = ?`).run(
+          ...worktreeValues,
+        );
       }
     } else if (body.status === 'running') {
       // Resume task

--- a/server/api.ts
+++ b/server/api.ts
@@ -1191,7 +1191,7 @@ export function setupRoutes(app: Express): void {
     }
   });
 
-  // ─── Worktrees (read-only index) ─────────────────────────────────────────
+  // ─── Worktrees (browser) ─────────────────────────────────────────────────
 
   app.get('/api/worktrees', (_req: Request, res: Response) => {
     const db = getDb();
@@ -1208,6 +1208,98 @@ export function setupRoutes(app: Express): void {
       )
       .all() as WorktreeSummary[];
     res.json(rows);
+  });
+
+  app.get('/api/worktrees/:id', (req: Request, res: Response) => {
+    const db = getDb();
+    const worktree = db.prepare('SELECT * FROM worktrees WHERE id = ?').get(req.params.id) as
+      | Worktree
+      | undefined;
+    if (!worktree) {
+      res.status(404).json({ error: 'Worktree not found' });
+      return;
+    }
+    const tasks = db
+      .prepare(`${SELECT_TASK_SQL} WHERE t.worktree_id = ? ORDER BY t.updated_at DESC`)
+      .all(worktree.id) as Task[];
+    const active = tasks.find((t) =>
+      (['draft', 'setting_up', 'running'] as const).includes(t.status as 'running'),
+    );
+    const history = tasks.filter((t) => t.id !== active?.id);
+    res.json({
+      worktree,
+      active_task: active ?? null,
+      history,
+    });
+  });
+
+  app.delete('/api/worktrees/:id', async (req: Request, res: Response) => {
+    const db = getDb();
+    const worktree = db.prepare('SELECT * FROM worktrees WHERE id = ?').get(req.params.id) as
+      | Worktree
+      | undefined;
+    if (!worktree) {
+      res.status(404).json({ error: 'Worktree not found' });
+      return;
+    }
+    if (worktree.status !== 'available') {
+      res.status(409).json({ error: 'Worktree is in use' });
+      return;
+    }
+    const referencingTasks = db
+      .prepare('SELECT id, status FROM tasks WHERE worktree_id = ?')
+      .all(worktree.id) as Array<{ id: string; status: string }>;
+    const activeRef = referencingTasks.find((t) =>
+      (['draft', 'setting_up', 'running'] as const).includes(t.status as 'running'),
+    );
+    if (activeRef) {
+      res.status(409).json({ error: 'Worktree has an active task' });
+      return;
+    }
+
+    // Only delete filesystem for worktree-owned modes (new/scratch).
+    if (worktree.mode === 'new' || worktree.mode === 'scratch') {
+      if (worktree.path) {
+        try {
+          if (worktree.mode === 'new' && worktree.repo_path) {
+            await execFile('git', [
+              '-C',
+              worktree.repo_path,
+              'worktree',
+              'remove',
+              worktree.path,
+              '--force',
+            ]).catch(() => {});
+            if (worktree.branch) {
+              await execFile('git', [
+                '-C',
+                worktree.repo_path,
+                'branch',
+                '-D',
+                worktree.branch,
+              ]).catch(() => {});
+            }
+          }
+          if (fs.existsSync(worktree.path)) {
+            fs.rmSync(worktree.path, { recursive: true, force: true });
+          }
+        } catch (err) {
+          apiLogger.warn(
+            { worktree_id: worktree.id, err, operation: 'delete_worktree' },
+            'filesystem cleanup failed',
+          );
+        }
+      }
+    }
+
+    // Unlink referencing (terminal-state) tasks before deleting the row.
+    db.prepare('UPDATE tasks SET worktree_id = NULL WHERE worktree_id = ?').run(worktree.id);
+    db.prepare('DELETE FROM worktrees WHERE id = ?').run(worktree.id);
+    apiLogger.info(
+      { worktree_id: worktree.id, mode: worktree.mode, operation: 'delete_worktree' },
+      'worktree deleted',
+    );
+    res.status(204).send();
   });
 
   // ─── Skills ──────────────────────────────────────────────────────────────────

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -95,8 +95,8 @@ export function listChats(): Agent[] {
 
 export function getChat(id: string): Agent | null {
   const db = getDb();
-  const row = db
-    .prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`)
-    .get(id) as Agent | undefined;
+  const row = db.prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`).get(id) as
+    | Agent
+    | undefined;
   return row ?? null;
 }

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -264,7 +264,13 @@ describe('Database', () => {
       const row = db
         .prepare('SELECT id, task_id, label, pinned, tmux_session FROM agents WHERE id = ?')
         .get(ORCHESTRATOR_AGENT_ID) as
-        | { id: string; task_id: string | null; label: string; pinned: number; tmux_session: string }
+        | {
+            id: string;
+            task_id: string | null;
+            label: string;
+            pinned: number;
+            tmux_session: string;
+          }
         | undefined;
       expect(row).toBeTruthy();
       expect(row!.task_id).toBeNull();
@@ -322,9 +328,7 @@ describe('Database', () => {
         .get('backfill-1') as { worktree_id: string | null };
       expect(task.worktree_id).toBeTruthy();
 
-      const wt = legacy
-        .prepare('SELECT * FROM worktrees WHERE id = ?')
-        .get(task.worktree_id) as
+      const wt = legacy.prepare('SELECT * FROM worktrees WHERE id = ?').get(task.worktree_id) as
         | { path: string; mode: string; branch: string; base_sha: string }
         | undefined;
       expect(wt).toBeTruthy();
@@ -334,9 +338,9 @@ describe('Database', () => {
       expect(wt!.base_sha).toBe('abc123');
 
       // Legacy columns must be gone after migration.
-      const cols = (
-        legacy.pragma('table_info(tasks)') as Array<{ name: string }>
-      ).map((c) => c.name);
+      const cols = (legacy.pragma('table_info(tasks)') as Array<{ name: string }>).map(
+        (c) => c.name,
+      );
       for (const c of ['worktree', 'run_mode', 'repo_path', 'branch', 'base_branch', 'base_sha']) {
         expect(cols).not.toContain(c);
       }

--- a/server/db.ts
+++ b/server/db.ts
@@ -141,9 +141,9 @@ function rebuildAgentsTable(instance: Database.Database): void {
   instance
     .transaction(() => {
       // Capture dynamically-added columns that may not exist in the CREATE.
-      const oldCols = (
-        instance.pragma('table_info(agents)') as Array<{ name: string }>
-      ).map((c) => c.name);
+      const oldCols = (instance.pragma('table_info(agents)') as Array<{ name: string }>).map(
+        (c) => c.name,
+      );
       const has = (c: string) => oldCols.includes(c);
 
       instance.exec(`
@@ -320,9 +320,7 @@ export function initDb(instance: Database.Database): void {
           `INSERT INTO worktrees (id, path, repo_path, branch, base_branch, base_sha, mode, status, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, 'in_use', ?)`,
         );
-        const linkTask = instance.prepare(
-          `UPDATE tasks SET worktree_id = ? WHERE id = ?`,
-        );
+        const linkTask = instance.prepare(`UPDATE tasks SET worktree_id = ? WHERE id = ?`);
 
         for (const r of rows) {
           const wtId = nanoid(12);

--- a/server/orchestrator.ts
+++ b/server/orchestrator.ts
@@ -25,9 +25,7 @@ function readOrchestratorSession(): string {
 }
 
 /** Update the orchestrator agent row's status. Silent on DB errors. */
-function writeOrchestratorStatus(
-  status: 'running' | 'idle' | 'stopped',
-): void {
+function writeOrchestratorStatus(status: 'running' | 'idle' | 'stopped'): void {
   try {
     getDb()
       .prepare(

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -100,6 +100,7 @@ const {
   cleanupLinkedSessions,
   cleanupOrphanedViewerSessions,
   preflightWorktree,
+  hopAgent,
 } = await import('./task-runner.js');
 const { execFile } = await import('child_process');
 const fs = await import('fs');
@@ -1841,5 +1842,92 @@ describe('preflightWorktree', () => {
       argsInclude: ['-c', 'bun run lint'],
     });
     expect(lintCall).toBeDefined();
+  });
+});
+
+// ─── hopAgent ────────────────────────────────────────────────────────────────
+
+describe('hopAgent', () => {
+  it('detaches a task agent to a standalone chat session', async () => {
+    insertTask(db, {
+      id: 'tFrom',
+      status: 'running',
+      tmux_session: 'octomux-agent-tFrom',
+    });
+    const agent = insertAgent(db, { id: 'agDet', task_id: 'tFrom', window_index: 3 });
+
+    const updated = await hopAgent(agent, null);
+    expect(updated.task_id).toBeNull();
+    expect(updated.tmux_session).toBe('octomux-chat-agDet');
+    expect(updated.status).toBe('running');
+
+    const killCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['kill-window', '-t', 'octomux-agent-tFrom:3'],
+    });
+    expect(killCall).toBeDefined();
+
+    const newSessionCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-session', '-d', '-s', 'octomux-chat-agDet'],
+    });
+    expect(newSessionCall).toBeDefined();
+
+    const resumeCall = vi.mocked(execFile).mock.calls.find((c) => {
+      const args = c[1] as string[];
+      return (
+        c[0] === 'tmux' &&
+        args.includes('send-keys') &&
+        args.some((a) => typeof a === 'string' && a.includes('claude --resume'))
+      );
+    });
+    expect(resumeCall).toBeDefined();
+  });
+
+  it('moves a task agent between tasks', async () => {
+    insertTask(db, { id: 'tA', status: 'running', tmux_session: 'octomux-agent-tA' });
+    insertTask(db, {
+      id: 'tB',
+      status: 'running',
+      tmux_session: 'octomux-agent-tB',
+      worktree: '/tmp/wt-b',
+    });
+    const agent = insertAgent(db, { id: 'agHop', task_id: 'tA', window_index: 2 });
+
+    const updated = await hopAgent(agent, 'tB');
+    expect(updated.task_id).toBe('tB');
+    expect(updated.tmux_session).toBeNull();
+
+    const newWindow = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-window', '-t', 'octomux-agent-tB'],
+    });
+    expect(newWindow).toBeDefined();
+  });
+
+  it('attaches a standalone chat to a task (kills the chat session)', async () => {
+    insertTask(db, {
+      id: 'tT',
+      status: 'running',
+      tmux_session: 'octomux-agent-tT',
+      worktree: '/tmp/wt-t',
+    });
+    const agent = insertAgent(db, { id: 'agChat', task_id: null });
+    db.prepare(`UPDATE agents SET tmux_session = 'octomux-chat-agChat' WHERE id = 'agChat'`).run();
+    const reloaded = {
+      ...agent,
+      task_id: null,
+      tmux_session: 'octomux-chat-agChat',
+    } as Agent;
+
+    const updated = await hopAgent(reloaded, 'tT');
+    expect(updated.task_id).toBe('tT');
+    expect(updated.tmux_session).toBeNull();
+
+    const killSession = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['kill-session', '-t', 'octomux-chat-agChat'],
+    });
+    expect(killSession).toBeDefined();
   });
 });

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -517,9 +517,10 @@ export async function startTask(task: Task): Promise<void> {
     // Phase 2a: worktrees is the source of truth. If the task already has a
     // linked worktree row (existing/none/draft-edited), update it. Otherwise
     // create a fresh one.
-    db.prepare(
-      `UPDATE tasks SET status = ?, updated_at = datetime('now') WHERE id = ?`,
-    ).run('setting_up', id);
+    db.prepare(`UPDATE tasks SET status = ?, updated_at = datetime('now') WHERE id = ?`).run(
+      'setting_up',
+      id,
+    );
 
     const worktreeRepoPath = runMode === 'scratch' ? null : task.repo_path;
     if (task.worktree_id) {

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -11,7 +11,8 @@ import { getSettings, resolveClaudeFlags } from './settings.js';
 import { getOrCreateRepoConfig } from './repo-config.js';
 import { childLogger } from './logger.js';
 import type { RepoConfig } from './repo-config.js';
-import type { Task, Agent, UserTerminal, RunMode } from './types.js';
+import type { Task, Agent, UserTerminal, RunMode, Worktree } from './types.js';
+import { chatDirFor, chatSessionName } from './chats.js';
 
 const logger = childLogger('task-runner');
 
@@ -1130,4 +1131,139 @@ export async function resumeTask(task: Task): Promise<void> {
       `UPDATE tasks SET status = 'error', error = ?, updated_at = datetime('now') WHERE id = ?`,
     ).run((err as Error).message, task.id);
   }
+}
+
+// ─── Agent task-hopping ──────────────────────────────────────────────────────
+
+/**
+ * Move `agent` to a different task (or detach it to a standalone chat when
+ * `targetTaskId` is null). Kills the old tmux window, creates a new one at the
+ * new cwd, and resumes with `claude --resume` so transcript context survives.
+ */
+export async function hopAgent(
+  agent: Agent,
+  targetTaskId: string | null,
+): Promise<Agent> {
+  const db = getDb();
+  const fromTaskId = agent.task_id;
+  logger.info(
+    {
+      agent_id: agent.id,
+      from_task_id: fromTaskId,
+      to_task_id: targetTaskId,
+      operation: 'task_hop',
+    },
+    'task_hop: start',
+  );
+
+  // Resolve old tmux target for the kill step.
+  let oldTarget: { session: string; window: number } | null = null;
+  if (agent.task_id) {
+    const prevTask = db
+      .prepare(`SELECT tmux_session FROM tasks WHERE id = ?`)
+      .get(agent.task_id) as { tmux_session: string | null } | undefined;
+    if (prevTask?.tmux_session) {
+      oldTarget = { session: prevTask.tmux_session, window: agent.window_index };
+    }
+  } else if (agent.tmux_session) {
+    // Standalone chat agents have their own session.
+    oldTarget = { session: agent.tmux_session, window: agent.window_index };
+  }
+
+  // Resolve new destination.
+  let newSession: string;
+  let cwd: string;
+  let isStandalone: boolean;
+  if (targetTaskId === null) {
+    // Detach → standalone chat.
+    isStandalone = true;
+    newSession = chatSessionName(agent.id);
+    cwd = chatDirFor(agent.id);
+    fs.mkdirSync(cwd, { recursive: true });
+  } else {
+    isStandalone = false;
+    const task = db.prepare(`SELECT * FROM tasks WHERE id = ?`).get(targetTaskId) as
+      | { id: string; tmux_session: string | null; worktree_id: string | null; status: string }
+      | undefined;
+    if (!task) throw new Error(`Task not found: ${targetTaskId}`);
+    if (!task.worktree_id) throw new Error(`Task ${targetTaskId} has no worktree`);
+    const worktree = db.prepare(`SELECT * FROM worktrees WHERE id = ?`).get(task.worktree_id) as
+      | Worktree
+      | undefined;
+    if (!worktree) throw new Error(`Worktree not found for task ${targetTaskId}`);
+    if (!worktree.path || !fs.existsSync(worktree.path)) {
+      throw new Error(`Worktree path does not exist: ${worktree.path}`);
+    }
+    if (!task.tmux_session) {
+      throw new Error(`Task ${targetTaskId} has no tmux session (not running)`);
+    }
+    newSession = task.tmux_session;
+    cwd = worktree.path;
+  }
+
+  // Kill the old window. For a standalone chat agent, kill the entire session
+  // (it belongs to this agent only).
+  if (oldTarget) {
+    try {
+      if (!agent.task_id && agent.tmux_session) {
+        await execFile('tmux', ['kill-session', '-t', agent.tmux_session]);
+      } else {
+        await execFile('tmux', ['kill-window', '-t', `${oldTarget.session}:${oldTarget.window}`]);
+      }
+    } catch (err) {
+      if (!isTmuxTargetMissing(err)) {
+        logger.warn(
+          { agent_id: agent.id, operation: 'task_hop', err },
+          'task_hop: kill old tmux target failed',
+        );
+      }
+    }
+  }
+
+  // Create the new tmux destination.
+  let newWindowIndex: number;
+  if (isStandalone) {
+    await execFile('tmux', ['new-session', '-d', '-s', newSession, '-c', cwd]);
+    await execFile('tmux', ['set-option', '-t', newSession, 'aggressive-resize', 'on']);
+    newWindowIndex = 0;
+  } else {
+    await execFile('tmux', ['new-window', '-t', newSession, '-c', cwd]);
+    newWindowIndex = await getLastWindowIndex(newSession);
+  }
+
+  // Resume claude in the new target.
+  const target = `${newSession}:${newWindowIndex}`;
+  const flags = await getClaudeFlags();
+  let baseCmd: string;
+  if (agent.claude_session_id) {
+    baseCmd = `claude --resume ${agent.claude_session_id}${flags}`;
+  } else {
+    const newId = crypto.randomUUID();
+    baseCmd = `claude --session-id ${newId}${flags}`;
+    db.prepare(`UPDATE agents SET claude_session_id = ? WHERE id = ?`).run(newId, agent.id);
+  }
+  await sendClaudeCommand({ target, baseCmd });
+
+  // Update DB row. For standalone agents we persist tmux_session; for
+  // task-scoped ones we read the session via the task join.
+  db.prepare(
+    `UPDATE agents
+        SET task_id = ?, window_index = ?, tmux_session = ?, status = 'running',
+            hook_activity = 'active', hook_activity_updated_at = datetime('now')
+      WHERE id = ?`,
+  ).run(targetTaskId, newWindowIndex, isStandalone ? newSession : null, agent.id);
+
+  logger.info(
+    {
+      agent_id: agent.id,
+      from_task_id: fromTaskId,
+      to_task_id: targetTaskId,
+      new_window_index: newWindowIndex,
+      new_tmux_session: newSession,
+      operation: 'task_hop',
+    },
+    'task_hop: complete',
+  );
+
+  return db.prepare(`SELECT * FROM agents WHERE id = ?`).get(agent.id) as Agent;
 }

--- a/server/terminal.ts
+++ b/server/terminal.ts
@@ -229,12 +229,7 @@ function handleChatConnection(ws: WebSocket, chatId: string): void {
     ws.close(4004, 'Chat not found');
     return;
   }
-  attachToTmuxSession(
-    ws,
-    row.tmux_session,
-    `chat:${chatId}`,
-    `Failed to attach to chat session`,
-  );
+  attachToTmuxSession(ws, row.tmux_session, `chat:${chatId}`, `Failed to attach to chat session`);
 }
 
 export function getActiveConnections(): Map<string, TerminalConnection[]> {

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -122,8 +122,7 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
   // Tests express "no worktree" by passing `worktree: null` explicitly; any
   // other shape (including the default repo_path) gets a row so joins work.
   const explicitlyNullWorktree = 'worktree' in overrides && overrides.worktree === null;
-  const shouldCreateRow =
-    !wtId && !explicitlyNullWorktree && (!!task.worktree || !!task.repo_path);
+  const shouldCreateRow = !wtId && !explicitlyNullWorktree && (!!task.worktree || !!task.repo_path);
   if (shouldCreateRow) {
     wtId = `wt-${task.id}`;
     db.prepare(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const SkillEditor = lazy(() => import('./pages/SkillEditor'));
 const AgentEditor = lazy(() => import('./pages/AgentEditor'));
 const ChatPage = lazy(() => import('./pages/ChatPage'));
+const WorkspacesPage = lazy(() => import('./pages/WorkspacesPage'));
+const WorkspaceDetailPage = lazy(() => import('./pages/WorkspaceDetailPage'));
 
 /** Runs at app root so notifications fire on every page. */
 function GlobalNotifications() {
@@ -152,6 +154,8 @@ export function AppShell() {
             <Route path="/skills/:name" element={<SkillEditor />} />
             <Route path="/agents/:name" element={<AgentEditor />} />
             <Route path="/chats/:id" element={<ChatPage />} />
+            <Route path="/workspaces" element={<WorkspacesPage />} />
+            <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
           </Routes>
         </Suspense>
       </main>

--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -23,6 +23,8 @@ interface AgentTabsProps {
   userTerminals?: UserTerminal[];
   onAddTerminal?: () => void;
   onCloseTerminal?: (terminalId: string) => void;
+  onMoveAgent?: (agentId: string) => void;
+  onDetachAgent?: (agentId: string) => void;
 }
 
 export function AgentTabs({
@@ -35,6 +37,8 @@ export function AgentTabs({
   userTerminals = [],
   onAddTerminal,
   onCloseTerminal,
+  onMoveAgent,
+  onDetachAgent,
 }: AgentTabsProps) {
   return (
     <div className="flex items-center gap-1 border-b border-border px-1 pb-1">
@@ -64,7 +68,15 @@ export function AgentTabs({
               )}
               {agent.label}
             </button>
-            {agent.status === 'running' && (
+            {agent.status === 'running' && (onMoveAgent || onDetachAgent) && (
+              <AgentTabMenu
+                agent={agent}
+                onMove={onMoveAgent}
+                onDetach={onDetachAgent}
+                onStop={onStopAgent}
+              />
+            )}
+            {agent.status === 'running' && !onMoveAgent && !onDetachAgent && (
               <button
                 className="ml-0.5 hidden rounded p-0.5 text-[#6a6a6a] hover:text-destructive group-hover:inline-flex"
                 onClick={(e) => {
@@ -122,6 +134,98 @@ export function AgentTabs({
         >
           +
         </button>
+      )}
+    </div>
+  );
+}
+
+function AgentTabMenu({
+  agent,
+  onMove,
+  onDetach,
+  onStop,
+}: {
+  agent: Agent;
+  onMove?: (id: string) => void;
+  onDetach?: (id: string) => void;
+  onStop: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    const timeout = window.setTimeout(() => {
+      document.addEventListener('click', close);
+    }, 0);
+    return () => {
+      window.clearTimeout(timeout);
+      document.removeEventListener('click', close);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative ml-0.5">
+      <button
+        className="hidden rounded p-0.5 text-[#6a6a6a] hover:text-foreground group-hover:inline-flex"
+        data-testid={`agent-tab-menu-${agent.id}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        title="Agent actions"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="12" cy="19" r="1.5" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          data-testid={`agent-tab-menu-items-${agent.id}`}
+          className="absolute right-0 top-full z-50 mt-1 min-w-44 bg-[#141414] border border-border py-1 text-xs outline-none"
+        >
+          {onMove && (
+            <button
+              role="menuitem"
+              className="block w-full px-3 py-1.5 text-left text-[#d0d0d0] hover:bg-[#1a1a1a]"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onMove(agent.id);
+              }}
+            >
+              Move to task…
+            </button>
+          )}
+          {onDetach && (
+            <button
+              role="menuitem"
+              className="block w-full px-3 py-1.5 text-left text-[#d0d0d0] hover:bg-[#1a1a1a]"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+                onDetach(agent.id);
+              }}
+            >
+              Detach to chat
+            </button>
+          )}
+          <div className="my-1 h-px bg-[#2f2f2f]" />
+          <button
+            role="menuitem"
+            className="block w-full px-3 py-1.5 text-left text-[#EF4444] hover:bg-[#1a1a1a]"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onStop(agent.id);
+            }}
+          >
+            Stop agent
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/components/MoveAgentDialog.test.tsx
+++ b/src/components/MoveAgentDialog.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithRouter, makeTask } from '../test-helpers';
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+const { apiMock, apiProxy } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('react-router-dom', routerMockFactory);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+const { MoveAgentDialog } = await import('./MoveAgentDialog');
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockNavigate.mockReset();
+  (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listTasks = vi
+    .fn()
+    .mockResolvedValue([
+      makeTask({ id: 't-running', title: 'Running work', status: 'running' }),
+      makeTask({ id: 't-current', title: 'Current task', status: 'running' }),
+      makeTask({ id: 't-closed', title: 'Closed', status: 'closed' }),
+    ]);
+  (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).moveAgentToTask = vi
+    .fn()
+    .mockResolvedValue({ id: 'a1', task_id: null });
+});
+
+describe('MoveAgentDialog', () => {
+  it('lists only active targets and omits the current task', async () => {
+    renderWithRouter(
+      <MoveAgentDialog
+        open={true}
+        onOpenChange={() => {}}
+        agentId="a1"
+        currentTaskId="t-current"
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('move-agent-target-t-running')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('move-agent-target-t-current')).toBeNull();
+    expect(screen.queryByTestId('move-agent-target-t-closed')).toBeNull();
+  });
+
+  it('detaches by default and navigates to /chats/:id', async () => {
+    renderWithRouter(
+      <MoveAgentDialog
+        open={true}
+        onOpenChange={() => {}}
+        agentId="a1"
+        currentTaskId={null}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText(/Detach/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /^Move$/i }));
+    await waitFor(() => {
+      expect(
+        (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).moveAgentToTask,
+      ).toHaveBeenCalledWith('a1', null);
+      expect(mockNavigate).toHaveBeenCalledWith('/chats/a1');
+    });
+  });
+
+  it('moves to a chosen task and navigates to /tasks/:id', async () => {
+    renderWithRouter(
+      <MoveAgentDialog
+        open={true}
+        onOpenChange={() => {}}
+        agentId="a1"
+        currentTaskId={null}
+      />,
+    );
+    const target = await screen.findByTestId('move-agent-target-t-running');
+    fireEvent.click(target.querySelector('input')!);
+    fireEvent.click(screen.getByRole('button', { name: /^Move$/i }));
+    await waitFor(() => {
+      expect(
+        (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).moveAgentToTask,
+      ).toHaveBeenCalledWith('a1', 't-running');
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks/t-running');
+    });
+  });
+
+  it('shows inline error on conflict', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).moveAgentToTask = vi
+      .fn()
+      .mockRejectedValue(new Error('Target task is not active (status=closed)'));
+    renderWithRouter(
+      <MoveAgentDialog
+        open={true}
+        onOpenChange={() => {}}
+        agentId="a1"
+        currentTaskId={null}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText(/Detach/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /^Move$/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('move-agent-error')).toHaveTextContent(/not active/i),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MoveAgentDialog.tsx
+++ b/src/components/MoveAgentDialog.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { Task } from '../../server/types';
+
+interface MoveAgentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentId: string;
+  currentTaskId: string | null;
+  /** Optional label for the agent in the dialog header. */
+  agentLabel?: string;
+  /** Called after a successful move. */
+  onMoved?: (newTaskId: string | null) => void;
+}
+
+const STANDALONE_OPTION = '__standalone__';
+
+export function MoveAgentDialog({
+  open,
+  onOpenChange,
+  agentId,
+  currentTaskId,
+  agentLabel,
+  onMoved,
+}: MoveAgentDialogProps) {
+  const navigate = useNavigate();
+  const [tasks, setTasks] = useState<Task[] | null>(null);
+  const [selected, setSelected] = useState<string>(STANDALONE_OPTION);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setError(null);
+    (async () => {
+      try {
+        const all = await api.listTasks();
+        if (cancelled) return;
+        const active = all.filter((t) =>
+          (['draft', 'setting_up', 'running'] as const).includes(t.status as 'running'),
+        );
+        setTasks(active);
+        setSelected(STANDALONE_OPTION);
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const eligible = useMemo(() => {
+    if (!tasks) return [] as Task[];
+    return tasks.filter((t) => t.id !== currentTaskId);
+  }, [tasks, currentTaskId]);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    setError(null);
+    const target = selected === STANDALONE_OPTION ? null : selected;
+    try {
+      await api.moveAgentToTask(agentId, target);
+      onMoved?.(target);
+      onOpenChange(false);
+      if (target === null) {
+        navigate(`/chats/${agentId}`);
+      } else {
+        navigate(`/tasks/${target}`);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Move {agentLabel ?? 'agent'}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          {error && (
+            <div
+              data-testid="move-agent-error"
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            >
+              {error}
+            </div>
+          )}
+          <div className="flex flex-col gap-1.5 text-xs">
+            <label className="flex items-center gap-2 rounded-md border border-border px-3 py-2 hover:bg-[#141414]">
+              <input
+                type="radio"
+                name="move-agent-target"
+                value={STANDALONE_OPTION}
+                checked={selected === STANDALONE_OPTION}
+                onChange={() => setSelected(STANDALONE_OPTION)}
+              />
+              <span className="font-medium">Detach — become a standalone chat</span>
+            </label>
+            {tasks === null ? (
+              <div className="text-xs text-[#8a8a8a]">Loading tasks…</div>
+            ) : eligible.length === 0 ? (
+              <div className="text-xs text-[#8a8a8a]">No other active tasks available.</div>
+            ) : (
+              <div className="max-h-64 overflow-auto">
+                {eligible.map((t) => (
+                  <label
+                    key={t.id}
+                    data-testid={`move-agent-target-${t.id}`}
+                    className="flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-2 hover:bg-[#141414]"
+                  >
+                    <input
+                      type="radio"
+                      name="move-agent-target"
+                      value={t.id}
+                      checked={selected === t.id}
+                      onChange={() => setSelected(t.id)}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{t.title}</span>
+                    <span className="shrink-0 text-[10px] uppercase text-[#8a8a8a]">{t.status}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              disabled={submitting || (selected !== STANDALONE_OPTION && !selected)}
+            >
+              {submitting ? 'Moving…' : 'Move'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useCallback, useRef, type KeyboardEvent } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { MoveAgentDialog } from '@/components/MoveAgentDialog';
 import { useTasksContext } from '@/lib/tasks-context';
 import {
   groupTasksForSidebar,
@@ -1098,32 +1099,38 @@ function MoreSection({ collapsed, activePath }: { collapsed: boolean; activePath
  */
 function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePath: string }) {
   const [chats, setChats] = useState<Agent[]>([]);
+  const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
+
+  const loadChats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/chats');
+      if (!res.ok) return;
+      const rows = (await res.json()) as Agent[];
+      setChats(rows.filter((c) => c.id !== 'orchestrator'));
+    } catch {
+      // silent — sidebar is non-critical
+    }
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
-    const load = async () => {
-      try {
-        const res = await fetch('/api/chats');
-        if (!res.ok) return;
-        const rows = (await res.json()) as Agent[];
-        if (!cancelled) setChats(rows.filter((c) => c.id !== 'orchestrator'));
-      } catch {
-        // silent — sidebar is non-critical
-      }
+    const tick = async () => {
+      if (cancelled) return;
+      await loadChats();
     };
-    void load();
-    const interval = setInterval(() => void load(), 5000);
+    void tick();
+    const interval = setInterval(() => void tick(), 5000);
     return () => {
       cancelled = true;
       clearInterval(interval);
     };
-  }, []);
+  }, [loadChats]);
 
-  if (chats.length === 0) return null;
+  if (chats.length === 0 && !movingAgentId) return null;
 
   return (
     <div style={{ paddingBottom: 16 }}>
-      {!collapsed && (
+      {!collapsed && chats.length > 0 && (
         <div
           className="font-bold uppercase tracking-wider"
           style={{ fontSize: 10, color: '#6a6a6a', padding: '0 20px 8px' }}
@@ -1135,25 +1142,123 @@ function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePat
         const to = `/chats/${chat.id}`;
         const isActive = activePath === to;
         const color = isActive ? '#3B82F6' : '#8a8a8a';
+        if (collapsed) {
+          return (
+            <Link
+              key={chat.id}
+              to={to}
+              className="flex items-center"
+              style={{
+                padding: '8px 0',
+                gap: 12,
+                backgroundColor: isActive ? '#3B82F620' : 'transparent',
+                color,
+                justifyContent: 'center',
+              }}
+            >
+              💬
+            </Link>
+          );
+        }
         return (
-          <Link
+          <div
             key={chat.id}
-            to={to}
-            className="flex items-center"
+            className="group/chatrow flex items-center"
             style={{
-              padding: collapsed ? '8px 0' : '8px 20px',
-              gap: 12,
+              padding: '8px 20px',
+              gap: 8,
               backgroundColor: isActive ? '#3B82F620' : 'transparent',
-              color,
-              fontWeight: isActive ? 700 : 500,
-              fontSize: 12,
-              justifyContent: collapsed ? 'center' : undefined,
             }}
           >
-            {collapsed ? '💬' : <span className="truncate">{chat.label}</span>}
-          </Link>
+            <Link
+              to={to}
+              className="min-w-0 flex-1 truncate"
+              style={{
+                color,
+                fontWeight: isActive ? 700 : 500,
+                fontSize: 12,
+              }}
+            >
+              {chat.label}
+            </Link>
+            <ChatRowMenu
+              chatId={chat.id}
+              onMoveToTask={() => setMovingAgentId(chat.id)}
+            />
+          </div>
         );
       })}
+      {movingAgentId && (
+        <MoveAgentDialog
+          open={!!movingAgentId}
+          onOpenChange={(open) => !open && setMovingAgentId(null)}
+          agentId={movingAgentId}
+          currentTaskId={null}
+          agentLabel={chats.find((c) => c.id === movingAgentId)?.label ?? 'chat'}
+          onMoved={() => {
+            setMovingAgentId(null);
+            void loadChats();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ChatRowMenu({ chatId, onMoveToTask }: { chatId: string; onMoveToTask: () => void }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: globalThis.MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label="Chat actions"
+        data-testid={`chat-row-menu-${chatId}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setOpen((v) => !v);
+        }}
+        className={
+          'flex h-5 w-5 items-center justify-center text-[#8a8a8a] hover:text-white ' +
+          (open ? 'opacity-100' : 'opacity-0 group-hover/chatrow:opacity-100')
+        }
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="12" cy="19" r="1.5" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          data-testid={`chat-row-menu-items-${chatId}`}
+          className="absolute right-0 top-full z-50 mt-1 min-w-44 bg-[#141414] border border-border py-1 text-xs outline-none"
+        >
+          <button
+            role="menuitem"
+            className="block w-full px-3 py-1.5 text-left text-[#d0d0d0] hover:bg-[#1a1a1a]"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onMoveToTask();
+            }}
+          >
+            Move to task…
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -230,6 +230,28 @@ function TerminalIcon({ color }: { color: string }) {
   );
 }
 
+function WorkspacesIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+    </svg>
+  );
+}
+
 function SettingsIcon({ color }: { color: string }) {
   return (
     <svg
@@ -257,6 +279,10 @@ const NAV_ITEMS = [
   { key: 'tasks', label: 'TASKS', to: '/tasks', Icon: TasksIcon },
   { key: 'orchestrator', label: 'ORCHESTRATOR', to: '/chats/orchestrator', Icon: TerminalIcon },
   { key: 'settings', label: 'SETTINGS', to: '/settings', Icon: SettingsIcon },
+] as const;
+
+const MORE_ITEMS = [
+  { key: 'workspaces', label: 'WORKSPACES', to: '/workspaces', Icon: WorkspacesIcon },
 ] as const;
 
 // ─── Fork refusal helper ────────────────────────────────────────────────────
@@ -669,6 +695,9 @@ export function UniversalSidebar() {
         })}
       </div>
 
+      {/* More (secondary nav: workspaces, etc.) */}
+      <MoreSection collapsed={collapsed} activePath={location.pathname} />
+
       {/* Chats section (non-orchestrator standalone agents) */}
       <ChatsSection collapsed={collapsed} activePath={location.pathname} />
 
@@ -959,6 +988,105 @@ function RenameInput({
       aria-label="Rename task"
       data-testid="sidebar-rename-input"
     />
+  );
+}
+
+// ─── More (collapsible secondary nav) ──────────────────────────────────────
+
+const MORE_STORAGE_KEY = 'octomux:sidebar:more-open';
+
+function MoreSection({ collapsed, activePath }: { collapsed: boolean; activePath: string }) {
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(MORE_STORAGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(MORE_STORAGE_KEY, String(next));
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  if (collapsed) {
+    return (
+      <div style={{ paddingBottom: 16 }}>
+        {MORE_ITEMS.map(({ key, to, Icon, label }) => {
+          const isActive = activePath === to || activePath.startsWith(to + '/');
+          const color = isActive ? '#3B82F6' : '#8a8a8a';
+          return (
+            <Link
+              key={key}
+              to={to}
+              title={label}
+              className="flex items-center"
+              style={{
+                padding: '12px 0',
+                justifyContent: 'center',
+                backgroundColor: isActive ? '#3B82F620' : 'transparent',
+              }}
+            >
+              <Icon color={color} />
+            </Link>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ paddingBottom: 16 }}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        data-testid="sidebar-more-toggle"
+        className="flex w-full items-center justify-between font-bold uppercase tracking-wider hover:text-white"
+        style={{ fontSize: 10, color: '#6a6a6a', padding: '0 20px 8px' }}
+      >
+        <span>{'// MORE'}</span>
+        <span
+          style={{
+            transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+            transition: 'transform 120ms',
+            display: 'inline-block',
+          }}
+        >
+          ⌄
+        </span>
+      </button>
+      {open &&
+        MORE_ITEMS.map(({ key, to, Icon, label }) => {
+          const isActive = activePath === to || activePath.startsWith(to + '/');
+          const color = isActive ? '#3B82F6' : '#8a8a8a';
+          return (
+            <Link
+              key={key}
+              to={to}
+              className="flex items-center"
+              style={{
+                padding: '10px 20px',
+                gap: 12,
+                backgroundColor: isActive ? '#3B82F620' : 'transparent',
+                color,
+                fontWeight: isActive ? 700 : 500,
+                fontSize: 12,
+              }}
+            >
+              <Icon color={color} />
+              {label}
+            </Link>
+          );
+        })}
+    </div>
   );
 }
 

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -491,10 +491,7 @@ export function UniversalSidebar() {
 
   // Active nav detection
   const activeNav = useMemo(() => {
-    if (
-      location.pathname === '/orchestrator' ||
-      location.pathname === '/chats/orchestrator'
-    )
+    if (location.pathname === '/orchestrator' || location.pathname === '/chats/orchestrator')
       return 'orchestrator';
     if (location.pathname === '/settings') return 'settings';
     if (location.pathname === '/tasks' || location.pathname.startsWith('/tasks/')) return 'tasks';
@@ -971,13 +968,7 @@ function RenameInput({
  * Lists standalone runtime agents ("chats"). The orchestrator is already shown
  * in the NAVIGATION section, so it's excluded here. Row click → /chats/:id.
  */
-function ChatsSection({
-  collapsed,
-  activePath,
-}: {
-  collapsed: boolean;
-  activePath: string;
-}) {
+function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePath: string }) {
   const [chats, setChats] = useState<Agent[]>([]);
 
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,7 +6,15 @@ import type {
   Agent,
   OrchestratorStatus,
   UserTerminal,
+  Worktree,
+  WorktreeSummary,
 } from '../../server/types';
+
+export interface WorktreeDetail {
+  worktree: Worktree;
+  active_task: Task | null;
+  history: Task[];
+}
 
 const BASE = '/api';
 
@@ -235,6 +243,12 @@ export const api = {
     request<AgentDetail>('/agents', { method: 'POST', body: JSON.stringify(data) }),
   deleteAgent: (name: string) =>
     request<{ ok: boolean }>(`/agents/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+
+  // Worktrees
+  listWorktrees: () => request<WorktreeSummary[]>('/worktrees'),
+  getWorktree: (id: string) => request<WorktreeDetail>(`/worktrees/${encodeURIComponent(id)}`),
+  deleteWorktree: (id: string) =>
+    request<void>(`/worktrees/${encodeURIComponent(id)}`, { method: 'DELETE' }),
 
   // Repo Config
   listRepoConfigs: () => request<RepoConfig[]>('/repo-configs'),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -244,6 +244,13 @@ export const api = {
   deleteAgent: (name: string) =>
     request<{ ok: boolean }>(`/agents/${encodeURIComponent(name)}`, { method: 'DELETE' }),
 
+  // Agent task hopping (runtime agent row ← tasks table)
+  moveAgentToTask: (agentId: string, taskId: string | null) =>
+    request<Agent>(`/agents/${encodeURIComponent(agentId)}/task`, {
+      method: 'PATCH',
+      body: JSON.stringify({ task_id: taskId }),
+    }),
+
   // Worktrees
   listWorktrees: () => request<WorktreeSummary[]>('/worktrees'),
   getWorktree: (id: string) => request<WorktreeDetail>(`/worktrees/${encodeURIComponent(id)}`),

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -40,9 +40,7 @@ export default function ChatPage() {
   }
 
   if (!chat) {
-    return (
-      <div className="flex h-full items-center justify-center text-[#6a6a6a]">Loading...</div>
-    );
+    return <div className="flex h-full items-center justify-center text-[#6a6a6a]">Loading...</div>;
   }
 
   return (

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -7,6 +7,7 @@ import { AgentTabs } from '@/components/AgentTabs';
 import { DiffViewer } from '@/components/DiffViewer';
 import { DraftEditForm } from '@/components/DraftEditForm';
 import { EmptyState } from '@/components/EmptyState';
+import { MoveAgentDialog } from '@/components/MoveAgentDialog';
 
 import { useTask } from '@/lib/hooks';
 import { api } from '@/lib/api';
@@ -124,6 +125,8 @@ export default function TaskDetail() {
       setLocalUserWindowIndex(null);
     }
   }, [task?.status]);
+
+  const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
 
   const handleAddAgent = useCallback(
     async (prompt?: string) => {
@@ -422,7 +425,33 @@ export default function TaskDetail() {
             userTerminals={isRunning ? task.user_terminals || [] : []}
             onAddTerminal={isRunning ? handleAddTerminal : undefined}
             onCloseTerminal={isRunning ? handleCloseTerminal : undefined}
+            onMoveAgent={isRunning ? (id) => setMovingAgentId(id) : undefined}
+            onDetachAgent={
+              isRunning
+                ? async (id) => {
+                    try {
+                      await api.moveAgentToTask(id, null);
+                      navigate(`/chats/${id}`);
+                    } catch (err) {
+                      console.error('Failed to detach agent:', err);
+                    }
+                  }
+                : undefined
+            }
           />
+          {movingAgentId && (
+            <MoveAgentDialog
+              open={!!movingAgentId}
+              onOpenChange={(open) => !open && setMovingAgentId(null)}
+              agentId={movingAgentId}
+              currentTaskId={task.id}
+              agentLabel={task.agents?.find((a) => a.id === movingAgentId)?.label}
+              onMoved={() => {
+                setMovingAgentId(null);
+                refresh();
+              }}
+            />
+          )}
           <div className="min-h-0 flex-1 overflow-hidden p-1">
             <TerminalView
               taskId={task.id}

--- a/src/pages/WorkspaceDetailPage.test.tsx
+++ b/src/pages/WorkspaceDetailPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithRouter, makeTask } from '../test-helpers';
+import type { Worktree } from '../../server/types';
+import type { WorktreeDetail } from '@/lib/api';
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+const { apiMock, apiProxy } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('react-router-dom', routerMockFactory);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+const WorkspaceDetailPage = (await import('./WorkspaceDetailPage')).default;
+
+const worktree = (overrides: Partial<Worktree> = {}): Worktree => ({
+  id: 'w1',
+  path: '/Users/dev/projects/repo/.worktrees/foo',
+  repo_path: '/Users/dev/projects/repo',
+  branch: 'agents/foo',
+  base_branch: 'main',
+  base_sha: null,
+  mode: 'new',
+  status: 'in_use',
+  created_at: '2026-04-20 12:00:00',
+  last_used_at: '2026-04-24 10:00:00',
+  ...overrides,
+});
+
+const detail = (overrides: Partial<WorktreeDetail> = {}): WorktreeDetail => ({
+  worktree: worktree(),
+  active_task: makeTask({ id: 't-active', title: 'Active work', status: 'running' }),
+  history: [makeTask({ id: 't-old', title: 'Old work', status: 'closed' })],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockNavigate.mockReset();
+});
+
+describe('WorkspaceDetailPage', () => {
+  it('renders active + history sections', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).getWorktree = vi
+      .fn()
+      .mockResolvedValue(detail());
+    renderWithRouter(<WorkspaceDetailPage />, {
+      path: '/workspaces/:id',
+      route: '/workspaces/w1',
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-task-t-active')).toBeInTheDocument();
+      expect(screen.getByTestId('workspace-task-t-old')).toBeInTheDocument();
+    });
+  });
+
+  it('new task button navigates with repo+worktree_path query', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).getWorktree = vi
+      .fn()
+      .mockResolvedValue(
+        detail({
+          worktree: worktree({ status: 'available' }),
+          active_task: null,
+        }),
+      );
+    renderWithRouter(<WorkspaceDetailPage />, {
+      path: '/workspaces/:id',
+      route: '/workspaces/w1',
+    });
+    const button = await screen.findByTestId('new-task-on-workspace');
+    fireEvent.click(button);
+    const arg = mockNavigate.mock.calls[0]?.[0] as string;
+    expect(arg).toContain('/?');
+    expect(arg).toContain('repo=%2FUsers%2Fdev%2Fprojects%2Frepo');
+    expect(arg).toContain('mode=existing');
+    expect(arg).toContain('worktree_path=');
+  });
+
+  it('remove workspace triggers deleteWorktree and navigates back', async () => {
+    const getWt = vi
+      .fn()
+      .mockResolvedValue(
+        detail({
+          worktree: worktree({ status: 'available' }),
+          active_task: null,
+          history: [],
+        }),
+      );
+    const delWt = vi.fn().mockResolvedValue(undefined);
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).getWorktree = getWt;
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).deleteWorktree = delWt;
+    vi.stubGlobal('confirm', vi.fn(() => true));
+
+    renderWithRouter(<WorkspaceDetailPage />, {
+      path: '/workspaces/:id',
+      route: '/workspaces/w1',
+    });
+    const removeBtn = await screen.findByTestId('remove-workspace');
+    fireEvent.click(removeBtn);
+
+    await waitFor(() => expect(delWt).toHaveBeenCalledWith('w1'));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces');
+  });
+
+  it('hides remove button when status is in_use', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).getWorktree = vi
+      .fn()
+      .mockResolvedValue(detail({ worktree: worktree({ status: 'in_use' }) }));
+    renderWithRouter(<WorkspaceDetailPage />, {
+      path: '/workspaces/:id',
+      route: '/workspaces/w1',
+    });
+    await waitFor(() => expect(screen.getByText(/Active task/i)).toBeInTheDocument());
+    expect(screen.queryByTestId('remove-workspace')).toBeNull();
+  });
+});

--- a/src/pages/WorkspaceDetailPage.tsx
+++ b/src/pages/WorkspaceDetailPage.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { api, type WorktreeDetail } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import type { RunMode, Task } from '../../server/types';
+
+const MODE_LABEL: Record<RunMode, string> = {
+  new: 'new',
+  existing: 'existing',
+  none: 'none',
+  scratch: 'scratch',
+};
+
+function shortRepoName(repoPath: string | null): string {
+  if (!repoPath) return '—';
+  const parts = repoPath.split('/').filter(Boolean);
+  return parts[parts.length - 1] || repoPath;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso.replace(' ', 'T') + 'Z');
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export default function WorkspaceDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [detail, setDetail] = useState<WorktreeDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setError(null);
+    try {
+      const data = await api.getWorktree(id);
+      setDetail(data);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleNewTask = useCallback(() => {
+    if (!detail) return;
+    const params = new URLSearchParams();
+    if (detail.worktree.repo_path) params.set('repo', detail.worktree.repo_path);
+    params.set('mode', 'existing');
+    if (detail.worktree.path) params.set('worktree_path', detail.worktree.path);
+    navigate(`/?${params.toString()}`);
+  }, [detail, navigate]);
+
+  const handleRemove = useCallback(async () => {
+    if (!detail) return;
+    const userOwned = detail.worktree.mode === 'existing' || detail.worktree.mode === 'none';
+    const confirmMessage = userOwned
+      ? 'Forget this workspace? The filesystem directory will be left untouched; only the Octomux record is removed.'
+      : 'Remove this workspace? This deletes the worktree directory and branch from disk.';
+    if (!window.confirm(confirmMessage)) return;
+    setRemoving(true);
+    try {
+      await api.deleteWorktree(detail.worktree.id);
+      navigate('/workspaces');
+    } catch (err) {
+      setError((err as Error).message);
+      setRemoving(false);
+    }
+  }, [detail, navigate]);
+
+  if (error && !detail) {
+    return (
+      <div className="h-full overflow-auto">
+        <div className="mx-auto max-w-4xl px-4 py-6 text-sm text-destructive">
+          Failed to load workspace: {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="h-full overflow-auto">
+        <div className="mx-auto max-w-4xl px-4 py-6 text-sm text-[#8a8a8a]">Loading…</div>
+      </div>
+    );
+  }
+
+  const w = detail.worktree;
+  const canRemove =
+    w.status === 'available' && detail.active_task === null && !removing;
+  const userOwned = w.mode === 'existing' || w.mode === 'none';
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        <button
+          onClick={() => navigate('/workspaces')}
+          className="mb-3 text-xs text-[#8a8a8a] hover:text-foreground"
+        >
+          ← All workspaces
+        </button>
+
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div className="min-w-0 flex flex-col gap-1.5">
+            <h1 className="font-display text-[28px] font-bold leading-tight">
+              {shortRepoName(w.repo_path)}
+              {w.branch ? (
+                <span className="ml-3 font-mono text-lg text-[#a0a0a0]">{w.branch}</span>
+              ) : null}
+            </h1>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-[#8a8a8a]">
+              <span
+                className="inline-flex items-center px-1.5 py-0.5"
+                style={{
+                  fontSize: 10,
+                  background: '#1a1a1a',
+                  border: '1px solid #2f2f2f',
+                  color: '#a0a0a0',
+                }}
+              >
+                {MODE_LABEL[w.mode]}
+              </span>
+              <span className={w.status === 'in_use' ? 'text-[#22C55E]' : ''}>{w.status}</span>
+            </div>
+            <div className="mt-1 break-all font-mono text-xs text-[#8a8a8a]">{w.path}</div>
+          </div>
+
+          <div className="flex shrink-0 flex-col items-end gap-2">
+            {w.status === 'available' && (
+              <Button size="sm" onClick={handleNewTask} data-testid="new-task-on-workspace">
+                New task on this workspace
+              </Button>
+            )}
+            {canRemove && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleRemove}
+                data-testid="remove-workspace"
+              >
+                {userOwned ? 'Forget workspace' : 'Remove workspace'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <section className="mb-6">
+          <h2 className="mb-2 text-xs font-bold uppercase tracking-wider text-[#8a8a8a]">
+            Active task
+          </h2>
+          {detail.active_task ? (
+            <TaskRow task={detail.active_task} onClick={() => navigate(`/tasks/${detail.active_task!.id}`)} />
+          ) : (
+            <div className="rounded-md border border-border bg-card p-4 text-sm text-[#8a8a8a]">
+              No active task.
+            </div>
+          )}
+        </section>
+
+        <section>
+          <h2 className="mb-2 text-xs font-bold uppercase tracking-wider text-[#8a8a8a]">
+            History ({detail.history.length})
+          </h2>
+          {detail.history.length === 0 ? (
+            <div className="rounded-md border border-border bg-card p-4 text-sm text-[#8a8a8a]">
+              No past tasks.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {detail.history.map((t) => (
+                <TaskRow key={t.id} task={t} onClick={() => navigate(`/tasks/${t.id}`)} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <div className="mt-6 text-[10px] text-[#6a6a6a]">
+          Created {formatDate(w.created_at)} · Last used {formatDate(w.last_used_at)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TaskRow({ task, onClick }: { task: Task; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={`workspace-task-${task.id}`}
+      className="flex w-full items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2 text-left hover:bg-[#141414]"
+    >
+      <div className="min-w-0 flex-1 truncate text-sm text-foreground">{task.title}</div>
+      <div className="shrink-0 text-xs text-[#8a8a8a]">{task.status}</div>
+    </button>
+  );
+}

--- a/src/pages/WorkspacesPage.test.tsx
+++ b/src/pages/WorkspacesPage.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithRouter, setupApiMock, setupRouterNavigateMock } from '../test-helpers';
+import type { WorktreeSummary } from '../../server/types';
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+const { apiMock, apiProxy } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('react-router-dom', routerMockFactory);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+void setupApiMock;
+void setupRouterNavigateMock;
+
+const WorkspacesPage = (await import('./WorkspacesPage')).default;
+
+const wt = (overrides: Partial<WorktreeSummary> = {}): WorktreeSummary => ({
+  id: 'w1',
+  path: '/Users/dev/projects/repo/.worktrees/foo',
+  repo_path: '/Users/dev/projects/repo',
+  branch: 'agents/foo',
+  base_branch: 'main',
+  base_sha: null,
+  mode: 'new',
+  status: 'in_use',
+  created_at: '2026-04-20 12:00:00',
+  last_used_at: '2026-04-24 10:00:00',
+  task_count: 1,
+  active_task_id: 't1',
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockNavigate.mockReset();
+  (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
+    .fn()
+    .mockResolvedValue([]);
+});
+
+describe('WorkspacesPage', () => {
+  it('renders the empty state', async () => {
+    renderWithRouter(<WorkspacesPage />);
+    await waitFor(() =>
+      expect(screen.getByText(/No workspaces yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders worktree rows', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
+      .fn()
+      .mockResolvedValue([wt({ id: 'w1' }), wt({ id: 'w2', repo_path: '/other', mode: 'existing' })]);
+    renderWithRouter(<WorkspacesPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument();
+      expect(screen.getByTestId('workspace-row-w2')).toBeInTheDocument();
+    });
+  });
+
+  it('filters by repo', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
+      .fn()
+      .mockResolvedValue([
+        wt({ id: 'w1', repo_path: '/repo/alpha' }),
+        wt({ id: 'w2', repo_path: '/repo/beta' }),
+      ]);
+    renderWithRouter(<WorkspacesPage />);
+    await waitFor(() => expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/Filter by repo/i), {
+      target: { value: '/repo/alpha' },
+    });
+    expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-row-w2')).toBeNull();
+  });
+
+  it('filters by mode', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
+      .fn()
+      .mockResolvedValue([
+        wt({ id: 'w1', mode: 'new' }),
+        wt({ id: 'w2', mode: 'scratch' }),
+      ]);
+    renderWithRouter(<WorkspacesPage />);
+    await waitFor(() => expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/Filter by mode/i), { target: { value: 'scratch' } });
+    expect(screen.queryByTestId('workspace-row-w1')).toBeNull();
+    expect(screen.getByTestId('workspace-row-w2')).toBeInTheDocument();
+  });
+
+  it('navigates to detail on row click', async () => {
+    (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
+      .fn()
+      .mockResolvedValue([wt({ id: 'wX' })]);
+    renderWithRouter(<WorkspacesPage />);
+    const row = await screen.findByTestId('workspace-row-wX');
+    fireEvent.click(row);
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces/wX');
+  });
+});

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '@/lib/api';
+import type { RunMode, WorktreeSummary } from '../../server/types';
+
+function shortRepoName(repoPath: string | null): string {
+  if (!repoPath) return '—';
+  const parts = repoPath.split('/').filter(Boolean);
+  return parts[parts.length - 1] || repoPath;
+}
+
+function truncate(s: string, n = 48): string {
+  if (!s) return '—';
+  if (s.length <= n) return s;
+  return '…' + s.slice(s.length - (n - 1));
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return '—';
+  const t = new Date(iso.replace(' ', 'T') + 'Z').getTime();
+  if (Number.isNaN(t)) return iso;
+  const diff = Date.now() - t;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+const MODE_LABEL: Record<RunMode, string> = {
+  new: 'new',
+  existing: 'existing',
+  none: 'none',
+  scratch: 'scratch',
+};
+
+export default function WorkspacesPage() {
+  const navigate = useNavigate();
+  const [worktrees, setWorktrees] = useState<WorktreeSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [repoFilter, setRepoFilter] = useState<string>('all');
+  const [modeFilter, setModeFilter] = useState<string>('all');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const rows = await api.listWorktrees();
+        if (!cancelled) setWorktrees(rows);
+      } catch (err) {
+        if (!cancelled) setError((err as Error).message);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const repoOptions = useMemo(() => {
+    if (!worktrees) return [] as string[];
+    const set = new Set<string>();
+    for (const w of worktrees) if (w.repo_path) set.add(w.repo_path);
+    return [...set].sort();
+  }, [worktrees]);
+
+  const filtered = useMemo(() => {
+    if (!worktrees) return [];
+    return worktrees.filter((w) => {
+      if (repoFilter !== 'all' && w.repo_path !== repoFilter) return false;
+      if (modeFilter !== 'all' && w.mode !== modeFilter) return false;
+      return true;
+    });
+  }, [worktrees, repoFilter, modeFilter]);
+
+  if (error) {
+    return (
+      <div className="h-full overflow-auto">
+        <div className="mx-auto max-w-6xl px-4 py-6 text-sm text-destructive">
+          Failed to load workspaces: {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto max-w-6xl px-4 py-6">
+        <div className="mb-6 flex flex-col gap-1.5">
+          <h1
+            className="font-display text-[36px] font-bold leading-none tracking-tight"
+            style={{ letterSpacing: '-1px' }}
+          >
+            WORKSPACES
+          </h1>
+          <span className="text-sm text-[#8a8a8a]">
+            // git worktrees + scratch dirs used by tasks
+          </span>
+        </div>
+
+        <div className="mb-4 flex flex-wrap items-center gap-3" data-testid="workspace-filters">
+          <label className="text-xs text-[#8a8a8a]">
+            Repo
+            <select
+              aria-label="Filter by repo"
+              value={repoFilter}
+              onChange={(e) => setRepoFilter(e.target.value)}
+              className="ml-2 bg-[#141414] px-2 py-1 text-xs text-foreground outline-none"
+              style={{ border: '1px solid #2f2f2f' }}
+            >
+              <option value="all">All</option>
+              {repoOptions.map((r) => (
+                <option key={r} value={r}>
+                  {shortRepoName(r)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-xs text-[#8a8a8a]">
+            Mode
+            <select
+              aria-label="Filter by mode"
+              value={modeFilter}
+              onChange={(e) => setModeFilter(e.target.value)}
+              className="ml-2 bg-[#141414] px-2 py-1 text-xs text-foreground outline-none"
+              style={{ border: '1px solid #2f2f2f' }}
+            >
+              <option value="all">All</option>
+              {(['new', 'existing', 'none', 'scratch'] as RunMode[]).map((m) => (
+                <option key={m} value={m}>
+                  {MODE_LABEL[m]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {worktrees === null ? (
+          <div className="text-sm text-[#8a8a8a]">Loading…</div>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-md border border-border bg-card p-8 text-center text-sm text-[#8a8a8a]">
+            {worktrees.length === 0
+              ? "No workspaces yet. They're created automatically when you start a task."
+              : 'No workspaces match these filters.'}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-border">
+            <table className="w-full text-left text-xs">
+              <thead className="bg-[#0f0f0f] text-[#8a8a8a] uppercase tracking-wider">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Repo</th>
+                  <th className="px-3 py-2 font-medium">Branch</th>
+                  <th className="px-3 py-2 font-medium">Mode</th>
+                  <th className="px-3 py-2 font-medium">Path</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Tasks</th>
+                  <th className="px-3 py-2 font-medium">Last used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((w) => (
+                  <tr
+                    key={w.id}
+                    data-testid={`workspace-row-${w.id}`}
+                    onClick={() => navigate(`/workspaces/${w.id}`)}
+                    className="cursor-pointer border-t border-border hover:bg-[#141414]"
+                  >
+                    <td className="px-3 py-2 text-foreground">{shortRepoName(w.repo_path)}</td>
+                    <td className="px-3 py-2 font-mono text-[#a0a0a0]">{w.branch ?? '—'}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className="inline-flex items-center px-1.5 py-0.5"
+                        style={{
+                          fontSize: 10,
+                          background: '#1a1a1a',
+                          border: '1px solid #2f2f2f',
+                          color: '#a0a0a0',
+                        }}
+                      >
+                        {MODE_LABEL[w.mode]}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[#8a8a8a]" title={w.path}>
+                      {truncate(w.path)}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          w.status === 'in_use' ? 'text-[#22C55E]' : 'text-[#8a8a8a]'
+                        }
+                      >
+                        {w.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-[#a0a0a0]">{w.task_count}</td>
+                    <td className="px-3 py-2 text-[#8a8a8a]">{relativeTime(w.last_used_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Second half of the Phase 2 chat-first UX overhaul.

- **Workspaces browser** — new `/workspaces` list and `/workspaces/:id` detail pages, reached from the sidebar's new `// MORE` collapsible section (not promoted to top-level nav). The list filters by repo and mode; the detail page shows the active task, task history, and actions to spin up a new task on the worktree or remove/forget it.
- **Agent task-hopping** — a running agent can now move between tasks (or detach to a standalone chat) via `PATCH /api/agents/:id/task`. The server kills the old tmux window, creates a new one at the target's cwd, and resumes with `claude --resume <claude_session_id>` so the Claude transcript survives. Entry points live on the sidebar Chats row `⋮` (Move to task…) and on the TaskDetail per-agent `⋮` (Move to task… / Detach to chat).

## New endpoints

- `GET /api/worktrees/:id` — returns `{worktree, active_task, history}`.
- `DELETE /api/worktrees/:id` — guarded: only deletes when the worktree is `available` and has no active referencing task. For `new`/`scratch` modes it also removes the directory (and branch for `new`). For `existing`/`none` it leaves the filesystem untouched.
- `PATCH /api/agents/:id/task` — body `{task_id: string | null}`. Validates the target is an active task with a resolvable worktree; 409 on conflict.

## New routes

- `/workspaces`
- `/workspaces/:id`

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (0 errors; pre-existing warnings only)
- [x] `bun run test` — 61 files, 1190 tests pass
- [x] API tests cover the joined GET shape, DELETE 409/204 constraints, and all PATCH cases (404 missing agent, 400 missing/same task_id, 404 target missing, 409 target not active, detach, move, attach from chat)
- [x] `hopAgent` task-runner tests cover the three lifecycles (detach kills window and spawns new chat session, move between tasks creates new window in target, attach from chat kills the chat session)
- [x] `WorkspacesPage` + `WorkspaceDetailPage` + `MoveAgentDialog` component tests