### PR TITLE
feat(ui): glass design system foundation

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -1770,9 +1770,7 @@ describe('DELETE /api/worktrees/:id', () => {
 
 describe('PATCH /api/agents/:id/task', () => {
   it('404 when agent does not exist', async () => {
-    const res = await request(app)
-      .patch('/api/agents/missing/task')
-      .send({ task_id: null });
+    const res = await request(app).patch('/api/agents/missing/task').send({ task_id: null });
     expect(res.status).toBe(404);
   });
 
@@ -1785,9 +1783,7 @@ describe('PATCH /api/agents/:id/task', () => {
   it('400 when task_id equals current task_id (no-op)', async () => {
     insertTask(db, { id: 'tSame', status: 'running' });
     insertAgent(db, { id: 'aSame', task_id: 'tSame' });
-    const res = await request(app)
-      .patch('/api/agents/aSame/task')
-      .send({ task_id: 'tSame' });
+    const res = await request(app).patch('/api/agents/aSame/task').send({ task_id: 'tSame' });
     expect(res.status).toBe(400);
   });
 
@@ -1802,9 +1798,7 @@ describe('PATCH /api/agents/:id/task', () => {
   it('409 when target task is not active', async () => {
     insertTask(db, { id: 'tClosed', status: 'closed' });
     insertAgent(db, { id: 'aC', task_id: null });
-    const res = await request(app)
-      .patch('/api/agents/aC/task')
-      .send({ task_id: 'tClosed' });
+    const res = await request(app).patch('/api/agents/aC/task').send({ task_id: 'tClosed' });
     expect(res.status).toBe(409);
   });
 
@@ -1812,9 +1806,7 @@ describe('PATCH /api/agents/:id/task', () => {
     insertTask(db, { id: 'tFrom', status: 'running' });
     insertAgent(db, { id: 'aDet', task_id: 'tFrom' });
 
-    const res = await request(app)
-      .patch('/api/agents/aDet/task')
-      .send({ task_id: null });
+    const res = await request(app).patch('/api/agents/aDet/task').send({ task_id: null });
     expect(res.status).toBe(200);
     expect(res.body.task_id).toBeNull();
     expect(res.body.tmux_session).toBe('octomux-chat-aDet');

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -1140,10 +1140,7 @@ export async function resumeTask(task: Task): Promise<void> {
  * `targetTaskId` is null). Kills the old tmux window, creates a new one at the
  * new cwd, and resumes with `claude --resume` so transcript context survives.
  */
-export async function hopAgent(
-  agent: Agent,
-  targetTaskId: string | null,
-): Promise<Agent> {
+export async function hopAgent(agent: Agent, targetTaskId: string | null): Promise<Agent> {
   const db = getDb();
   const fromTaskId = agent.task_id;
   logger.info(

--- a/src/components/MoveAgentDialog.test.tsx
+++ b/src/components/MoveAgentDialog.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderWithRouter, makeTask } from '../test-helpers';
 
-const { mockNavigate, routerMockFactory } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { apiMock, apiProxy } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupApiMock(),
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
 );
 
 vi.mock('react-router-dom', routerMockFactory);
@@ -48,12 +48,7 @@ describe('MoveAgentDialog', () => {
 
   it('detaches by default and navigates to /chats/:id', async () => {
     renderWithRouter(
-      <MoveAgentDialog
-        open={true}
-        onOpenChange={() => {}}
-        agentId="a1"
-        currentTaskId={null}
-      />,
+      <MoveAgentDialog open={true} onOpenChange={() => {}} agentId="a1" currentTaskId={null} />,
     );
     await waitFor(() => expect(screen.getByText(/Detach/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /^Move$/i }));
@@ -67,12 +62,7 @@ describe('MoveAgentDialog', () => {
 
   it('moves to a chosen task and navigates to /tasks/:id', async () => {
     renderWithRouter(
-      <MoveAgentDialog
-        open={true}
-        onOpenChange={() => {}}
-        agentId="a1"
-        currentTaskId={null}
-      />,
+      <MoveAgentDialog open={true} onOpenChange={() => {}} agentId="a1" currentTaskId={null} />,
     );
     const target = await screen.findByTestId('move-agent-target-t-running');
     fireEvent.click(target.querySelector('input')!);
@@ -90,12 +80,7 @@ describe('MoveAgentDialog', () => {
       .fn()
       .mockRejectedValue(new Error('Target task is not active (status=closed)'));
     renderWithRouter(
-      <MoveAgentDialog
-        open={true}
-        onOpenChange={() => {}}
-        agentId="a1"
-        currentTaskId={null}
-      />,
+      <MoveAgentDialog open={true} onOpenChange={() => {}} agentId="a1" currentTaskId={null} />,
     );
     await waitFor(() => expect(screen.getByText(/Detach/i)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /^Move$/i }));

--- a/src/components/MoveAgentDialog.tsx
+++ b/src/components/MoveAgentDialog.tsx
@@ -2,12 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '@/lib/api';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import type { Task } from '../../server/types';
 
 interface MoveAgentDialogProps {
@@ -130,7 +125,9 @@ export function MoveAgentDialog({
                       onChange={() => setSelected(t.id)}
                     />
                     <span className="min-w-0 flex-1 truncate">{t.title}</span>
-                    <span className="shrink-0 text-[10px] uppercase text-[#8a8a8a]">{t.status}</span>
+                    <span className="shrink-0 text-[10px] uppercase text-[#8a8a8a]">
+                      {t.status}
+                    </span>
                   </label>
                 ))}
               </div>

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -5,37 +5,34 @@ import { renderWithRouter, TASK_STATUSES } from '../test-helpers';
 import type { TaskStatus } from '../../server/types';
 
 describe('StatusBadge', () => {
-  // ─── Renders all statuses ─────────────────────────────────────────────────
+  // ─── Renders all statuses with glyph + label ──────────────────────────────
 
-  const statusLabels: [TaskStatus, string][] = [
-    ['draft', '[DRAFT]'],
-    ['setting_up', '[SETTING_UP]'],
-    ['running', '[RUNNING]'],
-    ['closed', '[CLOSED]'],
-    ['error', '[ERROR]'],
+  const statusLabels: [TaskStatus, string, string][] = [
+    ['draft', 'DRAFT', '○'],
+    ['setting_up', 'SETTING_UP', '◐'],
+    ['running', 'RUNNING', '●'],
+    ['closed', 'CLOSED', '○'],
+    ['error', 'ERROR', '✕'],
   ];
 
-  it.each(statusLabels)('renders "%s" with label "%s"', (status, label) => {
-    renderWithRouter(<StatusBadge status={status} />);
-    expect(screen.getByText(label)).toBeInTheDocument();
-  });
+  it.each(statusLabels)(
+    'renders "%s" with label "%s" prefixed by glyph "%s"',
+    (status, label, glyph) => {
+      renderWithRouter(<StatusBadge status={status} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByText(glyph)).toBeInTheDocument();
+    },
+  );
 
   it('covers every TaskStatus value', () => {
     const testedStatuses = statusLabels.map(([s]) => s);
     expect(testedStatuses).toEqual(TASK_STATUSES);
   });
 
-  // ─── Visual indicators ────────────────────────────────────────────────────
+  // ─── Glyph is always present ──────────────────────────────────────────────
 
-  it('shows pulse indicator only for running status', () => {
-    const { container } = renderWithRouter(<StatusBadge status="running" />);
-    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
-  });
-
-  const nonRunningStatuses = TASK_STATUSES.filter((s) => s !== 'running');
-
-  it.each(nonRunningStatuses)('does not show pulse indicator for "%s"', (status) => {
+  it.each(TASK_STATUSES)('renders a StatusGlyph for "%s"', (status) => {
     const { container } = renderWithRouter(<StatusBadge status={status} />);
-    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument();
+    expect(container.querySelector('[role="img"]')).toBeInTheDocument();
   });
 });

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,26 +1,39 @@
 import { memo } from 'react';
 
-const statusConfig: Record<string, { label: string; className: string }> = {
-  draft: { label: '[DRAFT]', className: 'text-[#6a6a6a]' },
-  setting_up: { label: '[SETTING_UP]', className: 'text-[#FFB800]' },
-  running: { label: '[RUNNING]', className: 'text-[#22C55E]' },
-  closed: { label: '[CLOSED]', className: 'text-[#6a6a6a]' },
-  error: { label: '[ERROR]', className: 'text-[#EF4444]' },
-  working: { label: '[WORKING]', className: 'text-[#22C55E]' },
-  needs_attention: { label: '[ALERT]', className: 'text-[#FFB800]' },
-  done: { label: '[DONE]', className: 'text-[#22C55E]' },
+import { StatusGlyph } from './ui/status-glyph';
+
+const labels: Record<string, string> = {
+  draft: 'DRAFT',
+  setting_up: 'SETTING_UP',
+  running: 'RUNNING',
+  closed: 'CLOSED',
+  error: 'ERROR',
+  working: 'WORKING',
+  needs_attention: 'ALERT',
+  done: 'DONE',
 };
 
-const fallbackConfig = { label: '[UNKNOWN]', className: 'text-[#6a6a6a]' };
+const colors: Record<string, string> = {
+  draft: 'text-[#6a6a6a]',
+  setting_up: 'text-[#FFB800]',
+  running: 'text-[#22C55E]',
+  closed: 'text-[#6a6a6a]',
+  error: 'text-[#EF4444]',
+  working: 'text-[#22C55E]',
+  needs_attention: 'text-[#FFB800]',
+  done: 'text-[#22C55E]',
+};
 
 export const StatusBadge = memo(function StatusBadge({ status }: { status: string }) {
-  const config = statusConfig[status] || fallbackConfig;
+  const label = labels[status] || 'UNKNOWN';
+  const colorClass = colors[status] || 'text-[#6a6a6a]';
   return (
-    <span className={`text-xs font-bold uppercase tracking-wider ${config.className}`}>
-      {(status === 'running' || status === 'working') && (
-        <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse bg-[#22C55E]" />
-      )}
-      {config.label}
+    <span
+      data-status={status}
+      className={`inline-flex items-center gap-1 text-xs font-bold tracking-wider uppercase ${colorClass}`}
+    >
+      <StatusGlyph status={status} size={10} />
+      <span>{label}</span>
     </span>
   );
 });

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -1181,10 +1181,7 @@ function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePat
             >
               {chat.label}
             </Link>
-            <ChatRowMenu
-              chatId={chat.id}
-              onMoveToTask={() => setMovingAgentId(chat.id)}
-            />
+            <ChatRowMenu chatId={chat.id} onMoveToTask={() => setMovingAgentId(chat.id)} />
           </div>
         );
       })}

--- a/src/components/ui/glass-panel.test.tsx
+++ b/src/components/ui/glass-panel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { GlassPanel } from './glass-panel';
+
+describe('GlassPanel', () => {
+  it('defaults to level 1 with l1 tint, l1 blur, and standard edge', () => {
+    const { container } = render(<GlassPanel>content</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.dataset.glassLevel).toBe('1');
+    expect(el.className).toContain('bg-glass-l1');
+    expect(el.className).toContain('glass-blur-l1');
+    expect(el.className).toContain('border-glass-edge');
+    expect(el.className).not.toContain('border-glass-edge-strong');
+  });
+
+  it('renders level 2 with l2 tint and l2 blur', () => {
+    const { container } = render(<GlassPanel level={2}>x</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.dataset.glassLevel).toBe('2');
+    expect(el.className).toContain('bg-glass-l2');
+    expect(el.className).toContain('glass-blur-l2');
+    expect(el.className).toContain('border-glass-edge');
+  });
+
+  it('renders level 3 with l3 tint, l3 blur, and strong edge', () => {
+    const { container } = render(<GlassPanel level={3}>x</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.dataset.glassLevel).toBe('3');
+    expect(el.className).toContain('bg-glass-l3');
+    expect(el.className).toContain('glass-blur-l3');
+    expect(el.className).toContain('border-glass-edge-strong');
+  });
+
+  it('applies inset specular highlight when specular is true', () => {
+    const { container } = render(<GlassPanel specular>x</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.dataset.glassSpecular).toBe('true');
+    expect(el.style.boxShadow).toContain('inset');
+    expect(el.style.boxShadow.toLowerCase()).toContain('rgba(255, 255, 255, 0.22)');
+  });
+
+  it('omits specular highlight by default', () => {
+    const { container } = render(<GlassPanel>x</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.dataset.glassSpecular).toBeUndefined();
+    expect(el.style.boxShadow).toBe('');
+  });
+
+  it('merges caller className', () => {
+    const { container } = render(<GlassPanel className="p-4 custom-x">x</GlassPanel>);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain('p-4');
+    expect(el.className).toContain('custom-x');
+    expect(el.className).toContain('bg-glass-l1');
+  });
+
+  it('forwards arbitrary props onto the underlying div', () => {
+    const { container } = render(
+      <GlassPanel data-testid="panel" aria-label="surface">
+        x
+      </GlassPanel>,
+    );
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.getAttribute('data-testid')).toBe('panel');
+    expect(el.getAttribute('aria-label')).toBe('surface');
+  });
+});

--- a/src/components/ui/glass-panel.tsx
+++ b/src/components/ui/glass-panel.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type GlassLevel = 1 | 2 | 3;
+
+export interface GlassPanelProps extends HTMLAttributes<HTMLDivElement> {
+  level?: GlassLevel;
+  specular?: boolean;
+}
+
+const tintByLevel: Record<GlassLevel, string> = {
+  1: 'bg-glass-l1 glass-blur-l1',
+  2: 'bg-glass-l2 glass-blur-l2',
+  3: 'bg-glass-l3 glass-blur-l3',
+};
+
+const edgeByLevel: Record<GlassLevel, string> = {
+  1: 'border border-glass-edge',
+  2: 'border border-glass-edge',
+  3: 'border border-glass-edge-strong',
+};
+
+const SPECULAR_SHADOW = 'inset 0 1px 0 0 rgba(255, 255, 255, 0.22)';
+
+export const GlassPanel = forwardRef<HTMLDivElement, GlassPanelProps>(function GlassPanel(
+  { level = 1, specular = false, className, style, children, ...rest },
+  ref,
+) {
+  const mergedStyle: CSSProperties | undefined = specular
+    ? { boxShadow: SPECULAR_SHADOW, ...style }
+    : style;
+  return (
+    <div
+      ref={ref}
+      data-glass-level={level}
+      data-glass-specular={specular ? 'true' : undefined}
+      className={cn(tintByLevel[level], edgeByLevel[level], className)}
+      style={mergedStyle}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});

--- a/src/components/ui/status-glyph.test.tsx
+++ b/src/components/ui/status-glyph.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusGlyph } from './status-glyph';
+
+describe('StatusGlyph', () => {
+  const cases: [string, string, string][] = [
+    ['running', '●', 'rgb(34, 197, 94)'],
+    ['working', '●', 'rgb(34, 197, 94)'],
+    ['done', '●', 'rgb(34, 197, 94)'],
+    ['awaiting', '▲', 'rgb(255, 184, 0)'],
+    ['needs_attention', '▲', 'rgb(255, 184, 0)'],
+    ['setting_up', '◐', 'rgb(255, 184, 0)'],
+    ['error', '✕', 'rgb(239, 68, 68)'],
+    ['closed', '○', 'rgb(106, 106, 106)'],
+    ['draft', '○', 'rgb(106, 106, 106)'],
+  ];
+
+  it.each(cases)('renders status "%s" as glyph "%s" in color %s', (status, glyph, rgb) => {
+    render(<StatusGlyph status={status} />);
+    const el = screen.getByRole('img');
+    expect(el.textContent).toBe(glyph);
+    expect(el.dataset.glyph).toBe(glyph);
+    expect(el.dataset.status).toBe(status);
+    expect(el.style.color).toBe(rgb);
+  });
+
+  it('falls back to grey ○ for unknown status', () => {
+    render(<StatusGlyph status="who_knows" />);
+    const el = screen.getByRole('img');
+    expect(el.textContent).toBe('○');
+    expect(el.getAttribute('aria-label')).toBe('unknown');
+  });
+
+  it('uses default size of 10px', () => {
+    render(<StatusGlyph status="running" />);
+    const el = screen.getByRole('img');
+    expect(el.style.fontSize).toBe('10px');
+  });
+
+  it('respects size prop', () => {
+    render(<StatusGlyph status="running" size={16} />);
+    const el = screen.getByRole('img');
+    expect(el.style.fontSize).toBe('16px');
+  });
+
+  it('exposes status as accessible label and data-status', () => {
+    render(<StatusGlyph status="needs_attention" />);
+    const el = screen.getByRole('img');
+    expect(el.getAttribute('aria-label')).toBe('needs attention');
+    expect(el.dataset.status).toBe('needs_attention');
+  });
+
+  it('merges caller className', () => {
+    render(<StatusGlyph status="running" className="ml-2 custom" />);
+    const el = screen.getByRole('img');
+    expect(el.className).toContain('ml-2');
+    expect(el.className).toContain('custom');
+  });
+});

--- a/src/components/ui/status-glyph.tsx
+++ b/src/components/ui/status-glyph.tsx
@@ -1,0 +1,50 @@
+import { memo, type CSSProperties } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface StatusGlyphProps {
+  status: string;
+  size?: number;
+  className?: string;
+}
+
+interface GlyphConfig {
+  glyph: string;
+  color: string;
+  label: string;
+}
+
+const config: Record<string, GlyphConfig> = {
+  running: { glyph: '●', color: '#22C55E', label: 'running' },
+  working: { glyph: '●', color: '#22C55E', label: 'working' },
+  done: { glyph: '●', color: '#22C55E', label: 'done' },
+  awaiting: { glyph: '▲', color: '#FFB800', label: 'awaiting' },
+  needs_attention: { glyph: '▲', color: '#FFB800', label: 'needs attention' },
+  setting_up: { glyph: '◐', color: '#FFB800', label: 'setting up' },
+  error: { glyph: '✕', color: '#EF4444', label: 'error' },
+  closed: { glyph: '○', color: '#6a6a6a', label: 'closed' },
+  draft: { glyph: '○', color: '#6a6a6a', label: 'draft' },
+};
+
+const fallback: GlyphConfig = { glyph: '○', color: '#6a6a6a', label: 'unknown' };
+
+export const StatusGlyph = memo(function StatusGlyph({
+  status,
+  size = 10,
+  className,
+}: StatusGlyphProps) {
+  const cfg = config[status] || fallback;
+  const style: CSSProperties = { color: cfg.color, fontSize: size, lineHeight: 1 };
+  return (
+    <span
+      role="img"
+      aria-label={cfg.label}
+      data-status={status}
+      data-glyph={cfg.glyph}
+      className={cn('inline-flex items-center justify-center', className)}
+      style={style}
+    >
+      {cfg.glyph}
+    </span>
+  );
+});

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,8 @@
   --secondary: #141414;
   --secondary-foreground: #ffffff;
   --muted: #141414;
-  --muted-foreground: #8a8a8a;
+  --muted-foreground: #b5b5bd;
+  --muted-soft: #8a8a8a;
   --accent: #141414;
   --accent-foreground: #ffffff;
   --destructive: #ef4444;
@@ -43,10 +44,19 @@
   /* Custom design tokens */
   --color-success: #22c55e;
   --color-warning: #ffb800;
-  --color-text-secondary: #8a8a8a;
+  --color-text-secondary: #b5b5bd;
   --color-text-muted: #6a6a6a;
   --color-surface-elevated: #141414;
   --color-terminal-bg: #09090b;
+
+  /* Glass material system */
+  --glass-l0: #0a0a0b;
+  --glass-l1: rgba(255, 255, 255, 0.08);
+  --glass-l2: rgba(255, 255, 255, 0.12);
+  --glass-l3: rgba(255, 255, 255, 0.18);
+  --glass-edge: rgba(255, 255, 255, 0.14);
+  --glass-edge-strong: rgba(255, 255, 255, 0.26);
+  --glass-specular: rgba(255, 255, 255, 0.22);
 }
 
 /* Dark-only app — no light theme. Keep .dark for shadcn compatibility. */
@@ -62,7 +72,8 @@
   --secondary: #141414;
   --secondary-foreground: #ffffff;
   --muted: #141414;
-  --muted-foreground: #8a8a8a;
+  --muted-foreground: #b5b5bd;
+  --muted-soft: #8a8a8a;
   --accent: #141414;
   --accent-foreground: #ffffff;
   --destructive: #ef4444;
@@ -109,6 +120,7 @@
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
   --color-muted: var(--muted);
+  --color-muted-soft: var(--muted-soft);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
   --color-primary-foreground: var(--primary-foreground);
@@ -121,6 +133,13 @@
   --color-background: var(--background);
   --color-success: var(--color-success);
   --color-warning: var(--color-warning);
+  --color-glass-l0: var(--glass-l0);
+  --color-glass-l1: var(--glass-l1);
+  --color-glass-l2: var(--glass-l2);
+  --color-glass-l3: var(--glass-l3);
+  --color-glass-edge: var(--glass-edge);
+  --color-glass-edge-strong: var(--glass-edge-strong);
+  --color-glass-specular: var(--glass-specular);
   --radius-sm: 0;
   --radius-md: 0;
   --radius-lg: 0;
@@ -139,5 +158,29 @@
   }
   html {
     @apply font-sans;
+  }
+}
+
+@utility glass-blur-l1 {
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+}
+
+@utility glass-blur-l2 {
+  backdrop-filter: blur(60px);
+  -webkit-backdrop-filter: blur(60px);
+}
+
+@utility glass-blur-l3 {
+  backdrop-filter: blur(80px);
+  -webkit-backdrop-filter: blur(80px);
+}
+
+@utility focus-ring {
+  &:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px #07080b,
+      0 0 0 4px #60a5fae6;
   }
 }

--- a/src/pages/WorkspaceDetailPage.test.tsx
+++ b/src/pages/WorkspaceDetailPage.test.tsx
@@ -4,11 +4,11 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 import type { Worktree } from '../../server/types';
 import type { WorktreeDetail } from '@/lib/api';
 
-const { mockNavigate, routerMockFactory } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { apiMock, apiProxy } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupApiMock(),
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
 );
 
 vi.mock('react-router-dom', routerMockFactory);
@@ -80,19 +80,20 @@ describe('WorkspaceDetailPage', () => {
   });
 
   it('remove workspace triggers deleteWorktree and navigates back', async () => {
-    const getWt = vi
-      .fn()
-      .mockResolvedValue(
-        detail({
-          worktree: worktree({ status: 'available' }),
-          active_task: null,
-          history: [],
-        }),
-      );
+    const getWt = vi.fn().mockResolvedValue(
+      detail({
+        worktree: worktree({ status: 'available' }),
+        active_task: null,
+        history: [],
+      }),
+    );
     const delWt = vi.fn().mockResolvedValue(undefined);
     (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).getWorktree = getWt;
     (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).deleteWorktree = delWt;
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true),
+    );
 
     renderWithRouter(<WorkspaceDetailPage />, {
       path: '/workspaces/:id',

--- a/src/pages/WorkspaceDetailPage.tsx
+++ b/src/pages/WorkspaceDetailPage.tsx
@@ -91,8 +91,7 @@ export default function WorkspaceDetailPage() {
   }
 
   const w = detail.worktree;
-  const canRemove =
-    w.status === 'available' && detail.active_task === null && !removing;
+  const canRemove = w.status === 'available' && detail.active_task === null && !removing;
   const userOwned = w.mode === 'existing' || w.mode === 'none';
 
   return (
@@ -160,7 +159,10 @@ export default function WorkspaceDetailPage() {
             Active task
           </h2>
           {detail.active_task ? (
-            <TaskRow task={detail.active_task} onClick={() => navigate(`/tasks/${detail.active_task!.id}`)} />
+            <TaskRow
+              task={detail.active_task}
+              onClick={() => navigate(`/tasks/${detail.active_task!.id}`)}
+            />
           ) : (
             <div className="rounded-md border border-border bg-card p-4 text-sm text-[#8a8a8a]">
               No active task.

--- a/src/pages/WorkspacesPage.test.tsx
+++ b/src/pages/WorkspacesPage.test.tsx
@@ -3,11 +3,11 @@ import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderWithRouter, setupApiMock, setupRouterNavigateMock } from '../test-helpers';
 import type { WorktreeSummary } from '../../server/types';
 
-const { mockNavigate, routerMockFactory } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupRouterNavigateMock(),
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { apiMock, apiProxy } = await vi.hoisted(
-  async () => (await import('../test-helpers')).setupApiMock(),
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
 );
 
 vi.mock('react-router-dom', routerMockFactory);
@@ -45,15 +45,16 @@ beforeEach(() => {
 describe('WorkspacesPage', () => {
   it('renders the empty state', async () => {
     renderWithRouter(<WorkspacesPage />);
-    await waitFor(() =>
-      expect(screen.getByText(/No workspaces yet/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/No workspaces yet/i)).toBeInTheDocument());
   });
 
   it('renders worktree rows', async () => {
     (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
       .fn()
-      .mockResolvedValue([wt({ id: 'w1' }), wt({ id: 'w2', repo_path: '/other', mode: 'existing' })]);
+      .mockResolvedValue([
+        wt({ id: 'w1' }),
+        wt({ id: 'w2', repo_path: '/other', mode: 'existing' }),
+      ]);
     renderWithRouter(<WorkspacesPage />);
     await waitFor(() => {
       expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument();
@@ -80,10 +81,7 @@ describe('WorkspacesPage', () => {
   it('filters by mode', async () => {
     (apiMock as unknown as Record<string, ReturnType<typeof vi.fn>>).listWorktrees = vi
       .fn()
-      .mockResolvedValue([
-        wt({ id: 'w1', mode: 'new' }),
-        wt({ id: 'w2', mode: 'scratch' }),
-      ]);
+      .mockResolvedValue([wt({ id: 'w1', mode: 'new' }), wt({ id: 'w2', mode: 'scratch' })]);
     renderWithRouter(<WorkspacesPage />);
     await waitFor(() => expect(screen.getByTestId('workspace-row-w1')).toBeInTheDocument());
     fireEvent.change(screen.getByLabelText(/Filter by mode/i), { target: { value: 'scratch' } });

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -188,11 +188,7 @@ export default function WorkspacesPage() {
                       {truncate(w.path)}
                     </td>
                     <td className="px-3 py-2">
-                      <span
-                        className={
-                          w.status === 'in_use' ? 'text-[#22C55E]' : 'text-[#8a8a8a]'
-                        }
-                      >
+                      <span className={w.status === 'in_use' ? 'text-[#22C55E]' : 'text-[#8a8a8a]'}>
                         {w.status}
                       </span>
                     </td>


### PR DESCRIPTION
## Summary

Foundation primitives for the liquid-glass redesign. **No page-level UI changes** — only tokens, helpers, and primitives that downstream PRs (sidebar, home/tasks, task-detail, composer, palette, system states) will build on.

### What's new

- **Glass tokens** in \`src/index.css\` — \`--color-glass-l0\`...\`l3\`, \`--color-glass-edge\`, \`--color-glass-edge-strong\`, \`--color-glass-specular\`, plus \`glass-blur-l1/l2/l3\` custom utilities (40/60/80px backdrop blur).
- **Muted text bump** — \`--muted-foreground\` from \`#8a8a8a\` → \`#B5B5BD\`; new \`--muted-soft\` (\`#8a8a8a\`) for tertiary text.
- **\`focus-ring\` utility** — single class that yields the standard 2px blue ring with a 2px offset against the app background, applied via \`:focus-visible\`.
- **\`<GlassPanel>\`** (\`src/components/ui/glass-panel.tsx\`) — \`level: 1|2|3\`, \`specular?: boolean\`. Applies tint + blur + stroke; specular adds a 1px inset top highlight via box-shadow.
- **\`<StatusGlyph>\`** (\`src/components/ui/status-glyph.tsx\`) — 5 shape+color pairs (running ●, awaiting/needs_attention ▲, setting_up ◐, error ✕, closed ○). Default size 10px. Colorblind-safe: shape and color together.
- **\`StatusBadge\`** now prefixes the label with the glyph (e.g. \`● RUNNING\`) and drops the bracketed format.

### Out of scope

Sidebar, page layouts, task-detail chrome, composer reducer, new routes — all reserved for follow-up PRs.

## Test plan

- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes (only pre-existing warnings)
- [x] \`bun run test\` — 1211/1211 passing, including new GlassPanel, StatusGlyph, and updated StatusBadge tests
- [ ] Visual smoke against \`design/review-snapshots/\` once the first consumer PR lands