### PR TITLE
feat(ui): glass home and tasks pages

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -47,7 +47,7 @@ describe('App routing', () => {
     await waitFor(() => {
       expect(screen.getByText(/welcome back/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText('COMMAND CENTER')).not.toBeInTheDocument();
+    expect(screen.queryByText('Command center')).not.toBeInTheDocument();
   });
 
   it('renders TasksPage (former Dashboard) at /tasks', async () => {
@@ -66,7 +66,7 @@ describe('App routing', () => {
       </MemoryRouter>,
     );
     await waitFor(() => {
-      expect(screen.getByText('COMMAND CENTER')).toBeInTheDocument();
+      expect(screen.getByText('Command center')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/SessionsInbox.test.tsx
+++ b/src/components/SessionsInbox.test.tsx
@@ -53,58 +53,139 @@ afterEach(() => {
 });
 
 describe('SessionsInbox', () => {
-  it('renders "caught up" when both sections empty', async () => {
+  it('renders "caught up" when all sections empty', async () => {
     renderInbox();
     await waitFor(() => expect(screen.getByTestId('inbox-empty')).toBeInTheDocument());
-    expect(screen.queryByTestId('inbox-section-needs_you')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-section-awaiting_reply')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-section-errored')).not.toBeInTheDocument();
     expect(screen.queryByTestId('inbox-section-activity')).not.toBeInTheDocument();
   });
 
-  it('renders Needs you and Activity sections with rows', async () => {
+  it('buckets errored tasks into ERRORED, not AWAITING REPLY', async () => {
     apiMock.getInbox.mockResolvedValue({
-      needs_you: [makeTask({ id: 'n1', title: 'Auth Rewrite', status: 'error' })],
-      activity: [makeTask({ id: 'a1', title: 'Feature XYZ', status: 'closed' })],
+      needs_you: [
+        makeTask({ id: 'err1', title: 'Failed Task', status: 'error', error: 'Boom' }),
+        makeTask({
+          id: 'wait1',
+          title: 'Waiting Task',
+          status: 'running',
+          pending_prompts: [
+            {
+              id: 'pp1',
+              task_id: 'wait1',
+              agent_id: null,
+              agent_label: 'a',
+              session_id: 's',
+              tool_name: 'Bash',
+              tool_input: {},
+              status: 'pending',
+              created_at: '',
+              resolved_at: null,
+            },
+          ],
+        }),
+      ],
+      activity: [],
     });
 
     renderInbox();
 
-    await waitFor(() => expect(screen.getByTestId('inbox-row-n1')).toBeInTheDocument());
-    expect(screen.getByTestId('inbox-row-a1')).toBeInTheDocument();
-    expect(screen.getByTestId('inbox-section-needs_you')).toHaveTextContent(/needs you/i);
-    expect(screen.getByTestId('inbox-section-activity')).toHaveTextContent(/activity/i);
-    expect(screen.queryByTestId('inbox-empty')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('inbox-row-err1')).toBeInTheDocument());
+
+    const erroredSection = screen.getByTestId('inbox-section-errored');
+    const awaitingSection = screen.getByTestId('inbox-section-awaiting_reply');
+
+    expect(erroredSection).toHaveTextContent(/errored/i);
+    expect(erroredSection).toHaveTextContent('Failed Task');
+    expect(erroredSection).not.toHaveTextContent('Waiting Task');
+
+    expect(awaitingSection).toHaveTextContent(/awaiting reply/i);
+    expect(awaitingSection).toHaveTextContent('Waiting Task');
+    expect(awaitingSection).not.toHaveTextContent('Failed Task');
   });
 
-  it('hides a section when it is empty but shows the other', async () => {
+  it('renders Reply → button on awaiting-reply rows and navigates to composer', async () => {
+    const user = userEvent.setup();
+    apiMock.getInbox.mockResolvedValue({
+      needs_you: [
+        makeTask({
+          id: 'wait1',
+          status: 'running',
+          pending_prompts: [
+            {
+              id: 'pp1',
+              task_id: 'wait1',
+              agent_id: null,
+              agent_label: 'a',
+              session_id: 's',
+              tool_name: 'Bash',
+              tool_input: {},
+              status: 'pending',
+              created_at: '',
+              resolved_at: null,
+            },
+          ],
+        }),
+      ],
+      activity: [],
+    });
+
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByTestId('inbox-reply-wait1')).toBeInTheDocument());
+    expect(screen.queryByTestId('inbox-reply-err1')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('inbox-reply-wait1'));
+    expect(mockNavigate).toHaveBeenCalledWith('/?add_agent=wait1');
+  });
+
+  it('collapses activity beyond 3 items with tap-to-expand', async () => {
+    const user = userEvent.setup();
     apiMock.getInbox.mockResolvedValue({
       needs_you: [],
-      activity: [makeTask({ id: 'a1', status: 'closed' })],
+      activity: [
+        makeTask({ id: 'a1', status: 'closed' }),
+        makeTask({ id: 'a2', status: 'closed' }),
+        makeTask({ id: 'a3', status: 'closed' }),
+        makeTask({ id: 'a4', status: 'closed' }),
+        makeTask({ id: 'a5', status: 'closed' }),
+      ],
     });
 
     renderInbox();
 
     await waitFor(() => expect(screen.getByTestId('inbox-section-activity')).toBeInTheDocument());
-    expect(screen.queryByTestId('inbox-section-needs_you')).not.toBeInTheDocument();
+    expect(screen.getByTestId('inbox-row-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-row-a2')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-row-a3')).toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-row-a4')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('inbox-activity-toggle'));
+    expect(screen.getByTestId('inbox-row-a4')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-row-a5')).toBeInTheDocument();
   });
 
   it('clicking a row navigates to the task', async () => {
     const user = userEvent.setup();
     apiMock.getInbox.mockResolvedValue({
-      needs_you: [makeTask({ id: 'n1' })],
+      needs_you: [makeTask({ id: 'n1', status: 'error' })],
       activity: [],
     });
 
     renderInbox();
 
     await waitFor(() => expect(screen.getByTestId('inbox-row-n1')).toBeInTheDocument());
-    await user.click(screen.getByTestId('inbox-row-n1'));
+    // Click the inner title button (not the reply button). For errored rows, only the title exists.
+    await user.click(
+      screen.getByTestId('inbox-row-n1').querySelector('button') as HTMLElement,
+    );
     expect(mockNavigate).toHaveBeenCalledWith('/tasks/n1');
   });
 
   it('mark-all-read calls API and refetches', async () => {
     const user = userEvent.setup();
     apiMock.getInbox
-      .mockResolvedValueOnce({ needs_you: [makeTask({ id: 'n1' })], activity: [] })
+      .mockResolvedValueOnce({ needs_you: [makeTask({ id: 'n1', status: 'error' })], activity: [] })
       .mockResolvedValueOnce({ needs_you: [], activity: [] });
 
     renderInbox();
@@ -125,14 +206,12 @@ describe('SessionsInbox', () => {
 
       await vi.waitFor(() => expect(apiMock.getInbox).toHaveBeenCalledTimes(1));
 
-      // Fire several events rapidly
       act(() => {
         fireEvent({ type: 'task:updated', payload: { taskId: 't1' } });
         fireEvent({ type: 'task:updated', payload: { taskId: 't2' } });
         fireEvent({ type: 'task:created', payload: { taskId: 't3' } });
       });
 
-      // Still only the initial call until the debounce expires
       expect(apiMock.getInbox).toHaveBeenCalledTimes(1);
 
       act(() => {

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -1,74 +1,113 @@
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Task } from '../../server/types';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { StatusGlyph } from '@/components/ui/status-glyph';
 import { useInbox } from '@/lib/inbox';
 import { timeAgo } from '@/lib/time';
 import { repoName } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 
-type RowKind = 'needs_you' | 'activity';
+type RowKind = 'awaiting_reply' | 'errored' | 'activity';
+
+const ACTIVITY_COLLAPSED_LIMIT = 3;
 
 function pendingPromptCount(task: Task): number {
-  return (task.pending_prompts?.length ?? 0) as number;
+  return task.pending_prompts?.length ?? 0;
+}
+
+function isErrored(task: Task): boolean {
+  if (task.status === 'error') return true;
+  const derived = task.derived_status as string | null | undefined;
+  return derived === 'error';
 }
 
 function subtitleFor(task: Task, kind: RowKind): string {
   if (kind === 'activity') return 'closed';
-  if (task.status === 'error') return task.error ? `errored · ${task.error}` : 'errored';
+  if (kind === 'errored') return task.error ? `errored · ${task.error}` : 'errored';
   const prompts = pendingPromptCount(task);
   if (prompts > 0)
     return prompts === 1 ? 'permission prompt open' : `${prompts} permission prompts`;
-  return 'needs attention';
+  return 'awaiting reply';
 }
 
-function Glyph({ kind, task }: { kind: RowKind; task: Task }) {
-  if (kind === 'needs_you') {
-    const isError = task.status === 'error';
-    return (
-      <span
-        aria-hidden
-        className={cn(
-          'inline-flex h-4 w-4 items-center justify-center text-sm',
-          isError ? 'text-[#EF4444]' : 'text-[#FFB800]',
-        )}
-      >
-        {isError ? '✕' : '⚠'}
-      </span>
-    );
-  }
+function glyphStatusFor(kind: RowKind): string {
+  if (kind === 'awaiting_reply') return 'awaiting';
+  if (kind === 'errored') return 'error';
+  return 'closed';
+}
+
+function ReplyButton({ taskId }: { taskId: string }) {
+  const navigate = useNavigate();
   return (
-    <span aria-hidden className="inline-flex h-4 w-4 items-center justify-center text-[#22C55E]">
-      ✓
-    </span>
+    <button
+      type="button"
+      data-testid={`inbox-reply-${taskId}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        navigate(`/?add_agent=${taskId}`);
+      }}
+      className="shrink-0 px-2.5 py-1 text-[11px] font-bold tracking-wider uppercase text-[#1f1300] transition-colors hover:brightness-110"
+      style={{
+        backgroundColor: '#FFB800',
+        boxShadow:
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.35), 0 0 16px 0 rgba(255, 184, 0, 0.35)',
+      }}
+    >
+      Reply →
+    </button>
   );
 }
 
 function InboxRow({ task, kind }: { task: Task; kind: RowKind }) {
   const navigate = useNavigate();
   return (
-    <button
-      type="button"
+    <div
       data-testid={`inbox-row-${task.id}`}
-      onClick={() => navigate(`/tasks/${task.id}`)}
-      className="group flex w-full items-center gap-3 rounded border border-transparent px-3 py-2 text-left transition-colors hover:border-[#2f2f2f] hover:bg-[#141414]"
+      className="group flex w-full items-center gap-3 border border-transparent px-3 py-2 transition-colors hover:border-[#2f2f2f] hover:bg-[#141414]"
     >
-      <Glyph kind={kind} task={task} />
-      <span className="flex min-w-0 flex-1 items-baseline gap-2">
-        <span className="truncate text-sm font-medium text-foreground">{task.title}</span>
-        <span className="truncate text-xs text-muted-foreground">{subtitleFor(task, kind)}</span>
-      </span>
-      <span className="shrink-0 text-[11px] text-[#6a6a6a]">
-        {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
-      </span>
-    </button>
+      <button
+        type="button"
+        onClick={() => navigate(`/tasks/${task.id}`)}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <StatusGlyph status={glyphStatusFor(kind)} size={12} />
+        <span className="flex min-w-0 flex-1 items-baseline gap-2">
+          <span className="truncate text-sm font-medium text-foreground">{task.title}</span>
+          <span className="truncate text-xs text-muted-foreground">{subtitleFor(task, kind)}</span>
+        </span>
+        <span className="shrink-0 text-[11px] text-[#6a6a6a]">
+          {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
+        </span>
+      </button>
+      {kind === 'awaiting_reply' && <ReplyButton taskId={task.id} />}
+    </div>
   );
 }
 
-function Section({ title, tasks, kind }: { title: string; tasks: Task[]; kind: RowKind }) {
+function Section({
+  title,
+  tasks,
+  kind,
+  testId,
+  eyebrow,
+}: {
+  title: string;
+  tasks: Task[];
+  kind: RowKind;
+  testId: string;
+  eyebrow?: string;
+}) {
   if (tasks.length === 0) return null;
   return (
-    <section data-testid={`inbox-section-${kind}`} className="flex flex-col gap-1">
-      <h3 className="px-3 text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
-        {title}
+    <section data-testid={testId} className="flex flex-col gap-1">
+      <h3 className="flex items-baseline gap-2 px-3 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
+        {eyebrow && (
+          <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
+            {eyebrow}
+          </span>
+        )}
+        <span>{title}</span>
       </h3>
       <div className="flex flex-col">
         {tasks.map((t) => (
@@ -79,17 +118,68 @@ function Section({ title, tasks, kind }: { title: string; tasks: Task[]; kind: R
   );
 }
 
+function ActivitySection({ tasks }: { tasks: Task[] }) {
+  const [expanded, setExpanded] = useState(false);
+  if (tasks.length === 0) return null;
+  const collapsed = !expanded && tasks.length > ACTIVITY_COLLAPSED_LIMIT;
+  const visible = collapsed ? tasks.slice(0, ACTIVITY_COLLAPSED_LIMIT) : tasks;
+  const hidden = tasks.length - visible.length;
+  return (
+    <section data-testid="inbox-section-activity" className="flex flex-col gap-1">
+      <h3 className="flex items-baseline gap-2 px-3 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
+        <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
+          //
+        </span>
+        <span>Activity</span>
+      </h3>
+      <div className="flex flex-col">
+        {visible.map((t) => (
+          <InboxRow key={t.id} task={t} kind="activity" />
+        ))}
+      </div>
+      {tasks.length > ACTIVITY_COLLAPSED_LIMIT && (
+        <button
+          type="button"
+          data-testid="inbox-activity-toggle"
+          onClick={() => setExpanded((v) => !v)}
+          className="self-start px-3 py-1 text-[11px] font-medium text-[#8a8a8a] hover:text-foreground"
+        >
+          {collapsed ? `Tap to expand (${hidden} more)` : 'Collapse'}
+        </button>
+      )}
+    </section>
+  );
+}
+
 export function SessionsInbox() {
   const { needsYou, activity, loading, error, markAllRead } = useInbox();
-  const isEmpty = !loading && needsYou.length === 0 && activity.length === 0;
+
+  const { awaitingReply, errored } = useMemo(() => {
+    const awaitingReply: Task[] = [];
+    const errored: Task[] = [];
+    for (const t of needsYou) {
+      if (isErrored(t)) errored.push(t);
+      else awaitingReply.push(t);
+    }
+    return { awaitingReply, errored };
+  }, [needsYou]);
+
+  const isEmpty =
+    !loading && awaitingReply.length === 0 && errored.length === 0 && activity.length === 0;
 
   return (
-    <div data-testid="sessions-inbox" className="flex flex-col gap-6">
+    <GlassPanel
+      level={1}
+      specular
+      data-testid="sessions-inbox"
+      className={cn('flex flex-col gap-5 p-4')}
+      style={{ borderRadius: '14px' }}
+    >
       <div className="flex items-baseline justify-between px-3">
         <h2 className="font-display text-sm font-bold uppercase tracking-wider text-[#6a6a6a]">
           Sessions
         </h2>
-        {(needsYou.length > 0 || activity.length > 0) && (
+        {(awaitingReply.length > 0 || errored.length > 0 || activity.length > 0) && (
           <button
             type="button"
             data-testid="inbox-mark-all-read"
@@ -116,10 +206,23 @@ export function SessionsInbox() {
         </p>
       ) : (
         <>
-          <Section title="Needs you" tasks={needsYou} kind="needs_you" />
-          <Section title="Activity" tasks={activity} kind="activity" />
+          <Section
+            title="Awaiting reply"
+            tasks={awaitingReply}
+            kind="awaiting_reply"
+            testId="inbox-section-awaiting_reply"
+            eyebrow="//"
+          />
+          <Section
+            title="Errored"
+            tasks={errored}
+            kind="errored"
+            testId="inbox-section-errored"
+            eyebrow="//"
+          />
+          <ActivitySection tasks={activity} />
         </>
       )}
-    </div>
+    </GlassPanel>
   );
 }

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { StatusGlyph } from '@/components/ui/status-glyph';
 import type { Task } from '../../server/types';
 import { StatusBadge } from './StatusBadge';
 import { AgentActivitySummary } from './AgentActivitySummary';
@@ -17,6 +18,49 @@ interface TaskCardProps {
   onResume?: (id: string) => void;
 }
 
+const EM_DASH = '—';
+
+function ModeBadge({ mode }: { mode: Task['run_mode'] }) {
+  const label =
+    mode === 'scratch' ? 'SCRATCH' : mode === 'existing' ? 'EXISTING' : mode === 'none' ? 'NONE' : 'NEW';
+  return (
+    <span
+      className="font-mono text-[10px] font-bold tracking-wider text-[#8a8a8a]"
+      style={{
+        padding: '2px 6px',
+        backgroundColor: 'rgba(255, 255, 255, 0.06)',
+        boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.08)',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function TelemetryRow({ task: _task }: { task: Task }) {
+  const parts = [
+    EM_DASH, // model (e.g. opus-4.7) — not tracked
+    `${EM_DASH} ctx`, // context tokens
+    EM_DASH, // cost
+    EM_DASH, // diff stats
+    `tests ${EM_DASH}`,
+    `lint ${EM_DASH}`,
+  ];
+  return (
+    <div
+      data-testid="telemetry-row"
+      className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[11px] text-[#6a6a6a]"
+    >
+      {parts.map((p, i) => (
+        <span key={i} className="inline-flex items-center">
+          {i > 0 && <span className="mr-2 text-[#2f2f2f]">·</span>}
+          <span className="tabular-nums">{p}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export const TaskCard = memo(function TaskCard({
   task,
   onClose,
@@ -26,35 +70,47 @@ export const TaskCard = memo(function TaskCard({
   const navigate = useNavigate();
   const canResume = (task.status === 'closed' || task.status === 'error') && !!task.worktree;
   const isActive = task.status === 'running' || task.status === 'setting_up';
+  const displayStatus = task.derived_status || task.status;
 
   return (
-    <Card
-      className="cursor-pointer bg-[#0A0A0A] border border-[#2f2f2f] transition-colors hover:bg-[#141414]"
+    <GlassPanel
+      level={2}
+      specular
       onClick={() => navigate(`/tasks/${task.id}`)}
+      className="group cursor-pointer transition-colors hover:bg-glass-l3"
+      style={{
+        borderRadius: '14px',
+        boxShadow:
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.22), 0 12px 30px -8px rgba(0, 0, 0, 0.55)',
+      }}
     >
-      <CardHeader className="px-6 py-5 pb-3">
-        <div className="flex items-start justify-between gap-3">
-          <CardTitle className="font-display min-w-0 text-base leading-snug line-clamp-2">
-            {task.title}
-          </CardTitle>
-          <div className="flex shrink-0 items-center gap-2">
-            <StatusBadge status={task.derived_status || task.status} />
-            <span className="text-xs tabular-nums whitespace-nowrap text-muted-foreground">
-              {timeAgo(task.created_at)}
-            </span>
-          </div>
+      <div className="flex items-start gap-3 px-5 py-4">
+        {/* Status dot */}
+        <div className="shrink-0 pt-1.5">
+          <StatusGlyph status={displayStatus} size={12} />
         </div>
-        <CardDescription className="line-clamp-1 font-mono text-[#6a6a6a]">
-          {task.description}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="px-6 pb-5 pt-0">
-        {/* Metadata row */}
-        <div className="flex items-center justify-between text-sm">
-          <div className="flex items-center gap-2 text-xs">
+
+        {/* Main content */}
+        <div className="min-w-0 flex-1">
+          {/* Title + mode badge */}
+          <div className="flex items-center gap-2">
+            <h3 className="font-display min-w-0 truncate text-base font-semibold leading-snug">
+              {task.title}
+            </h3>
+            <ModeBadge mode={task.run_mode} />
+          </div>
+
+          {task.description && (
+            <p className="mt-0.5 line-clamp-1 font-mono text-xs text-[#6a6a6a]">
+              {task.description}
+            </p>
+          )}
+
+          {/* Metadata row */}
+          <div className="mt-2 flex items-center gap-2 text-xs">
             <Badge
               variant="outline"
-              className="font-normal bg-[#141414] border-[#2f2f2f] px-2 py-1 text-xs"
+              className="border-[#2f2f2f] bg-[#141414] px-2 py-0.5 text-xs font-normal"
             >
               {repoName(task.repo_path)}
             </Badge>
@@ -87,7 +143,45 @@ export const TaskCard = memo(function TaskCard({
               </>
             )}
           </div>
+
+          {/* Telemetry row */}
+          <TelemetryRow task={task} />
+
+          {/* Error banner */}
+          {task.error && (
+            <div
+              className="mt-2 px-3 py-2 text-xs"
+              style={{ backgroundColor: 'rgba(239, 68, 68, 0.06)' }}
+              title={task.error}
+            >
+              <span className="font-bold text-red-500">Error:</span>{' '}
+              <span className="text-red-400">{task.error}</span>
+            </div>
+          )}
+
+          {task.agents && task.agents.length > 0 && task.status === 'running' && (
+            <div className="mt-2">
+              <AgentActivitySummary agents={task.agents} pendingPrompts={task.pending_prompts} />
+            </div>
+          )}
+          {task.pending_prompts && task.pending_prompts.length > 0 && (
+            <div className="mt-1 space-y-0.5">
+              {task.pending_prompts.map((pp) => (
+                <PermissionPromptRow key={pp.id} prompt={pp} taskId={task.id} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Right: status pill + timestamp + actions + arrow */}
+        <div className="flex shrink-0 flex-col items-end gap-2">
           <div className="flex items-center gap-2">
+            <StatusBadge status={displayStatus} />
+            <span className="text-xs tabular-nums whitespace-nowrap text-muted-foreground">
+              {timeAgo(task.created_at)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
             {canResume && onResume && (
               <Button
                 variant="ghost"
@@ -165,31 +259,15 @@ export const TaskCard = memo(function TaskCard({
                 </svg>
               </Button>
             )}
+            <span
+              aria-hidden
+              className="text-sm text-[#6a6a6a] opacity-0 transition-opacity group-hover:opacity-100"
+            >
+              →
+            </span>
           </div>
         </div>
-
-        {/* Error banner */}
-        {task.error && (
-          <div className="mt-3 rounded-none bg-[#EF444410] px-3 py-2 text-xs" title={task.error}>
-            <span className="font-bold text-red-500">Error:</span>{' '}
-            <span className="text-red-400">{task.error}</span>
-          </div>
-        )}
-
-        {/* Agent activity */}
-        {task.agents && task.agents.length > 0 && task.status === 'running' && (
-          <div className="mt-3">
-            <AgentActivitySummary agents={task.agents} pendingPrompts={task.pending_prompts} />
-          </div>
-        )}
-        {task.pending_prompts && task.pending_prompts.length > 0 && (
-          <div className="mt-1 space-y-0.5">
-            {task.pending_prompts.map((pp) => (
-              <PermissionPromptRow key={pp.id} prompt={pp} taskId={task.id} />
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+      </div>
+    </GlassPanel>
   );
 });

--- a/src/components/TaskFilterBar.test.tsx
+++ b/src/components/TaskFilterBar.test.tsx
@@ -5,8 +5,8 @@ import { TaskFilterBar } from './TaskFilterBar';
 import { renderWithRouter } from '../test-helpers';
 
 const defaultProps = {
-  activeStatus: 'open' as const,
-  counts: { open: 3, closed: 1, backlog: 2 },
+  activeStatus: 'all' as const,
+  counts: { all: 6, running: 3, needs_you: 2, closed: 1 },
   onStatusChange: () => {},
   repos: ['/path/to/alpha', '/path/to/beta'],
   activeRepo: '',
@@ -14,57 +14,62 @@ const defaultProps = {
 };
 
 describe('TaskFilterBar', () => {
-  it('renders Open, Backlog, and Closed tabs with counts', () => {
+  it('renders All, Running, Needs You, Closed chips with counts', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    expect(screen.getByText(/^Open/)).toBeInTheDocument();
-    expect(screen.getByText('(3)')).toBeInTheDocument();
-    expect(screen.getByText(/^Backlog/)).toBeInTheDocument();
-    expect(screen.getByText('(2)')).toBeInTheDocument();
-    expect(screen.getByText(/^Closed/)).toBeInTheDocument();
-    expect(screen.getByText('(1)')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-all')).toHaveTextContent(/All/);
+    expect(screen.getByTestId('filter-chip-all')).toHaveTextContent('(6)');
+    expect(screen.getByTestId('filter-chip-running')).toHaveTextContent(/Running/);
+    expect(screen.getByTestId('filter-chip-running')).toHaveTextContent('(3)');
+    expect(screen.getByTestId('filter-chip-needs_you')).toHaveTextContent(/Needs You/);
+    expect(screen.getByTestId('filter-chip-needs_you')).toHaveTextContent('(2)');
+    expect(screen.getByTestId('filter-chip-closed')).toHaveTextContent(/Closed/);
+    expect(screen.getByTestId('filter-chip-closed')).toHaveTextContent('(1)');
   });
 
-  it('highlights active tab', () => {
+  it('marks active chip with data-active', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    const openBtn = screen.getByText(/^Open/).closest('button')!;
-    expect(openBtn.className).toContain('border-b-2');
+    expect(screen.getByTestId('filter-chip-all')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('filter-chip-running')).not.toHaveAttribute('data-active');
   });
 
-  it('calls onStatusChange when clicking tab', async () => {
+  it('calls onStatusChange when clicking Closed chip', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onStatusChange={onChange} />);
-    await user.click(screen.getByText(/^Closed/).closest('button')!);
+    await user.click(screen.getByTestId('filter-chip-closed'));
     expect(onChange).toHaveBeenCalledWith('closed');
   });
 
-  it('calls onStatusChange when clicking backlog tab', async () => {
+  it('calls onStatusChange when clicking Needs You chip', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onStatusChange={onChange} />);
-    await user.click(screen.getByText(/^Backlog/).closest('button')!);
-    expect(onChange).toHaveBeenCalledWith('backlog');
+    await user.click(screen.getByTestId('filter-chip-needs_you'));
+    expect(onChange).toHaveBeenCalledWith('needs_you');
   });
 
   it('renders repo dropdown when multiple repos exist', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} />);
-    const trigger = screen.getByText('ALL REPOS');
-    expect(trigger).toBeInTheDocument();
+    expect(screen.getByText('all repos')).toBeInTheDocument();
   });
 
   it('hides repo dropdown when only one repo exists', () => {
     renderWithRouter(<TaskFilterBar {...defaultProps} repos={['/path/to/only-one']} />);
-    expect(screen.queryByText('ALL REPOS')).not.toBeInTheDocument();
+    expect(screen.queryByText('all repos')).not.toBeInTheDocument();
   });
 
   it('calls onRepoChange when selecting a repo', async () => {
     const user = userEvent.setup();
     const onRepoChange = vi.fn();
     renderWithRouter(<TaskFilterBar {...defaultProps} onRepoChange={onRepoChange} />);
-    // Open the popover
-    await user.click(screen.getByText('ALL REPOS'));
-    // Click the repo option
+    await user.click(screen.getByText('all repos'));
     await user.click(screen.getByText('beta'));
     expect(onRepoChange).toHaveBeenCalledWith('/path/to/beta');
+  });
+
+  it('wraps content in a glass panel', () => {
+    renderWithRouter(<TaskFilterBar {...defaultProps} />);
+    const bar = screen.getByTestId('task-filter-bar');
+    expect(bar).toHaveAttribute('data-glass-level', '1');
   });
 });

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -1,24 +1,78 @@
 import { memo, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Badge } from '@/components/ui/badge';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { StatusGlyph } from '@/components/ui/status-glyph';
 import type { StatusTab } from '@/lib/use-task-filters';
 import { repoName } from '@/lib/utils';
 import { ChevronDownIcon } from '@/components/icons';
+import { cn } from '@/lib/utils';
 
 interface TaskFilterBarProps {
   activeStatus: StatusTab;
-  counts: { open: number; closed: number; backlog: number };
+  counts: { all: number; running: number; needs_you: number; closed: number };
   onStatusChange: (status: StatusTab) => void;
   repos: string[];
   activeRepo: string;
   onRepoChange: (repo: string) => void;
 }
 
-const STATUS_TABS: ReadonlyArray<{ key: StatusTab; label: string }> = [
-  { key: 'open', label: 'Open' },
-  { key: 'backlog', label: 'Backlog' },
-  { key: 'closed', label: 'Closed' },
+interface ChipDef {
+  key: StatusTab;
+  label: string;
+  glyphStatus: string | null;
+}
+
+const STATUS_CHIPS: ReadonlyArray<ChipDef> = [
+  { key: 'all', label: 'All', glyphStatus: null },
+  { key: 'running', label: 'Running', glyphStatus: 'running' },
+  { key: 'needs_you', label: 'Needs You', glyphStatus: 'awaiting' },
+  { key: 'closed', label: 'Closed', glyphStatus: 'closed' },
 ];
+
+function FilterChip({
+  chip,
+  count,
+  active,
+  onClick,
+}: {
+  chip: ChipDef;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={`filter-chip-${chip.key}`}
+      data-active={active ? 'true' : undefined}
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium tracking-wider uppercase transition-colors',
+        active ? 'text-foreground' : 'text-[#8a8a8a] hover:text-foreground',
+      )}
+      style={
+        active
+          ? {
+              backgroundColor: 'rgba(255, 255, 255, 0.14)',
+              boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.18)',
+            }
+          : undefined
+      }
+    >
+      {chip.glyphStatus && <StatusGlyph status={chip.glyphStatus} size={10} />}
+      <span>{chip.label}</span>
+      <span
+        className={cn(
+          'tabular-nums',
+          active ? 'text-foreground' : 'text-[#6a6a6a]',
+        )}
+      >
+        ({count})
+      </span>
+    </button>
+  );
+}
 
 function RepoFilterDropdown({
   repos,
@@ -37,14 +91,14 @@ function RepoFilterDropdown({
         render={
           <button
             type="button"
-            className="mb-1 flex items-center gap-1.5 rounded border border-[#2f2f2f] bg-background px-[14px] py-[8px] text-[11px] text-[#8a8a8a] transition-colors hover:bg-muted"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] text-[#8a8a8a] transition-colors hover:text-foreground"
           >
             {activeRepo ? (
               <Badge variant="outline" className="text-xs font-normal">
                 {repoName(activeRepo)}
               </Badge>
             ) : (
-              <span>ALL REPOS</span>
+              <span>all repos</span>
             )}
             <ChevronDownIcon size={12} className="text-[#8a8a8a]" />
           </button>
@@ -92,25 +146,21 @@ export const TaskFilterBar = memo(function TaskFilterBar({
   onRepoChange,
 }: TaskFilterBarProps) {
   return (
-    <div className="mb-3 flex items-center justify-between border-b border-border">
-      <div className="flex gap-1">
-        {STATUS_TABS.map((tab) => (
-          <button
-            key={tab.key}
-            className={`px-[16px] py-[10px] text-xs tracking-wider uppercase ${
-              activeStatus === tab.key
-                ? 'border-b-2 border-[#3B82F6] font-bold text-[#3B82F6]'
-                : 'font-medium text-[#6a6a6a] hover:text-[#8a8a8a]'
-            }`}
-            onClick={() => onStatusChange(tab.key)}
-          >
-            {tab.label}{' '}
-            <span
-              className={`tabular-nums ${activeStatus === tab.key ? 'text-[#3B82F6]' : 'text-[#6a6a6a]'}`}
-            >
-              ({counts[tab.key]})
-            </span>
-          </button>
+    <GlassPanel
+      level={1}
+      specular
+      data-testid="task-filter-bar"
+      className="my-3 flex items-center justify-between px-2 py-1.5"
+    >
+      <div className="flex items-center gap-1">
+        {STATUS_CHIPS.map((chip) => (
+          <FilterChip
+            key={chip.key}
+            chip={chip}
+            count={counts[chip.key]}
+            active={activeStatus === chip.key}
+            onClick={() => onStatusChange(chip.key)}
+          />
         ))}
       </div>
       <div className="flex items-center gap-2">
@@ -118,6 +168,6 @@ export const TaskFilterBar = memo(function TaskFilterBar({
           <RepoFilterDropdown repos={repos} activeRepo={activeRepo} onRepoChange={onRepoChange} />
         )}
       </div>
-    </div>
+    </GlassPanel>
   );
 });

--- a/src/lib/use-task-filters.test.tsx
+++ b/src/lib/use-task-filters.test.tsx
@@ -16,32 +16,66 @@ describe('useTaskFilters', () => {
     makeTask({ id: 't4', status: 'error', repo_path: '/tmp/beta' }),
   ];
 
-  it('defaults to open filter showing non-closed, non-draft tasks', () => {
+  it('defaults to All filter showing every task', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
-    expect(result.current.filters.status).toBe('open');
-    const ids = result.current.filtered.map((t) => t.id);
-    expect(ids).toEqual(['t1', 't4']);
+    expect(result.current.filters.status).toBe('all');
+    const ids = result.current.filtered.map((t) => t.id).sort();
+    expect(ids).toEqual(['t1', 't2', 't3', 't4']);
   });
 
-  it('switches to closed filter', () => {
+  it('Running chip shows only running / setting_up tasks', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('status', 'running'));
+    const ids = result.current.filtered.map((t) => t.id);
+    expect(ids).toEqual(['t1']);
+  });
+
+  it('Needs You chip includes errored tasks', () => {
+    const { result } = renderHook(() => useTaskFilters(tasks));
+    act(() => result.current.setFilter('status', 'needs_you'));
+    const ids = result.current.filtered.map((t) => t.id);
+    expect(ids).toEqual(['t4']);
+  });
+
+  it('Needs You includes tasks with pending prompts', () => {
+    const extra = makeTask({
+      id: 't5',
+      status: 'running',
+      repo_path: '/tmp/beta',
+      pending_prompts: [
+        {
+          id: 'pp1',
+          task_id: 't5',
+          agent_id: null,
+          agent_label: 'a',
+          session_id: 's',
+          tool_name: 'Bash',
+          tool_input: {},
+          status: 'pending',
+          created_at: '',
+          resolved_at: null,
+        },
+      ],
+    });
+    const { result } = renderHook(() => useTaskFilters([...tasks, extra]));
+    act(() => result.current.setFilter('status', 'needs_you'));
+    const ids = result.current.filtered.map((t) => t.id).sort();
+    expect(ids).toEqual(['t4', 't5']);
+  });
+
+  it('Closed chip shows only closed tasks', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
     act(() => result.current.setFilter('status', 'closed'));
     const ids = result.current.filtered.map((t) => t.id);
     expect(ids).toEqual(['t3']);
   });
 
-  it('switches to backlog filter showing only drafts', () => {
+  it('provides status counts for all chips', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
-    act(() => result.current.setFilter('status', 'backlog'));
-    const ids = result.current.filtered.map((t) => t.id);
-    expect(ids).toEqual(['t2']);
-  });
-
-  it('provides status counts including backlog', () => {
-    const { result } = renderHook(() => useTaskFilters(tasks));
-    expect(result.current.counts.open).toBe(2);
+    expect(result.current.counts.all).toBe(4);
+    expect(result.current.counts.running).toBe(1);
+    expect(result.current.counts.needs_you).toBe(1);
     expect(result.current.counts.closed).toBe(1);
-    expect(result.current.counts.backlog).toBe(1);
   });
 
   // ─── Repo filtering ─────────────────────────────────────────────────────
@@ -59,17 +93,17 @@ describe('useTaskFilters', () => {
   it('filters tasks by repo', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
     act(() => result.current.setFilter('repo', '/tmp/alpha'));
-    const ids = result.current.filtered.map((t) => t.id);
-    // open filter + alpha repo = only t1 (running in alpha)
-    expect(ids).toEqual(['t1']);
+    const ids = result.current.filtered.map((t) => t.id).sort();
+    expect(ids).toEqual(['t1', 't3']);
   });
 
   it('updates counts when repo filter is active', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
     act(() => result.current.setFilter('repo', '/tmp/alpha'));
-    expect(result.current.counts.open).toBe(1);
+    expect(result.current.counts.all).toBe(2);
+    expect(result.current.counts.running).toBe(1);
+    expect(result.current.counts.needs_you).toBe(0);
     expect(result.current.counts.closed).toBe(1);
-    expect(result.current.counts.backlog).toBe(0);
   });
 
   it('shows all tasks for selected repo when switching status tabs', () => {
@@ -80,7 +114,7 @@ describe('useTaskFilters', () => {
     expect(ids).toEqual(['t3']);
   });
 
-  // ─── Status persistence ──────────────────────────────────────────────
+  // ─── Persistence ──────────────────────────────────────────────────────
 
   it('persists status filter to localStorage', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
@@ -96,21 +130,13 @@ describe('useTaskFilters', () => {
     expect(ids).toEqual(['t3']);
   });
 
-  it('persists backlog status filter to localStorage', () => {
+  it('restores needs_you status filter from localStorage', () => {
+    localStorage.setItem('octomux-status-filter', 'needs_you');
     const { result } = renderHook(() => useTaskFilters(tasks));
-    act(() => result.current.setFilter('status', 'backlog'));
-    expect(localStorage.getItem('octomux-status-filter')).toBe('backlog');
-  });
-
-  it('restores backlog status filter from localStorage', () => {
-    localStorage.setItem('octomux-status-filter', 'backlog');
-    const { result } = renderHook(() => useTaskFilters(tasks));
-    expect(result.current.filters.status).toBe('backlog');
+    expect(result.current.filters.status).toBe('needs_you');
     const ids = result.current.filtered.map((t) => t.id);
-    expect(ids).toEqual(['t2']);
+    expect(ids).toEqual(['t4']);
   });
-
-  // ─── Repo persistence ──────────────────────────────────────────────
 
   it('persists repo filter to localStorage', () => {
     const { result } = renderHook(() => useTaskFilters(tasks));
@@ -122,8 +148,7 @@ describe('useTaskFilters', () => {
     localStorage.setItem('octomux-repo-filter', '/tmp/beta');
     const { result } = renderHook(() => useTaskFilters(tasks));
     expect(result.current.filters.repo).toBe('/tmp/beta');
-    // Should filter immediately — open tasks in beta (no draft)
-    const ids = result.current.filtered.map((t) => t.id);
-    expect(ids).toEqual(['t4']);
+    const ids = result.current.filtered.map((t) => t.id).sort();
+    expect(ids).toEqual(['t2', 't4']);
   });
 });

--- a/src/lib/use-task-filters.ts
+++ b/src/lib/use-task-filters.ts
@@ -5,22 +5,29 @@ import { repoName } from './utils';
 const REPO_FILTER_KEY = 'octomux-repo-filter';
 const STATUS_FILTER_KEY = 'octomux-status-filter';
 
-export type StatusTab = 'open' | 'closed' | 'backlog';
+export type StatusTab = 'all' | 'running' | 'needs_you' | 'closed';
 
 export interface TaskFilters {
   status: StatusTab;
   repo: string; // full repo_path or '' for all
 }
 
-const OPEN_STATUSES = ['setting_up', 'running', 'error'];
+const RUNNING_STATUSES = ['setting_up', 'running'];
 
-const STATUS_TABS: readonly StatusTab[] = ['open', 'closed', 'backlog'];
+const STATUS_TABS: readonly StatusTab[] = ['all', 'running', 'needs_you', 'closed'];
+
+function isNeedsYou(t: Task): boolean {
+  if (t.status === 'error') return true;
+  if ((t.pending_prompts?.length ?? 0) > 0) return true;
+  if (t.derived_status === 'needs_attention') return true;
+  return false;
+}
 
 function readStatusTab(): StatusTab {
   const stored = localStorage.getItem(STATUS_FILTER_KEY);
   return stored && (STATUS_TABS as readonly string[]).includes(stored)
     ? (stored as StatusTab)
-    : 'open';
+    : 'all';
 }
 
 export function useTaskFilters(tasks: Task[]) {
@@ -37,19 +44,22 @@ export function useTaskFilters(tasks: Task[]) {
   const counts = useMemo(() => {
     const repoFiltered = filters.repo ? tasks.filter((t) => t.repo_path === filters.repo) : tasks;
     return {
-      open: repoFiltered.filter((t) => OPEN_STATUSES.includes(t.status)).length,
+      all: repoFiltered.length,
+      running: repoFiltered.filter((t) => RUNNING_STATUSES.includes(t.status)).length,
+      needs_you: repoFiltered.filter(isNeedsYou).length,
       closed: repoFiltered.filter((t) => t.status === 'closed').length,
-      backlog: repoFiltered.filter((t) => t.status === 'draft').length,
     };
   }, [tasks, filters.repo]);
 
   const filtered = useMemo(() => {
     const result = tasks.filter((t) => {
       let statusMatch: boolean;
-      if (filters.status === 'open') {
-        statusMatch = OPEN_STATUSES.includes(t.status);
-      } else if (filters.status === 'backlog') {
-        statusMatch = t.status === 'draft';
+      if (filters.status === 'all') {
+        statusMatch = true;
+      } else if (filters.status === 'running') {
+        statusMatch = RUNNING_STATUSES.includes(t.status);
+      } else if (filters.status === 'needs_you') {
+        statusMatch = isNeedsYou(t);
       } else {
         statusMatch = t.status === 'closed';
       }
@@ -57,24 +67,21 @@ export function useTaskFilters(tasks: Task[]) {
       return statusMatch && repoMatch;
     });
 
-    // Sort open tasks: needs_attention first, then working, then others
-    if (filters.status === 'open') {
-      const priorityOrder: Record<string, number> = {
-        needs_attention: 0,
-        working: 1,
-        running: 2,
-        setting_up: 3,
-        error: 4,
-        draft: 5,
-      };
-      result.sort((a, b) => {
-        const aPriority = priorityOrder[a.derived_status ?? a.status] ?? 9;
-        const bPriority = priorityOrder[b.derived_status ?? b.status] ?? 9;
-        if (aPriority !== bPriority) return aPriority - bPriority;
-        // Within same priority, keep newest first
-        return b.created_at.localeCompare(a.created_at);
-      });
-    }
+    // Priority sort: needs_attention → working → running → setting_up → error → draft
+    const priorityOrder: Record<string, number> = {
+      needs_attention: 0,
+      working: 1,
+      running: 2,
+      setting_up: 3,
+      error: 4,
+      draft: 5,
+    };
+    result.sort((a, b) => {
+      const aPriority = priorityOrder[a.derived_status ?? a.status] ?? 9;
+      const bPriority = priorityOrder[b.derived_status ?? b.status] ?? 9;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return b.created_at.localeCompare(a.created_at);
+    });
 
     return result;
   }, [tasks, filters]);

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -52,6 +52,14 @@ describe('HomePage', () => {
     expect(screen.getByTestId('sessions-inbox-slot')).toBeInTheDocument();
   });
 
+  it('renders the // INBOX eyebrow above the H1', () => {
+    renderHome('/');
+    const eyebrow = screen.getByTestId('page-eyebrow');
+    expect(eyebrow).toHaveTextContent('// INBOX');
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveClass('text-[32px]');
+  });
+
   it('hydrates composer from URL with repo + fork_of, then submits', async () => {
     const user = userEvent.setup();
     apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'spawned' }));

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,12 +6,21 @@ export default function HomePage() {
     <div className="flex h-full flex-col">
       <div className="flex-1 overflow-auto">
         <div className="mx-auto max-w-4xl px-8 py-12">
-          <h1
-            className="font-display text-[42px] font-bold leading-none tracking-tight"
-            style={{ letterSpacing: '-1px' }}
-          >
-            ✦ WELCOME BACK
-          </h1>
+          <div className="flex flex-col gap-2">
+            <span
+              data-testid="page-eyebrow"
+              className="font-mono text-[11px] font-bold text-[#B5B5BD]"
+              style={{ letterSpacing: '1.5px' }}
+            >
+              // INBOX
+            </span>
+            <h1
+              className="font-display text-[32px] font-bold leading-[1.1] tracking-tight"
+              style={{ letterSpacing: '-0.5px' }}
+            >
+              Welcome back
+            </h1>
+          </div>
           <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8">
             <SessionsInbox />
           </div>

--- a/src/pages/TasksPage.test.tsx
+++ b/src/pages/TasksPage.test.tsx
@@ -65,11 +65,13 @@ describe('TasksPage', () => {
 
   // ─── Header ────────────────────────────────────────────────────────────────
 
-  it('renders COMMAND CENTER heading', async () => {
+  it('renders Command center heading with // TASKS eyebrow', async () => {
     renderDashboard();
     await waitFor(() => {
-      expect(screen.getByText('COMMAND CENTER')).toBeInTheDocument();
+      expect(screen.getByText('Command center')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('page-eyebrow')).toHaveTextContent('// TASKS');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveClass('text-[32px]');
   });
 
   // ─── Task list rendering ──────────────────────────────────────────────────
@@ -105,15 +107,17 @@ describe('TasksPage', () => {
 
   // ─── Filter bar ─────────────────────────────────────────────────────────
 
-  it('shows Open and Closed filter tabs', async () => {
+  it('shows All, Running, Needs You, Closed filter chips', async () => {
     renderDashboard();
     await waitFor(() => {
-      expect(screen.getByText(/^Open/)).toBeInTheDocument();
-      expect(screen.getByText(/^Closed/)).toBeInTheDocument();
+      expect(screen.getByTestId('filter-chip-all')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('filter-chip-running')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-needs_you')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-closed')).toBeInTheDocument();
   });
 
-  it('defaults to Open filter', async () => {
+  it('defaults to All filter and shows all statuses', async () => {
     apiMock.listTasks.mockResolvedValue([
       makeTask({ id: 't1', title: 'Running Task', status: 'running' }),
       makeTask({ id: 't2', title: 'Closed Task', status: 'closed' }),
@@ -122,10 +126,11 @@ describe('TasksPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Running Task')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Closed Task')).not.toBeInTheDocument();
+    expect(screen.getByText('Closed Task')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-all')).toHaveAttribute('data-active', 'true');
   });
 
-  it('switches to Closed filter on tab click', async () => {
+  it('switches to Closed filter on chip click', async () => {
     const user = userEvent.setup();
     apiMock.listTasks.mockResolvedValue([
       makeTask({ id: 't1', title: 'Running Task', status: 'running' }),
@@ -135,29 +140,28 @@ describe('TasksPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Running Task')).toBeInTheDocument();
     });
-    await user.click(screen.getByText(/^Closed/));
+    await user.click(screen.getByTestId('filter-chip-closed'));
     await waitFor(() => {
-      expect(screen.getByText('Closed Task')).toBeInTheDocument();
+      expect(screen.queryByText('Running Task')).not.toBeInTheDocument();
     });
-    expect(screen.queryByText('Running Task')).not.toBeInTheDocument();
+    expect(screen.getByText('Closed Task')).toBeInTheDocument();
   });
 
-  it('shows draft tasks in Backlog filter', async () => {
+  it('shows errored tasks in Needs You filter', async () => {
     const user = userEvent.setup();
     apiMock.listTasks.mockResolvedValue([
-      makeTask({ id: 't1', title: 'Draft Task', status: 'draft' }),
+      makeTask({ id: 't1', title: 'Errored Task', status: 'error' }),
+      makeTask({ id: 't2', title: 'Running Task', status: 'running' }),
     ]);
     renderDashboard();
-    // Default filter is 'open', so draft should NOT appear
     await waitFor(() => {
-      expect(screen.getByText(/^Backlog/)).toBeInTheDocument();
+      expect(screen.getByText('Errored Task')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Draft Task')).not.toBeInTheDocument();
-    // Switch to backlog tab
-    await user.click(screen.getByText(/^Backlog/));
+    await user.click(screen.getByTestId('filter-chip-needs_you'));
     await waitFor(() => {
-      expect(screen.getByText('Draft Task')).toBeInTheDocument();
+      expect(screen.queryByText('Running Task')).not.toBeInTheDocument();
     });
+    expect(screen.getByText('Errored Task')).toBeInTheDocument();
   });
 
   // ─── Close ───────────────────────────────────────────────────────────────
@@ -184,12 +188,6 @@ describe('TasksPage', () => {
     const user = userEvent.setup();
     apiMock.listTasks.mockResolvedValue([makeTask({ status: 'closed' })]);
     renderDashboard();
-
-    // Switch to Closed filter to see closed tasks
-    await waitFor(() => {
-      expect(screen.getByText(/^Closed/)).toBeInTheDocument();
-    });
-    await user.click(screen.getByText(/^Closed/));
 
     await waitFor(() => {
       expect(screen.getByText('Fix order validation')).toBeInTheDocument();

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -11,7 +11,14 @@ import { PlusIcon } from '@/components/icons';
 
 function NewTaskButton({ onClick }: { onClick: () => void }) {
   return (
-    <Button onClick={onClick}>
+    <Button
+      onClick={onClick}
+      className="bg-[#3B82F6] text-white hover:bg-[#3B82F6]/90"
+      style={{
+        boxShadow:
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.35), 0 0 24px 0 rgba(59, 130, 246, 0.35)',
+      }}
+    >
       <PlusIcon data-icon="inline-start" />
       NEW TASK
     </Button>
@@ -111,15 +118,21 @@ export default function TasksPage() {
         ) : (
           <>
             {/* Header */}
-            <div className="flex items-center justify-between">
-              <div className="flex flex-col gap-1.5">
-                <h1
-                  className="font-display text-[42px] font-bold leading-none tracking-tight"
-                  style={{ letterSpacing: '-1px' }}
+            <div className="flex items-end justify-between">
+              <div className="flex flex-col gap-2">
+                <span
+                  data-testid="page-eyebrow"
+                  className="font-mono text-[11px] font-bold text-[#B5B5BD]"
+                  style={{ letterSpacing: '1.5px' }}
                 >
-                  COMMAND CENTER
+                  // TASKS
+                </span>
+                <h1
+                  className="font-display text-[32px] font-bold leading-[1.1] tracking-tight"
+                  style={{ letterSpacing: '-0.5px' }}
+                >
+                  Command center
                 </h1>
-                <span className="text-sm text-[#8a8a8a]">// autonomous agent orchestration</span>
               </div>
               <NewTaskButton onClick={openCreate} />
             </div>


### PR DESCRIPTION
## Summary

Applies the liquid-glass treatment to the Home (inbox) and Tasks (command center) pages, building on the T1 glass primitives (`GlassPanel`, `StatusGlyph`).

- **Typography** — Both pages gain a `// INBOX` / `// TASKS` eyebrow (JetBrains Mono 11px, 700, `#B5B5BD`, letter-spacing 1.5) above a sentence-case 32px H1. The subtitle on Tasks is dropped.
- **NEW TASK button** — Solid `#3B82F6` fill with inner white specular + outer cyan glow. Only solid-fill button on the page.
- **TaskFilterBar** — Unified L1 `GlassPanel` with segmented chips (`All` / `Running` / `Needs You` / `Closed`). Active chip is pressed glass (14% white + 1px inset stroke). Stateful chips show `<StatusGlyph>`. Repo dropdown right-aligned.
- **useTaskFilters** — Replaces `open/backlog/closed` with `all/running/needs_you/closed`. `needs_you` folds in errored tasks and tasks with pending permission prompts.
- **TaskCard** — Now an L2 `GlassPanel` with 14px radius and a drop shadow (y:12 blur:30 spread:-8). Row layout: status dot → title + mode badge → metadata → telemetry → status pill → hover arrow.
- **Telemetry row** — Scaffolds `model · ctx · cost · diff · tests · lint`. All fields fall back to em-dashes until the server exposes token/cost/diff/test data.
- **SessionsInbox** — Splits the old `NEEDS YOU` bucket into `AWAITING REPLY` (amber triangle) and `ERRORED` (red X). Adds an inline amber `Reply →` button on awaiting rows (links to `/?add_agent=<id>` — opens the composer on Home). Activity section collapses beyond 3 items with tap-to-expand.

> This branch is rebased on **T1 `feat/glass-design-system`** which has not been opened as a separate PR; its one foundation commit is included in the diff here.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — all 1215 tests pass, incl. new cases for the error→ERRORED split, Reply → navigation, activity disclosure, eyebrow rendering, and chip active state
- [x] `bun run build`
- [ ] Manual browser check of Home + Tasks against the design mockups (`design/glass-redesign.pen`, `01-home.png`, `02-tasks.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)