### PR TITLE
feat(ui): glass task detail with ship flow

### DIFF
--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -12,6 +12,25 @@ import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import type { Agent, UserTerminal } from '../../server/types';
 import { CloseIcon } from '@/components/icons';
+import { StatusGlyph } from '@/components/ui/status-glyph';
+
+/**
+ * Map an agent's server status + hook_activity into the StatusGlyph state set.
+ * - stopped                    → closed (○, grey) — filtered out above, but safe fallback
+ * - status=running, hook=active → running (● green)
+ * - status=running, hook=waiting → awaiting (▲ amber)
+ * - status=running, hook=idle   → closed (○ grey, still alive but quiet)
+ * - status=waiting              → awaiting (▲ amber)
+ * - status=idle                 → closed (○ grey)
+ */
+function agentDisplayStatus(agent: Agent): string {
+  if (agent.status === 'stopped') return 'closed';
+  if (agent.status === 'waiting') return 'awaiting';
+  if (agent.status === 'idle') return 'closed';
+  if (agent.hook_activity === 'waiting') return 'awaiting';
+  if (agent.hook_activity === 'idle') return 'closed';
+  return 'running';
+}
 
 interface AgentTabsProps {
   agents: Agent[];
@@ -41,55 +60,59 @@ export function AgentTabs({
   onDetachAgent,
 }: AgentTabsProps) {
   return (
-    <div className="flex items-center gap-1 border-b border-border px-1 pb-1">
+    <div className="flex items-center gap-1 border-b border-glass-edge px-1 pb-1">
       {agents
         .filter((agent) => agent.status !== 'stopped')
-        .map((agent) => (
-          <div key={agent.id} className="group flex items-center">
-            <button
-              className={cn(
-                'flex items-center gap-1.5 px-3.5 py-2.5 text-sm transition-colors',
-                agent.window_index === activeIndex
-                  ? 'border-b-2 border-[#3B82F6] text-[#3B82F6] font-bold'
-                  : 'text-[#8a8a8a] font-medium hover:text-foreground',
-              )}
-              onClick={() => onSelect(agent.window_index)}
-            >
-              {agent.status === 'running' && (
-                <span
-                  className={`inline-block h-2 w-2 ${
-                    agent.hook_activity === 'waiting'
-                      ? 'bg-[#FFB800]'
-                      : agent.hook_activity === 'idle'
-                        ? 'bg-[#6a6a6a]'
-                        : 'animate-pulse bg-[#22C55E]'
-                  }`}
+        .map((agent) => {
+          const displayStatus = agentDisplayStatus(agent);
+          const active = agent.window_index === activeIndex;
+          return (
+            <div key={agent.id} className="group flex items-center">
+              <button
+                data-testid={`agent-tab-${agent.id}`}
+                data-active={active ? 'true' : undefined}
+                data-display-status={displayStatus}
+                className={cn(
+                  'flex items-center gap-1.5 px-3.5 py-2 text-sm transition-colors',
+                  active
+                    ? 'border border-[#22D3EE] bg-[#0B0C0F] text-[#3B82F6] font-bold'
+                    : 'border border-transparent text-[#8a8a8a] font-medium hover:text-foreground',
+                )}
+                onClick={() => onSelect(agent.window_index)}
+              >
+                <StatusGlyph status={displayStatus} size={10} />
+                {agent.status === 'running' && agent.hook_activity === 'active' && (
+                  <span
+                    aria-hidden
+                    data-testid="agent-pulse"
+                    className="inline-block h-2 w-2 animate-pulse bg-[#22C55E]"
+                  />
+                )}
+                {agent.label}
+              </button>
+              {agent.status === 'running' && (onMoveAgent || onDetachAgent) && (
+                <AgentTabMenu
+                  agent={agent}
+                  onMove={onMoveAgent}
+                  onDetach={onDetachAgent}
+                  onStop={onStopAgent}
                 />
               )}
-              {agent.label}
-            </button>
-            {agent.status === 'running' && (onMoveAgent || onDetachAgent) && (
-              <AgentTabMenu
-                agent={agent}
-                onMove={onMoveAgent}
-                onDetach={onDetachAgent}
-                onStop={onStopAgent}
-              />
-            )}
-            {agent.status === 'running' && !onMoveAgent && !onDetachAgent && (
-              <button
-                className="ml-0.5 hidden rounded p-0.5 text-[#6a6a6a] hover:text-destructive group-hover:inline-flex"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onStopAgent(agent.id);
-                }}
-                title="Stop agent"
-              >
-                <CloseIcon />
-              </button>
-            )}
-          </div>
-        ))}
+              {agent.status === 'running' && !onMoveAgent && !onDetachAgent && (
+                <button
+                  className="ml-0.5 hidden rounded p-0.5 text-[#6a6a6a] hover:text-destructive group-hover:inline-flex"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStopAgent(agent.id);
+                  }}
+                  title="Stop agent"
+                >
+                  <CloseIcon />
+                </button>
+              )}
+            </div>
+          );
+        })}
       {canAddAgent && <AddAgentButton onAdd={onAddAgent} />}
       {(userTerminals.length > 0 || onAddTerminal) && (
         <div data-testid="tab-separator" className="mx-1 h-6 w-px bg-[#2f2f2f]" />
@@ -98,10 +121,10 @@ export function AgentTabs({
         <div key={terminal.id} className="group flex items-center">
           <button
             className={cn(
-              'flex items-center gap-1.5 px-3.5 py-2.5 text-sm transition-colors',
+              'flex items-center gap-1.5 px-3.5 py-2 text-sm transition-colors',
               terminal.window_index === activeIndex
-                ? 'border-b-2 border-[#3B82F6] text-[#3B82F6] font-bold'
-                : 'text-[#8a8a8a] font-medium hover:text-foreground',
+                ? 'border border-[#22D3EE] bg-[#0B0C0F] text-[#3B82F6] font-bold'
+                : 'border border-transparent text-[#8a8a8a] font-medium hover:text-foreground',
             )}
             onClick={() => onSelect(terminal.window_index)}
           >

--- a/src/components/DiffFileTree.tsx
+++ b/src/components/DiffFileTree.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
 import type { DiffFileEntry } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { CheckIcon } from '@/components/icons';
 
 interface Props {
   files: DiffFileEntry[];
@@ -8,6 +9,8 @@ interface Props {
   onSelect: (path: string) => void;
   taskId?: string;
   ignoredTruncated?: boolean;
+  reviewed?: Set<string>;
+  onToggleReview?: (path: string) => void;
 }
 
 export function ignoredGroupKey(taskId: string): string {
@@ -60,26 +63,63 @@ function TreeRow({
   depth,
   selected,
   onSelect,
+  reviewed,
+  onToggleReview,
 }: {
   node: Node;
   depth: number;
   selected: string | null;
   onSelect: (path: string) => void;
+  reviewed?: Set<string>;
+  onToggleReview?: (path: string) => void;
 }) {
   if (node.isFile && node.file) {
     const f = node.file;
     const active = selected === f.path;
+    const isReviewed = reviewed?.has(f.path) ?? false;
+    const handleKey = (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'r' && onToggleReview && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        onToggleReview(f.path);
+      }
+    };
     return (
       <button
         type="button"
+        data-testid={`diff-file-row-${f.path}`}
+        data-reviewed={isReviewed ? 'true' : undefined}
         onClick={() => onSelect(f.path)}
+        onKeyDown={handleKey}
         className={cn(
-          'flex w-full items-center justify-between gap-2 px-2 py-1 text-left text-xs hover:bg-accent',
+          'flex w-full items-center gap-2 px-2 py-1 text-left text-xs hover:bg-accent',
           active && 'bg-accent',
+          isReviewed && 'opacity-50',
         )}
         style={{ paddingLeft: `${depth * 12 + 8}px` }}
       >
-        <span className="flex min-w-0 items-center gap-1.5">
+        {onToggleReview ? (
+          <span
+            role="checkbox"
+            aria-checked={isReviewed}
+            aria-label={isReviewed ? `Unmark ${f.path} as reviewed` : `Mark ${f.path} as reviewed`}
+            data-testid={`review-toggle-${f.path}`}
+            tabIndex={-1}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleReview(f.path);
+            }}
+            className={cn(
+              'inline-flex h-3.5 w-3.5 shrink-0 cursor-pointer items-center justify-center border',
+              isReviewed
+                ? 'border-[#22C55E] bg-[#22C55E33] text-[#22C55E]'
+                : 'border-[#2f2f2f] bg-transparent text-transparent hover:border-[#6a6a6a]',
+            )}
+          >
+            {isReviewed ? <CheckIcon size={10} /> : null}
+          </span>
+        ) : null}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
           <span className={cn('font-mono text-[10px] font-bold', statusColor[f.status])}>
             {f.status}
           </span>
@@ -102,7 +142,8 @@ function TreeRow({
     <>
       {node.name && (
         <div
-          className="px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+          data-testid={`diff-group-${node.fullPath}`}
+          className="px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
           style={{ paddingLeft: `${depth * 12 + 8}px` }}
         >
           {node.name}
@@ -115,13 +156,23 @@ function TreeRow({
           depth={node.name ? depth + 1 : depth}
           selected={selected}
           onSelect={onSelect}
+          reviewed={reviewed}
+          onToggleReview={onToggleReview}
         />
       ))}
     </>
   );
 }
 
-export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncated }: Props) {
+export function DiffFileTree({
+  files,
+  selected,
+  onSelect,
+  taskId,
+  ignoredTruncated,
+  reviewed,
+  onToggleReview,
+}: Props) {
   const changed = useMemo(() => files.filter((f) => !f.ignored), [files]);
   const ignored = useMemo(() => files.filter((f) => f.ignored), [files]);
   const changedTree = useMemo(() => buildTree(changed), [changed]);
@@ -158,7 +209,14 @@ export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncat
   return (
     <div className="overflow-y-auto">
       {changed.length > 0 ? (
-        <TreeRow node={changedTree} depth={0} selected={selected} onSelect={onSelect} />
+        <TreeRow
+          node={changedTree}
+          depth={0}
+          selected={selected}
+          onSelect={onSelect}
+          reviewed={reviewed}
+          onToggleReview={onToggleReview}
+        />
       ) : null}
       {ignored.length > 0 ? (
         <div className="border-t border-border">
@@ -166,7 +224,7 @@ export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncat
             type="button"
             onClick={toggleIgnored}
             aria-expanded={ignoredOpen}
-            className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent"
+            className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left font-mono text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent"
           >
             <span aria-hidden className="inline-block w-3 font-mono">
               {ignoredOpen ? '▾' : '▸'}
@@ -177,7 +235,14 @@ export function DiffFileTree({ files, selected, onSelect, taskId, ignoredTruncat
             ) : null}
           </button>
           {ignoredOpen ? (
-            <TreeRow node={ignoredTree} depth={0} selected={selected} onSelect={onSelect} />
+            <TreeRow
+              node={ignoredTree}
+              depth={0}
+              selected={selected}
+              onSelect={onSelect}
+              reviewed={reviewed}
+              onToggleReview={onToggleReview}
+            />
           ) : null}
         </div>
       ) : null}

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useRef } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { diffExpandedKey } from '@/lib/diff-state';
+import { diffExpandedKey, reviewedKey } from '@/lib/diff-state';
 
 const { apiMock, apiProxy } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupApiMock(),
@@ -233,6 +233,79 @@ describe('DiffViewer', () => {
         screen.getByTestId('monaco-diff').getAttribute('data-options') ?? '{}',
       );
       expect(opts.hideUnchangedRegions.enabled).toBe(false);
+    });
+  });
+
+  // ─── Review flow ──────────────────────────────────────────────────────────
+
+  it('clicking the review checkbox persists to localStorage and updates the progress chip', async () => {
+    const user = userEvent.setup();
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [
+        { path: 'src/a.ts', status: 'M', additions: 1, deletions: 0 },
+        { path: 'src/b.ts', status: 'A', additions: 1, deletions: 0 },
+      ],
+    });
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+
+    const progress = await screen.findByTestId('review-progress');
+    expect(progress.textContent).toMatch(/0\s*\/\s*2\s*reviewed/);
+    expect(localStorage.getItem(reviewedKey('t1', 'src/a.ts'))).toBeNull();
+
+    await user.click(await screen.findByTestId('review-toggle-src/a.ts'));
+
+    expect(localStorage.getItem(reviewedKey('t1', 'src/a.ts'))).toBe('true');
+    await waitFor(() => {
+      expect(screen.getByTestId('review-progress').textContent).toMatch(/1\s*\/\s*2\s*reviewed/);
+    });
+
+    // Second click toggles off
+    await user.click(screen.getByTestId('review-toggle-src/a.ts'));
+    expect(localStorage.getItem(reviewedKey('t1', 'src/a.ts'))).toBeNull();
+  });
+
+  it('pressing "r" while focused on a file row toggles reviewed', async () => {
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [{ path: 'src/a.ts', status: 'M', additions: 1, deletions: 0 }],
+    });
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+
+    const row = await screen.findByTestId('diff-file-row-src/a.ts');
+    expect(row).not.toHaveAttribute('data-reviewed');
+    row.focus();
+    fireEvent.keyDown(row, { key: 'r' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-file-row-src/a.ts')).toHaveAttribute('data-reviewed', 'true');
+    });
+    expect(localStorage.getItem(reviewedKey('t1', 'src/a.ts'))).toBe('true');
+  });
+
+  it('reviewed files render dimmed (opacity-50) and the row carries a data-reviewed flag', async () => {
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [{ path: 'src/a.ts', status: 'M', additions: 1, deletions: 0 }],
+    });
+    localStorage.setItem(reviewedKey('t1', 'src/a.ts'), 'true');
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-file-row-src/a.ts')).toHaveAttribute('data-reviewed', 'true');
+    });
+    expect(screen.getByTestId('diff-file-row-src/a.ts').className).toMatch(/opacity-50/);
+  });
+
+  it('groups files by top-level directory in the file tree', async () => {
+    apiMock.getTaskDiffSummary.mockResolvedValue({
+      files: [
+        { path: 'design/page.md', status: 'M', additions: 1, deletions: 0 },
+        { path: 'src/components/Foo.tsx', status: 'A', additions: 10, deletions: 0 },
+        { path: 'src/components/Bar.tsx', status: 'M', additions: 2, deletions: 1 },
+      ],
+    });
+    render(<DiffViewer taskId="t1" isRunning={false} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-group-design')).toBeInTheDocument();
+      expect(screen.getByTestId('diff-group-src')).toBeInTheDocument();
+      expect(screen.getByTestId('diff-group-src/components')).toBeInTheDocument();
     });
   });
 

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,8 +1,13 @@
-import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DiffOnMount } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { api, type DiffFileEntry, type FileDiffResponse } from '@/lib/api';
-import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
+import {
+  getDiffExpanded,
+  setDiffExpanded,
+  getReviewed,
+  setReviewed as persistReviewed,
+} from '@/lib/diff-state';
 import { Button } from '@/components/ui/button';
 import { DiffFileTree } from './DiffFileTree';
 
@@ -50,6 +55,40 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   const [fileLoading, setFileLoading] = useState(false);
   const [expandedAll, setExpandedAll] = useState(false);
   const expandedFallback = useRef<Record<string, boolean>>({});
+  const [reviewed, setReviewedState] = useState<Set<string>>(new Set());
+
+  // Hydrate reviewed set from localStorage whenever the file list changes.
+  useEffect(() => {
+    const next = new Set<string>();
+    for (const f of files) {
+      if (getReviewed(taskId, f.path)) next.add(f.path);
+    }
+    setReviewedState(next);
+  }, [taskId, files]);
+
+  const toggleReviewed = useCallback(
+    (path: string) => {
+      setReviewedState((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) {
+          next.delete(path);
+          persistReviewed(taskId, path, false);
+        } else {
+          next.add(path);
+          persistReviewed(taskId, path, true);
+        }
+        return next;
+      });
+    },
+    [taskId],
+  );
+
+  const reviewCounts = useMemo(() => {
+    const nonIgnored = files.filter((f) => !f.ignored);
+    const total = nonIgnored.length;
+    const done = nonIgnored.filter((f) => reviewed.has(f.path)).length;
+    return { done, total };
+  }, [files, reviewed]);
 
   const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
   const editorKeyRef = useRef<string | null>(null);
@@ -195,7 +234,7 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   }
 
   return (
-    <div className="flex h-full min-h-0">
+    <div className="flex h-full min-h-0" style={{ background: '#0B0C0F' }}>
       <aside className="w-[280px] shrink-0 border-r border-border">
         {summaryLoading && files.length === 0 ? (
           <div className="p-4 text-xs text-muted-foreground">Loading diff...</div>
@@ -206,23 +245,40 @@ export function DiffViewer({ taskId, isRunning }: Props) {
             onSelect={handleSelect}
             taskId={taskId}
             ignoredTruncated={ignoredTruncated}
+            reviewed={reviewed}
+            onToggleReview={toggleReviewed}
           />
         )}
       </aside>
       <main className="flex min-w-0 flex-1 flex-col">
-        {showToolbar && selected ? (
-          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-            <span className="truncate text-xs text-muted-foreground">{selected}</span>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={toggleExpandedAll}
-              aria-label={expandedAll ? 'Collapse all' : 'Expand all'}
-            >
-              {expandedAll ? 'Collapse all' : 'Expand all'}
-            </Button>
-          </div>
-        ) : null}
+        <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-1.5">
+          <span className="flex min-w-0 items-center gap-3">
+            {showToolbar && selected ? (
+              <span className="truncate text-xs text-muted-foreground">{selected}</span>
+            ) : null}
+          </span>
+          <span className="flex shrink-0 items-center gap-2">
+            {reviewCounts.total > 0 ? (
+              <span
+                data-testid="review-progress"
+                aria-label={`${reviewCounts.done} of ${reviewCounts.total} reviewed`}
+                className="bg-glass-l1 glass-blur-l1 inline-flex items-center gap-1 border border-[#22D3EE] px-1.5 py-0.5 font-mono text-[11px] tracking-wider text-[#22D3EE]"
+              >
+                {reviewCounts.done} / {reviewCounts.total} reviewed
+              </span>
+            ) : null}
+            {showToolbar && selected ? (
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={toggleExpandedAll}
+                aria-label={expandedAll ? 'Collapse all' : 'Expand all'}
+              >
+                {expandedAll ? 'Collapse all' : 'Expand all'}
+              </Button>
+            ) : null}
+          </span>
+        </div>
         <div className="min-h-0 flex-1">
           {error && selected ? (
             <div className="flex h-full items-center justify-center text-sm text-destructive">

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -50,6 +50,27 @@ export function PlusIcon({ size = 16, ...props }: IconProps) {
   );
 }
 
+export function PullRequestIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <circle cx="6" cy="6" r="2.5" />
+      <circle cx="6" cy="18" r="2.5" />
+      <circle cx="18" cy="18" r="2.5" />
+      <path d="M6 8.5v7" />
+      <path d="M18 15.5V9a3 3 0 0 0-3-3h-3" />
+      <path d="m15 9-3-3 3-3" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ size = 12, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
 /** Rounded square with an arrow — used for "terminal" empty states. */
 export function TerminalRectIcon({ size = 48, strokeWidth = 1.5, ...props }: IconProps) {
   return (

--- a/src/lib/diff-state.ts
+++ b/src/lib/diff-state.ts
@@ -17,3 +17,25 @@ export function setDiffExpanded(taskId: string, filePath: string, value: boolean
     // localStorage unavailable (SSR, privacy mode) — degrade silently
   }
 }
+
+export function reviewedKey(taskId: string, filePath: string): string {
+  return `octomux:reviewed:${taskId}:${filePath}`;
+}
+
+export function getReviewed(taskId: string, filePath: string): boolean {
+  try {
+    return localStorage.getItem(reviewedKey(taskId, filePath)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setReviewed(taskId: string, filePath: string, value: boolean): void {
+  try {
+    const k = reviewedKey(taskId, filePath);
+    if (value) localStorage.setItem(k, 'true');
+    else localStorage.removeItem(k);
+  } catch {
+    // ignore
+  }
+}

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -116,20 +116,27 @@ describe('TaskDetail', () => {
     });
   });
 
-  // ─── Header content (table-driven) ────────────────────────────────────────
+  // ─── Header content ───────────────────────────────────────────────────────
 
-  const headerElements = [
-    { name: 'title', text: 'Fix order validation' },
-    { name: 'description', text: 'Add negative quantity checks' },
-  ];
-
-  it.each(headerElements)('shows $name in header', async ({ text }) => {
+  it('shows title in header', async () => {
     renderDetail();
     await waitFor(() => {
-      // Description may appear in both the truncated header and the body
-      const matches = screen.getAllByText(text);
-      expect(matches.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('Fix order validation')).toBeInTheDocument();
     });
+  });
+
+  it('does not render the description subtitle in the header (glass compact header)', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('Fix order validation')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Add negative quantity checks')).not.toBeInTheDocument();
+  });
+
+  it('renders the ⌘K keycap in the header action cluster for running tasks', async () => {
+    renderDetail();
+    const header = await screen.findByTestId('task-detail-header');
+    expect(header.textContent).toContain('⌘');
   });
 
   // ─── Running task controls ────────────────────────────────────────────────
@@ -141,16 +148,43 @@ describe('TaskDetail', () => {
     });
   });
 
-  it('clicking Close calls updateTask with status "closed"', async () => {
+  it('clicking Close opens an inline confirm sheet (no native dialog)', async () => {
     const user = userEvent.setup();
     renderDetail();
     await waitFor(() => {
       expect(screen.getByText('CLOSE')).toBeInTheDocument();
     });
     await user.click(screen.getByText('CLOSE'));
+    expect(await screen.findByTestId('close-confirm')).toBeInTheDocument();
+    // Not called until confirmed
+    expect(apiMock.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('confirming the Close sheet calls updateTask with status "closed"', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('CLOSE')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('CLOSE'));
+    await user.click(await screen.findByTestId('close-confirm-accept'));
     await waitFor(() => {
       expect(apiMock.updateTask).toHaveBeenCalledWith('test-task-01', { status: 'closed' });
     });
+  });
+
+  it('cancel in Close confirm sheet dismisses without calling updateTask', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('CLOSE')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('CLOSE'));
+    await user.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('close-confirm')).not.toBeInTheDocument();
+    });
+    expect(apiMock.updateTask).not.toHaveBeenCalled();
   });
 
   // ─── Draft task controls ────────────────────────────────────────────────
@@ -236,6 +270,44 @@ describe('TaskDetail', () => {
     await waitFor(() => {
       expect(screen.getByText('Agent 1')).toBeInTheDocument();
     });
+  });
+
+  it('active agent tab renders a state chip glyph (T1 StatusGlyph)', async () => {
+    renderDetail();
+    const tab = await screen.findByTestId('agent-tab-a1');
+    expect(tab).toHaveAttribute('data-active', 'true');
+    expect(tab).toHaveAttribute('data-display-status', 'running');
+    // StatusGlyph renders role=img with an aria-label for the state name
+    expect(tab.querySelector('[role="img"][aria-label="running"]')).not.toBeNull();
+  });
+
+  // ─── Ship button ──────────────────────────────────────────────────────────
+
+  it('shows the Ship button for a running task and dispatches open-pr-sheet on click', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    const ship = await screen.findByTestId('ship-button');
+    const spy = vi.fn();
+    window.addEventListener('octomux:open-pr-sheet', spy);
+    try {
+      await user.click(ship);
+      expect(spy).toHaveBeenCalled();
+      const evt = spy.mock.calls[0][0] as CustomEvent<{ taskId: string }>;
+      expect(evt.detail.taskId).toBe('test-task-01');
+    } finally {
+      window.removeEventListener('octomux:open-pr-sheet', spy);
+    }
+  });
+
+  it('hides the Ship button for a scratch task (no repo)', async () => {
+    apiMock.getTask.mockResolvedValue(
+      makeTask({ run_mode: 'scratch', status: 'running', agents: [makeAgent({ id: 'a1' })] }),
+    );
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('Fix order validation')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('ship-button')).not.toBeInTheDocument();
   });
 
   // ─── PR link ──────────────────────────────────────────────────────────────

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -12,8 +12,10 @@ import { MoveAgentDialog } from '@/components/MoveAgentDialog';
 import { useTask } from '@/lib/hooks';
 import { api } from '@/lib/api';
 import { repoName } from '@/lib/utils';
-import { TerminalRectIcon } from '@/components/icons';
+import { PullRequestIcon, TerminalRectIcon } from '@/components/icons';
 import type { RunMode } from '../../server/types';
+
+export const SHIP_EVENT = 'octomux:open-pr-sheet';
 
 const MODE_LABEL: Record<RunMode, string> = {
   new: 'N',
@@ -127,6 +129,13 @@ export default function TaskDetail() {
   }, [task?.status]);
 
   const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
+  const [closeConfirm, setCloseConfirm] = useState(false);
+
+  const handleShip = useCallback(() => {
+    if (!taskId) return;
+    // T7 will mount the PR sheet listener. Route stub deferred — event-only for now.
+    window.dispatchEvent(new CustomEvent(SHIP_EVENT, { detail: { taskId } }));
+  }, [taskId]);
 
   const handleAddAgent = useCallback(
     async (prompt?: string) => {
@@ -166,6 +175,7 @@ export default function TaskDetail() {
     if (!taskId) return;
     try {
       await api.updateTask(taskId, { status: 'closed' });
+      setCloseConfirm(false);
       refresh();
     } catch (err) {
       console.error('Failed to close task:', err);
@@ -285,33 +295,50 @@ export default function TaskDetail() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-3 py-2 sm:px-4 sm:py-3">
-        <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <h1 className="truncate text-base font-semibold sm:text-lg">{task.title}</h1>
-              <span
-                data-testid="mode-badge"
-                title={MODE_TOOLTIP[runMode]}
-                aria-label={`run mode: ${MODE_TOOLTIP[runMode]}`}
-                className="inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-[#2f2f2f] bg-[#1a1a1a] px-1.5 font-mono text-[10px] font-bold text-[#8a8a8a]"
-              >
-                {MODE_LABEL[runMode]}
-              </span>
-              <StatusBadge status={task.derived_status || task.status} />
-            </div>
-            <p className="hidden max-w-xl truncate text-xs text-muted-foreground sm:block">
-              {task.description}
-            </p>
-          </div>
+      {/* L1 glass header — compact 12px vertical padding */}
+      <div
+        data-testid="task-detail-header"
+        className="bg-glass-l1 glass-blur-l1 flex items-center justify-between gap-3 border-b border-glass-edge px-4 py-3"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="truncate text-[15px] font-semibold leading-none">{task.title}</h1>
+          <span
+            data-testid="mode-badge"
+            title={MODE_TOOLTIP[runMode]}
+            aria-label={`run mode: ${MODE_TOOLTIP[runMode]}`}
+            className="inline-flex h-5 min-w-[20px] items-center justify-center rounded border border-[#2f2f2f] bg-[#1a1a1a] px-1.5 font-mono text-[10px] font-bold text-[#8a8a8a]"
+          >
+            {MODE_LABEL[runMode]}
+          </span>
+          <StatusBadge status={task.derived_status || task.status} />
         </div>
-        <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+        <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
           {canResume && (
             <Button variant="default" size="sm" disabled={resuming} onClick={handleResume}>
               {resuming ? '...' : 'Resume'}
             </Button>
           )}
+
+          {canShowDiff && (
+            <Button
+              size="sm"
+              data-testid="ship-button"
+              onClick={handleShip}
+              className="gap-1.5 border border-[#22C55EAA] bg-[#22C55E1F] text-[#DCFCE7] shadow-[0_0_0_1px_rgba(34,197,94,0.4),0_0_18px_-4px_rgba(34,197,94,0.7)] hover:bg-[#22C55E33] hover:text-white"
+            >
+              <PullRequestIcon size={14} aria-hidden />
+              <span className="font-semibold tracking-wider uppercase">Ship</span>
+            </Button>
+          )}
+
+          <span
+            aria-label="open command palette"
+            title="Command palette (⌘K)"
+            className="bg-glass-l1 glass-blur-l1 hidden h-7 items-center gap-0.5 border border-glass-edge px-1.5 font-mono text-[11px] tracking-wider text-[#b5b5bd] sm:inline-flex"
+          >
+            <span className="text-[13px] leading-none">⌘</span>
+            <span>K</span>
+          </span>
 
           {isRunning && !!task.tmux_session && (
             <Button
@@ -342,16 +369,39 @@ export default function TaskDetail() {
               Start
             </Button>
           )}
-          {isRunning && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-[#2f2f2f] text-[#EF4444]"
-              onClick={handleClose}
-            >
-              CLOSE
-            </Button>
-          )}
+          {isRunning &&
+            (closeConfirm ? (
+              <div
+                role="alertdialog"
+                aria-label="Confirm close task"
+                data-testid="close-confirm"
+                className="bg-glass-l2 glass-blur-l2 flex items-center gap-2 border border-[#EF4444AA] px-2 py-1 text-[11px] text-[#FEE2E2]"
+              >
+                <span className="font-semibold tracking-wider uppercase">Close task?</span>
+                <button
+                  className="px-1.5 py-0.5 text-[#b5b5bd] hover:text-white"
+                  onClick={() => setCloseConfirm(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  data-testid="close-confirm-accept"
+                  className="border border-[#EF4444AA] bg-[#EF44441F] px-1.5 py-0.5 font-bold uppercase text-[#FEE2E2] hover:bg-[#EF444433]"
+                  onClick={handleClose}
+                >
+                  Confirm
+                </button>
+              </div>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-[#EF4444AA] bg-[#EF44441F] text-[#FEE2E2] hover:bg-[#EF444433] hover:text-white"
+                onClick={() => setCloseConfirm(true)}
+              >
+                CLOSE
+              </Button>
+            ))}
         </div>
       </div>
 
@@ -362,12 +412,19 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Metadata bar — hidden for scratch tasks which have no repo/branch */}
+      {/* Thin metadata bar — L1 lighter (5% white + 30px blur), 6px vertical padding */}
       {!isScratch && (
-        <div className="flex items-center gap-5 border-b border-border bg-[#141414] px-6 py-2">
+        <div
+          className="flex items-center gap-5 border-b border-glass-edge px-6 py-[6px]"
+          style={{
+            background: 'rgba(255,255,255,0.05)',
+            backdropFilter: 'blur(30px)',
+            WebkitBackdropFilter: 'blur(30px)',
+          }}
+        >
           {task.repo_path && (
             <>
-              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
                 REPO
               </span>
               <span className="text-[11px] text-[#8a8a8a]">{repoName(task.repo_path)}</span>
@@ -376,7 +433,7 @@ export default function TaskDetail() {
           {task.branch && (
             <>
               {task.repo_path && <span className="text-[11px] text-[#2f2f2f]">|</span>}
-              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
                 {runMode === 'existing' ? 'WORKTREE HEAD' : 'BRANCH'}
               </span>
               <span className="text-[11px] font-medium text-[#3B82F6]">
@@ -387,7 +444,7 @@ export default function TaskDetail() {
           {task.base_branch && (
             <>
               <span className="text-[11px] text-[#2f2f2f]">|</span>
-              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
                 BASE
               </span>
               <span className="text-[11px] text-[#8a8a8a]">{task.base_branch}</span>
@@ -396,7 +453,7 @@ export default function TaskDetail() {
           {task.pr_url && (
             <>
               <span className="text-[11px] text-[#2f2f2f]">|</span>
-              <span className="text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+              <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
                 PR
               </span>
               <a


### PR DESCRIPTION
## Summary
- Compact L1 glass header (15px/600 title, mode + status chips inline); dropped the description subtitle per spec
- Thin L1-lighter metadata bar (6px py) with mono REPO / BRANCH / BASE / PR chrome
- Added ⌘K keycap and destructive-glass CLOSE with inline confirm sheet
- Primary Ship button (green glow, pull-request icon) — dispatches \`octomux:open-pr-sheet\` as T7's integration point
- AgentTabs: active tab is opaque terminal container with 1px cyan stroke, inactive tabs are ghost, each tab carries a \`StatusGlyph\` state chip
- DiffViewer: per-file review checkbox (click or \`r\` when focused), dimmed reviewed rows, \`X / Y reviewed\` cyan progress chip, localStorage under \`octomux:reviewed:<task>:<file>\`
- Diff pane kept opaque (#0B0C0F) — readability is non-negotiable
- Depends on T1 (\`feat/glass-design-system\`); that branch is merged in here so \`GlassPanel\`/\`StatusGlyph\`/tokens are available

## Out of scope
- The actual PR Preview sheet (T7 will listen on \`octomux:open-pr-sheet\`)
- Parallel agent grid (T7)

## Test plan
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` — 0 errors (only pre-existing warnings)
- [x] \`bun run test\` — 1221 / 1221 pass
- [ ] Manually verify task detail header chrome, Ship button glow, CLOSE → confirm → actual close
- [ ] Manually verify AgentTabs active/inactive styling with running/waiting/idle hook states
- [ ] Manually verify diff review flow: click checkbox, press \`r\`, progress chip updates, localStorage round-trips across refresh
- [ ] Manually verify diff pane remains opaque (no glass bleed-through on code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)