### PR TITLE
refactor(ui): composer worktree checkbox with implicit run mode

### DIFF
--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -55,34 +55,32 @@ beforeEach(() => {
 // ─── URL hydration ────────────────────────────────────────────────────────
 
 describe('Composer / URL hydration', () => {
-  it('empty URL → scratch state (scratch intent, submittable with prompt only)', () => {
+  it('empty URL → scratch intent + scratch hint pill', () => {
     renderComposer('/');
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('scratch-hint')).toHaveTextContent(/scratch/i);
   });
 
   it('?mode=scratch → scratch intent', () => {
     renderComposer('/?mode=scratch');
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch session/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
   });
 
-  it('?repo=/r&mode=new → New task in basename', () => {
+  it('?repo=/r&mode=new → New task in basename, worktree checkbox ON', () => {
     renderComposer('/?repo=%2Fusers%2Fdev%2Focto&mode=new');
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/new task in octo/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/new worktree/i);
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('?repo=/r&mode=none → in-place intent', () => {
+  it('?repo=/r&mode=none → in-place intent, worktree checkbox OFF', () => {
     renderComposer('/?repo=%2Fusers%2Fdev%2Focto&mode=none');
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/in-place in octo/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/in-place/i);
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'false');
   });
 
   it('?repo=/r&mode=existing&worktree_path=/p → attach intent', () => {
     renderComposer('/?repo=%2Fusers%2Fdev%2Focto&mode=existing&worktree_path=%2Ftmp%2Fx');
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/attaching existing x/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/attach existing/i);
   });
 
   it('?repo=/r&mode=new&fork_of=abc shows Forking intent (title from source task)', () => {
@@ -95,7 +93,6 @@ describe('Composer / URL hydration', () => {
     const src = makeTask({ id: 't1', title: 'Parent Task' });
     renderComposer('/?add_agent=t1', { tasks: [src] });
     expect(screen.getByTestId('intent-header')).toHaveTextContent(/adding agent to parent task/i);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/add agent → parent task/i);
   });
 
   it('fork_of referencing non-existent task shows Source task not found', () => {
@@ -298,13 +295,19 @@ describe('Composer / intent dismiss', () => {
 describe('Composer / chip interactions', () => {
   const user = userEvent.setup();
 
-  it('toggle worktree → in-place switches derived label', async () => {
+  it('toggling worktree checkbox switches derived run_mode (new ↔ none)', async () => {
     renderComposer('/?repo=%2Fr&mode=new&branch=main');
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/new worktree/i);
-    await user.click(screen.getByTestId('worktree-toggle-in-place'));
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/in-place/i);
-    await user.click(screen.getByTestId('worktree-toggle-worktree'));
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/new worktree/i);
+    const checkbox = screen.getByTestId('worktree-checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/new task/i);
+
+    await user.click(checkbox);
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/in-place/i);
+
+    await user.click(screen.getByTestId('worktree-checkbox'));
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/new task/i);
   });
 
   it('removing repo chip switches to scratch mode', async () => {
@@ -313,7 +316,42 @@ describe('Composer / chip interactions', () => {
       .getByTestId('repo-chip')
       .querySelector('button[aria-label="Remove"]') as HTMLButtonElement;
     await user.click(removeBtn);
-    expect(screen.getByTestId('derived-mode-label')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('intent-header')).toHaveTextContent(/scratch/i);
+    expect(screen.getByTestId('scratch-hint')).toBeInTheDocument();
+  });
+
+  it('empty composer shows dashed "Add repo or folder" chip + scratch hint', () => {
+    renderComposer('/');
+    expect(screen.getByTestId('repo-chip-picker')).toHaveTextContent(/add repo or folder/i);
+    expect(screen.getByTestId('scratch-hint')).toBeInTheDocument();
+    expect(screen.queryByTestId('worktree-checkbox')).not.toBeInTheDocument();
+  });
+
+  // T5 deliverable: repo + worktree=on → run_mode 'new'; off → 'none'.
+  it('checking worktree before submit emits run_mode=new', async () => {
+    apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'wt-on' }));
+    renderComposer('/?repo=%2Fr&mode=none&branch=main');
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'false');
+    await user.click(screen.getByTestId('worktree-checkbox'));
+    await user.type(screen.getByTestId('composer-prompt'), 'fresh worktree');
+    await user.click(screen.getByTestId('composer-submit'));
+    await waitFor(() => {
+      expect(apiMock.createTask).toHaveBeenCalledWith(expect.objectContaining({ run_mode: 'new' }));
+    });
+  });
+
+  it('unchecking worktree before submit emits run_mode=none', async () => {
+    apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'wt-off' }));
+    renderComposer('/?repo=%2Fr&mode=new&branch=main');
+    expect(screen.getByTestId('worktree-checkbox')).toHaveAttribute('aria-checked', 'true');
+    await user.click(screen.getByTestId('worktree-checkbox'));
+    await user.type(screen.getByTestId('composer-prompt'), 'edit in place');
+    await user.click(screen.getByTestId('composer-submit'));
+    await waitFor(() => {
+      expect(apiMock.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ run_mode: 'none' }),
+      );
+    });
   });
 });
 

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -4,8 +4,10 @@ import {
   useState,
   useCallback,
   useRef,
+  forwardRef,
   type KeyboardEvent,
   type FormEvent,
+  type Ref,
 } from 'react';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import {
@@ -18,6 +20,7 @@ import {
 import { RepoPickerField } from './fields/RepoPickerField';
 import { BranchPickerField } from './fields/BranchPickerField';
 import { Button } from '@/components/ui/button';
+import { GlassPanel } from '@/components/ui/glass-panel';
 import { api } from '@/lib/api';
 import { useTasksContext } from '@/lib/tasks-context';
 import type { Task, Agent } from '../../server/types';
@@ -57,7 +60,6 @@ export function Composer({ onSubmitted }: Props = {}) {
   const navigate = useNavigate();
   const { tasks, refresh } = useTasksContext();
 
-  // Initial state is derived from the URL exactly once on mount.
   const [state, dispatch] = useReducer(reduce, searchParams, (params: URLSearchParams) =>
     hydrateFromUrl(params),
   );
@@ -69,9 +71,11 @@ export function Composer({ onSubmitted }: Props = {}) {
     conflictTaskId?: string | null;
   } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const repoChipRef = useRef<HTMLButtonElement>(null);
+  const branchChipRef = useRef<HTMLButtonElement>(null);
+  const worktreeCheckboxRef = useRef<HTMLButtonElement>(null);
 
-  // Re-hydrate when the URL is changed externally (e.g. sidebar click navigating
-  // to a new `?repo=...` URL while the Composer is already mounted).
+  // Re-hydrate when the URL is changed externally.
   const lastHydratedRef = useRef(searchParams.toString());
   useEffect(() => {
     const current = searchParams.toString();
@@ -81,7 +85,7 @@ export function Composer({ onSubmitted }: Props = {}) {
     setErrorBanner(null);
   }, [searchParams]);
 
-  // Mirror chip state → URL. Skip when nothing would change to avoid dirty loops.
+  // Mirror chip state → URL.
   useEffect(() => {
     const next = stateToUrlParams(state).toString();
     if (next === searchParams.toString()) return;
@@ -89,14 +93,13 @@ export function Composer({ onSubmitted }: Props = {}) {
     setSearchParams(next ? new URLSearchParams(next) : new URLSearchParams(), { replace: true });
   }, [state, searchParams, setSearchParams]);
 
-  // Source task lookup for add-agent + fork intent headers.
   const addAgentSourceId = state.mode === 'add-agent' ? state.sessionId : null;
   const forkOfId = state.mode === 'new' && state.forkOf ? state.forkOf : null;
   const sourceTaskId = addAgentSourceId ?? forkOfId ?? null;
   const sourceTask = sourceTaskId ? (tasks.find((t) => t.id === sourceTaskId) ?? null) : null;
   const sourceTaskMissing = sourceTaskId !== null && !sourceTask && tasks.length > 0;
 
-  // ─── Chip dispatchers ────────────────────────────────────────────────
+  // ─── Dispatchers ─────────────────────────────────────────────────────
 
   const onPickRepo = useCallback(async (repoPath: string) => {
     if (!repoPath) {
@@ -154,9 +157,6 @@ export function Composer({ onSubmitted }: Props = {}) {
           refresh();
           navigate(`/tasks/${state.sessionId}`);
         } else if (state.mode === 'scratch') {
-          // Phase 2a: scratch submit creates a standalone runtime agent (chat),
-          // not a scratch task. The prompt is not forwarded today — the Claude
-          // session starts fresh in the chat terminal.
           const chat = await createChatRequest({ label: deriveTitleFromPrompt(trimmed) });
           navigate(`/chats/${chat.id}`);
         } else if (state.mode !== 'empty') {
@@ -187,7 +187,6 @@ export function Composer({ onSubmitted }: Props = {}) {
         }
       } catch (err) {
         const message = (err as Error).message || 'Submission failed';
-        // Try to correlate server conflict messages to an existing task for an inline link.
         const conflictMatch = /task\s+([a-zA-Z0-9_-]{6,})/i.exec(message);
         setErrorBanner({
           message,
@@ -210,43 +209,67 @@ export function Composer({ onSubmitted }: Props = {}) {
     [handleSubmit],
   );
 
-  // Auto-focus on mount so the composer is immediately typeable — also gives
-  // ⌘⇧N (navigate to /) a predictable focus target on remount.
+  // Auto-focus on mount.
   useEffect(() => {
     textareaRef.current?.focus();
   }, []);
 
-  // Listen for global shortcut bridges (⌘⇧N → focus, ⌘Enter → submit).
+  // Global shortcut bridges (⌘⇧N → focus, ⌘Enter → submit) + local shortcuts
+  // (⌘R → repo, ⌘B → branch, ⌘W → toggle worktree).
   const submitRef = useRef(handleSubmit);
   submitRef.current = handleSubmit;
+  const toggleWorktreeRef = useRef(onToggleWorktree);
+  toggleWorktreeRef.current = onToggleWorktree;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   useEffect(() => {
     const onFocus = () => textareaRef.current?.focus();
     const onSubmit = () => {
       void submitRef.current();
     };
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      const key = e.key.toLowerCase();
+      if (key === 'r') {
+        e.preventDefault();
+        repoChipRef.current?.click();
+      } else if (key === 'b') {
+        e.preventDefault();
+        branchChipRef.current?.click();
+      } else if (key === 'w') {
+        const s = stateRef.current;
+        if (s.mode === 'new') {
+          e.preventDefault();
+          toggleWorktreeRef.current(false);
+        } else if (s.mode === 'none') {
+          e.preventDefault();
+          toggleWorktreeRef.current(true);
+        }
+      }
+    };
     window.addEventListener('focus-composer', onFocus);
     window.addEventListener('submit-composer', onSubmit);
+    window.addEventListener('keydown', onKey);
     return () => {
       window.removeEventListener('focus-composer', onFocus);
       window.removeEventListener('submit-composer', onSubmit);
+      window.removeEventListener('keydown', onKey);
     };
   }, []);
 
-  // ─── Render helpers ──────────────────────────────────────────────────
+  // ─── Render ──────────────────────────────────────────────────────────
 
-  const derivedLabel = useDerivedModeLabel(state, sourceTask);
-  const showRepoChip = state.mode !== 'add-agent';
-  const showBranchChip = state.mode === 'new';
-  const showWorktreeToggle = state.mode === 'new' || state.mode === 'none';
+  const hasRepo = state.mode === 'new' || state.mode === 'none' || state.mode === 'existing';
+  const worktreeOn = state.mode === 'new';
+  const showBranchChip = state.mode === 'new' || state.mode === 'none';
+  const showWorktreeCheckbox = state.mode === 'new' || state.mode === 'none';
   const showAttachChip = state.mode === 'new' || state.mode === 'existing' || state.mode === 'none';
   const disabledByAddAgent = state.mode === 'add-agent';
+  const showScratchHint = !hasRepo && state.mode !== 'add-agent';
 
   return (
-    <div
-      className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3"
-      data-testid="composer"
-    >
-      {/* ─── Intent header ───────────────────────────────────────────── */}
+    <GlassPanel level={3} specular className="flex flex-col gap-2 px-4 py-3" data-testid="composer">
       <IntentHeader
         state={state}
         sourceTask={sourceTask}
@@ -254,7 +277,6 @@ export function Composer({ onSubmitted }: Props = {}) {
         onClear={onClearIntent}
       />
 
-      {/* ─── Error banner ────────────────────────────────────────────── */}
       {errorBanner && (
         <div
           role="alert"
@@ -273,15 +295,16 @@ export function Composer({ onSubmitted }: Props = {}) {
         </div>
       )}
 
-      {/* ─── Chip row ────────────────────────────────────────────────── */}
+      {/* Chip row — derives run_mode from (repo ∧ worktree). */}
       <div
-        className={`flex flex-wrap items-center gap-2 ${disabledByAddAgent ? 'opacity-40 pointer-events-none' : ''}`}
+        className={`flex flex-wrap items-center gap-2 ${disabledByAddAgent ? 'pointer-events-none opacity-40' : ''}`}
         data-testid="chip-row"
       >
-        <span className="select-none text-xs font-mono text-muted-foreground">🏠 Local</span>
-
-        {showRepoChip && (
+        {!hasRepo ? (
+          <RepoChip ref={repoChipRef} value="" onChange={onPickRepo} onClear={onClearRepo} />
+        ) : (
           <RepoChip
+            ref={repoChipRef}
             value={
               state.mode === 'new' || state.mode === 'none' || state.mode === 'existing'
                 ? state.repo
@@ -292,14 +315,20 @@ export function Composer({ onSubmitted }: Props = {}) {
           />
         )}
 
-        {showBranchChip && state.mode === 'new' && (
-          <BranchChip repoPath={state.repo} value={state.branch ?? ''} onChange={onPickBranch} />
+        {showBranchChip && (
+          <BranchChip
+            ref={branchChipRef}
+            repoPath={state.mode === 'new' || state.mode === 'none' ? state.repo : ''}
+            value={state.branch ?? ''}
+            onChange={onPickBranch}
+          />
         )}
 
-        {showWorktreeToggle && (
-          <WorktreeToggle
-            value={state.mode === 'new' ? 'worktree' : 'in-place'}
-            onChange={(v) => onToggleWorktree(v === 'worktree')}
+        {showWorktreeCheckbox && (
+          <WorktreeCheckbox
+            ref={worktreeCheckboxRef}
+            checked={worktreeOn}
+            onChange={onToggleWorktree}
           />
         )}
 
@@ -316,42 +345,50 @@ export function Composer({ onSubmitted }: Props = {}) {
           onChange={onToggleDraft}
           disabled={state.mode === 'empty' || state.mode === 'add-agent'}
         />
+
+        {showScratchHint && (
+          <span
+            className="ml-auto select-none rounded border border-border/60 bg-muted/20 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground"
+            data-testid="scratch-hint"
+            title="No repo selected — submission creates a scratch chat."
+          >
+            <span className="mr-1 text-[9px] opacity-60">S</span>scratch
+          </span>
+        )}
       </div>
 
-      {/* ─── Prompt + submit ─────────────────────────────────────────── */}
+      {/* Prompt + submit. Textarea stays opaque (terminal rule). */}
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <textarea
           ref={textareaRef}
           data-testid="composer-prompt"
-          className="min-h-[72px] resize-y border border-input bg-transparent px-3 py-2 text-sm font-mono outline-none focus:border-ring"
+          className="min-h-[72px] resize-y rounded-2xl border border-white/10 px-3 py-2 text-sm font-mono text-foreground outline-none focus:border-ring"
+          style={{ backgroundColor: '#0B0C0F' }}
           placeholder={promptPlaceholder(state)}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={onTextareaKeyDown}
           aria-label="Task prompt"
         />
-        <div className="flex items-center justify-between">
-          <span className="text-[11px] text-muted-foreground" data-testid="derived-mode-label">
-            {derivedLabel}
-          </span>
-          <div className="flex items-center gap-2">
-            {blockedReason && prompt.trim() && (
-              <span className="text-[11px] text-muted-foreground" title={blockedReason}>
-                {blockedReason}
-              </span>
-            )}
-            <Button
-              type="submit"
-              disabled={!canSubmit}
-              data-testid="composer-submit"
-              title={blockedReason ?? undefined}
-            >
-              {submitting ? 'DISPATCHING…' : 'DISPATCH ⏎'}
-            </Button>
-          </div>
+        <div className="flex items-center justify-end gap-2">
+          {blockedReason && prompt.trim() && (
+            <span className="text-[11px] text-muted-foreground" title={blockedReason}>
+              {blockedReason}
+            </span>
+          )}
+          <Button
+            type="submit"
+            disabled={!canSubmit}
+            data-testid="composer-submit"
+            title={blockedReason ?? undefined}
+            className="bg-cyan-500 text-white hover:bg-cyan-400"
+            style={{ boxShadow: canSubmit ? '0 0 12px rgba(34,211,238,0.45)' : undefined }}
+          >
+            {submitting ? 'Starting…' : 'Start task'}
+          </Button>
         </div>
       </form>
-    </div>
+    </GlassPanel>
   );
 }
 
@@ -418,23 +455,6 @@ function intentHeaderText(
   }
 }
 
-function useDerivedModeLabel(state: ComposerState, sourceTask: Task | null): string {
-  switch (state.mode) {
-    case 'empty':
-      return '→ pick a repo or start typing';
-    case 'scratch':
-      return '→ scratch ⏎';
-    case 'new':
-      return '→ new worktree ⏎';
-    case 'none':
-      return '→ in-place ⏎';
-    case 'existing':
-      return '→ attach existing ⏎';
-    case 'add-agent':
-      return `→ add agent → ${sourceTask?.title ?? state.sessionId} ⏎`;
-  }
-}
-
 function promptPlaceholder(state: ComposerState): string {
   if (state.mode === 'add-agent') return 'Instructions for the new agent…';
   if (state.mode === 'empty') return 'Describe a task or ask a question…';
@@ -443,21 +463,33 @@ function promptPlaceholder(state: ComposerState): string {
 
 // ─── Chip primitives ─────────────────────────────────────────────────────
 
-function RepoChip({
-  value,
-  onChange,
-  onClear,
-}: {
+interface RepoChipProps {
   value: string;
   onChange: (v: string) => void;
   onClear: () => void;
-}) {
+}
+
+/**
+ * Empty state: a dashed-border chip `+ Add repo or folder`.
+ * Filled state: a pill showing the repo basename with a remove button.
+ */
+const RepoChip = forwardRef<HTMLButtonElement, RepoChipProps>(function RepoChip(
+  { value, onChange, onClear },
+  ref,
+) {
   const [expanded, setExpanded] = useState(false);
   if (!value && !expanded) {
     return (
-      <ChipButton onClick={() => setExpanded(true)} data-testid="repo-chip-picker">
-        📁 repo
-      </ChipButton>
+      <button
+        ref={ref}
+        type="button"
+        onClick={() => setExpanded(true)}
+        data-testid="repo-chip-picker"
+        className="inline-flex items-center gap-1 rounded border border-dashed border-border/80 px-3 py-1 text-[11px] font-mono text-muted-foreground hover:border-foreground hover:text-foreground"
+      >
+        <span aria-hidden>+</span>
+        <span>Add repo or folder</span>
+      </button>
     );
   }
   if (!value && expanded) {
@@ -478,72 +510,94 @@ function RepoChip({
   }
   return (
     <ChipRemovable
+      buttonRef={ref}
       label={`📁 ${repoBasename(value)}`}
       title={value}
       onRemove={onClear}
       data-testid="repo-chip"
     />
   );
-}
+});
 
-function BranchChip({
-  repoPath,
-  value,
-  onChange,
-}: {
+interface BranchChipProps {
   repoPath: string;
   value: string;
   onChange: (branch: string) => void;
-}) {
+}
+
+const BranchChip = forwardRef<HTMLButtonElement, BranchChipProps>(function BranchChip(
+  { repoPath, value, onChange },
+  ref,
+) {
   return (
     <div className="flex items-center gap-1" data-testid="branch-chip">
-      <span className="text-xs text-muted-foreground">⎇</span>
+      <span className="text-xs text-muted-foreground" aria-hidden>
+        ⎇
+      </span>
       <div className="min-w-[140px] max-w-[220px]">
-        <BranchPickerField repoPath={repoPath} value={value} onChange={onChange} />
+        <BranchPickerField triggerRef={ref} repoPath={repoPath} value={value} onChange={onChange} />
       </div>
     </div>
   );
+});
+
+interface WorktreeCheckboxProps {
+  checked: boolean;
+  onChange: (v: boolean) => void;
 }
 
-function WorktreeToggle({
-  value,
-  onChange,
-}: {
-  value: 'worktree' | 'in-place';
-  onChange: (v: 'worktree' | 'in-place') => void;
-}) {
-  return (
-    <div
-      className="inline-flex items-stretch border border-border text-[11px] font-mono"
-      role="group"
-      data-testid="worktree-toggle"
-      aria-label="Worktree mode"
-    >
+/**
+ * Worktree checkbox pill. Off = task runs on the branch's working tree
+ * (`run_mode: 'none'`). On = fresh worktree (`run_mode: 'new'`). When on, the
+ * pill fills cyan with a white checkmark.
+ */
+const WorktreeCheckbox = forwardRef<HTMLButtonElement, WorktreeCheckboxProps>(
+  function WorktreeCheckbox({ checked, onChange }, ref) {
+    return (
       <button
+        ref={ref}
         type="button"
-        onClick={() => onChange('worktree')}
-        className={`px-2 py-1 ${value === 'worktree' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-        aria-pressed={value === 'worktree'}
-        data-testid="worktree-toggle-worktree"
+        role="checkbox"
+        aria-checked={checked}
+        aria-label="Create a fresh worktree for this task"
+        onClick={() => onChange(!checked)}
+        data-testid="worktree-checkbox"
+        data-state={checked ? 'checked' : 'unchecked'}
+        className="inline-flex items-center gap-2 rounded border px-2 py-1 text-[11px] font-mono transition-colors"
+        style={{
+          borderColor: checked ? 'rgba(59,130,246,0.4)' : 'var(--border)',
+          backgroundColor: checked ? 'rgba(59,130,246,0.12)' : 'transparent',
+          color: checked ? 'rgb(147,197,253)' : 'var(--muted-foreground)',
+        }}
       >
-        worktree
+        <span
+          aria-hidden
+          className="inline-flex h-[14px] w-[14px] items-center justify-center rounded-sm border"
+          style={{
+            borderColor: checked ? 'rgba(59,130,246,0.6)' : 'var(--border)',
+            backgroundColor: checked ? 'rgb(59,130,246)' : 'transparent',
+          }}
+        >
+          {checked && (
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="white"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M20 6 9 17l-5-5" />
+            </svg>
+          )}
+        </span>
+        <span>worktree</span>
       </button>
-      <button
-        type="button"
-        onClick={() => onChange('in-place')}
-        className={`px-2 py-1 ${
-          value === 'in-place'
-            ? 'bg-amber-500/20 text-amber-300'
-            : 'text-muted-foreground hover:text-foreground'
-        }`}
-        aria-pressed={value === 'in-place'}
-        data-testid="worktree-toggle-in-place"
-      >
-        in-place
-      </button>
-    </div>
-  );
-}
+    );
+  },
+);
 
 function AttachChip({
   value,
@@ -650,11 +704,13 @@ function ChipRemovable({
   label,
   title,
   onRemove,
+  buttonRef,
   ...rest
 }: {
   label: string;
   title?: string;
   onRemove: () => void;
+  buttonRef?: Ref<HTMLButtonElement>;
 } & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
@@ -662,14 +718,15 @@ function ChipRemovable({
       title={title}
       className="inline-flex items-center gap-1 border border-border px-2 py-1 text-[11px] font-mono"
     >
-      <span>{label}</span>
       <button
+        ref={buttonRef}
         type="button"
         onClick={onRemove}
         aria-label="Remove"
-        className="text-muted-foreground hover:text-foreground"
+        className="inline-flex items-center gap-1 text-foreground hover:text-muted-foreground"
       >
-        ×
+        <span>{label}</span>
+        <span className="text-muted-foreground">×</span>
       </button>
     </div>
   );

--- a/src/components/fields/BranchPickerField.tsx
+++ b/src/components/fields/BranchPickerField.tsx
@@ -9,6 +9,8 @@ interface BranchPickerFieldProps {
   onChange: (value: string) => void;
   onBranchesLoaded?: (branches: string[], defaultBranch: string) => void;
   disabled?: boolean;
+  /** Optional ref to the trigger button (used by ⌘B to open the picker). */
+  triggerRef?: React.Ref<HTMLButtonElement>;
 }
 
 export function BranchPickerField({
@@ -17,6 +19,7 @@ export function BranchPickerField({
   onChange,
   onBranchesLoaded,
   disabled,
+  triggerRef,
 }: BranchPickerFieldProps) {
   const [branches, setBranches] = useState<string[]>([]);
   const [branchSearch, setBranchSearch] = useState('');
@@ -69,6 +72,7 @@ export function BranchPickerField({
         <PopoverTrigger
           render={
             <button
+              ref={triggerRef}
               type="button"
               disabled={disabled || branches.length === 0}
               className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"

--- a/src/lib/composer-state.test.tsx
+++ b/src/lib/composer-state.test.tsx
@@ -4,6 +4,7 @@ import {
   hydrateFromUrl,
   stateToUrlParams,
   validateForSubmit,
+  deriveRunMode,
   INITIAL_STATE,
   type ComposerState,
   type ComposerAction,
@@ -41,10 +42,13 @@ const addAgent: ComposerState = {
 
 describe('reduce / pickRepo', () => {
   const cases: Array<{ from: ComposerState; expectedMode: string }> = [
-    { from: empty, expectedMode: 'new' },
-    { from: scratch, expectedMode: 'new' },
+    // Fresh pick: worktree checkbox starts OFF → `none` mode.
+    { from: empty, expectedMode: 'none' },
+    { from: scratch, expectedMode: 'none' },
+    // Repo swap within `new` preserves the on-state of the checkbox.
     { from: newState, expectedMode: 'new' },
-    { from: noneState, expectedMode: 'new' },
+    // Repo swap within `none` preserves the off-state.
+    { from: noneState, expectedMode: 'none' },
     { from: existingState, expectedMode: 'existing' },
   ];
   it.each(cases)('$from.mode → $expectedMode on pickRepo', ({ from, expectedMode }) => {
@@ -52,15 +56,15 @@ describe('reduce / pickRepo', () => {
     expect(next.mode).toBe(expectedMode);
   });
 
-  it('pickRepo from empty yields new with default branch and worktree ON (not none)', () => {
+  it('pickRepo from empty yields none with default branch (worktree OFF by default)', () => {
     const next = reduce(empty, { type: 'pickRepo', repo: '/r', defaultBranch: 'main' });
-    expect(next).toEqual({ mode: 'new', repo: '/r', branch: 'main', isDraft: false });
+    expect(next).toEqual({ mode: 'none', repo: '/r', branch: 'main', isDraft: false });
   });
 
   it('pickRepo preserves isDraft', () => {
     const draftScratch: ComposerState = { mode: 'scratch', isDraft: true };
     const next = reduce(draftScratch, { type: 'pickRepo', repo: '/r', defaultBranch: 'main' });
-    expect(next).toMatchObject({ mode: 'new', isDraft: true });
+    expect(next).toMatchObject({ mode: 'none', isDraft: true });
   });
 
   it('pickRepo preserves forkOf from new mode', () => {
@@ -298,19 +302,35 @@ describe('hydrateFromUrl', () => {
       expected: { mode: 'scratch', isDraft: false },
     },
     {
-      name: '?repo=/r → new with null branch',
+      // New default: repo without explicit mode means worktree checkbox is off.
+      name: '?repo=/r → none with null branch (worktree OFF default)',
       qs: 'repo=%2Fr',
+      expected: { mode: 'none', repo: '/r', branch: null, isDraft: false },
+    },
+    {
+      name: '?repo=/r&branch=dev → none with dev',
+      qs: 'repo=%2Fr&branch=dev',
+      expected: { mode: 'none', repo: '/r', branch: 'dev', isDraft: false },
+    },
+    {
+      name: '?repo=/r&base_branch=main → none with main',
+      qs: 'repo=%2Fr&base_branch=main',
+      expected: { mode: 'none', repo: '/r', branch: 'main', isDraft: false },
+    },
+    {
+      name: '?repo=/r&mode=new → new (worktree ON)',
+      qs: 'repo=%2Fr&mode=new',
       expected: { mode: 'new', repo: '/r', branch: null, isDraft: false },
     },
     {
-      name: '?repo=/r&branch=dev → new with dev',
-      qs: 'repo=%2Fr&branch=dev',
-      expected: { mode: 'new', repo: '/r', branch: 'dev', isDraft: false },
+      name: '?repo=/r&worktree=1 → new (worktree ON via explicit flag)',
+      qs: 'repo=%2Fr&worktree=1',
+      expected: { mode: 'new', repo: '/r', branch: null, isDraft: false },
     },
     {
-      name: '?repo=/r&base_branch=main → new with main',
-      qs: 'repo=%2Fr&base_branch=main',
-      expected: { mode: 'new', repo: '/r', branch: 'main', isDraft: false },
+      name: '?repo=/r&fork_of=x → new with forkOf (fork_of implies worktree ON)',
+      qs: 'repo=%2Fr&fork_of=x',
+      expected: { mode: 'new', repo: '/r', branch: null, isDraft: false, forkOf: 'x' },
     },
     {
       name: '?repo=/r&mode=new&fork_of=x → new with forkOf',
@@ -361,6 +381,17 @@ describe('hydrateFromUrl', () => {
       params: new URLSearchParams('repo=%2Fr&mode=new'),
     });
     expect(next).toMatchObject({ mode: 'new', repo: '/r' });
+  });
+
+  // Per T5 spec: explicit `mode=new` must produce repo + worktree=on (i.e. `mode:'new'`).
+  it('hydrateFromUrl({ repo, mode: "new" }) → repo set + worktree ON (mode=new)', () => {
+    const state = hydrateFromUrl(new URLSearchParams('repo=%2Fr&mode=new&branch=main'));
+    expect(state).toEqual({
+      mode: 'new',
+      repo: '/r',
+      branch: 'main',
+      isDraft: false,
+    });
   });
 });
 
@@ -431,6 +462,33 @@ describe('validateForSubmit', () => {
   });
   it('requires sessionId for add-agent', () => {
     expect(validateForSubmit(addAgent, 'p')).toBeNull();
+  });
+});
+
+// ─── deriveRunMode — T5: run_mode is derived from (repo ∧ worktree) ──────
+
+describe('deriveRunMode', () => {
+  it('empty composer (no repo) → "scratch"', () => {
+    expect(deriveRunMode(scratch)).toBe('scratch');
+  });
+
+  it('repo + worktree ON → "new"', () => {
+    // Simulate "user clicked add repo, then checked the worktree box".
+    const afterPickRepo = reduce(empty, { type: 'pickRepo', repo: '/r', defaultBranch: 'main' });
+    const afterCheck = reduce(afterPickRepo, { type: 'toggleWorktree', worktree: true });
+    expect(deriveRunMode(afterCheck)).toBe('new');
+  });
+
+  it('repo + worktree OFF → "none"', () => {
+    // Default on first pick: worktree off → none.
+    const afterPickRepo = reduce(empty, { type: 'pickRepo', repo: '/r', defaultBranch: 'main' });
+    expect(deriveRunMode(afterPickRepo)).toBe('none');
+  });
+
+  it('attach chip takes precedence → "existing"', () => {
+    const afterPickRepo = reduce(empty, { type: 'pickRepo', repo: '/r', defaultBranch: 'main' });
+    const afterAttach = reduce(afterPickRepo, { type: 'setExistingPath', path: '/p' });
+    expect(deriveRunMode(afterAttach)).toBe('existing');
   });
 });
 

--- a/src/lib/composer-state.ts
+++ b/src/lib/composer-state.ts
@@ -1,9 +1,15 @@
 /**
  * Composer state machine for the Home chip-row composer.
  *
- * The four run modes (new / existing / none / scratch) plus add-agent are DERIVED
- * from chip state. The reducer encodes precedence rules so that every user
- * interaction with a chip results in exactly one valid state.
+ * `run_mode` is DERIVED from chip state — the composer no longer has an explicit
+ * mode chip. The mapping is:
+ *   - no repo                       → 'scratch'
+ *   - repo + worktree unchecked     → 'none'   (attach to branch's working tree)
+ *   - repo + worktree checked       → 'new'    (fresh worktree)
+ *   - repo + attach path            → 'existing' (advanced; reachable via the
+ *                                                 attach chip or `⌘⇧E`)
+ * Every user interaction produces exactly one valid state; there is no
+ * `setMode` action.
  */
 
 export type ComposerMode = 'empty' | 'new' | 'existing' | 'none' | 'scratch' | 'add-agent';
@@ -64,10 +70,21 @@ export function reduce(state: ComposerState, action: ComposerAction): ComposerSt
       if (state.mode === 'existing') {
         return { ...state, repo };
       }
-      // From empty / scratch / new / none — produce a `new` with the repo's default branch and worktree ON.
       const isDraft = 'isDraft' in state ? state.isDraft : false;
-      const forkOf = state.mode === 'new' ? state.forkOf : undefined;
-      return { mode: 'new', repo, branch: defaultBranch, isDraft, ...(forkOf ? { forkOf } : {}) };
+      // Preserve worktree-on when we were already in `new` (and carry any fork intent).
+      if (state.mode === 'new') {
+        const forkOf = state.forkOf;
+        return {
+          mode: 'new',
+          repo,
+          branch: defaultBranch,
+          isDraft,
+          ...(forkOf ? { forkOf } : {}),
+        };
+      }
+      // First repo pick from empty / scratch, and repo swap from `none`:
+      // worktree checkbox starts OFF → `none` mode.
+      return { mode: 'none', repo, branch: defaultBranch, isDraft };
     }
 
     case 'clearRepo': {
@@ -164,8 +181,10 @@ export function reduce(state: ComposerState, action: ComposerAction): ComposerSt
 /**
  * Parse URL search params into an initial ComposerState.
  *
- * Precedence: add_agent > repo+mode/attach > scratch. Unknown combinations fall back
- * sensibly (e.g. ?repo without ?mode defaults to `new`).
+ * Precedence: add_agent > repo+attach > repo+mode > scratch. Mirrors the
+ * UI-level derivation: `?repo` without `?mode=new` means the worktree checkbox
+ * is unchecked → `none`. Only explicit `?mode=new` (or `worktree=1`) produces a
+ * fresh worktree.
  */
 export function hydrateFromUrl(params: URLSearchParams): ComposerState {
   const addAgent = params.get('add_agent');
@@ -199,21 +218,22 @@ export function hydrateFromUrl(params: URLSearchParams): ComposerState {
     };
   }
 
-  if (modeParam === 'none' || worktreeParam === '0') {
+  if (modeParam === 'new' || worktreeParam === '1' || forkOf) {
     return {
-      mode: 'none',
+      mode: 'new',
       repo,
       branch: branch ?? null,
       isDraft: false,
+      ...(forkOf ? { forkOf } : {}),
     };
   }
 
+  // Default: repo present but no worktree intent → attach in-place.
   return {
-    mode: 'new',
+    mode: 'none',
     repo,
     branch: branch ?? null,
     isDraft: false,
-    ...(forkOf ? { forkOf } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Replaces the explicit N/E/Ø/S run-mode chip with a derived model: `run_mode` is now a function of whether a repo chip is set and whether the worktree checkbox is ticked.

- No repo → `scratch` (with a muted `S scratch` hint pill on the chip row; submission creates a scratch chat, unchanged)
- Repo + worktree **unchecked** → `none` (attach to the branch's working tree)
- Repo + worktree **checked** → `new` (fresh worktree under `.worktrees/<id>`)
- Repo + attach chip → `existing` (unchanged; still reachable as advanced)

Empty-state composer now shows a single dashed-border `+ Add repo or folder` chip. On repo pick the row becomes `[repo] [branch ▾] [☐ worktree]`. The worktree pill is a proper `role=checkbox` with a 14×14 glyph; when checked the pill fills cyan with a white checkmark.

The composer dock is wrapped in `<GlassPanel level={3} specular>` from T1 (now on `main`). Prompt textarea stays opaque (`#0B0C0F`). Primary button renamed to `Start task` with cyan fill + glow.

⌘R / ⌘B / ⌘W activate the repo picker, branch picker, and worktree toggle from anywhere in the app while the composer is mounted.

Reducer changes:
- `pickRepo` from empty/scratch now defaults to `none` (worktree OFF). `new` → `new` preserves worktree ON; `none` → `none` preserves OFF.
- URL hydration: `?repo=/r` without an explicit `mode` now defaults to `none` (symmetric with the UI default). `?mode=new`, `?worktree=1`, or any `?fork_of=...` still yields `new`.
- No `setMode` action (and there never was one) — mode is fully derived from chip state.

## Test plan

- [x] `bun run test` — 1226 pass (189 in the two touched test files).
- [x] `bun run lint` — 0 errors (24 pre-existing warnings elsewhere, untouched).
- [x] `bun run typecheck` — clean.
- Tests updated:
  - `composer-state.test.tsx`: `pickRepo` from empty → `none`; new cases for `deriveRunMode` covering scratch / new / none / existing; `hydrateFromUrl({ mode: 'new' })` → `new`; URL hydration default flipped to `none`.
  - `Composer.test.tsx`: replaced worktree two-button toggle assertions with checkbox `aria-checked`; added empty-state dashed-chip test; added two submit tests asserting `run_mode` derives correctly from checkbox state.

## Notes

- Rebased onto `origin/main` after T1 (`feat/glass-design-system`, #106) merged. Uses the real `<GlassPanel level={3} specular>` from `src/components/ui/glass-panel.tsx` — no shim.
- `existing` mode intentionally stays reachable via the attach chip only — not exposed on the chip row by default (advanced flow, per the T5 spec).