### PR TITLE
feat(ui): liquid-glass system states, empty states, PR sheet, parallel grid

### DIFF
--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -11,8 +11,14 @@ const { apiMock, apiProxy } = await vi.hoisted(async () =>
 );
 vi.mock('@/lib/api', () => ({ api: apiProxy }));
 vi.mock('./lib/api', () => ({ api: apiProxy }));
-vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
-vi.mock('./lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+vi.mock('./lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
 vi.mock('./lib/orchestrator-context', () => ({
   useOrchestratorContext: () => ({
     running: false,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,7 +9,10 @@ const { apiMock, apiProxy } = await vi.hoisted(async () =>
 );
 
 vi.mock('@/lib/api', () => ({ api: apiProxy }));
-vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
 vi.mock('@/lib/orchestrator-context', () => ({
   useOrchestratorContext: () => ({
     running: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, lazy, Suspense, useMemo, useState, type ReactNode } from 'react';
+import { Component, lazy, Suspense, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { useAttentionIndicator } from './lib/use-attention-indicator';
@@ -9,8 +9,12 @@ import { OrchestratorProvider } from './lib/orchestrator-context';
 import { TasksProvider, useTasksContext } from './lib/tasks-context';
 import { UniversalSidebar } from './components/UniversalSidebar';
 import { CommandPalette } from './components/CommandPalette';
+import { PrSheet } from './components/PrSheet';
+import { OfflineBanner } from './components/OfflineBanner';
+import { SHIP_EVENT } from './pages/TaskDetail';
 import { useGlobalShortcut } from './lib/shortcuts';
 import { groupTasksForSidebar } from './lib/sidebar-utils';
+import type { Task } from '../server/types';
 import {
   currentTaskIdFromPath,
   getNextSessionId,
@@ -20,6 +24,7 @@ import {
 
 const TasksPage = lazy(() => import('./pages/TasksPage'));
 const TaskDetail = lazy(() => import('./pages/TaskDetail'));
+const ParallelGridPage = lazy(() => import('./pages/ParallelGridPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const SkillEditor = lazy(() => import('./pages/SkillEditor'));
 const AgentEditor = lazy(() => import('./pages/AgentEditor'));
@@ -82,14 +87,31 @@ export default function App() {
 export function AppShell() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { tasks } = useTasksContext();
+  const { tasks, refresh: refreshTasks } = useTasksContext();
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [prSheetTask, setPrSheetTask] = useState<Task | null>(null);
 
   const groups = useMemo(() => groupTasksForSidebar(tasks), [tasks]);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ taskId?: string }>).detail;
+      if (!detail?.taskId) return;
+      const task = tasks.find((t) => t.id === detail.taskId);
+      if (task) setPrSheetTask(task);
+    };
+    window.addEventListener(SHIP_EVENT, handler);
+    return () => window.removeEventListener(SHIP_EVENT, handler);
+  }, [tasks]);
 
   useGlobalShortcut({ key: 'k', mod: true }, (e) => {
     e.preventDefault();
     setPaletteOpen(true);
+  });
+
+  useGlobalShortcut({ key: 'g', mod: true, shift: true }, (e) => {
+    e.preventDefault();
+    navigate('/tasks/grid');
   });
 
   useGlobalShortcut({ key: 'n', mod: true, shift: true }, (e) => {
@@ -127,39 +149,50 @@ export function AppShell() {
   });
 
   return (
-    <div className="flex h-screen bg-background text-foreground">
-      <Toaster
-        theme="dark"
-        position="bottom-right"
-        toastOptions={{
-          unstyled: true,
-        }}
-      />
-      <GlobalNotifications />
-      <UniversalSidebar />
-      <main className="min-h-0 min-w-0 flex-1">
-        <Suspense
-          fallback={
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-              Loading...
-            </div>
-          }
-        >
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/tasks" element={<TasksPage />} />
-            <Route path="/tasks/:id" element={<TaskDetail />} />
-            <Route path="/orchestrator" element={<Navigate to="/chats/orchestrator" replace />} />
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/skills/:name" element={<SkillEditor />} />
-            <Route path="/agents/:name" element={<AgentEditor />} />
-            <Route path="/chats/:id" element={<ChatPage />} />
-            <Route path="/workspaces" element={<WorkspacesPage />} />
-            <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
-          </Routes>
-        </Suspense>
-      </main>
-      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <OfflineBanner />
+      <div className="flex min-h-0 flex-1">
+        <Toaster
+          theme="dark"
+          position="bottom-right"
+          toastOptions={{
+            unstyled: true,
+          }}
+        />
+        <GlobalNotifications />
+        <UniversalSidebar />
+        <main className="min-h-0 min-w-0 flex-1">
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                Loading...
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/tasks" element={<TasksPage />} />
+              <Route path="/tasks/grid" element={<ParallelGridPage />} />
+              <Route path="/orchestrator/grid" element={<ParallelGridPage />} />
+              <Route path="/tasks/:id" element={<TaskDetail />} />
+              <Route path="/orchestrator" element={<Navigate to="/chats/orchestrator" replace />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/skills/:name" element={<SkillEditor />} />
+              <Route path="/agents/:name" element={<AgentEditor />} />
+              <Route path="/chats/:id" element={<ChatPage />} />
+              <Route path="/workspaces" element={<WorkspacesPage />} />
+              <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
+            </Routes>
+          </Suspense>
+        </main>
+        <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+        <PrSheet
+          open={!!prSheetTask}
+          task={prSheetTask}
+          onClose={() => setPrSheetTask(null)}
+          onShipped={() => refreshTasks()}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -154,22 +154,27 @@ describe('CommandPalette', () => {
     const escape = await screen.findByTestId('command-palette-escape');
     expect(escape).toBeInTheDocument();
     expect(escape.textContent).toContain("'brand new thing'");
+    expect(screen.getByTestId('command-palette-no-results')).toHaveTextContent(/no matches/i);
   });
 
-  it('Enter on escape-hatch calls api.createTask and navigates', async () => {
+  it('Enter on escape-hatch navigates to composer with prefill', async () => {
     const user = userEvent.setup();
-    apiMock.createTask.mockResolvedValue(makeTask({ id: 'new-42', title: 'fresh task' }));
-    renderPalette([]);
-    const input = screen.getByTestId('command-palette-input');
-    await user.type(input, 'fresh task');
-    // Escape row is the only row; active is 0 → Enter runs it.
-    await user.keyboard('{Enter}');
-    expect(apiMock.createTask).toHaveBeenCalledTimes(1);
-    const arg = apiMock.createTask.mock.calls[0][0] as Record<string, unknown>;
-    expect(arg.title).toBe('fresh task');
-    expect(arg.run_mode).toBe('scratch');
-    await screen.findByTestId('command-palette-input'); // flush microtasks
-    expect(mockNavigate).toHaveBeenCalledWith('/tasks/new-42');
+    const focusSpy = vi.fn();
+    window.addEventListener('focus-composer', focusSpy);
+    try {
+      renderPalette([]);
+      const input = screen.getByTestId('command-palette-input');
+      await user.type(input, 'fresh task');
+      // Escape row is the only row; active is 0 → Enter runs it.
+      await user.keyboard('{Enter}');
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+      expect(focusSpy).toHaveBeenCalled();
+      const call = focusSpy.mock.calls[0][0] as CustomEvent<{ prefill: string }>;
+      expect(call.detail?.prefill).toBe('fresh task');
+    } finally {
+      window.removeEventListener('focus-composer', focusSpy);
+    }
   });
 
   it('renders ACTIONS group with New task action', () => {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,8 +4,6 @@ import { useTasksContext } from '@/lib/tasks-context';
 import { repoName } from '@/lib/utils';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { StatusGlyph } from '@/components/ui/status-glyph';
-import { api } from '@/lib/api';
-import { showToast } from '@/components/CustomToast';
 import type { Task } from '../../server/types';
 
 interface Props {
@@ -70,7 +68,7 @@ export function CommandPalette({ open, onClose }: Props) {
   const { tasks } = useTasksContext();
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
-  const [creating, setCreating] = useState(false);
+  const creating = false;
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -89,23 +87,15 @@ export function CommandPalette({ open, onClose }: Props) {
     });
   };
 
-  const createFromQuery = async (title: string) => {
-    if (!title.trim() || creating) return;
-    setCreating(true);
-    try {
-      const task = await api.createTask({
-        title: title.trim(),
-        description: title.trim(),
-        initial_prompt: title.trim(),
-        run_mode: 'scratch',
-      });
-      onClose();
-      navigate(`/tasks/${task.id}`);
-    } catch (err) {
-      showToast('error', 'ERROR', err instanceof Error ? err.message : 'Failed to create task');
-    } finally {
-      setCreating(false);
-    }
+  const createFromQuery = (title: string) => {
+    const trimmed = title.trim();
+    if (!trimmed || creating) return;
+    // Open composer pre-filled — don't create immediately, let user finish composing.
+    onClose();
+    navigate('/', { replace: true });
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('focus-composer', { detail: { prefill: trimmed } }));
+    });
   };
 
   const actionNewTask = () => {
@@ -264,8 +254,15 @@ export function CommandPalette({ open, onClose }: Props) {
           className="max-h-[60vh] overflow-y-auto"
         >
           {rows.length === 0 && (
-            <li className="px-4 py-3 text-xs text-muted-foreground" aria-live="polite">
-              No matches
+            <li
+              data-testid="command-palette-no-results"
+              className="flex flex-col items-center gap-3 px-4 py-8 text-center"
+              aria-live="polite"
+            >
+              <h2 className="text-[15px] font-semibold text-[#D0D0D0]">No matches</h2>
+              <p className="max-w-[260px] text-[12px] leading-relaxed text-[#8a8a8a]">
+                Try a different term, or press ⌘N to start a new task.
+              </p>
             </li>
           )}
 
@@ -299,13 +296,23 @@ export function CommandPalette({ open, onClose }: Props) {
           })}
 
           {rows.length === 1 && rows[0].kind === 'escape' && (
-            <EscapeRowView
-              query={(rows[0] as EscapeRow).query}
-              active={active === 0}
-              disabled={creating}
-              onMouseEnter={() => setActive(0)}
-              onSelect={() => createFromQuery((rows[0] as EscapeRow).query)}
-            />
+            <li
+              data-testid="command-palette-no-results"
+              className="flex flex-col items-center gap-3 px-4 py-8 text-center"
+              aria-live="polite"
+            >
+              <h2 className="text-[15px] font-semibold text-[#D0D0D0]">No matches</h2>
+              <p className="max-w-[260px] text-[12px] leading-relaxed text-[#8a8a8a]">
+                Try a different term, or press ⌘N to start a new task.
+              </p>
+              <EscapeChip
+                query={(rows[0] as EscapeRow).query}
+                active={active === 0}
+                disabled={creating}
+                onMouseEnter={() => setActive(0)}
+                onSelect={() => createFromQuery((rows[0] as EscapeRow).query)}
+              />
+            </li>
           )}
         </ul>
       </GlassPanel>
@@ -359,7 +366,13 @@ function SessionRowView({
     >
       <div className="flex items-center gap-2">
         <StatusGlyph status={task.status} size={10} />
-        <span className="min-w-0 flex-1 truncate font-medium">{task.title}</span>
+        <span
+          className="min-w-0 flex-1 truncate font-medium"
+          title={task.title}
+          aria-label={task.title}
+        >
+          {task.title}
+        </span>
         {task.repo_path && (
           <span className="truncate text-xs text-muted-foreground">{repoName(task.repo_path)}</span>
         )}
@@ -401,7 +414,7 @@ function ActionRowView({
   );
 }
 
-function EscapeRowView({
+function EscapeChip({
   query,
   active,
   disabled,
@@ -415,8 +428,8 @@ function EscapeRowView({
   onSelect: () => void;
 }) {
   return (
-    <li
-      role="option"
+    <button
+      type="button"
       aria-selected={active}
       onMouseDown={(e) => {
         e.preventDefault();
@@ -426,16 +439,13 @@ function EscapeRowView({
       data-testid="command-palette-escape"
       data-row-kind="escape"
       data-active={active ? 'true' : undefined}
-      className={rowClass(active)}
-      style={active ? SELECTED_ROW_STYLE : undefined}
+      disabled={disabled}
+      className="inline-flex items-center gap-2 rounded-lg border border-[#3B82F666] bg-[#3B82F61F] px-3 py-1.5 text-[12px] font-medium text-[#3B82F6] hover:bg-[#3B82F633] disabled:opacity-50"
     >
-      <div className="flex items-center gap-2">
-        <span className="min-w-0 flex-1 truncate">
-          <span className="text-[#60a5fa]">⌘N</span> New task with{' '}
-          <span className="text-white">'{query}'</span>
-        </span>
-        <Keycap>↵</Keycap>
-      </div>
-    </li>
+      <span className="font-mono text-[11px] font-semibold">⌘N</span>
+      <span>
+        New task with <span className="text-white">'{query}'</span>
+      </span>
+    </button>
   );
 }

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -224,7 +224,13 @@ export function Composer({ onSubmitted }: Props = {}) {
   stateRef.current = state;
 
   useEffect(() => {
-    const onFocus = () => textareaRef.current?.focus();
+    const onFocus = (e: Event) => {
+      const detail = (e as CustomEvent<{ prefill?: string } | undefined>).detail;
+      if (detail?.prefill) {
+        setPrompt((prev) => (prev ? prev : detail.prefill!));
+      }
+      textareaRef.current?.focus();
+    };
     const onSubmit = () => {
       void submitRef.current();
     };

--- a/src/components/OfflineBanner.test.tsx
+++ b/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { OfflineBanner } from './OfflineBanner';
+
+type StateCb = (connected: boolean) => void;
+const subscribers = new Set<StateCb>();
+
+vi.mock('@/lib/event-source', () => ({
+  subscribeConnectionState: (cb: StateCb) => {
+    subscribers.add(cb);
+    cb(true);
+    return () => subscribers.delete(cb);
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  subscribers.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function simulate(connected: boolean) {
+  for (const cb of subscribers) cb(connected);
+}
+
+describe('OfflineBanner', () => {
+  it('does not render when connected', () => {
+    render(<OfflineBanner />);
+    expect(screen.queryByTestId('global-offline-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders after 10s of disconnect, hides on reconnect', () => {
+    render(<OfflineBanner />);
+    act(() => simulate(false));
+    // Before 10s: not visible
+    act(() => {
+      vi.advanceTimersByTime(9_000);
+    });
+    expect(screen.queryByTestId('global-offline-banner')).not.toBeInTheDocument();
+    // After 10s: visible
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(screen.getByTestId('global-offline-banner')).toBeInTheDocument();
+    // Reconnect hides it
+    act(() => simulate(true));
+    expect(screen.queryByTestId('global-offline-banner')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { subscribeConnectionState } from '@/lib/event-source';
+import { CloudOffIcon } from './icons';
+
+const SHOW_AFTER_MS = 10_000;
+
+export function OfflineBanner() {
+  const [offline, setOffline] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = subscribeConnectionState((connected) => {
+      if (connected) {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        setOffline(false);
+      } else {
+        if (timer) return;
+        timer = setTimeout(() => {
+          setOffline(true);
+          timer = null;
+        }, SHOW_AFTER_MS);
+      }
+    });
+    return () => {
+      unsub();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (!offline) return null;
+  return (
+    <div
+      role="status"
+      data-testid="global-offline-banner"
+      className="bg-glass-l1 glass-blur-l1 flex items-center justify-center gap-2 border-b border-[#FFB80033] bg-[#FFB80014] px-4 py-1.5"
+    >
+      <CloudOffIcon size={12} className="text-[#FFB800]" />
+      <span className="text-[11px] font-medium text-[#FFB800]">
+        You&rsquo;re offline — reconnecting…
+      </span>
+    </div>
+  );
+}

--- a/src/components/PrSheet.test.tsx
+++ b/src/components/PrSheet.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PrSheet } from './PrSheet';
+import { makeTask } from '../test-helpers';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.getTaskDiffSummary.mockResolvedValue({
+    files: [{ path: 'src/a.ts', status: 'M', additions: 5, deletions: 2 }],
+  });
+  apiMock.createPr.mockResolvedValue({ ok: true, url: 'https://github.com/x/y/pull/1', number: 1 });
+});
+
+describe('PrSheet', () => {
+  it('renders pre-filled title and body after fetching diff', async () => {
+    const task = makeTask({
+      id: 't-1',
+      title: 'fix bug',
+      branch: 'agents/fix-bug',
+      description: 'one-liner description',
+    });
+    render(<PrSheet open task={task} onClose={() => {}} />);
+    const title = screen.getByTestId('pr-sheet-title') as HTMLInputElement;
+    expect(title.value).toBe('fix bug');
+    await waitFor(() => {
+      const body = screen.getByTestId('pr-sheet-body') as HTMLTextAreaElement;
+      expect(body.value).toContain('## Summary');
+      expect(body.value).toContain('## Changes');
+      expect(body.value).toContain('src/a.ts');
+      expect(body.value).toContain('## Test plan');
+    });
+  });
+
+  it('calls api.createPr when Create PR is clicked', async () => {
+    const user = userEvent.setup();
+    const task = makeTask({ id: 't-2', title: 'ship it', branch: 'agents/x' });
+    render(<PrSheet open task={task} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(apiMock.getTaskDiffSummary).toHaveBeenCalled();
+    });
+    await user.click(screen.getByTestId('pr-sheet-submit'));
+    await waitFor(() => {
+      expect(apiMock.createPr).toHaveBeenCalledWith(
+        't-2',
+        expect.objectContaining({ title: 'ship it', draft: false }),
+      );
+    });
+  });
+});

--- a/src/components/PrSheet.tsx
+++ b/src/components/PrSheet.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api, type DiffSummaryResponse } from '@/lib/api';
+import { PullRequestIcon } from '@/components/icons';
+import { showToast } from '@/components/CustomToast';
+import type { Task } from '../../server/types';
+
+interface Props {
+  open: boolean;
+  task: Task | null;
+  onClose: () => void;
+  onShipped?: () => void;
+}
+
+const SHEET_STYLE: React.CSSProperties = {
+  boxShadow: '0 32px 80px -16px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.22)',
+};
+
+const BACKDROP_STYLE: React.CSSProperties = {
+  backgroundColor: 'rgba(0,0,0,0.44)',
+  backdropFilter: 'blur(20px)',
+  WebkitBackdropFilter: 'blur(20px)',
+};
+
+function deriveTitle(task: Task): string {
+  return task.title || 'Update from agent';
+}
+
+function deriveBody(task: Task, diff: DiffSummaryResponse | null): string {
+  const changes = diff?.files ?? [];
+  const changesList =
+    changes.length > 0
+      ? changes
+          .slice(0, 20)
+          .map((f) => `- \`${f.path}\` (${f.status} +${f.additions} −${f.deletions})`)
+          .join('\n')
+      : '- (no file changes detected)';
+  return (
+    `## Summary\n${task.description?.trim() || task.title}\n\n` +
+    `## Changes\n${changesList}\n\n` +
+    `## Test plan\n- [ ] Manual smoke test\n- [ ] Unit tests pass\n- [ ] Lint + typecheck clean\n`
+  );
+}
+
+export function PrSheet({ open, task, onClose, onShipped }: Props) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [diff, setDiff] = useState<DiffSummaryResponse | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open || !task) return;
+    setTitle(deriveTitle(task));
+    setDiff(null);
+    let cancelled = false;
+    api
+      .getTaskDiffSummary(task.id)
+      .then((d) => {
+        if (!cancelled) {
+          setDiff(d);
+          setBody(deriveBody(task, d));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setBody(deriveBody(task, null));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, task]);
+
+  const stats = useMemo(() => {
+    const files = diff?.files ?? [];
+    const adds = files.reduce((s, f) => s + f.additions, 0);
+    const dels = files.reduce((s, f) => s + f.deletions, 0);
+    return { files: files.length, adds, dels };
+  }, [diff]);
+
+  const handleSubmit = async (draft: boolean) => {
+    if (!task || !title.trim() || submitting) return;
+    setSubmitting(true);
+    showToast('info', 'SHIPPING', 'Creating PR…');
+    try {
+      const result = await api.createPr(task.id, { title: title.trim(), body, draft });
+      if (result.url) {
+        showToast('success', 'PR OPENED', `PR #${result.number ?? ''} created`);
+      } else {
+        showToast('success', 'SHIPPED', 'PR draft prepared');
+      }
+      onShipped?.();
+      onClose();
+    } catch (err) {
+      console.warn('createPr failed (endpoint may be stubbed):', { taskId: task.id, draft });
+      showToast('error', 'SHIP FAILED', err instanceof Error ? err.message : 'Could not create PR');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        void handleSubmit(false);
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'd') {
+        e.preventDefault();
+        void handleSubmit(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, title, body, task?.id]);
+
+  if (!open || !task) return null;
+
+  return (
+    <div
+      role="presentation"
+      data-testid="pr-sheet-backdrop"
+      className="fixed inset-0 z-[110] flex items-start justify-center pt-[10vh]"
+      style={BACKDROP_STYLE}
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ship this work"
+        data-testid="pr-sheet"
+        className="bg-glass-l3 glass-blur-l3 flex w-full max-w-[760px] flex-col gap-0 rounded-2xl border border-glass-edge-strong"
+        style={SHEET_STYLE}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center gap-3 px-6 pb-3 pt-5">
+          <PullRequestIcon size={18} className="text-[#22C55E]" />
+          <h1 className="text-[20px] font-bold leading-none tracking-tight text-white">
+            Ship this work
+          </h1>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-glass-l1 glass-blur-l1 rounded border border-glass-edge px-2 py-0.5 font-mono text-[11px] text-[#8a8a8a] hover:text-white"
+            aria-label="Close"
+          >
+            esc
+          </button>
+        </header>
+
+        <div className="flex items-center gap-3 px-6 pb-3">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#3B82F640] bg-[#3B82F61F] px-2 py-0.5 font-mono text-[10px] font-medium text-[#3B82F6]">
+            main ← {task.branch || 'agents/…'}
+          </span>
+          <span className="font-mono text-[10px] text-[#B5B5BD]">
+            {stats.files} files · +{stats.adds} −{stats.dels}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-4 px-6 pb-0">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="pr-title"
+              className="font-mono text-[9px] font-bold uppercase tracking-wider text-[#8a8a8a]"
+            >
+              PR TITLE
+            </label>
+            <input
+              id="pr-title"
+              type="text"
+              data-testid="pr-sheet-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="focus-ring rounded-md border border-glass-edge bg-[#0B0C0F] px-3.5 py-2.5 text-[14px] font-medium text-white outline-none"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="pr-body"
+              className="font-mono text-[9px] font-bold uppercase tracking-wider text-[#8a8a8a]"
+            >
+              PR BODY
+            </label>
+            <textarea
+              id="pr-body"
+              data-testid="pr-sheet-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={12}
+              className="focus-ring min-h-[260px] resize-y rounded-md border border-glass-edge bg-[#0B0C0F] px-3.5 py-3 font-mono text-[12px] leading-relaxed text-[#B5B5BD] outline-none"
+            />
+          </div>
+        </div>
+
+        <footer className="mt-4 flex items-center gap-3 border-t border-glass-edge bg-[#FFFFFF05] px-6 py-3.5">
+          <span className="font-mono text-[11px] text-[#8a8a8a]">
+            ⌘↵ Ship · ⌘D Draft PR · ⌘K Close
+          </span>
+          <div className="flex-1" />
+          <button
+            type="button"
+            data-testid="pr-sheet-draft"
+            disabled={submitting || !title.trim()}
+            onClick={() => void handleSubmit(true)}
+            className="bg-glass-l1 glass-blur-l1 rounded-md border border-glass-edge px-3.5 py-1.5 text-[12px] font-medium text-[#D0D0D0] hover:bg-[#FFFFFF14] disabled:opacity-50"
+          >
+            Save draft
+          </button>
+          <button
+            type="button"
+            data-testid="pr-sheet-submit"
+            disabled={submitting || !title.trim()}
+            onClick={() => void handleSubmit(false)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-[#22C55E] px-4 py-1.5 text-[13px] font-bold text-[#0A0A0B] shadow-[0_6px_20px_-4px_rgba(34,197,94,0.6),inset_0_1px_0_rgba(255,255,255,0.25)] hover:bg-[#4ADE80] disabled:opacity-50"
+          >
+            <PullRequestIcon size={13} />
+            Create PR
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionsInbox.test.tsx
+++ b/src/components/SessionsInbox.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/lib/event-source', () => ({
       unsubscribe();
     };
   }),
+  subscribeConnectionState: vi.fn(() => () => {}),
 }));
 
 function fireEvent(event: any): void {

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -4,9 +4,11 @@ import type { Task } from '../../server/types';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { StatusGlyph } from '@/components/ui/status-glyph';
 import { useInbox } from '@/lib/inbox';
+import { useTasksContextOptional } from '@/lib/tasks-context';
 import { timeAgo } from '@/lib/time';
 import { repoName } from '@/lib/utils';
 import { cn } from '@/lib/utils';
+import { CircleCheckIcon } from '@/components/icons';
 
 type RowKind = 'awaiting_reply' | 'errored' | 'activity';
 
@@ -152,6 +154,8 @@ function ActivitySection({ tasks }: { tasks: Task[] }) {
 
 export function SessionsInbox() {
   const { needsYou, activity, loading, error, markAllRead } = useInbox();
+  const tasksCtx = useTasksContextOptional();
+  const tasks = tasksCtx?.tasks ?? [];
 
   const { awaitingReply, errored } = useMemo(() => {
     const awaitingReply: Task[] = [];
@@ -163,8 +167,11 @@ export function SessionsInbox() {
     return { awaitingReply, errored };
   }, [needsYou]);
 
+  const runningCount = useMemo(() => tasks.filter((t) => t.status === 'running').length, [tasks]);
+
   const isEmpty =
     !loading && awaitingReply.length === 0 && errored.length === 0 && activity.length === 0;
+  const isInboxZero = !loading && !isEmpty && awaitingReply.length === 0 && errored.length === 0;
 
   return (
     <GlassPanel
@@ -205,20 +212,43 @@ export function SessionsInbox() {
         </p>
       ) : (
         <>
-          <Section
-            title="Awaiting reply"
-            tasks={awaitingReply}
-            kind="awaiting_reply"
-            testId="inbox-section-awaiting_reply"
-            eyebrow="//"
-          />
-          <Section
-            title="Errored"
-            tasks={errored}
-            kind="errored"
-            testId="inbox-section-errored"
-            eyebrow="//"
-          />
+          {isInboxZero ? (
+            <div
+              data-testid="inbox-zero"
+              className="bg-glass-l2 glass-blur-l2 mx-3 flex flex-col items-center gap-3 rounded-xl border border-glass-edge px-6 py-8 text-center"
+            >
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-full border border-[#22C55E66] bg-[#22C55E1F]"
+                aria-hidden
+              >
+                <CircleCheckIcon size={20} className="text-[#22C55E]" />
+              </div>
+              <h3 className="text-[16px] font-bold tracking-tight text-white">Inbox zero</h3>
+              <p className="max-w-sm text-[13px] leading-relaxed text-[#B5B5BD]">
+                Nothing needs your attention.
+                {runningCount > 0
+                  ? ` Your ${runningCount} running ${runningCount === 1 ? 'agent' : 'agents'} will ping you when they're blocked.`
+                  : ''}
+              </p>
+            </div>
+          ) : (
+            <>
+              <Section
+                title="Awaiting reply"
+                tasks={awaitingReply}
+                kind="awaiting_reply"
+                testId="inbox-section-awaiting_reply"
+                eyebrow="//"
+              />
+              <Section
+                title="Errored"
+                tasks={errored}
+                kind="errored"
+                testId="inbox-section-errored"
+                eyebrow="//"
+              />
+            </>
+          )}
           <ActivitySection tasks={activity} />
         </>
       )}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -100,7 +100,11 @@ export const TaskCard = memo(function TaskCard({
         <div className="min-w-0 flex-1">
           {/* Title + mode badge */}
           <div className="flex items-center gap-2">
-            <h3 className="font-display min-w-0 truncate text-base font-semibold leading-snug">
+            <h3
+              title={task.title}
+              aria-label={task.title}
+              className="font-display min-w-0 truncate text-base font-semibold leading-snug"
+            >
               {task.title}
             </h3>
             <ModeBadge mode={task.run_mode} />

--- a/src/components/TaskErrorView.tsx
+++ b/src/components/TaskErrorView.tsx
@@ -1,0 +1,76 @@
+import { TriangleAlertIcon } from '@/components/icons';
+import { timeAgo } from '@/lib/time';
+import type { Task } from '../../server/types';
+
+interface Props {
+  task: Task;
+  onRetry: () => void;
+  onDelete: () => void;
+  onViewLogs?: () => void;
+  logLines?: string[];
+}
+
+export function TaskErrorView({ task, onRetry, onDelete, onViewLogs, logLines }: Props) {
+  const tail =
+    logLines && logLines.length > 0
+      ? logLines
+      : task.error
+        ? [task.error]
+        : ['(no log output available)'];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="task-error-view">
+      <div
+        data-testid="task-error-banner"
+        className="flex items-start gap-3 border-b border-[#EF444433] bg-[#EF44440F] px-5 py-3.5"
+        role="alert"
+      >
+        <TriangleAlertIcon size={16} className="mt-0.5 shrink-0 text-[#EF4444]" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="text-[13px] font-semibold text-white">Task failed</div>
+          <div className="whitespace-pre-wrap font-mono text-[11px] text-[#B5B5BD]">
+            {task.error || 'No error details.'}
+          </div>
+        </div>
+        <button
+          type="button"
+          data-testid="task-error-retry"
+          onClick={onRetry}
+          className="shrink-0 rounded-md bg-[#EF4444] px-3 py-1.5 text-[12px] font-bold text-white hover:bg-[#DC2626]"
+        >
+          Retry
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto bg-[#0B0C0F] px-5 py-4 font-mono text-[11px] text-[#8a8a8a]">
+        {tail.map((line, idx) => (
+          <div key={idx} className="whitespace-pre-wrap leading-snug">
+            {line}
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-3 border-t border-glass-edge bg-[#FFFFFF05] px-5 py-2.5">
+        <span className="font-mono text-[11px] text-[#B5B5BD]">
+          Exited · {timeAgo(task.updated_at)}
+        </span>
+        <div className="flex-1" />
+        {onViewLogs && (
+          <button
+            type="button"
+            onClick={onViewLogs}
+            className="bg-glass-l1 glass-blur-l1 rounded-md border border-glass-edge px-3 py-1.5 text-[12px] font-medium text-[#D0D0D0] hover:bg-[#FFFFFF14]"
+          >
+            View logs
+          </button>
+        )}
+        <button
+          type="button"
+          data-testid="task-error-delete"
+          onClick={onDelete}
+          className="rounded-md border border-[#EF444433] bg-[#EF44440F] px-3 py-1.5 text-[12px] font-semibold text-[#EF4444] hover:bg-[#EF444422]"
+        >
+          Delete task
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskSettingUpView.tsx
+++ b/src/components/TaskSettingUpView.tsx
@@ -1,0 +1,112 @@
+import { CheckIcon } from '@/components/icons';
+import type { Task } from '../../server/types';
+
+interface Props {
+  task: Task;
+  onViewLogs?: () => void;
+}
+
+interface Step {
+  status: 'done' | 'active' | 'pending';
+  label: string;
+}
+
+function buildSteps(task: Task): Step[] {
+  const hasWorktree = !!(task.worktree || task.worktree_id);
+  const hasTmux = !!task.tmux_session;
+  const firstAgent = task.agents?.[0];
+  const hasAgent = !!firstAgent;
+  const hasOutput = firstAgent?.hook_activity === 'active';
+
+  const worktreeLabel = task.worktree
+    ? `Git worktree created · ${task.worktree.split('/').slice(-2).join('/')}`
+    : 'Git worktree created';
+  const tmuxLabel = task.tmux_session
+    ? `tmux session started · ${task.tmux_session}`
+    : 'tmux session started';
+
+  return [
+    { status: hasWorktree ? 'done' : 'active', label: worktreeLabel },
+    {
+      status: hasWorktree && hasTmux ? 'done' : hasWorktree ? 'active' : 'pending',
+      label: tmuxLabel,
+    },
+    {
+      status: hasAgent ? 'done' : hasTmux ? 'active' : 'pending',
+      label: 'Launching Claude Code (opus-4.7)…',
+    },
+    {
+      status: hasOutput ? 'done' : hasAgent ? 'active' : 'pending',
+      label: 'Waiting for first output',
+    },
+  ];
+}
+
+export function TaskSettingUpView({ task, onViewLogs }: Props) {
+  const steps = buildSteps(task);
+  return (
+    <div
+      className="flex flex-1 items-center justify-center p-6"
+      data-testid="task-setting-up"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="bg-glass-l1 glass-blur-l1 flex w-full max-w-[640px] flex-col items-center gap-6 rounded-2xl border border-glass-edge p-12 text-center shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)]">
+        <div
+          className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-[#FFB800] bg-[#FFB80014] text-[22px] font-bold text-[#FFB800]"
+          aria-hidden
+        >
+          <span className="setting-up-spinner inline-block">◐</span>
+        </div>
+        <h1 className="text-[20px] font-bold leading-none tracking-tight text-white">
+          Setting up task
+        </h1>
+        <ul className="flex w-full max-w-[440px] flex-col gap-2.5 text-left">
+          {steps.map((step, idx) => (
+            <li key={idx} className="flex items-center gap-3">
+              {step.status === 'done' ? (
+                <CheckIcon size={14} className="shrink-0 text-[#22C55E]" />
+              ) : step.status === 'active' ? (
+                <span
+                  className="setting-up-pulse inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-[#FFB800]"
+                  aria-hidden
+                />
+              ) : (
+                <span
+                  className="inline-block h-2.5 w-2.5 shrink-0 rounded-full border border-[#6a6a6a]"
+                  aria-hidden
+                />
+              )}
+              <span
+                className={
+                  'text-[13px] leading-snug ' +
+                  (step.status === 'active'
+                    ? 'font-medium text-[#FFB800]'
+                    : step.status === 'done'
+                      ? 'text-[#D0D0D0]'
+                      : 'text-[#6a6a6a]')
+                }
+              >
+                {step.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-[11px] text-[#8a8a8a]">
+            Usually takes under 5 seconds. Long? Click 'View logs'.
+          </p>
+          {onViewLogs && (
+            <button
+              type="button"
+              onClick={onViewLogs}
+              className="bg-glass-l1 glass-blur-l1 rounded-md border border-glass-edge px-3 py-1.5 text-[12px] font-medium text-[#D0D0D0] hover:bg-[#FFFFFF14]"
+            >
+              View logs
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
+import { CloudOffIcon } from './icons';
 
 interface TerminalViewProps {
   taskId?: string;
@@ -13,6 +14,7 @@ interface TerminalViewProps {
 
 const MAX_RECONNECT_DELAY = 10_000;
 const INITIAL_RECONNECT_DELAY = 1_000;
+const STALL_THRESHOLD_MS = 5_000;
 
 export function TerminalView({
   taskId,
@@ -27,6 +29,10 @@ export function TerminalView({
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectDelay = useRef(INITIAL_RECONNECT_DELAY);
   const unmounted = useRef(false);
+  const stallTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [disconnected, setDisconnected] = useState(false);
+  const [retrySecs, setRetrySecs] = useState<number>(0);
 
   const getWsUrl = useCallback(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -54,6 +60,20 @@ export function TerminalView({
     }
   }, []);
 
+  const clearStallTimer = useCallback(() => {
+    if (stallTimer.current) {
+      clearTimeout(stallTimer.current);
+      stallTimer.current = null;
+    }
+  }, []);
+
+  const armStallTimer = useCallback(() => {
+    clearStallTimer();
+    stallTimer.current = setTimeout(() => {
+      setDisconnected(true);
+    }, STALL_THRESHOLD_MS);
+  }, [clearStallTimer]);
+
   const connectWs = useCallback(
     (term: Terminal) => {
       if (unmounted.current) return;
@@ -62,6 +82,12 @@ export function TerminalView({
 
       ws.onopen = () => {
         reconnectDelay.current = INITIAL_RECONNECT_DELAY;
+        setDisconnected(false);
+        if (countdownTimer.current) {
+          clearInterval(countdownTimer.current);
+          countdownTimer.current = null;
+        }
+        armStallTimer();
         // Re-fit now that we know layout is settled (WS connect takes a few ms,
         // guaranteeing the browser has completed layout), then send correct dimensions.
         fitAndSendResize(ws);
@@ -72,6 +98,7 @@ export function TerminalView({
       };
 
       ws.onmessage = (event) => {
+        armStallTimer();
         term.write(event.data);
       };
 
@@ -83,11 +110,18 @@ export function TerminalView({
         if (unmounted.current || wsRef.current !== ws) return;
         if (event.code !== 1000 && event.code !== 1001) {
           term.write('\r\n\x1b[31m[Terminal disconnected — reconnecting...]\x1b[0m\r\n');
+          setDisconnected(true);
+          const delay = reconnectDelay.current;
+          setRetrySecs(Math.ceil(delay / 1000));
+          if (countdownTimer.current) clearInterval(countdownTimer.current);
+          countdownTimer.current = setInterval(() => {
+            setRetrySecs((s) => (s > 0 ? s - 1 : 0));
+          }, 1000);
           // Exponential backoff reconnection
           reconnectTimer.current = setTimeout(() => {
             reconnectDelay.current = Math.min(reconnectDelay.current * 2, MAX_RECONNECT_DELAY);
             connectWs(term);
-          }, reconnectDelay.current);
+          }, delay);
         }
       };
 
@@ -97,7 +131,7 @@ export function TerminalView({
 
       wsRef.current = ws;
     },
-    [getWsUrl],
+    [getWsUrl, fitAndSendResize, armStallTimer],
   );
 
   const connect = useCallback(() => {
@@ -167,6 +201,22 @@ export function TerminalView({
     connectWs(term);
   }, [connectWs]);
 
+  const handleRetryNow = useCallback(() => {
+    if (reconnectTimer.current) {
+      clearTimeout(reconnectTimer.current);
+      reconnectTimer.current = null;
+    }
+    if (countdownTimer.current) {
+      clearInterval(countdownTimer.current);
+      countdownTimer.current = null;
+    }
+    reconnectDelay.current = INITIAL_RECONNECT_DELAY;
+    setRetrySecs(0);
+    if (termRef.current) {
+      connectWs(termRef.current);
+    }
+  }, [connectWs]);
+
   // Connect on mount and reconnect when taskId/windowIndex changes
   useEffect(() => {
     unmounted.current = false;
@@ -176,6 +226,12 @@ export function TerminalView({
       unmounted.current = true;
       if (reconnectTimer.current) {
         clearTimeout(reconnectTimer.current);
+      }
+      if (stallTimer.current) {
+        clearTimeout(stallTimer.current);
+      }
+      if (countdownTimer.current) {
+        clearInterval(countdownTimer.current);
       }
       wsRef.current?.close();
       termRef.current?.dispose();
@@ -222,6 +278,31 @@ export function TerminalView({
   }, [visible, fitAndSendResize]);
 
   return (
-    <div ref={containerRef} className="h-full w-full overflow-hidden rounded-lg bg-[#09090b]" />
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        className="h-full w-full overflow-hidden rounded-lg bg-[#09090b] transition-opacity"
+        style={{ opacity: disconnected ? 0.7 : 1 }}
+      />
+      {disconnected && (
+        <div
+          data-testid="terminal-disconnected-overlay"
+          role="alert"
+          className="bg-glass-l1 glass-blur-l1 pointer-events-auto absolute left-3 right-3 top-3 flex items-center gap-3 rounded-md border border-[#FFB80033] bg-[#FFB80014] px-4 py-2.5"
+        >
+          <CloudOffIcon size={14} className="shrink-0 text-[#FFB800]" />
+          <span className="flex-1 text-[12px] font-medium text-[#FFB800]">
+            Server unreachable — reconnecting in {Math.max(retrySecs, 0)}s…
+          </span>
+          <button
+            type="button"
+            onClick={handleRetryNow}
+            className="rounded-md border border-[#FFB80066] bg-[#FFB80022] px-2.5 py-1 text-[11px] font-semibold text-[#FFB800] hover:bg-[#FFB80033]"
+          >
+            Retry now
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -12,7 +12,10 @@ const { apiMock, apiProxy } = await vi.hoisted(async () =>
 );
 
 vi.mock('@/lib/api', () => ({ api: apiProxy }));
-vi.mock('@/lib/event-source', () => ({ subscribe: vi.fn(() => () => {}) }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
 vi.mock('@/lib/orchestrator-context', () => ({
   useOrchestratorContext: () => ({
     running: false,

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -1206,6 +1206,8 @@ function SessionRow({
           <Link
             to={`/tasks/${item.id}`}
             aria-current={isActive ? 'page' : undefined}
+            title={item.title}
+            aria-label={item.title}
             className={`min-w-0 flex-1 truncate font-medium rounded-[4px] ${FOCUS_RING}`}
             style={{
               fontSize: 11,
@@ -1455,6 +1457,8 @@ function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePat
               <Link
                 to={to}
                 aria-current={isActive ? 'page' : undefined}
+                title={chat.label}
+                aria-label={chat.label}
                 className={`min-w-0 flex-1 truncate rounded-[4px] ${FOCUS_RING}`}
                 style={{
                   color: isActive ? '#3B82F6' : NAV_INACTIVE_FG,

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -81,3 +81,63 @@ export function TerminalRectIcon({ size = 48, strokeWidth = 1.5, ...props }: Ico
     </svg>
   );
 }
+
+export function TriangleAlertIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </svg>
+  );
+}
+
+export function CloudOffIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <path d="M2 2l20 20" />
+      <path d="M5.782 5.782A7 7 0 0 0 9 19h8.5a4.5 4.5 0 0 0 1.307-.193" />
+      <path d="M21.532 16.5A4.5 4.5 0 0 0 17.5 10h-1.79A7.008 7.008 0 0 0 10 5.07" />
+    </svg>
+  );
+}
+
+export function LayoutGridIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <rect width="7" height="7" x="3" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="14" rx="1" />
+      <rect width="7" height="7" x="3" y="14" rx="1" />
+    </svg>
+  );
+}
+
+export function SearchIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+export function RocketIcon({ size = 20, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+      <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+    </svg>
+  );
+}
+
+export function CircleCheckIcon({ size = 20, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -184,3 +184,32 @@
       0 0 0 4px #60a5fae6;
   }
 }
+
+@keyframes setting-up-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes setting-up-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.85);
+  }
+}
+
+.setting-up-spinner {
+  animation: setting-up-spin 1.4s linear infinite;
+}
+
+.setting-up-pulse {
+  animation: setting-up-pulse 1.2s ease-in-out infinite;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -168,6 +168,11 @@ export const api = {
   startTask: (id: string) => request<Task>(`/tasks/${id}/start`, { method: 'POST' }),
   deleteTask: (id: string) => request<void>(`/tasks/${id}`, { method: 'DELETE' }),
   getTaskDiffSummary: (id: string) => request<DiffSummaryResponse>(`/tasks/${id}/diff`),
+  createPr: (id: string, data: { title: string; body: string; draft?: boolean }) =>
+    request<{ ok: boolean; url?: string; number?: number }>(`/tasks/${id}/pr`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   getTaskDiffFile: (id: string, relPath: string) =>
     request<FileDiffResponse>(
       `/tasks/${id}/diff/${relPath.split('/').map(encodeURIComponent).join('/')}`,

--- a/src/lib/event-source.ts
+++ b/src/lib/event-source.ts
@@ -15,7 +15,23 @@ export interface ServerEvent {
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectDelay = INITIAL_RECONNECT_DELAY;
+let connectedState = true;
 const subscribers = new Set<(event: ServerEvent) => void>();
+const stateSubscribers = new Set<(connected: boolean) => void>();
+
+function setConnected(v: boolean) {
+  if (connectedState === v) return;
+  connectedState = v;
+  for (const cb of stateSubscribers) cb(v);
+}
+
+export function subscribeConnectionState(cb: (connected: boolean) => void): () => void {
+  stateSubscribers.add(cb);
+  cb(connectedState);
+  return () => {
+    stateSubscribers.delete(cb);
+  };
+}
 
 function getWsUrl(): string {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -29,6 +45,7 @@ function connect(): void {
 
   ws.onopen = () => {
     reconnectDelay = INITIAL_RECONNECT_DELAY;
+    setConnected(true);
   };
 
   ws.onmessage = (event) => {
@@ -44,6 +61,7 @@ function connect(): void {
   ws.onclose = (event) => {
     ws = null;
     if (event.code !== 1000 && subscribers.size > 0) {
+      setConnected(false);
       reconnectTimer = setTimeout(() => {
         reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
         connect();

--- a/src/lib/tasks-context.tsx
+++ b/src/lib/tasks-context.tsx
@@ -25,3 +25,8 @@ export function useTasksContext(): TasksState {
   if (!ctx) throw new Error('useTasksContext must be used within TasksProvider');
   return ctx;
 }
+
+/** Optional variant — returns null when no provider is mounted (e.g. isolated component tests). */
+export function useTasksContextOptional(): TasksState | null {
+  return useContext(TasksContext);
+}

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,11 +1,28 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { StatusGlyph } from '@/components/ui/status-glyph';
 import { api } from '@/lib/api';
 import { useOrchestratorContext } from '@/lib/orchestrator-context';
 import { showToast } from '@/components/CustomToast';
+import { LayoutGridIcon } from '@/components/icons';
 import type { Agent } from '../../server/types';
+
+function OrchestratorGridToggle() {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      data-testid="orchestrator-grid-toggle"
+      onClick={() => navigate('/tasks/grid')}
+      title="Parallel grid (⌘⇧G)"
+      className="focus-ring bg-glass-l1 glass-blur-l1 inline-flex items-center gap-1.5 rounded-md border border-glass-edge px-2 py-1 font-mono text-[10px] font-bold uppercase tracking-wider text-[#b5b5bd] hover:text-white"
+    >
+      <LayoutGridIcon size={11} />
+      Grid
+    </button>
+  );
+}
 
 const TerminalView = lazy(() =>
   import('@/components/TerminalView').then((m) => ({ default: m.TerminalView })),
@@ -181,6 +198,7 @@ function OrchestratorHeader({
           </span>
         )}
         <div className="ml-auto flex items-center gap-3">
+          <OrchestratorGridToggle />
           {running && (
             <button
               type="button"

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -60,6 +60,25 @@ describe('HomePage', () => {
     expect(h1).toHaveClass('text-[32px]');
   });
 
+  it('renders first-run CTA when there are no tasks', () => {
+    renderHome('/', { tasks: [] });
+    expect(screen.getByTestId('home-first-run')).toBeInTheDocument();
+    expect(screen.getByTestId('home-first-run-cta')).toHaveTextContent(/create your first task/i);
+  });
+
+  it('clicking first-run CTA dispatches focus-composer event', async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    window.addEventListener('focus-composer', spy);
+    try {
+      renderHome('/', { tasks: [] });
+      await user.click(screen.getByTestId('home-first-run-cta'));
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('focus-composer', spy);
+    }
+  });
+
   it('hydrates composer from URL with repo + fork_of, then submits', async () => {
     const user = userEvent.setup();
     apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'spawned' }));

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,47 @@
 import { Composer } from '@/components/Composer';
 import { SessionsInbox } from '@/components/SessionsInbox';
+import { useTasksContext } from '@/lib/tasks-context';
+import { RocketIcon } from '@/components/icons';
+
+function FirstRunEmptyState() {
+  const focusComposer = () => {
+    window.dispatchEvent(new CustomEvent('focus-composer'));
+  };
+  return (
+    <div
+      data-testid="home-first-run"
+      className="bg-glass-l2 glass-blur-l2 mx-auto flex max-w-xl flex-col items-center gap-5 rounded-2xl border border-glass-edge p-12 text-center shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)]"
+    >
+      <div
+        className="flex h-14 w-14 items-center justify-center rounded-full border border-[#3B82F666] bg-[#3B82F61F]"
+        aria-hidden
+      >
+        <RocketIcon size={22} className="text-[#3B82F6]" />
+      </div>
+      <h2 className="text-[20px] font-bold leading-tight tracking-tight text-white">
+        Ship work faster with Claude
+      </h2>
+      <p className="max-w-sm text-[13px] leading-relaxed text-[#B5B5BD]">
+        Dispatch autonomous agents to fix bugs and build features. Each task gets its own git
+        worktree and tmux session.
+      </p>
+      <button
+        type="button"
+        data-testid="home-first-run-cta"
+        onClick={focusComposer}
+        className="inline-flex items-center gap-2 rounded-md bg-[#3B82F6] px-4 py-2.5 text-[13px] font-bold text-white shadow-[0_6px_20px_-4px_rgba(59,130,246,0.6)] hover:bg-[#2563EB]"
+      >
+        Create your first task
+        <span className="font-mono text-[11px] text-white/80">⌘N</span>
+      </button>
+    </div>
+  );
+}
 
 export default function HomePage() {
+  const { tasks, loading } = useTasksContext();
+  const isFirstRun = !loading && tasks.length === 0;
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 overflow-auto">
@@ -22,7 +62,7 @@ export default function HomePage() {
             </h1>
           </div>
           <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8">
-            <SessionsInbox />
+            {isFirstRun ? <FirstRunEmptyState /> : <SessionsInbox />}
           </div>
         </div>
       </div>

--- a/src/pages/ParallelGridPage.test.tsx
+++ b/src/pages/ParallelGridPage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { TasksProvider } from '@/lib/tasks-context';
+import ParallelGridPage from './ParallelGridPage';
+import { makeTask } from '../test-helpers';
+import type { Task } from '../../server/types';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+
+const mockTasksRef = { current: [] as Task[] };
+vi.mock('@/lib/hooks', () => ({
+  useTasks: () => ({
+    tasks: mockTasksRef.current,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function renderGrid(tasks: Task[]) {
+  mockTasksRef.current = tasks;
+  return render(
+    <MemoryRouter>
+      <TasksProvider>
+        <ParallelGridPage />
+      </TasksProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNavigate.mockReset();
+  apiMock.listTasks.mockResolvedValue([]);
+});
+
+describe('ParallelGridPage', () => {
+  it('renders a pane per running task', () => {
+    renderGrid([
+      makeTask({ id: 'a', title: 'one', status: 'running', branch: 'agents/one' }),
+      makeTask({ id: 'b', title: 'two', status: 'running', branch: 'agents/two' }),
+    ]);
+    expect(screen.getByTestId('grid-pane-a')).toBeInTheDocument();
+    expect(screen.getByTestId('grid-pane-b')).toBeInTheDocument();
+  });
+
+  it('clicking a pane navigates to the task detail', async () => {
+    const user = userEvent.setup();
+    renderGrid([makeTask({ id: 'x', title: 'foo', status: 'running' })]);
+    await user.click(screen.getByTestId('grid-pane-x'));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks/x');
+  });
+
+  it('shows empty state when there are no active agents', () => {
+    renderGrid([]);
+    expect(screen.getByText(/no active agents/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/ParallelGridPage.tsx
+++ b/src/pages/ParallelGridPage.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTasksContext } from '@/lib/tasks-context';
+import { StatusGlyph } from '@/components/ui/status-glyph';
+import { LayoutGridIcon, TriangleAlertIcon } from '@/components/icons';
+import type { Task } from '../../server/types';
+
+interface MiniPaneProps {
+  task: Task;
+  onOpen: () => void;
+}
+
+function hasAttention(task: Task): boolean {
+  const d = task.derived_status;
+  return d === 'needs_attention' || task.status === 'error';
+}
+
+function MiniPane({ task, onOpen }: MiniPaneProps) {
+  const agents = task.agents ?? [];
+  const activeAgent = agents.find((a) => a.status === 'running') || agents[0];
+  const lines: string[] = [
+    `branch: ${task.branch ?? '—'}`,
+    `agents: ${agents.length}`,
+    activeAgent ? `label: ${activeAgent.label}` : '',
+    activeAgent?.hook_activity ? `activity: ${activeAgent.hook_activity}` : '',
+  ].filter(Boolean);
+  const attention = hasAttention(task);
+  return (
+    <button
+      type="button"
+      data-testid={`grid-pane-${task.id}`}
+      onClick={onOpen}
+      className="group flex h-[260px] flex-col overflow-hidden rounded-xl border border-glass-edge bg-[#0B0C0F] text-left shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)] transition hover:border-[#3B82F666]"
+    >
+      <header
+        className="flex items-center gap-2 border-b bg-[#FFFFFF08] px-3 py-2"
+        style={
+          attention
+            ? { borderBottomColor: 'rgba(255,255,255,0.08)', borderLeft: '2px solid #FFB800' }
+            : { borderBottomColor: 'rgba(255,255,255,0.08)' }
+        }
+      >
+        <span
+          className="flex-1 truncate font-mono text-[11px] font-medium text-white"
+          title={task.branch || task.title}
+        >
+          {task.branch || task.title}
+        </span>
+        <StatusGlyph status={task.derived_status || task.status} size={10} />
+      </header>
+      <div className="flex-1 overflow-hidden px-4 py-3 font-mono text-[11px] leading-snug text-[#8a8a8a]">
+        {lines.map((line, idx) => (
+          <div key={idx} className="truncate">
+            {line}
+          </div>
+        ))}
+      </div>
+      <footer className="flex items-center gap-2 border-t border-[#FFFFFF0A] bg-[#FFFFFF05] px-3 py-1.5 font-mono text-[10px] text-[#8a8a8a]">
+        <span>opus-4.7</span>
+        <div className="flex-1" />
+        <span className="text-[#B5B5BD]">
+          {agents.length} agent{agents.length === 1 ? '' : 's'}
+        </span>
+      </footer>
+    </button>
+  );
+}
+
+export default function ParallelGridPage() {
+  const navigate = useNavigate();
+  const { tasks } = useTasksContext();
+
+  const { running, waiting, errored } = useMemo(() => {
+    const running: Task[] = [];
+    const waiting: Task[] = [];
+    const errored: Task[] = [];
+    for (const t of tasks) {
+      if (t.status === 'error') errored.push(t);
+      else if (hasAttention(t)) waiting.push(t);
+      else if (t.status === 'running' || t.status === 'setting_up') running.push(t);
+    }
+    return { running, waiting, errored };
+  }, [tasks]);
+
+  const visible = useMemo(
+    () => [...running, ...waiting, ...errored].slice(0, 12),
+    [running, waiting, errored],
+  );
+
+  return (
+    <div className="flex h-full flex-col p-6" data-testid="parallel-grid-page">
+      <div className="bg-glass-l1 glass-blur-l1 mb-4 flex items-center gap-3 rounded-xl border border-glass-edge px-4 py-2.5">
+        <LayoutGridIcon size={14} className="text-[#D0D0D0]" />
+        <span className="text-[12px] font-semibold text-white">Grid</span>
+        <span className="h-4 w-px bg-white/10" />
+        <span className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-[11px] text-[#B5B5BD]">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-[#22C55E]" aria-hidden />
+          {running.length} running
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-[11px] text-[#B5B5BD]">
+          <TriangleAlertIcon size={10} className="text-[#FFB800]" />
+          {waiting.length} waiting
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 font-mono text-[11px] text-[#B5B5BD]">
+          <span className="text-[#EF4444]">✕</span>
+          {errored.length} errored
+        </span>
+        <div className="flex-1" />
+        <span className="font-mono text-[11px] text-[#8a8a8a]">⌘⇧G to toggle grid</span>
+      </div>
+
+      {visible.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center rounded-xl border border-glass-edge bg-[#FFFFFF05] p-12 text-center">
+          <div className="flex flex-col items-center gap-2">
+            <LayoutGridIcon size={32} className="text-[#6a6a6a]" />
+            <span className="text-[14px] font-semibold text-[#D0D0D0]">No active agents</span>
+            <span className="text-[12px] text-[#8a8a8a]">
+              Running tasks will appear here as panes.
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div
+          data-testid="parallel-grid"
+          className="grid flex-1 gap-3.5 overflow-auto"
+          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}
+        >
+          {visible.map((task) => (
+            <MiniPane key={task.id} task={task} onOpen={() => navigate(`/tasks/${task.id}`)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -544,9 +544,24 @@ function RepoConfigsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
       )}
 
       {!loading && !error && configs.length === 0 && (
-        <div className="py-8 text-center text-sm text-[#8a8a8a]">
-          No repositories configured yet. Repositories appear here automatically when you create
-          tasks.
+        <div
+          data-testid="repos-empty"
+          className="flex flex-col items-center gap-2 py-10 text-center"
+        >
+          <button
+            type="button"
+            data-testid="repos-add-first"
+            onClick={() => {
+              navigate('/');
+              requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('focus-composer')));
+            }}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[#3B82F666] bg-[#3B82F61F] px-3 py-2 text-[12px] font-semibold text-[#60a5fa] hover:bg-[#3B82F633]"
+          >
+            + Add your first repo
+          </button>
+          <p className="text-[11px] text-[#8a8a8a]">
+            Repositories appear here automatically when you create tasks.
+          </p>
         </div>
       )}
 

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/lib/event-source', () => ({
     eventCallbacks.add(cb);
     return () => eventCallbacks.delete(cb);
   }),
+  subscribeConnectionState: vi.fn(() => () => {}),
 }));
 
 function simulateEvent(taskId = 'test-task-01') {
@@ -333,8 +334,24 @@ describe('TaskDetail', () => {
     apiMock.getTask.mockResolvedValue(makeTask({ status: 'error', error: 'Setup failed' }));
     renderDetail();
     await waitFor(() => {
-      expect(screen.getByText('Setup failed')).toBeInTheDocument();
+      expect(screen.getByTestId('task-error-view')).toBeInTheDocument();
     });
+    const banner = screen.getByTestId('task-error-banner');
+    expect(banner).toHaveTextContent('Setup failed');
+    expect(screen.getByTestId('task-error-retry')).toBeInTheDocument();
+    expect(screen.getByTestId('task-error-delete')).toBeInTheDocument();
+  });
+
+  it('renders setting_up checklist when status=setting_up and no terminal yet', async () => {
+    apiMock.getTask.mockResolvedValue(
+      makeTask({ status: 'setting_up', agents: [], tmux_session: null }),
+    );
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId('task-setting-up')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/setting up task/i)).toBeInTheDocument();
+    expect(screen.getByText(/Launching Claude Code/i)).toBeInTheDocument();
   });
 
   // ─── Editor toggle ───────────────────────────────────────────────────────
@@ -405,7 +422,7 @@ describe('TaskDetail', () => {
       apiMock.getTask.mockResolvedValue(makeTask({ status: 'setting_up', agents: [] }));
       simulateEvent();
       await waitFor(() => {
-        expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
+        expect(screen.getByTestId('task-setting-up')).toBeInTheDocument();
       });
 
       apiMock.getTask.mockResolvedValue(runningTask);
@@ -534,7 +551,7 @@ describe('TaskDetail', () => {
       apiMock.getTask.mockResolvedValue(makeTask({ status: 'setting_up', agents: [] }));
       simulateEvent();
       await waitFor(() => {
-        expect(screen.getByText('Setting up terminal...')).toBeInTheDocument();
+        expect(screen.getByTestId('task-setting-up')).toBeInTheDocument();
       });
     });
   });

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -8,6 +8,8 @@ import { DiffViewer } from '@/components/DiffViewer';
 import { DraftEditForm } from '@/components/DraftEditForm';
 import { EmptyState } from '@/components/EmptyState';
 import { MoveAgentDialog } from '@/components/MoveAgentDialog';
+import { TaskSettingUpView } from '@/components/TaskSettingUpView';
+import { TaskErrorView } from '@/components/TaskErrorView';
 
 import { useTask } from '@/lib/hooks';
 import { api } from '@/lib/api';
@@ -192,6 +194,16 @@ export default function TaskDetail() {
     }
   }, [taskId, refresh]);
 
+  const handleDelete = useCallback(async () => {
+    if (!taskId) return;
+    try {
+      await api.deleteTask(taskId);
+      navigate('/tasks');
+    } catch (err) {
+      console.error('Failed to delete task:', err);
+    }
+  }, [taskId, navigate]);
+
   const handleResume = useCallback(async () => {
     if (!taskId) return;
     setResuming(true);
@@ -301,7 +313,13 @@ export default function TaskDetail() {
         className="bg-glass-l1 glass-blur-l1 flex items-center justify-between gap-3 border-b border-glass-edge px-4 py-3"
       >
         <div className="flex min-w-0 items-center gap-2">
-          <h1 className="truncate text-[15px] font-semibold leading-none">{task.title}</h1>
+          <h1
+            title={task.title}
+            aria-label={task.title}
+            className="truncate text-[15px] font-semibold leading-none"
+          >
+            {task.title}
+          </h1>
           <span
             data-testid="mode-badge"
             title={MODE_TOOLTIP[runMode]}
@@ -405,8 +423,8 @@ export default function TaskDetail() {
         </div>
       </div>
 
-      {/* Error display */}
-      {task.error && (
+      {/* Error display — only when status !== 'error' (dedicated error view shows error) */}
+      {task.error && task.status !== 'error' && (
         <div className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive">
           {task.error}
         </div>
@@ -469,8 +487,20 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Agent view — shown in agents mode */}
-      {hasTerminal ? (
+      {/* Dedicated lifecycle state: setting_up */}
+      {task.status === 'setting_up' && !hasTerminal && mode === 'agents' && (
+        <TaskSettingUpView task={task} />
+      )}
+
+      {/* Dedicated lifecycle state: error */}
+      {task.status === 'error' && mode === 'agents' && (
+        <TaskErrorView task={task} onRetry={handleResume} onDelete={handleDelete} />
+      )}
+
+      {/* Agent view — shown in agents mode. Skip entirely when a dedicated
+          lifecycle state (setting_up / error) is rendering above. */}
+      {task.status === 'error' ||
+      (task.status === 'setting_up' && !hasTerminal) ? null : hasTerminal ? (
         <div className={mode === 'agents' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}>
           <AgentTabs
             agents={agents}
@@ -529,9 +559,7 @@ export default function TaskDetail() {
               : 'hidden'
           }
         >
-          {task.status === 'setting_up' ? (
-            'Setting up terminal...'
-          ) : task.status === 'closed' || task.status === 'error' ? (
+          {task.status === 'closed' ? (
             <>
               <TerminalRectIcon size={32} className="text-muted-foreground/50" />
               <span className="text-sm">Terminal session ended</span>

--- a/src/pages/TasksPage.test.tsx
+++ b/src/pages/TasksPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/lib/api', () => ({ api: apiProxy }));
 
 vi.mock('@/lib/event-source', () => ({
   subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/lib/orchestrator-context', () => ({

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -127,6 +127,7 @@ export function mockApi(overrides: Record<string, unknown> = {}) {
     startTask: vi.fn().mockResolvedValue(TASK_DEFAULTS),
     deleteTask: vi.fn().mockResolvedValue(undefined),
     getTaskDiffSummary: vi.fn().mockResolvedValue({ files: [] }),
+    createPr: vi.fn().mockResolvedValue({ ok: true }),
     getTaskDiffFile: vi.fn().mockResolvedValue({
       oldContent: '',
       newContent: '',


### PR DESCRIPTION
## Summary

Completes the liquid-glass redesign series (closes the arc that began with #106 and continued through #107, #108, #109, #110, #111).

**Lifecycle states** — dedicated `setting_up` checklist view and `error` view (banner + opaque log tail + View logs / Delete) replace the generic "Setting up terminal..." text inside TaskDetail.

**Terminal disconnect overlay** — TerminalView detects >5s websocket silence, dims the pane to 70%, and surfaces an amber cloud-off banner with countdown + Retry now.

**Empty states** —
- *Home first-run* (no tasks): cyan rocket L2 card with "⌘N" CTA that focuses the composer.
- *Inbox zero*: green circle-check card when needs-you is empty but activity has items.
- *Palette no-results*: centered "No matches" + cyan chip "New task with '<query>'" that opens the composer pre-filled (uses a new `focus-composer` detail payload).
- *Settings repositories*: centered "+ Add your first repo" CTA.

**PR Preview sheet** (new L3 surface, 760px, blurred scrim) — pre-fills title from task title and body from description + diff files + test-plan checklist. `⌘↵` ships, `⌘D` drafts, `⌘K` / Esc closes. Mounted at AppShell and opened via the existing `SHIP_EVENT` dispatched from TaskDetail's Ship button. Talks to `api.createPr`; stubbed endpoint returns a toast so the UI still gives feedback.

**Parallel Agent Grid** (`/tasks/grid`, `/orchestrator/grid`, `⌘⇧G`) — responsive grid of mini-panes per running/waiting/errored task with branch + activity + status pill + telemetry footer. Amber left stroke on attention panes. Click navigates to TaskDetail. Orchestrator header gets a "Grid" toggle chip.

**Global offline banner** — thin L1 amber strip at top of AppShell when `/ws/events` has been down >10s; auto-hides on reconnect. Event-source now exposes `subscribeConnectionState`.

**Long-title truncation** — added `title`/`aria-label` to task titles in sidebar rows, task-detail header, task cards, and command-palette session rows.

Closes the glass redesign series (T1–T6 merged as #106–#111).

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (24 pre-existing warnings)
- [x] `bun run test` — 1263 / 1263 passing (10 new tests)
- New tests cover: setting_up checklist render; error banner + retry/delete testids; home first-run CTA + composer focus event; palette no-results chip navigates with prefill; PR sheet pre-fills body + calls `api.createPr`; grid panes + navigation; offline banner 10s threshold + reconnect hide.
- [ ] Manual: run `bun run dev`, create task, observe setting_up checklist; kill server, confirm offline banner after 10s; press ⌘⇧G to toggle grid; click Ship to open PR sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)