### PR TITLE
refactor(ui): align liquid-glass redesign to pen mockups (T1–T5)

### DIFF
--- a/.octomux/rollup/t1-foundation-shell.md
+++ b/.octomux/rollup/t1-foundation-shell.md
@@ -1,0 +1,74 @@
+# t1-foundation-shell — rollup summary
+
+## Scope audited
+
+Foundation + app shell against frames `PsSGN` (title strip + material
+legend) and the sidebar embedded in `9VzuO` / `TF8jb` / `y3FOS` /
+`Ykdgp` / `cN3Ko` / `1NGJ5`. Frame `uReOg` (Sidebar Variants) was
+referenced in the brief but is absent from `design/glass-redesign.pen`;
+sidebar was cross-verified against all six page frames instead.
+
+## Gaps found → fixes landed
+
+1. **L2 / L3 tints off-spec** — legend calls for 0.14 and 0.22; tokens
+   were at 0.12 / 0.18. Corrected in `src/index.css`.
+2. **Ambient tint blobs missing** — content canvas had no cyan/purple
+   backdrop, so L1/L2/L3 glass had nothing to blur through. Added
+   `--ambient-cyan` / `--ambient-purple` tokens + an `ambient-tint-
+   backdrop` utility; mounted on `<main>` only in `src/App.tsx` so
+   terminal panes (`<TerminalView>` inside `<main>` still renders on
+   top of its own opaque `#0B0C0F` fill) stay opaque.
+3. **Sidebar nav active row shape drift** — code used a 1px all-around
+   cyan border; mock shows a 2px left accent bar + 14% cyan fill.
+   Swapped `border` for `borderLeft: 2px solid #3B82F6` with matching
+   left padding compensation in `ExpandedNavRow` and the expanded
+   `MoreSection` row. Dropped the unused `ACTIVE_STROKE` constant.
+4. **Sidebar session / chat active rows** — mock shows fill-only, no
+   stroke. Removed the 1px border from expanded session rows, collapsed
+   session tiles, expanded chat rows, and collapsed chat tiles.
+5. **Keycap active chip off-spec** — active fill bumped from 0.16→0.12,
+   stroke 0.3→0.25, text swapped from `#7DD3FC` to `#3B82F6` to match
+   the keycap cluster in the legend.
+6. **Collapsed rail active tile** — kept a 1px rgba(59,130,246,0.4)
+   stroke so the tile reads as selected against the 36×36 icon; the
+   pen file has no collapsed-rail reference frame to audit against.
+
+## Areas already correct (no-ops)
+
+- `--glass-l1` at 0.08 + 40px blur — matches legend.
+- Focus-ring utility: `0 0 0 4px #60A5FAE6` with a 2px dark offset,
+  triggered only on `:focus-visible` — matches token spec.
+- Specular inset highlight at `rgba(255,255,255,0.22)`, within the
+  README's 18–30% range.
+- `GlassPanel` primitive variants (L1/L2/L3 + specular) — unchanged.
+- `<OfflineBanner>` — already a thin L1 strip, amber, cloud-off icon,
+  10s reconnect delay.
+- `<StatusGlyph>` and `<StatusBadge>` glyphs — unchanged.
+- `title` + `aria-label` already present on sidebar session rows,
+  chat rows, and the task-detail header (long-title truncation).
+
+## Files touched
+
+- `src/index.css` — bumped L2/L3 tint tokens, added ambient tint
+  tokens and `ambient-tint-backdrop` utility.
+- `src/App.tsx` — wired ambient backdrop into `<main>` behind routes.
+- `src/components/UniversalSidebar.tsx` — nav / session / chat active
+  styles + keycap active colors.
+- `src/components/UniversalSidebar.test.tsx` — updated active-row
+  assertion to match the new left-accent-bar shape.
+
+## Verification
+
+- `bun run lint` → 0 errors (24 pre-existing warnings unchanged).
+- `bun run typecheck` → clean.
+- `bun run test` → 1263 / 1263 pass.
+
+## Notes for follow-on tasks
+
+- The pen file is missing a dedicated **Sidebar Variants** frame
+  (`uReOg`) — collapsed-rail tile sizing and needs-you pill spec had
+  to be inferred from the README and embedded usages. Worth asking
+  design to add the standalone variant frame before T2 iterations.
+- The README reads "1px cyan stroke, no left accent bar" for active
+  rows, but the six page frames and the T1 audit brief consistently
+  show the 2px left accent bar. Implementation follows the frames.

--- a/.octomux/rollup/t2-home-tasks.md
+++ b/.octomux/rollup/t2-home-tasks.md
@@ -1,0 +1,47 @@
+# T2 · Home + Tasks glass audit
+
+Scope: Sessions Inbox (Home) + Command Center (Tasks) aligned against
+pen frames `9VzuO` (Home) + `TF8jb` (Tasks).
+
+## Gaps closed
+
+- **SessionsInbox restructure.** Dropped the outer L2 `GlassPanel`
+  wrapper that flattened every row into one card. Per the mockup:
+  - `Awaiting reply` cards are now per-item L2 glass (16px radius,
+    inset specular top-edge + `0 12px 30px -8px` shadow) with an
+    **amber** `#FFB80040` tinted border.
+  - `Errored` cards use the same L2 treatment with a **red**
+    `#EF444440` border.
+  - `Activity` rows are L1 glass (12px radius, lighter stroke),
+    separated from the Awaiting/Errored group by a thin rule + the
+    `// ACTIVITY` all-caps mono eyebrow.
+- **TaskCard end-pill.** `StatusBadge` now takes a `variant` prop;
+  the task card uses `variant="pill"` so status reads as a tinted
+  pill (running=green, needs-you/setting-up=amber, closed=grey,
+  error=red) with inner 1px stroke — matching the right-side end-pill
+  in the Tasks mockup.
+- **TaskFilterBar.** Added explicit `rounded-[14px]` to match the
+  unified L1 filter-bar panel and inserted a thin inline separator
+  between the status chips and the repo dropdown (replaces the
+  implicit gap with the `fbSep` rule in the pen).
+- **Composer dock.** Home now renders the Composer as a floating
+  L3 dock: absolute-positioned at `bottom-6`, centered, `w-[90%]
+  max-w-[1056px]`, with a drop-shadow filter for lift. Scroll body
+  gets `pb-[280px]` so inbox content no longer slides under the
+  dock. Composer itself now has an explicit `rounded-[20px]` outer
+  radius to match the pen.
+
+## Verification
+
+- `bun run typecheck` — clean
+- `bun run lint` — no new errors (24 pre-existing warnings unchanged)
+- `bun run test` — 1263/1263 passing
+
+## Files touched
+
+- `src/components/SessionsInbox.tsx`
+- `src/components/StatusBadge.tsx`
+- `src/components/TaskCard.tsx`
+- `src/components/TaskFilterBar.tsx`
+- `src/components/Composer.tsx`
+- `src/pages/HomePage.tsx`

--- a/.octomux/rollup/t3-task-detail.md
+++ b/.octomux/rollup/t3-task-detail.md
@@ -1,0 +1,44 @@
+# T3 Task Detail / Diff / PR Sheet — Glass Audit
+
+Scope: Task Detail (Agents view + Diff view + Ship flow) and the PR Preview sheet.
+Slug: `t3-task-detail`.
+Branch: `agents/glass-audit-t3-task-detail-diff-pr-sheet-3PULJT` → rolled up to `feat/glass-redesign`.
+
+## Frames audited
+
+- **y3FOS + MifSX** — Task Detail / Agents
+- **Ykdgp + OXzCy** — Task Detail / Diff
+- **h3PJl** — Ship / PR Preview sheet (frame id not present in the pen; used the annotation spec supplied in the task prompt)
+
+## Gaps found and fixed
+
+1. **Task detail header typography.** Title was `text-[15px]` and header padding was `py-3 px-4`. Mockup specifies a 17px title on an L1 bar with 18px/24px padding. → bumped to `text-[17px]` + `tracking-tight` and `px-6 py-[18px]`.
+2. **DIFF toggle active state.** Was a muted outline with just cyan text; mockup calls for "pressed cyan glass" (the same selection vocabulary used in sidebar/palette). → active state is now `border-[#3B82F666] bg-[#3B82F61F] text-[#3B82F6]` with cyan hover.
+3. **Metadata bar stroke.** Used `border-glass-edge` (14% white) — heavier than the mockup's thin L1 feel. → switched to an inline 6% white bottom stroke; padding nudged to 10px so it reads thinner.
+4. **Diff file list chrome.** The sidebar was `border-r border-border` (flat panel). Mockup specifies a 260px L1 glass panel (8% white + 40px blur + 14% stroke + inset padding). → wrapped the aside in `bg-glass-l1 glass-blur-l1 border border-glass-edge`, dropped to 260px wide, and gave the file tree 4px inset padding so rows breathe like in the mockup.
+5. **Selected file row vocabulary.** Was `bg-accent` (`#141414`). Mockup reuses the cyan-tinted selection material used by the sidebar / palette / active diff toggle. → active row is now `border-[#3B82F666] bg-[#3B82F61F] text-[#3B82F6]` (with a transparent border on inactive rows so layout stays stable).
+6. **Diff pane material.** Plain border and no shadow previously. → now has a 14% white stroke, `#101217` L1-tinted header bar (with `#FFFFFF0F` bottom stroke), and a subtle `0 8px 24px -6px rgba(0,0,0,0.5)` drop-shadow so it reads as a separate opaque pane sitting on top of the ambient canvas. Monospace filename in the header switched to `#B5B5BD`.
+7. **Collapsible top-level directory groups.** `IGNORED FILES` was already collapsible but `DESIGN` / `SRC` group headers were static divs. Mockup shows all top-level directory buckets collapsing independently — one interaction vocabulary across the file list. → `TreeRow` now accepts `collapsible` + `openGroups` + `onToggleGroup`; default open; state persisted to localStorage under `octomux:diff-group-open:<taskId>:<path>`. Existing `diff-group-*` test IDs preserved.
+8. **PR sheet scrim opacity.** Was `rgba(0,0,0,0.44)`; spec calls for 48% black. → bumped to `0.48`.
+
+## Left alone (already matches mockup)
+
+- CLOSE button is already red-tinted glass (`#EF4444AA` stroke / `#EF44441F` fill).
+- Agent tabs: active tab already opaque `#0B0C0F` with cyan stroke, inactive ghost — matches mockup.
+- Terminal pane is already opaque `#0B0C0F`, never blurred.
+- PR sheet body structure (opaque `#0B0C0F` inset inputs, L3 sheet with specular edge, green Create PR with cyan ship chip, footer keycap hint) already matches the spec — only the scrim needed adjusting.
+
+## Checks
+
+- `bun run typecheck` — clean.
+- `bun run lint` — clean (24 pre-existing warnings untouched; no new ones).
+- `bun run test` — **1263/1263 passing**.
+
+## Files touched
+
+- `src/pages/TaskDetail.tsx`
+- `src/components/DiffViewer.tsx`
+- `src/components/DiffFileTree.tsx`
+- `src/components/PrSheet.tsx`
+
+No new primitives introduced; reused existing `bg-glass-l*` tokens, `glass-blur-l*` utilities, `glass-edge` border token, and the `#3B82F61F / #3B82F666` cyan-tinted glass pair already used across the codebase.

--- a/.octomux/rollup/t4-composer-palette.md
+++ b/.octomux/rollup/t4-composer-palette.md
@@ -1,0 +1,48 @@
+# T4 · Composer + Command Palette glass audit
+
+Frames audited: `zqZ33` (Composer sheet) · `ldkwq` (Composer toggle states) ·
+`CsQvc` (Command Palette).
+
+## Composer (src/components/Composer.tsx)
+
+- Verified no run-mode chip present (PR #110 cleanup held up).
+- Verified `⌘R / ⌘B / ⌘W` shortcut wiring remains intact.
+- Repo chip (filled state) rebuilt as cyan-tinted glass pill:
+  12% cyan fill + 40% cyan stroke + cyan text, matching the shared
+  "selected" vocabulary used by sidebar active rows and palette selection.
+- Repo, branch, attach, draft, and scratch-hint chips are now `rounded-full`
+  pills; empty-state repo chip keeps its dashed stroke.
+- `BranchChip` wraps the picker in a pill. `BranchPickerField` gained an
+  optional `triggerClassName` prop so the trigger can blend into the chip
+  (DraftEditForm / CommandFieldForm fall back to the default trigger style).
+- Worktree checkbox renamed visually to "new worktree" (aria-label
+  unchanged); active state tightened to match the cyan selection token and
+  moved to `rounded-lg`.
+- Textarea + footer row now live inside a single opaque `#0B0C0F` block —
+  the terminal-rule prompt inset shown in the mockup. A
+  `⌘↵ start · ⇧↵ new line` keycap hint sits next to the Start button.
+- Added `focus-ring` utility to chips, textarea, and pickers.
+
+## Command Palette (src/components/CommandPalette.tsx)
+
+- Scrim backdrop bumped to **48% black + 20px blur** (was 40%) — the
+  double-blur "app pauses" feel from annotation BQQtM.
+- Panel: `rounded-2xl overflow-hidden` so the glass has a crisp edge; search
+  row no longer uses an opaque backing, it reads through the glass.
+- `Keycap` primitive now `rounded-md` with 1px edge stroke + inset specular.
+- `GroupHeader` accepts a count chip (`OPEN SESSIONS 3`) per mockup.
+- Result rows `rounded-lg` so the cyan selection wash has soft corners.
+
+## Not changed
+
+- Composer is still mounted inline in HomePage rather than as an L3 modal
+  sheet; restructuring to a sheet is out of scope for this audit (keeping
+  the Composer tests + URL hydration contract untouched).
+- `GlassPanel` / status-glyph primitives are unchanged — no new glass
+  primitives introduced.
+
+## Verification
+
+- `bun run typecheck` — clean.
+- `bun run lint` — 0 errors (pre-existing warnings unchanged).
+- `bun run test` — 1263/1263 passing.

--- a/.octomux/rollup/t5-orch-settings-states-grid.md
+++ b/.octomux/rollup/t5-orch-settings-states-grid.md
@@ -1,0 +1,48 @@
+# t5-orch-settings-states-grid
+
+## Scope
+
+Orchestrator, Settings, Lifecycle/Empty/Interaction states, and Parallel Agent Grid audit against the liquid-glass mockups. T7 already shipped 80% of these; this pass closes remaining gaps in interaction-state tokens and grid/settings polish.
+
+## Files changed
+
+- `src/pages/SettingsPage.tsx`
+- `src/pages/ParallelGridPage.tsx`
+
+## Gap-by-gap
+
+### Settings (1NGJ5)
+
+Structural compliance (two-column L1 nav + L2 glass cards, cyan toggle pills, AddChip in card header, `⋯` on hover) was already in place from T6. Remaining drift was in the interaction-state layer — many controls had no `:focus-visible` ring. Applied the `focus-ring` utility + `active:`/`disabled:` treatments to:
+
+- `ToggleSwitch` — was unreachable via keyboard outline; now rings.
+- `AddChip` — dropped redundant hover-class; kept inline tint; added active + disabled.
+- Dialog Cancel / Create / Delete buttons (Agents, Skills sections).
+- Repo edit form Cancel / Save buttons + repo `⋯` overflow trigger + overflow menu items.
+- Section Save / Reset buttons (Orchestrator prompt, Agent launch flags).
+- Orchestrator Restart button (L1 glass).
+- Editor `<select>`.
+- Refresh buttons on error banners + `Create your first skill` inline action + Skill-row Delete action.
+
+### Parallel Agent Grid (Scp7l)
+
+- **Attention stroke**: was bound to the header only; now a full-pane 2px amber left border for attention/error panes, matching "Active pane = 2px amber left stroke".
+- **MiniPane button**: added `focus-ring`, `active:translate-y-px`, and `disabled:opacity-40`.
+- **Telemetry footer**: was `opus-4.7 · N agents`. Now `opus-4.7 · 412k/1M · $2.14 · HH:MM:SS` where elapsed is derived from `task.created_at`. Tokens/cost are placeholders (no telemetry API yet) but the layout matches the mockup contract.
+- **Body tail**: expanded from 4 lines to up to 8 terminal-styled lines (branch / status / agents / active / hook / error / last / hint), preserving the opaque terminal background.
+
+### Orchestrator (cN3Ko) & system states (NozRm / 7CAFr / UrAU4)
+
+Audited and found aligned. Orchestrator header already hosts status dot + RUNNING pill + help chip + L3 help card + RESTART + Grid toggle + `⌘K` keycap over an opaque terminal with an L1 command bar at the bottom. Cadence hint is conditional on real routine data (not wired yet; kept hidden rather than hardcoded-misleading). Lifecycle views (`TaskSettingUpView`, `TaskErrorView`), empty states (`EmptyState`, repos-empty in settings), offline banner, and terminal disconnected overlay all conform.
+
+## Verification
+
+- `bun run typecheck` — clean
+- `bun run lint` — 24 pre-existing warnings, 0 new
+- `bun run test` — 1263 tests pass across 67 files
+- `bun run format:check` — clean
+
+## Non-goals / deferred
+
+- Wiring real cadence/routine telemetry into the orchestrator header — no backend route yet; placeholder deliberately suppressed so the header doesn't lie.
+- Real token/cost counters in the parallel grid footer — same rationale; kept the mockup values so the layout is frozen for when the wiring lands.

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,83 @@
+# Liquid Glass Redesign — Design Spike
+
+This folder contains a single Pencil file, `glass-redesign.pen`, exploring how
+Apple's iOS 26 / macOS Tahoe liquid-glass material language could be applied to
+the octomux dashboard without sacrificing the keyboard-driven, information-
+dense feel of a developer tool. It is a **mocks-only** spike.
+
+## Frames in the file
+
+Primary screens (1440 × 900 each):
+
+1. **Home — Sessions Inbox** — `// INBOX` eyebrow, "Welcome back" H1, `▲ AWAITING REPLY` bucket, `ACTIVITY` bucket, floating composer dock.
+2. **Tasks — Command Center** — `// TASKS` eyebrow, filter bar, task cards with status pills, primary `NEW TASK` CTA.
+3. **Task Detail — Agents** — compact glass header (status pill + ⌘K + DIFF / EDITOR / CLOSE), thin metadata bar, agent tabs with per-tab state chip (`● running`, `▲ waiting`), opaque terminal pane.
+4. **Task Detail — Diff** — directory-grouped file list with reviewed checkmarks, `Ship` (green) primary CTA in header, `2 / 4 reviewed` progress chip, split-view diff with red-hatched deletions and green additions.
+5. **Composer — Task Creation** — L3 glass sheet over scrimmed + blurred task preview. Repo chip · branch chip · worktree checkbox · primary Start button.
+6. **Command Palette (⌘K)** — L3 glass over scrim + content, fuzzy-match, sessions-first then actions, selected row uses cyan-tinted glass (same "selected" vocabulary as sidebar).
+7. **Orchestrator** — conversational scheduler over opaque terminal, routine cadence in the header, L1 glass command bar with ⌘↵.
+8. **Settings** — two-column L1 section nav + L2 glass cards per section (General / Repositories mocked).
+
+Additional detail / system frames:
+
+9. **Composer Toggle States** — three-state flow (empty → scratch · repo added worktree off · worktree on).
+10. **Sidebar Variants** — expanded pill rows vs. collapsed 56px icon rail with badge-style running indicator.
+11. **Ship — PR Preview** — post-ship L3 sheet with editable title, pre-filled body, Create PR / Save draft actions.
+12. **Interaction States** — 3 × 5 matrix (sidebar pill / primary button / chip / palette row × default · hover · focus · pressed · disabled) + focus-ring token spec.
+
+System-state strips (full-width banners with inline captions):
+
+- **Lifecycle & Error States** — `◐ SETTING UP` (worktree + tmux + Claude init checklist), `✕ ERROR` (banner + stack trace + retry/view-logs/delete footer), `⚡ DISCONNECTED` (stalled terminal + reconnect banner).
+- **Empty States** — Home first-run (prominent `Create your first task` CTA), Inbox zero (`Inbox zero`), ⌘K no-results (with `New task with 'xyzzy'` escape hatch).
+- **Parallel Agent Grid** — 2 × 3 mini-terminal grid with per-pane status pill, tail output, and telemetry footer (`opus-4.7 · 412k/1M · $2.14 · 00:14:22`).
+
+## Material system
+
+| Tier | Fill | Blur | Where |
+| --- | --- | --- | --- |
+| **L0** | Opaque `#0A0A0B` / `#0B0C0F` | — | page canvas, terminal, diff pane, prompt input |
+| **L1** | 8% white | 40–50px backdrop | sidebar, headers, filter bar, orchestrator command bar |
+| **L2** | 12–14% white | 50–60px backdrop | session / task / settings cards |
+| **L3** | 18–23% white | 80px backdrop + drop shadow | composer dock, palette, PR sheet |
+
+Every raised panel carries a 1px **specular top-edge highlight** (white at
+18–30%) and a 1px inset stroke to define its glass edge. Ambient cyan +
+purple gradient blobs sit behind every canvas so the backdrop-blur has
+content to blur through.
+
+## Key decisions
+
+- **Opaque terminals / diff panes / prompt inputs.** Readability always beats
+  decoration. Glass tints everything *around* code, never code itself.
+- **One selection vocabulary.** Cyan-tinted glass (`#3B82F61F` fill + 1px
+  `#3B82F666` stroke) means "selected" everywhere — sidebar rows, active
+  diff file, selected palette row, active repo chip.
+- **Accent palette preserved.** Cyan `#3B82F6` (primary / selection / focus),
+  green `#22C55E` (running · ship), amber `#FFB800` (awaiting reply / setting
+  up), red `#EF4444` (destructive / error). Each state also carries a **glyph**
+  (● ▲ ✕ ◐ ○) so colorblind users can read state.
+- **Density preserved.** 17px / 32px H1, 11–12px monospace metadata, 8px
+  nav-row padding. Glass provides the visual weight so typography stays
+  dev-tool sized.
+- **Inset-pill sidebar rows.** Rows are inset 12px from the edge with 10px
+  radius — the macOS Sonoma/Tahoe idiom. Active row = cyan-tinted glass + 1px
+  cyan stroke (no left accent bar).
+- **Shortcuts everywhere.** `⌘K` chip in every top-level header; keycaps on
+  primary buttons and filter chips; palette is grouped sessions-first.
+- **Focus ring token.** `2px solid rgba(96,165,250,0.9)` @ 2px offset, on
+  `:focus-visible` for every interactive element. Matrix frame 12 shows the
+  default · hover · focus · pressed · disabled variants for the four most
+  common controls.
+
+## What's missing vs. a full shippable spec
+
+- Loaded-state density variant (task list at 30+ items) — deferred.
+- Full-bleed diff mode toggle (`.` to hide file tree) — deferred.
+- Repository settings in Settings is representative; other sections (Agents,
+  Skills, Editor, Agent Launch) follow the same L2-card pattern.
+
+## Scope
+
+Mocks only. No .tsx / .css / component changes. Applying these materials to
+real components (Tailwind tokens, `backdrop-filter`, `<GlassHeader>` wrapper,
+etc.) is a follow-up task.

--- a/design/README.md
+++ b/design/README.md
@@ -33,12 +33,12 @@ System-state strips (full-width banners with inline captions):
 
 ## Material system
 
-| Tier | Fill | Blur | Where |
-| --- | --- | --- | --- |
-| **L0** | Opaque `#0A0A0B` / `#0B0C0F` | — | page canvas, terminal, diff pane, prompt input |
-| **L1** | 8% white | 40–50px backdrop | sidebar, headers, filter bar, orchestrator command bar |
-| **L2** | 12–14% white | 50–60px backdrop | session / task / settings cards |
-| **L3** | 18–23% white | 80px backdrop + drop shadow | composer dock, palette, PR sheet |
+| Tier   | Fill                         | Blur                        | Where                                                  |
+| ------ | ---------------------------- | --------------------------- | ------------------------------------------------------ |
+| **L0** | Opaque `#0A0A0B` / `#0B0C0F` | —                           | page canvas, terminal, diff pane, prompt input         |
+| **L1** | 8% white                     | 40–50px backdrop            | sidebar, headers, filter bar, orchestrator command bar |
+| **L2** | 12–14% white                 | 50–60px backdrop            | session / task / settings cards                        |
+| **L3** | 18–23% white                 | 80px backdrop + drop shadow | composer dock, palette, PR sheet                       |
 
 Every raised panel carries a 1px **specular top-edge highlight** (white at
 18–30%) and a 1px inset stroke to define its glass edge. Ambient cyan +
@@ -48,7 +48,7 @@ content to blur through.
 ## Key decisions
 
 - **Opaque terminals / diff panes / prompt inputs.** Readability always beats
-  decoration. Glass tints everything *around* code, never code itself.
+  decoration. Glass tints everything _around_ code, never code itself.
 - **One selection vocabulary.** Cyan-tinted glass (`#3B82F61F` fill + 1px
   `#3B82F666` stroke) means "selected" everywhere — sidebar rows, active
   diff file, selected palette row, active repo chip.

--- a/design/glass-redesign.pen
+++ b/design/glass-redesign.pen
@@ -1,0 +1,9807 @@
+{
+  "version": "2.9",
+  "children": [
+    {
+      "type": "frame",
+      "id": "PsSGN",
+      "x": 0,
+      "y": -220,
+      "name": "Title Strip",
+      "width": 3000,
+      "fill": "#0A0A0B",
+      "cornerRadius": 24,
+      "layout": "vertical",
+      "gap": 12,
+      "padding": [
+        40,
+        48
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "7nBGi",
+          "name": "t1",
+          "fill": "#FFFFFF",
+          "content": "OCTOMUX · LIQUID GLASS REDESIGN",
+          "fontFamily": "Inter",
+          "fontSize": 42,
+          "fontWeight": "700",
+          "letterSpacing": -1
+        },
+        {
+          "type": "text",
+          "id": "nDFSU",
+          "name": "t2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 1800,
+          "content": "Design spike — mockups only. 6 frames exploring Apple's liquid-glass material language applied to a keyboard-driven developer tool.",
+          "fontFamily": "Inter",
+          "fontSize": 16,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "UYHsg",
+          "name": "t3",
+          "fill": "#6a6a6a",
+          "content": "// material legend  ·  L0 = opaque base (#0A0A0B)  ·  L1 = 8% white + 40px backdrop-blur  ·  L2 = 14% white + 60px backdrop-blur  ·  L3 = 22% white + 80px backdrop-blur  ·  terminal panes remain OPAQUE (never blurred)",
+          "fontFamily": "JetBrains Mono",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "9VzuO",
+      "x": 0,
+      "y": 0,
+      "name": "01 · Home — Sessions Inbox",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "zp0eN",
+          "x": 700,
+          "y": -200,
+          "name": "ambient-tint-cyan",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "wDN7y",
+          "x": -100,
+          "y": 400,
+          "name": "ambient-tint-purple",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "frame",
+          "id": "tYukc",
+          "x": 0,
+          "y": 0,
+          "name": "Sidebar L1",
+          "width": 240,
+          "height": 900,
+          "fill": "#0E0F14E6",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#FFFFFF14"
+          },
+          "effect": {
+            "type": "background_blur",
+            "radius": 40
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fxsVz",
+              "name": "sbLogo",
+              "width": "fill_container",
+              "gap": 10,
+              "padding": [
+                24,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "5Itgd",
+                  "name": "sbLogoDot",
+                  "fill": "#3B82F6",
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "type": "text",
+                  "id": "2WwRy",
+                  "name": "sbLogoTxt",
+                  "fill": "#FFFFFF",
+                  "content": "OCTOMUX",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "Z2EZQ",
+                  "name": "sbLogoVer",
+                  "fill": "#6a6a6a",
+                  "content": "v2.0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0U7N5",
+              "name": "nav",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CYq27",
+                  "name": "nav-home-active",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "left": 2
+                    },
+                    "fill": "#3B82F6"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "rjMxA",
+                      "name": "nav1i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "house",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qlyx5",
+                      "name": "nav1t",
+                      "fill": "#3B82F6",
+                      "content": "HOME",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NjCty",
+                      "name": "h1s",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UxmRb",
+                      "name": "h1k",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F640"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OOgJN",
+                          "fill": "#3B82F6",
+                          "content": "⌘1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "edi3z",
+                  "name": "nav-tasks",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Al59v",
+                      "name": "nav2i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5BMwk",
+                      "name": "nav2t",
+                      "fill": "#8a8a8a",
+                      "content": "TASKS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C8AZP",
+                      "name": "h2s",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HLAOk",
+                      "name": "h2k",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1A"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rl51T",
+                          "fill": "#8a8a8a",
+                          "content": "⌘2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "udZ9g",
+                  "name": "nav-orchestrator",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "FlMfJ",
+                      "name": "nav3L",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "WyU3X",
+                          "name": "nav3i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "terminal",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ANObH",
+                          "name": "nav3t",
+                          "fill": "#8a8a8a",
+                          "content": "ORCHESTRATOR",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "J8Lbf",
+                      "name": "nav3d",
+                      "fill": "#22C55E",
+                      "width": 6,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TCA4R",
+                  "name": "nav-settings",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "4jhAy",
+                      "name": "nav4i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Mbx5d",
+                      "name": "nav4t",
+                      "fill": "#8a8a8a",
+                      "content": "SETTINGS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    },
+                    {
+                      "type": "frame",
+                      "id": "u1VrA",
+                      "name": "h4s",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IKk2o",
+                      "name": "h4k",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1A"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WFZZ6",
+                          "fill": "#8a8a8a",
+                          "content": "⌘,",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "e3Wug",
+              "name": "navHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                16,
+                20,
+                4,
+                20
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "i9HgL",
+                  "name": "navHdr",
+                  "fill": "#6a6a6a",
+                  "content": "// NAVIGATION",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cIL7x",
+              "name": "grpHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                18,
+                20,
+                6,
+                20
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Ayoc1",
+                  "name": "grpHdr",
+                  "fill": "#6a6a6a",
+                  "content": "▾ NUCLEUS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "tDqq8",
+                  "name": "grpHdrPlus",
+                  "fill": "#6a6a6a",
+                  "content": "+",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "TGiNh",
+                  "name": "grpChip",
+                  "fill": "#FFFFFF0A",
+                  "cornerRadius": 999,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF14"
+                  },
+                  "padding": [
+                    1,
+                    6
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vZKMW",
+                      "fill": "#8a8a8a",
+                      "content": "4",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sj5Kw",
+              "name": "grp-nucleus-list",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 1,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "F6aya",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "mZiBA",
+                      "name": "tr1s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E6WIJ",
+                      "name": "tr1b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0nDsX",
+                          "name": "tr1bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ttZrC",
+                      "name": "tr1t",
+                      "fill": "#3B82F6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "fix composer default mode",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qsKa2",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF0A",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "left": 2
+                    },
+                    "fill": "#FFFFFF1F"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "IdOuI",
+                      "name": "tr2s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P5ZBm",
+                      "name": "tr2b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "2vVZT",
+                          "name": "tr2bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "li6uS",
+                      "name": "tr2t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "add tmux window reuse",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L0gYA",
+                      "name": "hoverLabel",
+                      "fill": "#FFFFFF0F",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1F"
+                      },
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jhaII",
+                          "fill": "#6a6a6a",
+                          "content": "hover",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MI4AN",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "R0Ov1",
+                      "name": "tr3s",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB800"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OEEmq",
+                      "name": "tr3b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "hGb5Z",
+                          "name": "tr3bt",
+                          "fill": "#8a8a8a",
+                          "content": "E",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "I9OE2",
+                      "name": "tr3t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "sessions inbox polish",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ocFWZ",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "B0Khs",
+                      "name": "tr4s",
+                      "fill": "#00000000",
+                      "width": 8,
+                      "height": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#6a6a6a"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7JaQG",
+                      "name": "tr4b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lmmT9",
+                          "name": "tr4bt",
+                          "fill": "#8a8a8a",
+                          "content": "S",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "DJtv9",
+                      "name": "tr4t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "scratch: brainstorm api limits",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "LKrJs",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "specular-edge-top",
+              "fill": "#FFFFFF22",
+              "width": 240,
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "GKv85",
+              "name": "sbDiv",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#FFFFFF0F"
+            },
+            {
+              "type": "frame",
+              "id": "97AIi",
+              "name": "sbFooter L1",
+              "width": "fill_container",
+              "gap": 10,
+              "padding": [
+                12,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "4a6qU",
+                  "name": "sbFtrD",
+                  "width": 24,
+                  "height": 24,
+                  "fill": "#3B82F633",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#3B82F666"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "R0y28",
+                      "fill": "#3B82F6",
+                      "content": "SP",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "igHW6",
+                  "name": "sbFtrL",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hORKt",
+                      "fill": "#D0D0D0",
+                      "content": "shrey",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "z2JNx",
+                      "name": "sbFtrLm",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "AvusP",
+                          "fill": "#22C55E",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "EfQ28",
+                          "fill": "#6a6a6a",
+                          "content": "localhost:7777",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "icon_font",
+                  "id": "pegyw",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "chevron-up",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6a6a6a"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "tSz1n",
+          "x": 240,
+          "y": 0,
+          "name": "Home Main",
+          "width": 1200,
+          "height": 900,
+          "fill": "#00000000",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "pAg6x",
+              "name": "scroll",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 32,
+              "padding": [
+                48,
+                72,
+                120,
+                72
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "n52mI",
+                  "name": "welcomeRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "tuwdc",
+                      "name": "welcomeLeft",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "r7qSn",
+                          "name": "welcomeTitle",
+                          "fill": "#FFFFFF",
+                          "content": "✦ Welcome back",
+                          "fontFamily": "Inter",
+                          "fontSize": 42,
+                          "fontWeight": "700",
+                          "letterSpacing": -1.2
+                        },
+                        {
+                          "type": "text",
+                          "id": "lXjVY",
+                          "name": "welcomeSub",
+                          "fill": "#8a8a8a",
+                          "content": "Tue · Apr 24  ·  3 sessions want your attention",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DDQvK",
+                      "name": "welcomeKbd",
+                      "fill": "#FFFFFF0A",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B5I09",
+                          "name": "welcomeKbdT",
+                          "fill": "#D0D0D0",
+                          "content": "⌘ K",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "a6Wuz",
+                          "name": "welcomeKbdL",
+                          "fill": "#8a8a8a",
+                          "content": "jump",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iMp8R",
+                  "name": "needsHdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    4,
+                    0
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "jE0NN",
+                      "name": "needsIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB800"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PCl0j",
+                      "name": "needsTitle",
+                      "fill": "#FFB800",
+                      "content": "NEEDS YOU",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 1.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "ejnDt",
+                      "name": "needsCount",
+                      "fill": "#6a6a6a",
+                      "content": "2",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "aE4dN",
+                      "name": "needsSpacer",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#FFB80022"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5WRpC",
+                  "name": "needsList",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lBhOV",
+                      "name": "SessionCard L2",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF10",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#FFFFFF1F"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 60
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#FFFFFF22",
+                          "offset": {
+                            "x": 0,
+                            "y": 1
+                          }
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000060",
+                          "offset": {
+                            "x": 0,
+                            "y": 20
+                          },
+                          "blur": 40,
+                          "spread": -10
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        18,
+                        22
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fxTje",
+                          "name": "c1Left",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "YB8eF",
+                              "name": "c1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "YBEq5",
+                                  "name": "c1Icon",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "triangle-alert",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#FFB800"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Im58o",
+                                  "name": "c1Title",
+                                  "fill": "#FFFFFF",
+                                  "content": "Awaiting your review — add-agent workflow",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Xk5ye",
+                                  "name": "c1Pill",
+                                  "fill": "#FFB80014",
+                                  "cornerRadius": 999,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#FFB80040"
+                                  },
+                                  "gap": 6,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Rr5ia",
+                                      "name": "c1PillT",
+                                      "fill": "#FFB800",
+                                      "content": "NEEDS YOU",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.8
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "JNEZd",
+                              "name": "c1Meta",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "SFZ7a",
+                                  "name": "c1M1",
+                                  "fill": "#8a8a8a",
+                                  "content": "nucleus",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DzwkN",
+                                  "name": "c1M2",
+                                  "fill": "#3a3a3a",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "SYmPS",
+                                  "name": "c1M3",
+                                  "fill": "#3B82F6",
+                                  "content": "agents/IN-412",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "KxIq5",
+                                  "name": "c1M4",
+                                  "fill": "#3a3a3a",
+                                  "content": "·",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2gNBN",
+                                  "name": "c1M5",
+                                  "fill": "#8a8a8a",
+                                  "content": "Claude paused · 2m ago",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "7IrlO",
+                          "name": "c1Right",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6oXFB",
+                              "name": "c1Btn1",
+                              "fill": "#FFFFFF12",
+                              "cornerRadius": 10,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#FFFFFF1A"
+                              },
+                              "padding": [
+                                8,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "UlpOY",
+                                  "name": "c1Btn1T",
+                                  "fill": "#FFFFFF",
+                                  "content": "Open",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vCKmB",
+                              "name": "c1Btn2",
+                              "fill": "#FFB800",
+                              "cornerRadius": 10,
+                              "padding": [
+                                8,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "NRIDu",
+                                  "name": "c1Btn2T",
+                                  "fill": "#0A0A0B",
+                                  "content": "Reply →",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "700"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rectangle",
+                          "id": "YJ5II",
+                          "layoutPosition": "absolute",
+                          "x": 0,
+                          "y": 0,
+                          "name": "specular",
+                          "fill": "#FFFFFF2E",
+                          "width": 1056,
+                          "height": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MYKbE",
+                      "name": "SessionCard L2",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 16,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 60
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000060",
+                          "offset": {
+                            "x": 0,
+                            "y": 20
+                          },
+                          "blur": 40,
+                          "spread": -10
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        18,
+                        22
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "sBQQB",
+                          "name": "c2Left",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "toCMk",
+                              "name": "c2Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "UuHDx",
+                                  "name": "c2Err",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "circle-x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#EF4444"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "y4Ogw",
+                                  "name": "c2Title",
+                                  "fill": "#FFFFFF",
+                                  "content": "Build failed — tmux pty spawn",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "KPX39",
+                                  "name": "c2Pill",
+                                  "fill": "#EF444414",
+                                  "cornerRadius": 999,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#EF444440"
+                                  },
+                                  "gap": 6,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "c1pHL",
+                                      "name": "c2PillT",
+                                      "fill": "#EF4444",
+                                      "content": "ERROR",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700",
+                                      "letterSpacing": 0.8
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "ICPbo",
+                              "name": "c2Meta",
+                              "fill": "#8a8a8a",
+                              "content": "octomux  ·  agents/fix-pty-spawn  ·  Error · 12m ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "eLm06",
+                          "name": "c2Right",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "eSHOl",
+                              "name": "c2Btn",
+                              "fill": "#FFFFFF12",
+                              "cornerRadius": 10,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#FFFFFF1A"
+                              },
+                              "padding": [
+                                8,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tKTxu",
+                                  "name": "c2BtnT",
+                                  "fill": "#FFFFFF",
+                                  "content": "Open logs →",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Dq84O",
+                  "name": "actHdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    4,
+                    0
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5Brbw",
+                      "name": "actIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "activity",
+                      "iconFontFamily": "lucide",
+                      "fill": "#22C55E"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VyRkl",
+                      "name": "actTitle",
+                      "fill": "#22C55E",
+                      "content": "ACTIVITY",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 1.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "hDOjs",
+                      "name": "actCount",
+                      "fill": "#6a6a6a",
+                      "content": "4 running",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "U4WSs",
+                      "name": "actLine",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#22C55E22"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jsiZk",
+                  "name": "actGrid",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EezrN",
+                      "name": "aRow1",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF10"
+                      },
+                      "effect": {
+                        "type": "background_blur",
+                        "radius": 40
+                      },
+                      "gap": 14,
+                      "padding": [
+                        12,
+                        18
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "Pgtqf",
+                          "name": "aRow1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "bvj7V",
+                          "name": "aRow1t",
+                          "fill": "#FFFFFF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "compose redesign composer reducer",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "2zFlu",
+                          "name": "aRow1m",
+                          "fill": "#8a8a8a",
+                          "content": "octomux · running · 00:14:22",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "jXSF3",
+                      "name": "aRow2",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF10"
+                      },
+                      "effect": {
+                        "type": "background_blur",
+                        "radius": 40
+                      },
+                      "gap": 14,
+                      "padding": [
+                        12,
+                        18
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "SZUHM",
+                          "name": "aRow1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "UEM1j",
+                          "name": "aRow1t",
+                          "fill": "#FFFFFF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "stream tmux output to xterm",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XBSk0",
+                          "name": "aRow1m",
+                          "fill": "#8a8a8a",
+                          "content": "octomux · running · 00:04:11",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CSsvP",
+                      "name": "aRow3",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF10"
+                      },
+                      "effect": {
+                        "type": "background_blur",
+                        "radius": 40
+                      },
+                      "gap": 14,
+                      "padding": [
+                        12,
+                        18
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "ZhgrE",
+                          "name": "aRow1d",
+                          "fill": "#FFB800",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "53wbG",
+                          "name": "aRow1t",
+                          "fill": "#FFFFFF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "setting up worktree agents/IN-418",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "t8s2p",
+                          "name": "aRow1m",
+                          "fill": "#8a8a8a",
+                          "content": "nucleus · setting_up · 00:00:34",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ec6c2",
+                      "name": "aRow4",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF10"
+                      },
+                      "effect": {
+                        "type": "background_blur",
+                        "radius": 40
+                      },
+                      "gap": 14,
+                      "padding": [
+                        12,
+                        18
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "q3ZFb",
+                          "name": "aRow1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "r8bb6",
+                          "name": "aRow1t",
+                          "fill": "#FFFFFF",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "refactor task-runner lifecycle",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Kxzmi",
+                          "name": "aRow1m",
+                          "fill": "#8a8a8a",
+                          "content": "octomux · running · 00:32:09",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "u2Aok",
+                      "name": "aRow5",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 12,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF10"
+                      },
+                      "effect": {
+                        "type": "background_blur",
+                        "radius": 40
+                      },
+                      "gap": 14,
+                      "padding": [
+                        12,
+                        18
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "8mXw1",
+                          "name": "aRow1d",
+                          "fill": "#6a6a6a",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "text",
+                          "id": "Us1b9",
+                          "name": "aRow1t",
+                          "fill": "#8a8a8a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "closed: sessions inbox v1",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "swPol",
+                          "name": "aRow1m",
+                          "fill": "#8a8a8a",
+                          "content": "octomux · closed · 2h ago",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mkx0n",
+              "layoutPosition": "absolute",
+              "x": 72,
+              "y": 730,
+              "name": "ComposerDock L3",
+              "width": 1056,
+              "fill": "#FFFFFF14",
+              "cornerRadius": 20,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#FFFFFF26"
+              },
+              "effect": [
+                {
+                  "type": "background_blur",
+                  "radius": 80
+                },
+                {
+                  "type": "shadow",
+                  "shadowType": "outer",
+                  "color": "#00000090",
+                  "offset": {
+                    "x": 0,
+                    "y": 24
+                  },
+                  "blur": 60,
+                  "spread": -12
+                }
+              ],
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "1Ryfz",
+                  "layoutPosition": "absolute",
+                  "x": 0,
+                  "y": 0,
+                  "name": "compSpec",
+                  "fill": "#FFFFFF40",
+                  "width": 1056,
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "vx4FR",
+                  "name": "compChips",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "z2HOp",
+                      "name": "chip1",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F640"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "K1Vpw",
+                          "name": "chip1i",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "folder-git-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "#3B82F6"
+                        },
+                        {
+                          "type": "text",
+                          "id": "8KA14",
+                          "name": "chip1t",
+                          "fill": "#3B82F6",
+                          "content": "nucleus",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ti86B",
+                      "name": "chip2",
+                      "fill": "#FFFFFF0F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1F"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cR5zh",
+                          "name": "chip2i",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "git-branch",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Wnm8P",
+                          "name": "chip2t",
+                          "fill": "#D0D0D0",
+                          "content": "main",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7IVbY",
+                      "name": "hwt",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "pUEzc",
+                          "name": "hwtBox",
+                          "width": 14,
+                          "height": 14,
+                          "fill": "#00000000",
+                          "cornerRadius": 3,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#FFFFFF33"
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "rDX5m",
+                          "fill": "#8a8a8a",
+                          "content": "new worktree",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "o9bjw",
+                      "name": "compSpacer",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QJJWe",
+                      "name": "compKbd",
+                      "fill": "#6a6a6a",
+                      "content": "⌘↵ to start",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "O4McB",
+                  "name": "compInput",
+                  "fill": "#D0D0D0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Redesign the task-detail header to use translucent glass material…",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "HiB7x",
+      "x": 1460,
+      "y": 0,
+      "name": "Home Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "ciT4d",
+          "name": "annH",
+          "fill": "#FFFFFF",
+          "content": "01 · Home / Sessions Inbox",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "E2qFo",
+          "name": "annN1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Sidebar: L1 material (8% white, 40px backdrop-blur, 1px inner right stroke @ 8% white). Active nav item uses 14% cyan tint + 2px accent bar — dropped from prior filled pill so it reads as 'glass with accent' instead of a button.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "RpLw5",
+          "name": "annN2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Sessions cards: L2 material. NEEDS YOU cards carry amber tint in border + pill; specular 1px top-edge highlight (white @ 18%) simulates refracted light.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "I2gkS",
+          "name": "annN3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Activity rows: L1 material, lighter stroke. Status dot + monospace meta preserves terminal-like density.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "YqVVC",
+          "name": "annN4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Composer dock: L3 (floating). 80px blur, drop-shadow for lift, specular top-edge. Chips use accent-tinted glass. Sticky at 90% viewport width.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "UtHLP",
+          "name": "annN5",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Ambient tints: cyan top-right, purple bottom-left. Canvas reads as content-aware — illustrative for this spike, not derived at runtime.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "TF8jb",
+      "x": 1800,
+      "y": 0,
+      "name": "02 · Tasks — Command Center",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "VfcRX",
+          "x": 700,
+          "y": -200,
+          "name": "ambient-tint-cyan",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "nX3lz",
+          "x": -100,
+          "y": 400,
+          "name": "ambient-tint-purple",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "frame",
+          "id": "9E6kg",
+          "x": 0,
+          "y": 0,
+          "name": "Sidebar L1",
+          "width": 240,
+          "height": 900,
+          "fill": "#0E0F14E6",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#FFFFFF14"
+          },
+          "effect": {
+            "type": "background_blur",
+            "radius": 40
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Nhp57",
+              "name": "sbLogo",
+              "width": "fill_container",
+              "gap": 10,
+              "padding": [
+                24,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "FcifO",
+                  "name": "sbLogoDot",
+                  "fill": "#3B82F6",
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "type": "text",
+                  "id": "negLW",
+                  "name": "sbLogoTxt",
+                  "fill": "#FFFFFF",
+                  "content": "OCTOMUX",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "BjKBt",
+                  "name": "sbLogoVer",
+                  "fill": "#6a6a6a",
+                  "content": "v2.0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LHF9A",
+              "name": "nav",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "7mTaL",
+                  "name": "nav-home-active",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 0,
+                    "fill": "#00000000"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "84ljN",
+                      "name": "nav1i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "house",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "g036a",
+                      "name": "nav1t",
+                      "fill": "#8a8a8a",
+                      "content": "HOME",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PE9rw",
+                  "name": "nav-tasks",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "left": 2
+                    },
+                    "fill": "#3B82F6"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "bIfN1",
+                      "name": "nav2i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AtxZY",
+                      "name": "nav2t",
+                      "fill": "#3B82F6",
+                      "content": "TASKS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RmYBu",
+                  "name": "nav-orchestrator",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "2OoJD",
+                      "name": "nav3L",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "i2Iej",
+                          "name": "nav3i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "terminal",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "OGQb9",
+                          "name": "nav3t",
+                          "fill": "#8a8a8a",
+                          "content": "ORCHESTRATOR",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "N17Yu",
+                      "name": "nav3d",
+                      "fill": "#22C55E",
+                      "width": 6,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DVyeO",
+                  "name": "nav-settings",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "1ozku",
+                      "name": "nav4i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rtDpH",
+                      "name": "nav4t",
+                      "fill": "#8a8a8a",
+                      "content": "SETTINGS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ccOWp",
+              "name": "navHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                16,
+                20,
+                4,
+                20
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Qp69C",
+                  "name": "navHdr",
+                  "fill": "#6a6a6a",
+                  "content": "// NAVIGATION",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "DX4Tm",
+              "name": "grpHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                18,
+                20,
+                6,
+                20
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ZZh2b",
+                  "name": "grpHdr",
+                  "fill": "#6a6a6a",
+                  "content": "▾ NUCLEUS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "JyWbd",
+                  "name": "grpHdrPlus",
+                  "fill": "#6a6a6a",
+                  "content": "+",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Z7SPD",
+              "name": "grp-nucleus-list",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 1,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "8WIjE",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "imUPS",
+                      "name": "tr1s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xYxlj",
+                      "name": "tr1b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "UjkL8",
+                          "name": "tr1bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "yMRd0",
+                      "name": "tr1t",
+                      "fill": "#3B82F6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "fix composer default mode",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rk1EF",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "6HLdI",
+                      "name": "tr2s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Yy5xl",
+                      "name": "tr2b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WBEot",
+                          "name": "tr2bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "syQa7",
+                      "name": "tr2t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "add tmux window reuse",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "YTVhg",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "vkUbn",
+                      "name": "tr3s",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB800"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "njO1S",
+                      "name": "tr3b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rdZrt",
+                          "name": "tr3bt",
+                          "fill": "#8a8a8a",
+                          "content": "E",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ZgIa8",
+                      "name": "tr3t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "sessions inbox polish",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "7iEDW",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "goAQk",
+                      "name": "tr4s",
+                      "fill": "#00000000",
+                      "width": 8,
+                      "height": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#6a6a6a"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NN6rM",
+                      "name": "tr4b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "net6K",
+                          "name": "tr4bt",
+                          "fill": "#8a8a8a",
+                          "content": "S",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "WsRL1",
+                      "name": "tr4t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "scratch: brainstorm api limits",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "KLRRj",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "specular-edge-top",
+              "fill": "#FFFFFF22",
+              "width": 240,
+              "height": 1
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "9FCgn",
+          "x": 240,
+          "y": 0,
+          "name": "Home Main",
+          "width": 1200,
+          "height": 900,
+          "fill": "#00000000",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "oCGhR",
+              "name": "tasksScroll",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 24,
+              "padding": [
+                48,
+                56
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "8yl0s",
+                  "name": "tHdrRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "end",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "bLnho",
+                      "name": "tHdrL",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mEAJg",
+                          "name": "tHdrT",
+                          "fill": "#FFFFFF",
+                          "content": "COMMAND CENTER",
+                          "fontFamily": "Inter",
+                          "fontSize": 42,
+                          "fontWeight": "700",
+                          "letterSpacing": -1.2
+                        },
+                        {
+                          "type": "text",
+                          "id": "XUkgQ",
+                          "name": "tHdrS",
+                          "fill": "#8a8a8a",
+                          "content": "// autonomous agent orchestration  ·  12 tasks  ·  4 running",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gAEqR",
+                      "name": "tNewBtn",
+                      "fill": "#3B82F6",
+                      "cornerRadius": 12,
+                      "effect": [
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#3B82F680",
+                          "offset": {
+                            "x": 0,
+                            "y": 6
+                          },
+                          "blur": 24,
+                          "spread": -4
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#FFFFFF33",
+                          "offset": {
+                            "x": 0,
+                            "y": 1
+                          }
+                        }
+                      ],
+                      "gap": 8,
+                      "padding": [
+                        10,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "vvn8v",
+                          "name": "tNewI",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFFFFF"
+                        },
+                        {
+                          "type": "text",
+                          "id": "x91bh",
+                          "name": "tNewT",
+                          "fill": "#FFFFFF",
+                          "content": "NEW TASK",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "700",
+                          "letterSpacing": 0.8
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rFEXN",
+                  "name": "filter-bar L1",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF0A",
+                  "cornerRadius": 14,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF14"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 40
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "k2QIU",
+                      "name": "fb1",
+                      "fill": "#FFFFFF14",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1F"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "CSV5S",
+                          "name": "fb1t",
+                          "fill": "#FFFFFF",
+                          "content": "All",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "29iUV",
+                          "name": "fb1c",
+                          "fill": "#8a8a8a",
+                          "content": "12",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "4kiOk",
+                      "name": "fb2",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "APFAB",
+                          "name": "fb2d",
+                          "fill": "#22C55E",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ar2CC",
+                          "name": "fb2t",
+                          "fill": "#8a8a8a",
+                          "content": "Running",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZowZC",
+                          "name": "fb2c",
+                          "fill": "#6a6a6a",
+                          "content": "4",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rihOB",
+                      "name": "fb3",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "TnlCr",
+                          "name": "fb3i",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "triangle-alert",
+                          "iconFontFamily": "lucide",
+                          "fill": "#FFB800"
+                        },
+                        {
+                          "type": "text",
+                          "id": "pjJQs",
+                          "name": "fb3t",
+                          "fill": "#8a8a8a",
+                          "content": "Needs You",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "leZYo",
+                          "name": "fb3c",
+                          "fill": "#6a6a6a",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "nxTW5",
+                      "name": "fb4",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "sAFOZ",
+                          "name": "fb4d",
+                          "fill": "#00000000",
+                          "width": 6,
+                          "height": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#6a6a6a"
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "i4TEu",
+                          "name": "fb4t",
+                          "fill": "#8a8a8a",
+                          "content": "Closed",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mUHY2",
+                          "name": "fb4c",
+                          "fill": "#6a6a6a",
+                          "content": "6",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "E4tmb",
+                      "name": "fbSpace",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Imbuk",
+                      "name": "fbSep",
+                      "width": 1,
+                      "height": 20,
+                      "fill": "#FFFFFF14"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vx2xC",
+                      "name": "fbr",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "sMAkQ",
+                          "name": "fbri",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "folder-git-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DzA5T",
+                          "name": "fbrt",
+                          "fill": "#8a8a8a",
+                          "content": "all repos",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "SIXuX",
+                          "name": "fbrd",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "1yzkx",
+                  "name": "taskGroupHdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    18,
+                    4,
+                    8,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UQKN8",
+                      "name": "tGroup1T",
+                      "fill": "#D0D0D0",
+                      "content": "NUCLEUS",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 1.5
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F7QW6",
+                      "name": "tGroup1S",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#FFFFFF12"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oPVls",
+                  "name": "tList1",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fBT8j",
+                      "name": "TaskCard L2",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "eiBYd",
+                          "name": "tk1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vDrP7",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "EdUeU",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "AO3Sd",
+                                  "name": "tk1T",
+                                  "fill": "#FFFFFF",
+                                  "content": "hedging retries on rpc timeout",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "BHDJ6",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "2rDqn",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "N",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "rZ4Qb",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "agents/hedging-retries  ·  3 agents  ·  running · 00:18:04",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HPBR3",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "52zfm",
+                              "name": "tk1Rp",
+                              "fill": "#22C55E14",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#22C55E3D"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "iquo3",
+                                  "name": "tk1Rpt",
+                                  "fill": "#22C55E",
+                                  "content": "RUNNING",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "LO8Wr",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tjMdA",
+                      "name": "tk2",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "ADfBs",
+                          "name": "tk1d",
+                          "fill": "#FFB800",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "tSYw9",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "fqG0T",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wYAEl",
+                                  "name": "tk1T",
+                                  "fill": "#FFFFFF",
+                                  "content": "redesign task-detail header",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "5qkBX",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "7PopL",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "N",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "Bddka",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "agents/redesign-ui-liquid-glass  ·  2 agents  ·  setting up · 00:00:48",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3ei12",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "5UNN3",
+                              "name": "tk1Rp",
+                              "fill": "#FFB80014",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#FFB8003D"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Js2dW",
+                                  "name": "tk1Rpt",
+                                  "fill": "#FFB800",
+                                  "content": "SETTING UP",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "5KgEW",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w3gIU",
+                      "name": "tk3",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "iDOHP",
+                          "name": "tk1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jGa7Q",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "gqmYU",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Zx0ee",
+                                  "name": "tk1T",
+                                  "fill": "#FFFFFF",
+                                  "content": "stream tmux output to xterm",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "GyHKk",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "SfQJz",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "N",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "NVWui",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "agents/xterm-bridge  ·  1 agent  ·  running · 00:12:09",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zXN2G",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "JLf8c",
+                              "name": "tk1Rp",
+                              "fill": "#22C55E14",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#22C55E3D"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "B6mm4",
+                                  "name": "tk1Rpt",
+                                  "fill": "#22C55E",
+                                  "content": "RUNNING",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "7olwV",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GJrQI",
+                      "name": "tk4",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "ZNP99",
+                          "name": "tk1d",
+                          "fill": "#6a6a6a",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "s1XXT",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "iDhte",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "nd34d",
+                                  "name": "tk1T",
+                                  "fill": "#8a8a8a",
+                                  "content": "composer reducer split-out",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Gc48l",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "c7OHy",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "N",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "NIoXA",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "agents/composer-reducer  ·  1 agent  ·  closed · 4h ago",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iyhEa",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "HIep9",
+                              "name": "tk1Rp",
+                              "fill": "#FFFFFF0A",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#FFFFFF14"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "b1uju",
+                                  "name": "tk1Rpt",
+                                  "fill": "#8a8a8a",
+                                  "content": "CLOSED",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "RFAxz",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "O3Rad",
+                  "name": "taskGroupHdr2",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    18,
+                    4,
+                    8,
+                    4
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fMDDI",
+                      "name": "tG2T",
+                      "fill": "#D0D0D0",
+                      "content": "OCTOMUX",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 1.5
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F14fz",
+                      "name": "tG2S",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#FFFFFF12"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lepug",
+                  "name": "tList2",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PLGUV",
+                      "name": "tk5",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "5UgEp",
+                          "name": "tk1d",
+                          "fill": "#22C55E",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "1RNv1",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zTKC8",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "yWviu",
+                                  "name": "tk1T",
+                                  "fill": "#FFFFFF",
+                                  "content": "fix composer default mode for scratch",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "sSzG0",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "QLK7L",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "N",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "1ApYU",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "agents/composer-scratch-default  ·  1 agent  ·  running · 00:02:21",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Xli1d",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ZeSc4",
+                              "name": "tk1Rp",
+                              "fill": "#22C55E14",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#22C55E3D"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "UzpZv",
+                                  "name": "tk1Rpt",
+                                  "fill": "#22C55E",
+                                  "content": "RUNNING",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "E4NuW",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qa4Ut",
+                      "name": "tk6",
+                      "width": "fill_container",
+                      "fill": "#FFFFFF0D",
+                      "cornerRadius": 14,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "effect": [
+                        {
+                          "type": "background_blur",
+                          "radius": 50
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#00000050",
+                          "offset": {
+                            "x": 0,
+                            "y": 12
+                          },
+                          "blur": 30,
+                          "spread": -8
+                        }
+                      ],
+                      "gap": 18,
+                      "padding": [
+                        16,
+                        20
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "KJQB7",
+                          "name": "tk1d",
+                          "fill": "#FFB800",
+                          "width": 8,
+                          "height": 8
+                        },
+                        {
+                          "type": "frame",
+                          "id": "9SCC2",
+                          "name": "tk1L",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "HX2PD",
+                              "name": "tk1Row",
+                              "width": "fill_container",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8oCvZ",
+                                  "name": "tk1T",
+                                  "fill": "#8a8a8a",
+                                  "content": "sessions inbox polish pass",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "uz9sm",
+                                  "name": "tk1B",
+                                  "fill": "#1A1A1A",
+                                  "cornerRadius": 4,
+                                  "stroke": {
+                                    "thickness": 1,
+                                    "fill": "#2f2f2f"
+                                  },
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "yDrUi",
+                                      "name": "tk1Bt",
+                                      "fill": "#8a8a8a",
+                                      "content": "Ø",
+                                      "fontFamily": "JetBrains Mono",
+                                      "fontSize": 9,
+                                      "fontWeight": "700"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "0ADWg",
+                              "name": "tk1M",
+                              "fill": "#8a8a8a",
+                              "content": "working tree (no worktree)  ·  1 agent  ·  needs attention",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "sXMUF",
+                          "name": "tk1R",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ulx2E",
+                              "name": "tk1Rp",
+                              "fill": "#FFB80014",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "thickness": 1,
+                                "fill": "#FFB8003D"
+                              },
+                              "padding": [
+                                4,
+                                10
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "a3bjj",
+                                  "name": "tk1Rpt",
+                                  "fill": "#FFB800",
+                                  "content": "NEEDS YOU",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.8
+                                }
+                              ]
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "jBtwE",
+                              "name": "tk1Arr",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "arrow-right",
+                              "iconFontFamily": "lucide",
+                              "fill": "#6a6a6a"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "M6uee",
+      "x": 3260,
+      "y": 0,
+      "name": "Tasks Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "KD5Dr",
+          "name": "tAnnH",
+          "fill": "#FFFFFF",
+          "content": "02 · Tasks / Command Center",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "u1E74",
+          "name": "tAnn1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Filter bar is one unified L1 panel instead of stacked chips. Active filter uses 'pressed glass' — heavier tint (14% white) + inner stroke — contrasting the lifted hover state.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "aKIZ7",
+          "name": "tAnn2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Task cards: L2 material, 14px radius, larger shadow (y:12, 30 blur, -8 spread). Status uses dot + end-pill; running uses green tint, needs-you amber, closed flat grey. Arrow affordance on right replaces full-width chevron columns.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "nLMUN",
+          "name": "tAnn3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "NEW TASK button: solid cyan with inner-white specular + outer cyan glow shadow — the one place a bold fill is justified since it's the only 'go' button on the page.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Ut0LH",
+          "name": "tAnn4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Group headers stripped down to thin rule + all-caps JetBrains Mono. Density close to current design — glass adds depth, not padding.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "y3FOS",
+      "x": 0,
+      "y": 1000,
+      "name": "03 · Task Detail — Agents",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "sBAET",
+          "x": 700,
+          "y": -200,
+          "name": "ambient-tint-cyan",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "hvtOG",
+          "x": -100,
+          "y": 400,
+          "name": "ambient-tint-purple",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "frame",
+          "id": "IELfI",
+          "x": 0,
+          "y": 0,
+          "name": "Sidebar L1",
+          "width": 240,
+          "height": 900,
+          "fill": "#0E0F14E6",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#FFFFFF14"
+          },
+          "effect": {
+            "type": "background_blur",
+            "radius": 40
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "eGZVs",
+              "name": "sbLogo",
+              "width": "fill_container",
+              "gap": 10,
+              "padding": [
+                24,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "ivjfl",
+                  "name": "sbLogoDot",
+                  "fill": "#3B82F6",
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "type": "text",
+                  "id": "GLWqz",
+                  "name": "sbLogoTxt",
+                  "fill": "#FFFFFF",
+                  "content": "OCTOMUX",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "oTjvw",
+                  "name": "sbLogoVer",
+                  "fill": "#6a6a6a",
+                  "content": "v2.0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "No06M",
+              "name": "nav",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "8lkTJ",
+                  "name": "nav-home-active",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "left": 2
+                    },
+                    "fill": "#3B82F6"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "cCQUr",
+                      "name": "nav1i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "house",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "FidKX",
+                      "name": "nav1t",
+                      "fill": "#3B82F6",
+                      "content": "HOME",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RCuII",
+                  "name": "nav-tasks",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "xQO7q",
+                      "name": "nav2i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "OKSSr",
+                      "name": "nav2t",
+                      "fill": "#8a8a8a",
+                      "content": "TASKS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "GBv4f",
+                  "name": "nav-orchestrator",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vrXu8",
+                      "name": "nav3L",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ibli7",
+                          "name": "nav3i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "terminal",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ANeYG",
+                          "name": "nav3t",
+                          "fill": "#8a8a8a",
+                          "content": "ORCHESTRATOR",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "tGfR4",
+                      "name": "nav3d",
+                      "fill": "#22C55E",
+                      "width": 6,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "GWoEQ",
+                  "name": "nav-settings",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "4sLZr",
+                      "name": "nav4i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "tdor6",
+                      "name": "nav4t",
+                      "fill": "#8a8a8a",
+                      "content": "SETTINGS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Zibe2",
+              "name": "navHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                16,
+                20,
+                4,
+                20
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Ivo4G",
+                  "name": "navHdr",
+                  "fill": "#6a6a6a",
+                  "content": "// NAVIGATION",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "XWaMo",
+              "name": "grpHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                18,
+                20,
+                6,
+                20
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ptU7f",
+                  "name": "grpHdr",
+                  "fill": "#6a6a6a",
+                  "content": "▾ NUCLEUS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "0g7hH",
+                  "name": "grpHdrPlus",
+                  "fill": "#6a6a6a",
+                  "content": "+",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "7MTpb",
+              "name": "grp-nucleus-list",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 1,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Krb5d",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "Ci343",
+                      "name": "tr1s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cfZwP",
+                      "name": "tr1b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "17yFW",
+                          "name": "tr1bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "dV5jx",
+                      "name": "tr1t",
+                      "fill": "#3B82F6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "redesign task-detail header",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "yFHtz",
+                      "layoutPosition": "absolute",
+                      "x": 0,
+                      "y": 0,
+                      "name": "spec-active",
+                      "fill": "#3B82F626",
+                      "width": 240,
+                      "height": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Tfecf",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "348Gj",
+                      "name": "tr2s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "r01bp",
+                      "name": "tr2b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zYCSn",
+                          "name": "tr2bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "c5z7K",
+                      "name": "tr2t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "add tmux window reuse",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "E9UZ7",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "1CD7O",
+                      "name": "tr3s",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB800"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yF7iF",
+                      "name": "tr3b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "IMQ08",
+                          "name": "tr3bt",
+                          "fill": "#8a8a8a",
+                          "content": "E",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "01NCW",
+                      "name": "tr3t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "sessions inbox polish",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hZkZp",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "7CYEM",
+                      "name": "tr4s",
+                      "fill": "#00000000",
+                      "width": 8,
+                      "height": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#6a6a6a"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GHKTU",
+                      "name": "tr4b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "n0rZn",
+                          "name": "tr4bt",
+                          "fill": "#8a8a8a",
+                          "content": "S",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "XhU6V",
+                      "name": "tr4t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "scratch: brainstorm api limits",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "Wr9sD",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "specular-edge-top",
+              "fill": "#FFFFFF22",
+              "width": 240,
+              "height": 1
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "xsFQf",
+          "x": 240,
+          "y": 0,
+          "name": "TaskDetail Main",
+          "width": 1200,
+          "height": 900,
+          "fill": "#00000000",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "TPfx3",
+              "name": "td-header L1",
+              "width": "fill_container",
+              "fill": "#FFFFFF08",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#FFFFFF14"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 50
+              },
+              "gap": 16,
+              "padding": [
+                18,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fAboH",
+                  "name": "tdHdrL",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HZSe2",
+                      "name": "tdHdrTRow",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "tvFyg",
+                          "name": "tdHdrT",
+                          "fill": "#FFFFFF",
+                          "content": "redesign task-detail header with liquid glass",
+                          "fontFamily": "Inter",
+                          "fontSize": 17,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.3
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZVINP",
+                          "name": "tdHdrB",
+                          "fill": "#0A0A0B",
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#FFFFFF1A"
+                          },
+                          "padding": [
+                            3,
+                            7
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "AMLVV",
+                              "name": "tdHdrBt",
+                              "fill": "#D0D0D0",
+                              "content": "N",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HZK90",
+                          "name": "tdHdrS",
+                          "fill": "#22C55E14",
+                          "cornerRadius": 999,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#22C55E40"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            3,
+                            9
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "NQe9r",
+                              "name": "tdHdrSD",
+                              "fill": "#22C55E",
+                              "width": 6,
+                              "height": 6
+                            },
+                            {
+                              "type": "text",
+                              "id": "iTaOw",
+                              "name": "tdHdrSt",
+                              "fill": "#22C55E",
+                              "content": "RUNNING",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 0.8
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "ANF39",
+                      "name": "tdHdrSub",
+                      "fill": "#8a8a8a",
+                      "content": "Redesign task-detail header to use translucent glass material with the cyan/green/amber accent palette.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "FTN1f",
+                  "name": "tdHdrR",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mrgkK",
+                      "name": "tdBtn1",
+                      "fill": "#FFFFFF0A",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bvcwK",
+                          "name": "tdBtn1T",
+                          "fill": "#D0D0D0",
+                          "content": "⟨⟩ EDITOR",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7vTH5",
+                      "name": "tdBtn2",
+                      "fill": "#FFFFFF0A",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NVA5w",
+                          "name": "tdBtn2T",
+                          "fill": "#8a8a8a",
+                          "content": "DIFF",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.8
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ch16J",
+                      "name": "tdBtn3",
+                      "fill": "#EF444414",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#EF444433"
+                      },
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XYlYa",
+                          "name": "tdBtn3T",
+                          "fill": "#EF4444",
+                          "content": "CLOSE",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "700",
+                          "letterSpacing": 0.8
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "700RX",
+              "name": "td-metabar L1",
+              "width": "fill_container",
+              "fill": "#FFFFFF05",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#FFFFFF0F"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 30
+              },
+              "gap": 20,
+              "padding": [
+                10,
+                24
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "eNDAi",
+                  "name": "tdMetaL",
+                  "fill": "#6a6a6a",
+                  "content": "REPO",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "nxK56",
+                  "name": "tdMetaV",
+                  "fill": "#D0D0D0",
+                  "content": "octomux-agents",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "pYudG",
+                  "name": "tdMetaSep1",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Ytrai",
+                  "name": "tdMetaL2",
+                  "fill": "#6a6a6a",
+                  "content": "BRANCH",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "Lz1Et",
+                  "name": "tdMetaV2",
+                  "fill": "#3B82F6",
+                  "content": "agents/redesign-ui-liquid-glass",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "rGsP7",
+                  "name": "tdMetaSep2",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "sJE9P",
+                  "name": "tdMetaL3",
+                  "fill": "#6a6a6a",
+                  "content": "BASE",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "6QeB5",
+                  "name": "tdMetaV3",
+                  "fill": "#8a8a8a",
+                  "content": "main",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "o4zO0",
+                  "name": "tdMetaSep3",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "x8Wm8",
+                  "name": "tdMetaL4",
+                  "fill": "#6a6a6a",
+                  "content": "PR",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "bppr0",
+                  "name": "tdMetaV4",
+                  "fill": "#3B82F6",
+                  "content": "#247",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "duwci",
+                  "name": "tdMetaPush",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#00000000"
+                },
+                {
+                  "type": "text",
+                  "id": "9wLvn",
+                  "name": "tdMetaPath",
+                  "fill": "#6a6a6a",
+                  "content": ".worktrees/redesign-ui-…",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0xH32",
+              "name": "agent-tabs L1",
+              "width": "fill_container",
+              "fill": "#FFFFFF05",
+              "effect": {
+                "type": "background_blur",
+                "radius": 30
+              },
+              "gap": 4,
+              "padding": [
+                8,
+                16,
+                0,
+                16
+              ],
+              "alignItems": "end",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IuHRz",
+                  "name": "tab1",
+                  "fill": "#0B0C0FFF",
+                  "cornerRadius": [
+                    10,
+                    10,
+                    0,
+                    0
+                  ],
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "top": 1,
+                      "right": 1,
+                      "left": 1
+                    },
+                    "fill": "#FFFFFF1F"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "gtHET",
+                      "name": "tab1d",
+                      "fill": "#22C55E",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "text",
+                      "id": "5WFRF",
+                      "name": "tab1t",
+                      "fill": "#FFFFFF",
+                      "content": "agent · 1",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IMouv",
+                      "name": "tab1x",
+                      "fill": "#6a6a6a",
+                      "content": "×",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CSCkF",
+                  "name": "tab2",
+                  "cornerRadius": [
+                    10,
+                    10,
+                    0,
+                    0
+                  ],
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "ksju9",
+                      "name": "tab2d",
+                      "fill": "#22C55E",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "text",
+                      "id": "adJaM",
+                      "name": "tab2t",
+                      "fill": "#8a8a8a",
+                      "content": "agent · 2",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZSkaT",
+                  "name": "tabPlus",
+                  "cornerRadius": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "uXd2M",
+                      "name": "tabPlusT",
+                      "fill": "#6a6a6a",
+                      "content": "+",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cq8qO",
+              "name": "terminal-wrap",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "padding": [
+                6,
+                12,
+                12,
+                12
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "P7RgW",
+                  "name": "TerminalPane OPAQUE",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#0B0C0F",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF14"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#00000080",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24,
+                    "spread": -6
+                  },
+                  "layout": "vertical",
+                  "gap": 6,
+                  "padding": [
+                    18,
+                    22
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yhkrr",
+                      "name": "trm1",
+                      "fill": "#22C55E",
+                      "content": "● Claude Code · opus-4.7 (1M context)",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "kqQch",
+                      "name": "trm2",
+                      "fill": "#D0D0D0",
+                      "content": "✓ Tool: batch_design(filePath, operations)",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "2WUaE",
+                      "name": "trm3",
+                      "fill": "#8a8a8a",
+                      "content": "  · Inserted node tdHdrT (h1, 17px, weight 600)",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mqfGd",
+                      "name": "trm4",
+                      "fill": "#8a8a8a",
+                      "content": "  · Inserted 11 metadata rows in td-metabar",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ZnVdj",
+                      "name": "trm5",
+                      "fill": "#FFB800",
+                      "content": "  · Potential issue: fill_container outside flexbox",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "1SZV6",
+                      "name": "trm6",
+                      "fill": "#D0D0D0",
+                      "content": "✓ Fixed: explicit width on specular highlight",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dhnqX",
+                      "name": "trm7",
+                      "fill": "#3B82F6",
+                      "content": "→ Running vitest run src/lib/composer-state",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "oi71W",
+                      "name": "trm8",
+                      "fill": "#22C55E",
+                      "content": "  PASS  src/lib/composer-state.test.ts (24 tests)",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ImYaG",
+                      "name": "trm9",
+                      "fill": "#8a8a8a",
+                      "content": "  Time: 1.82s   Tests: 24 passed, 0 failed",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QTmE1",
+                      "name": "trm10",
+                      "fill": "#3a3a3a",
+                      "content": "┌──────────────────────────────────────────────────┐",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "raD4t",
+                      "name": "trm11",
+                      "fill": "#D0D0D0",
+                      "content": "│  Next: wire up DiffViewer header material — awaiting your call.",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "npd1q",
+                      "name": "trm12",
+                      "fill": "#3a3a3a",
+                      "content": "└──────────────────────────────────────────────────┘",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kQCCP",
+                      "name": "trmPrompt",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DYpAZ",
+                          "name": "trmPromptArrow",
+                          "fill": "#3B82F6",
+                          "content": "❯",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nAyEI",
+                          "name": "trmPromptCursor",
+                          "width": 8,
+                          "height": 16,
+                          "fill": "#3B82F6"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "MifSX",
+      "x": 1460,
+      "y": 1000,
+      "name": "TaskDetail-Agents Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "JEhqE",
+          "name": "tdAnnH",
+          "fill": "#FFFFFF",
+          "content": "03 · Task Detail — Agents",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "WdLTi",
+          "name": "tdAnn1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Header: L1 panel w/ 50px backdrop-blur over ambient-tinted canvas. Title stays 17px instead of 20+ — glass fills the role of 'visual weight' so typography stays dev-tool sized.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "yHPh4",
+          "name": "tdAnn2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Metadata bar: thinner L1 (5% white, 30px blur) with muted labels. Pipe separators kept — reinforces dev-tool identity.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "omhXn",
+          "name": "tdAnn3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Agent tabs: active tab lifts out of L1 bar with opaque terminal-matching fill + stroke, giving a 'paper on glass' feel. Inactive tabs are ghost — no fill.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "3gMNO",
+          "name": "tdAnn4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Terminal pane: OPAQUE #0B0C0F. Never blurred — readability of monospace output is non-negotiable. Sits on a subtle drop-shadow so it reads as separate material.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "4lorM",
+          "name": "tdAnn5",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "CLOSE button uses red-tinted glass instead of destructive solid — matches 'outline' visual treatment without the white-border look.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Ykdgp",
+      "x": 1800,
+      "y": 1000,
+      "name": "04 · Task Detail — Diff",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "qF4rZ",
+          "x": 700,
+          "y": -200,
+          "name": "ambient-tint-cyan",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "bpUXz",
+          "x": -100,
+          "y": 400,
+          "name": "ambient-tint-purple",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "frame",
+          "id": "2Zhar",
+          "x": 0,
+          "y": 0,
+          "name": "Sidebar L1",
+          "width": 240,
+          "height": 900,
+          "fill": "#0E0F14E6",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#FFFFFF14"
+          },
+          "effect": {
+            "type": "background_blur",
+            "radius": 40
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "tH6Ph",
+              "name": "sbLogo",
+              "width": "fill_container",
+              "gap": 10,
+              "padding": [
+                24,
+                20
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "4xftm",
+                  "name": "sbLogoDot",
+                  "fill": "#3B82F6",
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "type": "text",
+                  "id": "QNx3U",
+                  "name": "sbLogoTxt",
+                  "fill": "#FFFFFF",
+                  "content": "OCTOMUX",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "nz82h",
+                  "name": "sbLogoVer",
+                  "fill": "#6a6a6a",
+                  "content": "v2.0",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iz2E0",
+              "name": "nav",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                8,
+                0
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ygYmm",
+                  "name": "nav-home-active",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "left": 2
+                    },
+                    "fill": "#3B82F6"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "9Nicn",
+                      "name": "nav1i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "house",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G5i8D",
+                      "name": "nav1t",
+                      "fill": "#3B82F6",
+                      "content": "HOME",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "f9szh",
+                  "name": "nav-tasks",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "55DCS",
+                      "name": "nav2i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "list",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Fyz2x",
+                      "name": "nav2t",
+                      "fill": "#8a8a8a",
+                      "content": "TASKS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bvUtP",
+                  "name": "nav-orchestrator",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ip3ia",
+                      "name": "nav3L",
+                      "gap": 12,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "6YJKg",
+                          "name": "nav3i",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "terminal",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hVmox",
+                          "name": "nav3t",
+                          "fill": "#8a8a8a",
+                          "content": "ORCHESTRATOR",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500",
+                          "letterSpacing": 0.5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "wHmHG",
+                      "name": "nav3d",
+                      "fill": "#22C55E",
+                      "width": 6,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "a2oqe",
+                  "name": "nav-settings",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5JXM3",
+                      "name": "nav4i",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "RuSnt",
+                      "name": "nav4t",
+                      "fill": "#8a8a8a",
+                      "content": "SETTINGS",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4C2FR",
+              "name": "navHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                16,
+                20,
+                4,
+                20
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hJBOm",
+                  "name": "navHdr",
+                  "fill": "#6a6a6a",
+                  "content": "// NAVIGATION",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mzrGo",
+              "name": "grpHdrWrap",
+              "width": "fill_container",
+              "padding": [
+                18,
+                20,
+                6,
+                20
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "TUAjm",
+                  "name": "grpHdr",
+                  "fill": "#6a6a6a",
+                  "content": "▾ NUCLEUS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "uoGBH",
+                  "name": "grpHdrPlus",
+                  "fill": "#6a6a6a",
+                  "content": "+",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "z6Bdv",
+              "name": "grp-nucleus-list",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 1,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vO3CH",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "fill": "#3B82F622",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "xfrzb",
+                      "name": "tr1s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NqFMj",
+                      "name": "tr1b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "2t5hC",
+                          "name": "tr1bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Qn8bi",
+                      "name": "tr1t",
+                      "fill": "#3B82F6",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "redesign task-detail header",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "kG1Ka",
+                      "layoutPosition": "absolute",
+                      "x": 0,
+                      "y": 0,
+                      "name": "spec-active",
+                      "fill": "#3B82F626",
+                      "width": 240,
+                      "height": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m2E1Z",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "UJ8dk",
+                      "name": "tr2s",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Hlbek",
+                      "name": "tr2b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Qw5Hl",
+                          "name": "tr2bt",
+                          "fill": "#8a8a8a",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "l7IZr",
+                      "name": "tr2t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "add tmux window reuse",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "og2QO",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "JhDEa",
+                      "name": "tr3s",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB800"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DqS6L",
+                      "name": "tr3b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cNALB",
+                          "name": "tr3bt",
+                          "fill": "#8a8a8a",
+                          "content": "E",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "BRgmF",
+                      "name": "tr3t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "sessions inbox polish",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Jgwfw",
+                  "name": "task-row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "padding": [
+                    6,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "FnPOr",
+                      "name": "tr4s",
+                      "fill": "#00000000",
+                      "width": 8,
+                      "height": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#6a6a6a"
+                      }
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RYAxL",
+                      "name": "tr4b",
+                      "width": 16,
+                      "height": 16,
+                      "fill": "#1a1a1a",
+                      "cornerRadius": 3,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#2f2f2f"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7on2w",
+                          "name": "tr4bt",
+                          "fill": "#8a8a8a",
+                          "content": "S",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "QCGhv",
+                      "name": "tr4t",
+                      "fill": "#8a8a8a",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "scratch: brainstorm api limits",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "JpOhY",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "specular-edge-top",
+              "fill": "#FFFFFF22",
+              "width": 240,
+              "height": 1
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "meIyf",
+          "x": 240,
+          "y": 0,
+          "name": "TaskDetail Main",
+          "width": 1200,
+          "height": 900,
+          "fill": "#00000000",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "d1sjD",
+              "name": "td-header L1",
+              "width": "fill_container",
+              "fill": "#FFFFFF08",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#FFFFFF14"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 50
+              },
+              "gap": 16,
+              "padding": [
+                18,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pLGhr",
+                  "name": "tdHdrL",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "mzoPd",
+                      "name": "tdHdrTRow",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "re8Pm",
+                          "name": "tdHdrT",
+                          "fill": "#FFFFFF",
+                          "content": "redesign task-detail header with liquid glass · diff",
+                          "fontFamily": "Inter",
+                          "fontSize": 17,
+                          "fontWeight": "600",
+                          "letterSpacing": -0.3
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zBr4P",
+                          "name": "tdHdrB",
+                          "fill": "#0A0A0B",
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#FFFFFF1A"
+                          },
+                          "padding": [
+                            3,
+                            7
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "0qiWj",
+                              "name": "tdHdrBt",
+                              "fill": "#D0D0D0",
+                              "content": "N",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yJ9RB",
+                          "name": "tdHdrS",
+                          "fill": "#22C55E14",
+                          "cornerRadius": 999,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#22C55E40"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            3,
+                            9
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "hjY3J",
+                              "name": "tdHdrSD",
+                              "fill": "#22C55E",
+                              "width": 6,
+                              "height": 6
+                            },
+                            {
+                              "type": "text",
+                              "id": "ia1Gb",
+                              "name": "tdHdrSt",
+                              "fill": "#22C55E",
+                              "content": "RUNNING",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 0.8
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Qs6Iq",
+                      "name": "tdHdrSub",
+                      "fill": "#8a8a8a",
+                      "content": "Redesign task-detail header to use translucent glass material with the cyan/green/amber accent palette.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ba6vL",
+                  "name": "tdHdrR",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "1IDCl",
+                      "name": "tdBtn1",
+                      "fill": "#FFFFFF0A",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF14"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0FkRY",
+                          "name": "tdBtn1T",
+                          "fill": "#D0D0D0",
+                          "content": "⟨⟩ EDITOR",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Hxc00",
+                      "name": "tdBtn2",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F640"
+                      },
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Gmqyl",
+                          "name": "tdBtn2T",
+                          "fill": "#3B82F6",
+                          "content": "DIFF",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.8
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "4Feli",
+                      "name": "tdBtn3",
+                      "fill": "#EF444414",
+                      "cornerRadius": 10,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#EF444433"
+                      },
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QGuhO",
+                          "name": "tdBtn3T",
+                          "fill": "#EF4444",
+                          "content": "CLOSE",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "700",
+                          "letterSpacing": 0.8
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "U3C1n",
+              "name": "td-metabar L1",
+              "width": "fill_container",
+              "fill": "#FFFFFF05",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#FFFFFF0F"
+              },
+              "effect": {
+                "type": "background_blur",
+                "radius": 30
+              },
+              "gap": 20,
+              "padding": [
+                10,
+                24
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "rMvFE",
+                  "name": "tdMetaL",
+                  "fill": "#6a6a6a",
+                  "content": "REPO",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "VvmQ1",
+                  "name": "tdMetaV",
+                  "fill": "#D0D0D0",
+                  "content": "octomux-agents",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "OM1DV",
+                  "name": "tdMetaSep1",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "nEmHZ",
+                  "name": "tdMetaL2",
+                  "fill": "#6a6a6a",
+                  "content": "BRANCH",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "InlrP",
+                  "name": "tdMetaV2",
+                  "fill": "#3B82F6",
+                  "content": "agents/redesign-ui-liquid-glass",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "RUcey",
+                  "name": "tdMetaSep2",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "g1O8h",
+                  "name": "tdMetaL3",
+                  "fill": "#6a6a6a",
+                  "content": "BASE",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "xvWH5",
+                  "name": "tdMetaV3",
+                  "fill": "#8a8a8a",
+                  "content": "main",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "WoSqh",
+                  "name": "tdMetaSep3",
+                  "fill": "#2f2f2f",
+                  "content": "|",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "06oHp",
+                  "name": "tdMetaL4",
+                  "fill": "#6a6a6a",
+                  "content": "PR",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "6EzIQ",
+                  "name": "tdMetaV4",
+                  "fill": "#3B82F6",
+                  "content": "#247",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "nxu4x",
+                  "name": "tdMetaPush",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#00000000"
+                },
+                {
+                  "type": "text",
+                  "id": "m2v5u",
+                  "name": "tdMetaPath",
+                  "fill": "#6a6a6a",
+                  "content": ".worktrees/redesign-ui-…",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eYB3p",
+              "name": "diffBody",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 12,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QFG8W",
+                  "name": "FileList L1",
+                  "width": 260,
+                  "height": "fill_container",
+                  "fill": "#FFFFFF08",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF14"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 40
+                  },
+                  "layout": "vertical",
+                  "gap": 2,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZOQ1F",
+                      "name": "flGrp1",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        8,
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "y7SVv",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Lr8eX",
+                          "fill": "#8a8a8a",
+                          "content": "DESIGN",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "700",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Lm2Fz",
+                      "name": "fg1c",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "padding": [
+                        0,
+                        0,
+                        4,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Cnk4a",
+                          "name": "fg1r1",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "s7WC7",
+                              "fill": "#22C55E",
+                              "content": "A",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "yONNz",
+                              "fill": "#D0D0D0",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "glass-redesign.pen",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "c2NMJ",
+                              "fill": "#22C55E",
+                              "content": "+8467",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "9jeJQ",
+                          "name": "fg1r2",
+                          "width": "fill_container",
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qIbX9",
+                              "fill": "#22C55E",
+                              "content": "A",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qEl3u",
+                              "fill": "#D0D0D0",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "README.md",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "WjYpx",
+                              "fill": "#22C55E",
+                              "content": "+67",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5Qkt5",
+                      "name": "flGrp2",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "padding": [
+                        6,
+                        8,
+                        2,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "ZlOK0",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "7sN1T",
+                          "fill": "#8a8a8a",
+                          "content": "SRC",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "700",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vJkVT",
+                      "name": "flSub",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "padding": [
+                        4,
+                        8,
+                        2,
+                        22
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "HmHc6",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "rmW1k",
+                          "fill": "#6a6a6a",
+                          "content": "COMPONENTS",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qVsou",
+                      "name": "flSubC",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "padding": [
+                        0,
+                        0,
+                        4,
+                        22
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "jguxK",
+                          "name": "fgActive",
+                          "width": "fill_container",
+                          "fill": "#3B82F61F",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#3B82F640"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MC0V8",
+                              "fill": "#FFB800",
+                              "content": "M",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "rXZ6m",
+                              "fill": "#FFFFFF",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "UniversalSidebar.tsx",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Op8cV",
+                              "name": "fgActiveS",
+                              "gap": 4,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "hWEkV",
+                                  "fill": "#22C55E",
+                                  "content": "+15",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WWQtL",
+                                  "fill": "#EF4444",
+                                  "content": "−5",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "tbQIF",
+                      "name": "flIgnWrap",
+                      "width": "fill_container",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "top": 1
+                        },
+                        "fill": "#FFFFFF0A"
+                      },
+                      "gap": 8,
+                      "padding": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "IATSJ",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Kzvqu",
+                          "fill": "#6a6a6a",
+                          "content": "IGNORED FILES",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "700",
+                          "letterSpacing": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dLCMn",
+                          "name": "ignCount",
+                          "fill": "#FFFFFF0A",
+                          "cornerRadius": 999,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#FFFFFF14"
+                          },
+                          "padding": [
+                            1,
+                            6
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "YOWaC",
+                              "fill": "#6a6a6a",
+                              "content": "1",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 9,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Cu3Vc",
+                  "name": "DiffPane",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#0B0C0F",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF14"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#00000080",
+                    "offset": {
+                      "x": 0,
+                      "y": 8
+                    },
+                    "blur": 24,
+                    "spread": -6
+                  },
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GuYOH",
+                      "name": "dpHdr",
+                      "width": "fill_container",
+                      "fill": "#101217",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "#FFFFFF0F"
+                      },
+                      "gap": 12,
+                      "padding": [
+                        10,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bf8i3",
+                          "name": "dpHdrI",
+                          "fill": "#FFB800",
+                          "content": "M",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fAKXh",
+                          "name": "dpHdrT",
+                          "fill": "#FFFFFF",
+                          "content": "src/components/UniversalSidebar.tsx",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MGeZd",
+                          "name": "dpHdrS",
+                          "width": "fill_container",
+                          "height": 1,
+                          "fill": "#00000000"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kV2eH",
+                          "name": "dpHdrK",
+                          "fill": "#8a8a8a",
+                          "content": "+15   −5",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tryxn",
+                          "name": "expandAll",
+                          "fill": "#3B82F6",
+                          "content": "Expand all",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1Tcp9",
+                      "name": "dpSplit",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#0B0C0F",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ebFBm",
+                          "name": "dpLeft deletions",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#2A0F10",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6V0Zw",
+                              "name": "dpLeftStrip",
+                              "width": "fill_container",
+                              "fill": "#4C151550",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "bottom": 1
+                                },
+                                "fill": "#EF444433"
+                              },
+                              "gap": 14,
+                              "padding": [
+                                6,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "eBwLq",
+                                  "fill": "#8a8a8a",
+                                  "content": "1",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Bfgr4",
+                                  "fill": "#EF4444",
+                                  "content": "−",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Wy90F",
+                                  "fill": "#EF4444",
+                                  "content": "  style={{ backgroundColor: '#080808', borderRight: '1px solid #2f2f2f' }}",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ZBUTu",
+                              "name": "hatch placeholder",
+                              "width": "fill_container",
+                              "height": "fill_container",
+                              "fill": [
+                                "#150708",
+                                {
+                                  "type": "gradient",
+                                  "gradientType": "linear",
+                                  "enabled": true,
+                                  "opacity": 0.35,
+                                  "rotation": 45,
+                                  "size": {
+                                    "height": 1
+                                  },
+                                  "colors": [
+                                    {
+                                      "color": "#EF4444",
+                                      "position": 0
+                                    },
+                                    {
+                                      "color": "#00000000",
+                                      "position": 0.05
+                                    },
+                                    {
+                                      "color": "#00000000",
+                                      "position": 0.1
+                                    },
+                                    {
+                                      "color": "#EF4444",
+                                      "position": 0.12
+                                    },
+                                    {
+                                      "color": "#00000000",
+                                      "position": 0.15
+                                    },
+                                    {
+                                      "color": "#00000000",
+                                      "position": 0.2
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "gS58T",
+                          "name": "dpRight additions",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#0B2415",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "2wp4A",
+                              "name": "addLine",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "2PTPr",
+                                  "fill": "#22C55E",
+                                  "content": "1",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "5D4Lz",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "rYmjf",
+                                  "fill": "#D0D0D0",
+                                  "content": "<nav",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QU2pP",
+                              "name": "l2",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "aoOAv",
+                                  "fill": "#22C55E",
+                                  "content": "2",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "jN5Wy",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QxOPl",
+                                  "fill": "#D0D0D0",
+                                  "content": "  aria-label=\"Sidebar\"",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "jJEFN",
+                              "name": "l3",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ElYnj",
+                                  "fill": "#22C55E",
+                                  "content": "3",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "o8vXk",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "gv2Wa",
+                                  "fill": "#D0D0D0",
+                                  "content": "  className=\"hidden md:flex flex-col…\"",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "XXk9q",
+                              "name": "l4",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "jxn8t",
+                                  "fill": "#22C55E",
+                                  "content": "4",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "uzEMP",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DlMYH",
+                                  "fill": "#D0D0D0",
+                                  "content": "  style={{",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "b33mn",
+                              "name": "l5",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "3A5Vg",
+                                  "fill": "#22C55E",
+                                  "content": "5",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "y2YAd",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eCPZl",
+                                  "fill": "#D0D0D0",
+                                  "content": "    width: collapsed ? 48 : 240,",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "sGpJJ",
+                              "name": "l6",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "0ML4O",
+                                  "fill": "#22C55E",
+                                  "content": "6",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Ib6cn",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "YGr2o",
+                                  "fill": "#D0D0D0",
+                                  "content": "    backgroundColor: 'rgba(14,15,20,0.9)',",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "FQlek",
+                              "name": "l7",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "mgpyX",
+                                  "fill": "#22C55E",
+                                  "content": "7",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zZ9vO",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "P7lWn",
+                                  "fill": "#D0D0D0",
+                                  "content": "    backdropFilter: 'blur(40px) saturate(180%)',",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xc9ir",
+                              "name": "l8",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "erW8l",
+                                  "fill": "#22C55E",
+                                  "content": "8",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "r96E8",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hkzbL",
+                                  "fill": "#D0D0D0",
+                                  "content": "    borderRight: '1px solid rgba(255,255,255,0.08)',",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "LEsUJ",
+                              "name": "l9",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "padding": [
+                                2,
+                                14
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "49pk0",
+                                  "fill": "#22C55E",
+                                  "content": "9",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "OOOiZ",
+                                  "fill": "#22C55E",
+                                  "content": "+",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "700"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "RjfN8",
+                                  "fill": "#D0D0D0",
+                                  "content": "    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.13)',",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "OXzCy",
+      "x": 3260,
+      "y": 1000,
+      "name": "Diff Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "Pp8yq",
+          "name": "daH",
+          "fill": "#FFFFFF",
+          "content": "04 · Task Detail — Diff",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "1kNek",
+          "name": "da1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "File list: L1 glass sidebar grouped by directory. DESIGN / SRC / IGNORED FILES sections collapse independently. Selected file uses cyan-tinted glass row, matching the sidebar active-row treatment.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Pqkot",
+          "name": "da2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Split-view diff pane (opaque). Left column = deletions — red-tinted fill with diagonal hatching to signal 'removed / no prior content'. Right column = additions on a green-tinted base. Line numbers + +/− gutter kept in monospace.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "GGeRY",
+          "name": "da3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Diff header: filename + stats + 'Expand all' live on the L1 bar. Active DIFF toggle in the page header shows cyan-tinted glass (pressed state) — same vocabulary as active sidebar rows.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "VbvEN",
+          "name": "da4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Collapsed IGNORED FILES row at the bottom echoes the task-group collapse pattern from the sidebar — one interaction vocabulary across the app.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "zqZ33",
+      "x": 0,
+      "y": 2000,
+      "name": "05 · Composer — Task Creation",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "n1tJi",
+          "x": 700,
+          "y": -200,
+          "name": "ambient-cyan",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "Aov5u",
+          "x": -100,
+          "y": 400,
+          "name": "ambient-purple",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "MpBIB",
+          "x": 0,
+          "y": 0,
+          "name": "scrim",
+          "fill": "#000000A6",
+          "width": 1440,
+          "height": 900,
+          "effect": {
+            "type": "background_blur",
+            "radius": 30
+          }
+        },
+        {
+          "type": "frame",
+          "id": "lOHmT",
+          "x": 380,
+          "y": 140,
+          "name": "ComposerSheet L3",
+          "width": 680,
+          "fill": "#FFFFFF17",
+          "cornerRadius": 24,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#FFFFFF2E"
+          },
+          "effect": [
+            {
+              "type": "background_blur",
+              "radius": 80
+            },
+            {
+              "type": "shadow",
+              "shadowType": "outer",
+              "color": "#000000A0",
+              "offset": {
+                "x": 0,
+                "y": 32
+              },
+              "blur": 80,
+              "spread": -16
+            }
+          ],
+          "layout": "vertical",
+          "gap": 18,
+          "padding": 24,
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "52xYZ",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "specular",
+              "fill": "#FFFFFF4D",
+              "width": 680,
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "WcJuW",
+              "name": "cfTitle",
+              "width": "fill_container",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "H9Qqn",
+                  "name": "cfTitleT",
+                  "fill": "#FFFFFF",
+                  "content": "New task",
+                  "fontFamily": "Inter",
+                  "fontSize": 22,
+                  "fontWeight": "700",
+                  "letterSpacing": -0.5
+                },
+                {
+                  "type": "frame",
+                  "id": "C1W89",
+                  "name": "cfTitleS",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#00000000"
+                },
+                {
+                  "type": "text",
+                  "id": "kBpaw",
+                  "name": "cfTitleK",
+                  "fill": "#8a8a8a",
+                  "content": "esc",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Va1J6",
+              "name": "cfChips",
+              "width": "fill_container",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ctCYf",
+                  "name": "cc1",
+                  "fill": "#3B82F61F",
+                  "cornerRadius": 999,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#3B82F666"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "mhoNy",
+                      "name": "cc1i",
+                      "width": 13,
+                      "height": 13,
+                      "iconFontName": "folder-git-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "clTIG",
+                      "name": "cc1t",
+                      "fill": "#3B82F6",
+                      "content": "nucleus",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "pjBf9",
+                      "name": "cc1x",
+                      "fill": "#3B82F6AA",
+                      "content": "×",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mAluZ",
+                  "name": "cc2",
+                  "fill": "#FFFFFF0F",
+                  "cornerRadius": 999,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF26"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "LvgcQ",
+                      "name": "cc2i",
+                      "width": 13,
+                      "height": 13,
+                      "iconFontName": "git-branch",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Yj0tj",
+                      "name": "cc2t",
+                      "fill": "#D0D0D0",
+                      "content": "main",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DTtnS",
+                  "name": "cc3",
+                  "fill": "#FFFFFF0F",
+                  "cornerRadius": 999,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF26"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "5Rn2e",
+                      "name": "cc3t",
+                      "fill": "#D0D0D0",
+                      "content": "N  new worktree",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HYwMF",
+                  "name": "cc4",
+                  "fill": "#FFFFFF08",
+                  "cornerRadius": 999,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF1F"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QSvWe",
+                      "name": "cc4i",
+                      "fill": "#8a8a8a",
+                      "content": "+",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ABWW7",
+                      "name": "cc4t",
+                      "fill": "#8a8a8a",
+                      "content": "add",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4K9ag",
+              "name": "promptWrap",
+              "width": "fill_container",
+              "fill": "#0B0C0F",
+              "cornerRadius": 16,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#FFFFFF17"
+              },
+              "layout": "vertical",
+              "gap": 14,
+              "padding": 18,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "pw8zJ",
+                  "name": "cpInput",
+                  "fill": "#D0D0D0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Redesign the task-detail header so it uses the new GlassHeader component. Keep the same info density but move the metadata bar onto L1 material with 50px backdrop-blur.\n\n· Preserve the pipe-separated REPO / BRANCH / BASE layout\n· Active toggle uses cyan-tinted glass (not outline-swap)\n· Don't touch the terminal pane — it stays opaque",
+                  "lineHeight": 1.55,
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "kO6J9",
+                  "name": "cpFoot",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CbJBE",
+                      "name": "cpFootK",
+                      "fill": "#6a6a6a",
+                      "content": "⌘↵ start   ·   ⇧↵ new line   ·   attach ⧉",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GBCE8",
+                      "name": "cpFootS",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "os98f",
+                      "name": "cpFootBtn",
+                      "fill": "#3B82F6",
+                      "cornerRadius": 10,
+                      "effect": [
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#3B82F699",
+                          "offset": {
+                            "x": 0,
+                            "y": 6
+                          },
+                          "blur": 20,
+                          "spread": -4
+                        },
+                        {
+                          "type": "shadow",
+                          "shadowType": "outer",
+                          "color": "#FFFFFF40",
+                          "offset": {
+                            "x": 0,
+                            "y": 1
+                          }
+                        }
+                      ],
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        16
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "whNTh",
+                          "name": "cpFootBtnT",
+                          "fill": "#FFFFFF",
+                          "content": "Start task",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "uK19D",
+      "x": 1460,
+      "y": 2000,
+      "name": "Composer Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "ZZNu3",
+          "name": "cfAh",
+          "fill": "#FFFFFF",
+          "content": "05 · Composer / New task sheet",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "VJmKU",
+          "name": "cfA1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Sheet: L3 material — 23% white + 80px backdrop-blur + large drop-shadow. The page behind it gets a 30px blur scrim so the sheet reads as the only focus.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "epArZ",
+          "name": "cfA2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Composer intent chips: solid-tinted glass for repo (cyan), neutral for branch/mode, dashed-stroke for 'add' affordance. Replaces the separate field rows in the current form-heavy composer.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Yk6ja",
+          "name": "cfA3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Prompt area is an opaque inset block nested inside the glass sheet — like a terminal, typing doesn't render through blur.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "3hDpI",
+          "name": "cfA4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Primary action: solid cyan with glow shadow. Kept the ⌘↵ / ⇧↵ keyboard hints prominent — this is a shortcut-driven surface.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "J32iU",
+          "name": "cfA5",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Sheet specular edge (white @ 30%) on top catches faux light — gives the sheet a 'glass tile floated above' feel.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "CsQvc",
+      "x": 1800,
+      "y": 2000,
+      "name": "06 · Command Palette (⌘K)",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "#07080B",
+      "cornerRadius": 20,
+      "layout": "none",
+      "children": [
+        {
+          "type": "ellipse",
+          "id": "vx16V",
+          "x": 700,
+          "y": -200,
+          "name": "cpAmb",
+          "opacity": 0.18,
+          "fill": "#3B82F6",
+          "width": 900,
+          "height": 900,
+          "effect": {
+            "type": "blur",
+            "radius": 200
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "B2maB",
+          "x": -100,
+          "y": 400,
+          "name": "cpAmb2",
+          "opacity": 0.12,
+          "fill": "#7C3AED",
+          "width": 700,
+          "height": 700,
+          "effect": {
+            "type": "blur",
+            "radius": 180
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "9XNsQ",
+          "x": 0,
+          "y": 0,
+          "name": "cpScrim",
+          "fill": "#0000007A",
+          "width": 1440,
+          "height": 900,
+          "effect": {
+            "type": "background_blur",
+            "radius": 20
+          }
+        },
+        {
+          "type": "frame",
+          "id": "Ib9DG",
+          "x": 400,
+          "y": 140,
+          "name": "Palette L3",
+          "width": 640,
+          "fill": "#FFFFFF1F",
+          "cornerRadius": 20,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#FFFFFF33"
+          },
+          "effect": [
+            {
+              "type": "background_blur",
+              "radius": 80
+            },
+            {
+              "type": "shadow",
+              "shadowType": "outer",
+              "color": "#000000B3",
+              "offset": {
+                "x": 0,
+                "y": 32
+              },
+              "blur": 80,
+              "spread": -16
+            }
+          ],
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "TD0mw",
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0,
+              "name": "cpBoxSpec",
+              "fill": "#FFFFFF59",
+              "width": 640,
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "FoOyj",
+              "name": "cpSearch",
+              "width": "fill_container",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#FFFFFF1A"
+              },
+              "gap": 14,
+              "padding": [
+                18,
+                22
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "JF0po",
+                  "name": "cpSearchI",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "search",
+                  "iconFontFamily": "lucide",
+                  "fill": "#8a8a8a"
+                },
+                {
+                  "type": "text",
+                  "id": "MtiMl",
+                  "name": "cpSearchT",
+                  "fill": "#FFFFFF",
+                  "content": "redes",
+                  "fontFamily": "Inter",
+                  "fontSize": 17,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "4ULbe",
+                  "name": "cpSearchC",
+                  "width": 2,
+                  "height": 20,
+                  "fill": "#3B82F6"
+                },
+                {
+                  "type": "frame",
+                  "id": "a2Yts",
+                  "name": "cpSearchS",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#00000000"
+                },
+                {
+                  "type": "frame",
+                  "id": "f7MUF",
+                  "name": "cpSearchK",
+                  "fill": "#FFFFFF0F",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF1F"
+                  },
+                  "padding": [
+                    3,
+                    8
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "4DfbX",
+                      "name": "cpSearchKt",
+                      "fill": "#D0D0D0",
+                      "content": "⌘K",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LojKx",
+              "name": "cpRH",
+              "width": "fill_container",
+              "gap": 8,
+              "padding": [
+                10,
+                22,
+                6,
+                22
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "uFbfq",
+                  "name": "cpRHt",
+                  "fill": "#6a6a6a",
+                  "content": "OPEN SESSIONS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.2
+                },
+                {
+                  "type": "text",
+                  "id": "QftE3",
+                  "name": "cpRHc",
+                  "fill": "#6a6a6a",
+                  "content": "3",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ww5Cb",
+              "name": "cpList",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                0,
+                8,
+                8,
+                8
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rGi9K",
+                  "name": "cr1",
+                  "width": "fill_container",
+                  "fill": "#3B82F61F",
+                  "cornerRadius": 10,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#3B82F640"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "5obeD",
+                      "name": "cr1d",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hjBFR",
+                      "name": "cr1b",
+                      "fill": "#0A0A0B",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1A"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jy8FN",
+                          "name": "cr1bt",
+                          "fill": "#D0D0D0",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "wCzD0",
+                      "name": "cr1t",
+                      "fill": "#FFFFFF",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "redesign task-detail header with liquid glass",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "S097U",
+                      "name": "cr1m",
+                      "fill": "#8a8a8a",
+                      "content": "nucleus",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Q9Oyl",
+                      "name": "cr1k",
+                      "fill": "#FFFFFF0F",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1F"
+                      },
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vuPTZ",
+                          "name": "cr1kt",
+                          "fill": "#D0D0D0",
+                          "content": "↵",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TWTZ6",
+                  "name": "cr2",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 10,
+                  "stroke": {
+                    "thickness": 0,
+                    "fill": "#00000000"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "beKgY",
+                      "name": "cr1d",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Qe1SB",
+                      "name": "cr1b",
+                      "fill": "#0A0A0B",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1A"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Cnisw",
+                          "name": "cr1bt",
+                          "fill": "#D0D0D0",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "PrGPe",
+                      "name": "cr1t",
+                      "fill": "#D0D0D0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "redesign sessions inbox glass material",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IhMB9",
+                      "name": "cr1m",
+                      "fill": "#8a8a8a",
+                      "content": "octomux",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bey5G",
+                      "name": "cr1k",
+                      "fill": "#00000000",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "thickness": 0,
+                        "fill": "#00000000"
+                      },
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "DywaE",
+                          "name": "cr1kt",
+                          "fill": "#00000000",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Ta1LC",
+                  "name": "cr3",
+                  "width": "fill_container",
+                  "fill": "#00000000",
+                  "cornerRadius": 10,
+                  "stroke": {
+                    "thickness": 0,
+                    "fill": "#00000000"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "HeXGj",
+                      "name": "cr1d",
+                      "fill": "#22C55E",
+                      "width": 8,
+                      "height": 8
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pvaiV",
+                      "name": "cr1b",
+                      "fill": "#0A0A0B",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF1A"
+                      },
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mC0ek",
+                          "name": "cr1bt",
+                          "fill": "#D0D0D0",
+                          "content": "N",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 9,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "u5Hvw",
+                      "name": "cr1t",
+                      "fill": "#D0D0D0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "fix composer default scratch mode",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "d7N9k",
+                      "name": "cr1m",
+                      "fill": "#8a8a8a",
+                      "content": "octomux",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CfgzQ",
+                      "name": "cr1k",
+                      "fill": "#00000000",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "thickness": 0,
+                        "fill": "#00000000"
+                      },
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dYNKx",
+                          "name": "cr1kt",
+                          "fill": "#00000000",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tU9yY",
+              "name": "cpRH2",
+              "width": "fill_container",
+              "gap": 8,
+              "padding": [
+                10,
+                22,
+                6,
+                22
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "9k1G6",
+                  "name": "cpRH2t",
+                  "fill": "#6a6a6a",
+                  "content": "ACTIONS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "700",
+                  "letterSpacing": 1.2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gI2He",
+              "name": "cpList2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "padding": [
+                0,
+                8,
+                14,
+                8
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "tQzzB",
+                  "name": "cra1",
+                  "width": "fill_container",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "C71CQ",
+                      "name": "cra1i",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#3B82F6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "NvPLo",
+                      "name": "cra1t",
+                      "fill": "#D0D0D0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "New task…",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mlW5j",
+                      "name": "cra1k",
+                      "fill": "#6a6a6a",
+                      "content": "⌘N",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WSNbs",
+                  "name": "cra2",
+                  "width": "fill_container",
+                  "cornerRadius": 10,
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "SllDl",
+                      "name": "cra2i",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "terminal",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8a8a8a"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zMbj4",
+                      "name": "cra2t",
+                      "fill": "#D0D0D0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Attach terminal to active task",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AXYdA",
+                      "name": "cra2k",
+                      "fill": "#6a6a6a",
+                      "content": "⌘T",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "BQQtM",
+      "x": 3260,
+      "y": 2000,
+      "name": "Palette Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "k2tJl",
+          "name": "cpAh",
+          "fill": "#FFFFFF",
+          "content": "06 · Command Palette (⌘K)",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "Ab3xh",
+          "name": "cpA1",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Palette: L3 glass — 12% white + 80px blur. Scrim behind: 48% black + 20px blur. The double-blur reads as 'the app pauses' without a solid modal.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "WxhuF",
+          "name": "cpA2",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Selected row uses cyan-tinted glass — identical to selected sidebar row and active diff toggle, reinforcing one 'selection' material across the app.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "Xn1Bz",
+          "name": "cpA3",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Group headers (OPEN SESSIONS / ACTIONS) stay tiny monospace — preserves the palette's 'type-to-jump' speed feel. Open sessions first, then actions, matches common shortcut-app patterns.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "T8Nx4",
+          "name": "cpA4",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Keybindings shown on-row as pressed glass chips — consistent with buttons on other surfaces. The ⌘K in header echoes the invocation, aiding recall.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ldkwq",
+      "x": -1522,
+      "y": 422,
+      "name": "Composer Toggle States",
+      "width": 1120,
+      "fill": "#0A0A0B",
+      "cornerRadius": 20,
+      "stroke": {
+        "thickness": 1,
+        "fill": "#FFFFFF0F"
+      },
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 32,
+      "children": [
+        {
+          "type": "frame",
+          "id": "7V9cw",
+          "name": "tsHdr",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 4,
+          "children": [
+            {
+              "type": "text",
+              "id": "RFskm",
+              "fill": "#6a6a6a",
+              "content": "COMPOSER TOGGLE STATES",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 11,
+              "fontWeight": "700",
+              "letterSpacing": 1.5
+            },
+            {
+              "type": "text",
+              "id": "Od262",
+              "fill": "#FFFFFF",
+              "content": "What happens when you click each chip above the composer input",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "600",
+              "letterSpacing": -0.3
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "iuZOA",
+          "name": "tsRow",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "0e31z",
+              "name": "ts1",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZF5hf",
+                  "name": "ts1Hdr",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ckGFf",
+                      "width": 18,
+                      "height": 18,
+                      "fill": "#3B82F6",
+                      "cornerRadius": 9,
+                      "justifyContent": "center",
+                      "alignItems": "center"
+                    },
+                    {
+                      "type": "text",
+                      "id": "BOO7b",
+                      "fill": "#FFFFFF",
+                      "content": "DEFAULT — nothing selected",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NJyvu",
+                  "name": "ts1Preview",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF0D",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF17"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 40
+                  },
+                  "gap": 8,
+                  "padding": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LxNbA",
+                      "name": "addBtn",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF26"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "G9j1f",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "plus",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "L8w7o",
+                          "fill": "#8a8a8a",
+                          "content": "Add repo or folder",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SkSYF",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "0Vshc",
+                      "name": "modeHintS",
+                      "fill": "#FFFFFF08",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF17"
+                      },
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Oqr3y",
+                          "fill": "#8a8a8a",
+                          "content": "S",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "XCG6I",
+                          "fill": "#6a6a6a",
+                          "content": "scratch",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "CjBGR",
+                  "fill": "#8a8a8a",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Empty state. No repo, no branch — the task runs as Scratch (pure chat with the agent, no git).  The 'S' hint on the right indicates the implicit mode; no explicit run-mode chip needed.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "e8fFf",
+              "name": "ts2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nUK4Z",
+                  "name": "ts2Hdr",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "UUsT6",
+                      "width": 18,
+                      "height": 18,
+                      "fill": "#3B82F6",
+                      "cornerRadius": 9,
+                      "justifyContent": "center",
+                      "alignItems": "center"
+                    },
+                    {
+                      "type": "text",
+                      "id": "EQuYr",
+                      "fill": "#FFFFFF",
+                      "content": "REPO ADDED — worktree: off",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "OpLY8",
+                  "name": "ts2Preview",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF0D",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF17"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 40
+                  },
+                  "gap": 8,
+                  "padding": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "M269V",
+                      "name": "ts2C1",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F666"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "DZ3oD",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "folder-git-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "#3B82F6"
+                        },
+                        {
+                          "type": "text",
+                          "id": "z8DwJ",
+                          "fill": "#3B82F6",
+                          "content": "nucleus",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qN5jM",
+                      "name": "ts2C2",
+                      "fill": "#FFFFFF0F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF26"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "TUcFt",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "git-branch",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PnKRE",
+                          "fill": "#D0D0D0",
+                          "content": "main",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "OsbET",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oQnUB",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ePEan",
+                      "name": "wt2",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wc2jB",
+                          "width": 14,
+                          "height": 14,
+                          "fill": "#00000000",
+                          "cornerRadius": 3,
+                          "stroke": {
+                            "thickness": 1,
+                            "fill": "#FFFFFF33"
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "kevtm",
+                          "fill": "#8a8a8a",
+                          "content": "new worktree",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "FF04t",
+                  "fill": "#8a8a8a",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Repo added → default branch (main) is auto-selected; branch chip opens the picker on click. The 'new worktree' checkbox is OFF — the task attaches to the branch's existing working tree. No 'mode' chip anywhere; it's derived.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Cwqqu",
+              "name": "ts3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "8qX30",
+                  "name": "ts3Hdr",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OyFGa",
+                      "width": 18,
+                      "height": 18,
+                      "fill": "#3B82F6",
+                      "cornerRadius": 9,
+                      "justifyContent": "center",
+                      "alignItems": "center"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ELAfF",
+                      "fill": "#FFFFFF",
+                      "content": "REPO ADDED — worktree: on",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vjeB0",
+                  "name": "ts3Preview",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF0D",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#FFFFFF17"
+                  },
+                  "effect": {
+                    "type": "background_blur",
+                    "radius": 40
+                  },
+                  "gap": 8,
+                  "padding": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "eoBaa",
+                      "name": "ts3C1",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F666"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cQsla",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "folder-git-2",
+                          "iconFontFamily": "lucide",
+                          "fill": "#3B82F6"
+                        },
+                        {
+                          "type": "text",
+                          "id": "3owwd",
+                          "fill": "#3B82F6",
+                          "content": "nucleus",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "fYsjQ",
+                      "name": "ts3C2",
+                      "fill": "#FFFFFF0F",
+                      "cornerRadius": 999,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#FFFFFF26"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        5,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "DBbZU",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "git-branch",
+                          "iconFontFamily": "lucide",
+                          "fill": "#8a8a8a"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SFUyc",
+                          "fill": "#D0D0D0",
+                          "content": "agents/IN-412",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "cRqGI",
+                          "width": 10,
+                          "height": 10,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#6a6a6a"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "46fdj",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#00000000"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ULBBH",
+                      "name": "wt3",
+                      "fill": "#3B82F61F",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "thickness": 1,
+                        "fill": "#3B82F640"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fqII5",
+                          "name": "wt3Box",
+                          "width": 14,
+                          "height": 14,
+                          "fill": "#3B82F6",
+                          "cornerRadius": 3,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "YUnOf",
+                              "fill": "#FFFFFF",
+                              "content": "✓",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "xcOsG",
+                          "fill": "#3B82F6",
+                          "content": "new worktree",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "szcxL",
+                  "fill": "#8a8a8a",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Same repo + branch, but 'new worktree' is CHECKED — the task creates a fresh worktree (branched from selected branch) so it runs isolated from your working tree. Worktree toggle IS the only mode control the user needs.",
+                  "lineHeight": 1.5,
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "nRZhf",
+      "x": -368,
+      "y": 567,
+      "name": "Toggle-States Annotations",
+      "width": 300,
+      "fill": "#00000000",
+      "layout": "vertical",
+      "gap": 14,
+      "padding": 20,
+      "children": [
+        {
+          "type": "text",
+          "id": "7GRAv",
+          "fill": "#FFFFFF",
+          "content": "Composer toggle states",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "1eGNC",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "One repo chip + one branch chip + one 'new worktree' checkbox. No run-mode chip. No repo → task runs as Scratch; repo → task attaches to its working tree; repo + ✓ → task gets a fresh worktree.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "avC7R",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Default branch pre-selected on repo pick. Branch and worktree are the only editable controls after; mode is always derived from current state.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "text",
+          "id": "4G9Nl",
+          "fill": "#8a8a8a",
+          "textGrowth": "fixed-width",
+          "width": 260,
+          "content": "Keyboard: ⌘R focuses repo, ⌘B branch, ⌘W toggles worktree. The composer stays one line until you type.",
+          "lineHeight": 1.5,
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "normal"
+        }
+      ]
+    }
+  ]
+}

--- a/design/task-backlog.md
+++ b/design/task-backlog.md
@@ -9,6 +9,7 @@ primitives), then T2–T6 in parallel, then T7 last (integrates lifecycle/empty
 states into surfaces touched by earlier tasks).
 
 **All tasks share these constraints:**
+
 - Repo: `/Users/shreypaharia/Documents/Projects/Ostium/octomux-agents`, base branch `main`.
 - `bun run lint`, `bun run typecheck`, `bun run test` must pass.
 - Conventional commits. No `Co-Authored-By` lines.

--- a/design/task-backlog.md
+++ b/design/task-backlog.md
@@ -1,0 +1,163 @@
+# Liquid-Glass Implementation Backlog
+
+Seven tasks that take the octomux React codebase from its current state to the
+target state mocked in `design/glass-redesign.pen`. Each task is scoped to
+~one-agent-session of work, with minimal file overlap.
+
+**Dispatch order:** `T1` first (foundation — other tasks depend on its
+primitives), then T2–T6 in parallel, then T7 last (integrates lifecycle/empty
+states into surfaces touched by earlier tasks).
+
+**All tasks share these constraints:**
+- Repo: `/Users/shreypaharia/Documents/Projects/Ostium/octomux-agents`, base branch `main`.
+- `bun run lint`, `bun run typecheck`, `bun run test` must pass.
+- Conventional commits. No `Co-Authored-By` lines.
+- Open a PR via `gh pr create` when done.
+- Reference: `design/glass-redesign.pen` (mockups) + `design/review-snapshots/*.png` (rendered) + `design/README.md` (material spec).
+
+---
+
+## T1 · `feat/glass-design-system` — foundation (tokens, glyphs, focus ring) · **do first**
+
+**Scope:** Only tokens and primitives. No page or layout changes.
+
+- Tailwind tokens for L0/L1/L2/L3 glass (fill tints, blur radii, stroke colors, specular highlight).
+- `--muted` bumped `#8a8a8a` → `#B5B5BD`; add `--muted-soft` `#8a8a8a` for tertiary.
+- `focus-ring` utility: `:focus-visible` → `ring-2 ring-[#60A5FAE6] ring-offset-2 ring-offset-[#07080B]`.
+- `<GlassPanel level={1|2|3} specular?>` primitive at `src/components/ui/glass-panel.tsx`.
+- `<StatusGlyph status>` primitive at `src/components/ui/status-glyph.tsx` — ● ▲ ◐ ✕ ○ shape+color per status.
+- Update `StatusBadge` to include the glyph in pill text by default (`● RUNNING`).
+- Unit tests for all three primitives.
+
+**PR title:** `feat(ui): glass design system foundation`
+
+---
+
+## T2 · `feat/glass-sidebar` — inset-pill sidebar + shortcuts + footer
+
+**File:** `src/components/UniversalSidebar.tsx` (+ test file).
+
+- Convert nav rows and task rows to **inset pills** (12px inset, 10px radius). Active row = `#3B82F61F` fill + 1px `#3B82F666` stroke, no left accent bar.
+- Panel itself uses L1 glass material (`<GlassPanel level={1} specular>`).
+- Add keyboard shortcut keycaps on nav items: ⌘1 Home, ⌘2 Tasks, ⌘3 Orchestrator, ⌘, Settings.
+- Orchestrator "running" indicator = green dot badge on the icon's top-right when collapsed (iOS-style).
+- Session row uses `<StatusGlyph>` from T1; `⋯` overflow button visible on hover, opens existing `RowMenu`.
+- Nucleus/repo group headers gain a count chip (`4`) and reveal a `+` button on hover.
+- Sidebar footer: user avatar + handle + connection dot + disclosure for settings/sign-out.
+- Collapsed state (56px): icon rail with 36px rounded tiles; active tile = cyan-tinted glass.
+
+**PR title:** `feat(ui): glass sidebar with inset pills and keycaps`
+
+---
+
+## T3 · `feat/glass-home-tasks` — Home + Tasks glass pass
+
+**Files:** `src/pages/HomePage.tsx`, `src/pages/TasksPage.tsx`, `src/components/SessionsInbox.tsx`, `src/components/TaskList.tsx`, `src/components/TaskFilterBar.tsx`.
+
+- Both pages gain eyebrow pattern: `// INBOX` / `// TASKS` JetBrains Mono 11px + sentence-case H1 32px (down from 42px).
+- Tasks `NEW TASK` button: solid `#3B82F6` with cyan glow shadow, inner white specular.
+- Filter bar becomes **one unified L1 glass panel** with segmented pills; active chip = "pressed" state (14% white fill, 1px inner stroke).
+- Task cards → `<GlassPanel level={2}>`, 14px radius, shadow (y:12 blur:30 spread:-8).
+- Each task card carries a telemetry footer line: `opus-4.7 · 412k/1M ctx · $2.14 · +18 −4 · tests 24/24 · lint clean` (placeholder values from API; wire what's available).
+- Home inbox: rename `NEEDS YOU` → `AWAITING REPLY` (amber); add `ERRORED` sub-bucket (red triangle). Collapse `ACTIVITY` behind a `· tap to expand` disclosure.
+- Inline `Reply →` button on inbox cards (amber solid, opens composer targeted at that session without leaving Home).
+- All status pills use `<StatusGlyph>` from T1.
+
+**PR title:** `feat(ui): glass home and tasks pages`
+
+---
+
+## T4 · `feat/glass-task-detail-diff-ship` — Task detail chrome compaction + Ship flow
+
+**Files:** `src/pages/TaskDetail.tsx`, `src/components/DiffViewer.tsx`, `src/components/AgentTabs.tsx`.
+
+- Header: collapse title + metadata + description into **one compact L1 bar** (12px vertical padding, 15px H1, no subtitle). Metadata bar thinner (5% white, 30px blur).
+- ⌘K keycap in the header's right cluster.
+- CLOSE button uses red-tinted destructive glass (`#EF44441F` fill, 1px `#EF4444AA` stroke).
+- Agent tabs: active tab opaque terminal-colored, inactive ghost. Each tab carries a `<StatusGlyph>` chip with per-agent state (`● running`, `▲ waiting`, `✕ errored`) derived from Claude output parsing.
+- **Ship flow** (new):
+  - Green `Ship` primary button in the diff-mode header (pull-request icon + green glow) — wired to open the PR Preview sheet added in T7.
+  - `2 / 4 reviewed` progress chip in the diff pane header.
+  - Active file in the file list gets an empty review checkbox; reviewed files show a green check + muted row.
+  - `r` keybinding toggles the current file's reviewed state.
+- File list on diff view grouped by directory (`DESIGN`, `SRC > COMPONENTS`, `IGNORED FILES (1)` collapsed).
+- Diff pane stays opaque (terminal rule).
+
+**PR title:** `feat(ui): glass task detail with ship flow`
+
+---
+
+## T5 · `refactor/composer-worktree-checkbox` — Composer flow model change
+
+**Files:** `src/components/Composer.tsx`, `src/lib/composer-state.ts` (reducer), `src/components/fields/RepoPickerField.tsx`, `src/components/fields/BranchPickerField.tsx`.
+
+- **Model change:** remove the explicit run-mode chip (`N / E / Ø / S`). `run_mode` is now **derived**:
+  - No repo chip → `scratch`
+  - Repo chip + worktree checkbox `off` → `none` (attaches to existing working tree)
+  - Repo chip + worktree checkbox `on` → `new`
+  - `existing` mode is accessible via a secondary menu / keyboard shortcut (no chip).
+- Default state is **empty composer with a single `+ Add repo or folder` dashed-border chip**. The `S` implicit-mode hint appears on the right.
+- On repo pick: default branch auto-selected; branch chip opens a filterable picker (unchanged UI).
+- New `worktree` checkbox chip — boolean, default off.
+- Composer modal sheet uses `<GlassPanel level={3} specular>` with a scrim that shows the blurred page behind (not pure black).
+- Prompt textarea is an opaque inset block nested inside the glass sheet (terminal rule).
+- Primary button `Start task` (solid cyan with glow) stays; remove the derived-mode label display.
+- Update existing composer unit tests to match the new derivation logic.
+
+**PR title:** `refactor(ui): composer worktree checkbox with implicit run mode`
+
+---
+
+## T6 · `feat/glass-palette-orch-settings` — Palette + Orchestrator + Settings glass pass
+
+**Files:** `src/components/CommandPalette.tsx`, `src/pages/OrchestratorPage.tsx`, `src/pages/SettingsPage.tsx`.
+
+- **CommandPalette:** `<GlassPanel level={3}>` over a reduced-opacity scrim (40% black + 20px blur) so content behind is visible through it. Selected row = cyan-tinted glass (same vocabulary as sidebar active). Groups: `OPEN SESSIONS` (first) then `ACTIONS`. Keycaps right-aligned. Focus ring on search input.
+- **OrchestratorPage:** compact L1 header holding `// ORCHESTRATOR` eyebrow + status dot + `● RUNNING` pill + `?` help chip + routine cadence hint (`every 30m · last fired 3m ago`) + `RESTART`. Terminal stays opaque. L1 command bar at bottom with sparkles icon, placeholder, `⌘↵` keycap.
+- **SettingsPage:** two-column layout — left L1 section nav (`GENERAL`, `ORCHESTRATOR`, `AGENTS`, `SKILLS`, `REPOSITORIES`, `EDITOR`, `AGENT LAUNCH`), right scrolling body. Each section becomes an `<GlassPanel level={2}>` card with a title bar and rows divided by 10% white strokes. Toggle switches = solid cyan when on. `Repositories` card gains a cyan `+ Add repo` chip in the header; row `⋯` overflow reveals on hover.
+- ⌘K keycap in the top-right of all three page headers.
+
+**PR title:** `feat(ui): glass palette, orchestrator, and settings`
+
+---
+
+## T7 · `feat/glass-system-states-and-new-surfaces` — lifecycle, empty states, PR sheet, parallel grid · **do last**
+
+**Depends on T1–T6** (integrates with `TaskDetail`, `HomePage`, `CommandPalette`, and adds one new route).
+
+- **Lifecycle states** for `TaskDetail`:
+  - `setting_up` — checklist screen (worktree created, tmux started, Claude launching…, waiting for output) with amber spinner and "View logs" escape hatch.
+  - `error` — red banner with task error message, full stack trace in the terminal below, footer with `View logs` + destructive `Delete task`.
+  - Disconnected / stalled terminal banner — amber `cloud-off` pill over a dimmed terminal with `Reconnecting in 3s…` and `Retry now` CTA.
+- **Empty states:**
+  - Home first-run: hero with `Create your first task (⌘N)` primary button.
+  - Inbox zero: green circle + `Inbox zero` header + friendly subtitle.
+  - Palette no-results: `No matches` + `⌘N New task with '<query>'` escape hatch (creates a new task with the current query as title).
+  - Tasks zero-state: a cleaner empty with the same CTA.
+- **PR Preview sheet** (new route or modal): `<GlassPanel level={3}>` centered sheet. Editable PR title + pre-filled body templated from task title + diff summary. `Save draft` secondary, `Create PR` primary (green with glow). After success, transitions the task to a `closed-merged` state and shows the PR URL.
+- **Parallel Agent Grid** (new view, reachable from Orchestrator or via `⌘⇧G`): 2×3 grid of compact opaque terminal panes, each with a header (branch · state pill), tail output body, and telemetry footer (`opus-4.7 · 412k/1M · $2.14 · 00:14:22`). State pills per pane: running / waiting / errored / closed — cover all four.
+- **Global offline banner** (thin L1 strip, amber) surfaced when the websocket can't reconnect for >10s.
+- Long-title truncation on sidebar and task-detail header (ellipsize after N chars, full title on hover/focus).
+
+**PR title:** `feat(ui): liquid-glass system states, empty states, PR sheet, parallel grid`
+
+---
+
+## Blocker on dispatch
+
+Tried dispatching via `octomux create-task` — the running server (main branch) returns `table tasks has no column named repo_path` for every create. Main appears mid-migration to the workspaces/worktrees split schema. Dispatch once that lands, via:
+
+```bash
+octomux create-task \
+  --title '<title from above>' \
+  --description '<1-line summary>' \
+  --repo-path /Users/shreypaharia/Documents/Projects/Ostium/octomux-agents \
+  --branch <branch from above> \
+  --base-branch main \
+  --initial-prompt "$(cat <<'EOF'
+<paste the relevant T# section from this file>
+EOF
+)"
+```
+
+Or create each task in the dashboard UI using the task body above verbatim.

--- a/scripts/rollup-to-feat.sh
+++ b/scripts/rollup-to-feat.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Rollup script for glass-redesign parallel audit tasks.
+# Rebases current agent branch onto origin/feat/glass-redesign, pushes, and
+# appends a summary to .octomux/rollup/<slug>.md.
+#
+# Usage: scripts/rollup-to-feat.sh <slug> <summary-file>
+#   <slug>          short identifier for this task, e.g. "t1-tokens-sidebar"
+#   <summary-file>  path to a markdown file with your completion summary
+#
+# Retries up to 5× on push races. Never runs lint/test — caller should have
+# already verified those locally before invoking rollup.
+
+set -euo pipefail
+
+SLUG="${1:?Usage: rollup-to-feat.sh <slug> <summary-file>}"
+SUMMARY_FILE="${2:?Usage: rollup-to-feat.sh <slug> <summary-file>}"
+TARGET_BRANCH="feat/glass-redesign"
+
+if [ ! -f "$SUMMARY_FILE" ]; then
+  echo "rollup: summary file not found: $SUMMARY_FILE" >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" = "$TARGET_BRANCH" ]; then
+  echo "rollup: refusing to run on $TARGET_BRANCH directly" >&2
+  exit 1
+fi
+
+echo "rollup: current branch = $CURRENT_BRANCH"
+echo "rollup: target branch  = $TARGET_BRANCH"
+echo "rollup: slug           = $SLUG"
+
+# Stage any stray changes first — caller should have committed, but be defensive.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "rollup: refusing to run with uncommitted changes" >&2
+  git status --short
+  exit 1
+fi
+
+# Step 1: rebase onto latest feat/glass-redesign
+echo "rollup: fetching $TARGET_BRANCH"
+git fetch origin "$TARGET_BRANCH"
+
+echo "rollup: rebasing $CURRENT_BRANCH onto origin/$TARGET_BRANCH"
+if ! git rebase "origin/$TARGET_BRANCH"; then
+  echo "rollup: rebase hit conflicts — Claude should resolve them now." >&2
+  echo "rollup: when resolved: git add -A && git rebase --continue && re-run this script" >&2
+  exit 2
+fi
+
+# Step 2: push to feat/glass-redesign (with retry loop)
+PUSHED=0
+for attempt in 1 2 3 4 5; do
+  git fetch origin "$TARGET_BRANCH"
+  # Ensure still fast-forwardable after fresh fetch
+  git rebase "origin/$TARGET_BRANCH" || {
+    echo "rollup: rebase after fetch hit conflicts (attempt $attempt) — resolve and re-run" >&2
+    exit 2
+  }
+  if git push origin "HEAD:$TARGET_BRANCH" --no-verify 2>&1; then
+    PUSHED=1
+    break
+  fi
+  echo "rollup: push attempt $attempt failed (race?), retrying after backoff"
+  sleep $((RANDOM % 12 + 4))
+done
+
+if [ "$PUSHED" != "1" ]; then
+  echo "rollup: failed to push after 5 attempts" >&2
+  exit 3
+fi
+
+echo "rollup: pushed $CURRENT_BRANCH → $TARGET_BRANCH"
+
+# Step 3: append summary to feat/glass-redesign
+echo "rollup: switching to $TARGET_BRANCH to add summary"
+git checkout "$TARGET_BRANCH"
+git pull --ff-only origin "$TARGET_BRANCH"
+
+mkdir -p .octomux/rollup
+DEST=".octomux/rollup/${SLUG}.md"
+cp "$SUMMARY_FILE" "$DEST"
+
+git add "$DEST"
+git commit -m "chore(rollup): ${SLUG} ✓" --no-verify
+
+for attempt in 1 2 3 4 5; do
+  if git push origin "$TARGET_BRANCH" --no-verify; then
+    echo "rollup: summary pushed"
+    exit 0
+  fi
+  echo "rollup: summary push failed, rebasing + retry ($attempt)"
+  git pull --rebase origin "$TARGET_BRANCH"
+  sleep $((RANDOM % 8 + 3))
+done
+
+echo "rollup: failed to push summary after 5 attempts" >&2
+exit 4

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,9 @@ export function AppShell() {
         />
         <GlobalNotifications />
         <UniversalSidebar />
-        <main className="min-h-0 min-w-0 flex-1">
+        <main className="relative isolate flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="ambient-tint-backdrop" aria-hidden="true" />
+          <div className="relative z-10 flex min-h-0 flex-1 flex-col">
           <Suspense
             fallback={
               <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -184,6 +186,7 @@ export function AppShell() {
               <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
             </Routes>
           </Suspense>
+          </div>
         </main>
         <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
         <PrSheet

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -39,15 +39,20 @@ function scoreMatch(haystack: string, needle: string): number {
 const OPEN_STATUSES = new Set(['running', 'setting_up', 'error']);
 
 const BACKDROP_STYLE: React.CSSProperties = {
-  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  backgroundColor: 'rgba(0, 0, 0, 0.48)',
   backdropFilter: 'blur(20px)',
   WebkitBackdropFilter: 'blur(20px)',
 };
 
-function Keycap({ children }: { children: React.ReactNode }) {
+function Keycap({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
     <span
-      className="ml-auto inline-flex h-5 items-center gap-0.5 border border-glass-edge bg-glass-l1 px-1.5 font-mono text-[10px] text-[#b5b5bd]"
+      className={[
+        'inline-flex h-5 items-center gap-0.5 rounded-md border border-glass-edge bg-glass-l1 px-1.5 font-mono text-[10px] text-[#b5b5bd]',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       style={{ boxShadow: 'inset 0 1px 0 0 rgba(255,255,255,0.12)' }}
     >
       {children}
@@ -55,10 +60,13 @@ function Keycap({ children }: { children: React.ReactNode }) {
   );
 }
 
-function GroupHeader({ label }: { label: string }) {
+function GroupHeader({ label, count }: { label: string; count?: number }) {
   return (
-    <div className="px-4 pt-3 pb-1.5 text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
-      {label}
+    <div className="flex items-center gap-2 px-4 pt-3 pb-1.5 text-[10px] font-bold uppercase tracking-wider text-[#6a6a6a]">
+      <span>{label}</span>
+      {count !== undefined && count > 0 && (
+        <span className="font-mono text-[10px] font-bold text-[#6a6a6a]">{count}</span>
+      )}
     </div>
   );
 }
@@ -222,13 +230,10 @@ export function CommandPalette({ open, onClose }: Props) {
         aria-modal="true"
         aria-label="Command palette"
         data-testid="command-palette"
-        className="w-full max-w-xl"
+        className="w-full max-w-xl overflow-hidden rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div
-          className="flex items-center gap-2 border-b border-glass-edge px-3"
-          style={{ backgroundColor: '#0B0C0F' }}
-        >
+        <div className="flex items-center gap-3 border-b border-[rgba(255,255,255,0.1)] px-5 py-3">
           <input
             ref={inputRef}
             type="text"
@@ -241,7 +246,7 @@ export function CommandPalette({ open, onClose }: Props) {
             placeholder="search tasks…"
             aria-label="Search tasks"
             data-testid="command-palette-input"
-            className="focus-ring w-full bg-transparent px-1 py-3 text-sm text-white caret-[#60a5fa] placeholder:text-[#6a6a6a] outline-none"
+            className="focus-ring w-full bg-transparent text-sm text-white caret-[#60a5fa] placeholder:text-[#6a6a6a] outline-none"
             style={{ caretColor: '#60a5fa' }}
           />
           <Keycap>⌘K</Keycap>
@@ -266,7 +271,9 @@ export function CommandPalette({ open, onClose }: Props) {
             </li>
           )}
 
-          {sessionRows.length > 0 && <GroupHeader label="OPEN SESSIONS" />}
+          {sessionRows.length > 0 && (
+            <GroupHeader label="OPEN SESSIONS" count={sessionRows.length} />
+          )}
           {sessionRows.map((row, i) => {
             const idx = sessionsFrom + i;
             const isActive = idx === active;
@@ -329,8 +336,8 @@ function rowClass(active: boolean, extra?: string) {
   return [
     'command-palette-row',
     active
-      ? 'cursor-pointer px-4 py-2 text-sm text-foreground'
-      : 'cursor-pointer px-4 py-2 text-sm text-muted-foreground',
+      ? 'cursor-pointer rounded-lg px-4 py-2 text-sm text-foreground'
+      : 'cursor-pointer rounded-lg px-4 py-2 text-sm text-muted-foreground',
     active ? 'command-palette-row--selected' : '',
     extra,
   ]

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -275,7 +275,12 @@ export function Composer({ onSubmitted }: Props = {}) {
   const showScratchHint = !hasRepo && state.mode !== 'add-agent';
 
   return (
-    <GlassPanel level={3} specular className="flex flex-col gap-2 px-4 py-3" data-testid="composer">
+    <GlassPanel
+      level={3}
+      specular
+      className="flex flex-col gap-2 rounded-[20px] px-4 py-3"
+      data-testid="composer"
+    >
       <IntentHeader
         state={state}
         sourceTask={sourceTask}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -359,29 +359,37 @@ export function Composer({ onSubmitted }: Props = {}) {
 
         {showScratchHint && (
           <span
-            className="ml-auto select-none rounded border border-border/60 bg-muted/20 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground"
+            className="ml-auto inline-flex select-none items-center gap-1 rounded-full border border-white/[0.12] bg-white/[0.03] px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground"
             data-testid="scratch-hint"
             title="No repo selected — submission creates a scratch chat."
           >
-            <span className="mr-1 text-[9px] opacity-60">S</span>scratch
+            <span className="text-[9px] font-bold opacity-70">S</span>
+            <span>scratch</span>
           </span>
         )}
       </div>
 
-      {/* Prompt + submit. Textarea stays opaque (terminal rule). */}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      {/* Prompt + submit — opaque block (terminal rule). */}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3 rounded-2xl border border-white/10 p-3"
+        style={{ backgroundColor: '#0B0C0F' }}
+      >
         <textarea
           ref={textareaRef}
           data-testid="composer-prompt"
-          className="min-h-[72px] resize-y rounded-2xl border border-white/10 px-3 py-2 text-sm font-mono text-foreground outline-none focus:border-ring"
-          style={{ backgroundColor: '#0B0C0F' }}
+          className="focus-ring min-h-[72px] resize-y rounded-lg bg-transparent px-1 py-1 text-sm font-mono text-foreground outline-none"
           placeholder={promptPlaceholder(state)}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={onTextareaKeyDown}
           aria-label="Task prompt"
         />
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-[11px] text-[#6a6a6a]" aria-hidden>
+            ⌘↵ start · ⇧↵ new line
+          </span>
+          <span className="flex-1" />
           {blockedReason && prompt.trim() && (
             <span className="text-[11px] text-muted-foreground" title={blockedReason}>
               {blockedReason}
@@ -393,7 +401,7 @@ export function Composer({ onSubmitted }: Props = {}) {
             data-testid="composer-submit"
             title={blockedReason ?? undefined}
             className="bg-cyan-500 text-white hover:bg-cyan-400"
-            style={{ boxShadow: canSubmit ? '0 0 12px rgba(34,211,238,0.45)' : undefined }}
+            style={{ boxShadow: canSubmit ? '0 0 20px rgba(59,130,246,0.45)' : undefined }}
           >
             {submitting ? 'Starting…' : 'Start task'}
           </Button>
@@ -496,7 +504,7 @@ const RepoChip = forwardRef<HTMLButtonElement, RepoChipProps>(function RepoChip(
         type="button"
         onClick={() => setExpanded(true)}
         data-testid="repo-chip-picker"
-        className="inline-flex items-center gap-1 rounded border border-dashed border-border/80 px-3 py-1 text-[11px] font-mono text-muted-foreground hover:border-foreground hover:text-foreground"
+        className="focus-ring inline-flex items-center gap-1.5 rounded-full border border-dashed border-white/20 bg-white/[0.03] px-3 py-1 text-[11px] font-mono text-muted-foreground hover:border-foreground hover:text-foreground"
       >
         <span aria-hidden>+</span>
         <span>Add repo or folder</span>
@@ -520,13 +528,31 @@ const RepoChip = forwardRef<HTMLButtonElement, RepoChipProps>(function RepoChip(
     );
   }
   return (
-    <ChipRemovable
-      buttonRef={ref}
-      label={`📁 ${repoBasename(value)}`}
-      title={value}
-      onRemove={onClear}
+    <div
       data-testid="repo-chip"
-    />
+      title={value}
+      className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-mono"
+      style={{
+        backgroundColor: 'rgba(59, 130, 246, 0.12)',
+        borderColor: 'rgba(59, 130, 246, 0.4)',
+        color: '#3B82F6',
+      }}
+    >
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClear}
+        aria-label="Remove"
+        className="inline-flex items-center gap-1.5 font-semibold hover:opacity-80"
+        style={{ color: '#3B82F6' }}
+      >
+        <span aria-hidden>📁</span>
+        <span>{repoBasename(value)}</span>
+        <span aria-hidden style={{ color: 'rgba(59, 130, 246, 0.7)' }}>
+          ×
+        </span>
+      </button>
+    </div>
   );
 });
 
@@ -541,12 +567,21 @@ const BranchChip = forwardRef<HTMLButtonElement, BranchChipProps>(function Branc
   ref,
 ) {
   return (
-    <div className="flex items-center gap-1" data-testid="branch-chip">
-      <span className="text-xs text-muted-foreground" aria-hidden>
+    <div
+      className="inline-flex items-center gap-1.5 rounded-full border border-white/[0.15] bg-white/[0.06] px-3 py-[3px] text-[11px] font-mono"
+      data-testid="branch-chip"
+    >
+      <span className="text-[11px] text-muted-foreground" aria-hidden>
         ⎇
       </span>
-      <div className="min-w-[140px] max-w-[220px]">
-        <BranchPickerField triggerRef={ref} repoPath={repoPath} value={value} onChange={onChange} />
+      <div className="min-w-[100px] max-w-[220px]">
+        <BranchPickerField
+          triggerRef={ref}
+          repoPath={repoPath}
+          value={value}
+          onChange={onChange}
+          triggerClassName="focus-ring flex w-full items-center justify-between gap-1.5 bg-transparent font-mono text-[11px] text-[#D0D0D0] outline-none hover:text-white disabled:opacity-60"
+        />
       </div>
     </div>
   );
@@ -574,18 +609,19 @@ const WorktreeCheckbox = forwardRef<HTMLButtonElement, WorktreeCheckboxProps>(
         onClick={() => onChange(!checked)}
         data-testid="worktree-checkbox"
         data-state={checked ? 'checked' : 'unchecked'}
-        className="inline-flex items-center gap-2 rounded border px-2 py-1 text-[11px] font-mono transition-colors"
+        className="focus-ring inline-flex items-center gap-2 rounded-lg border px-2.5 py-1 text-[11px] font-mono transition-colors"
         style={{
-          borderColor: checked ? 'rgba(59,130,246,0.4)' : 'var(--border)',
+          borderColor: checked ? 'rgba(59,130,246,0.4)' : 'rgba(255,255,255,0.18)',
           backgroundColor: checked ? 'rgba(59,130,246,0.12)' : 'transparent',
-          color: checked ? 'rgb(147,197,253)' : 'var(--muted-foreground)',
+          color: checked ? '#3B82F6' : 'var(--muted-foreground)',
+          fontWeight: checked ? 600 : 500,
         }}
       >
         <span
           aria-hidden
           className="inline-flex h-[14px] w-[14px] items-center justify-center rounded-sm border"
           style={{
-            borderColor: checked ? 'rgba(59,130,246,0.6)' : 'var(--border)',
+            borderColor: checked ? 'rgba(59,130,246,0.6)' : 'rgba(255,255,255,0.22)',
             backgroundColor: checked ? 'rgb(59,130,246)' : 'transparent',
           }}
         >
@@ -604,7 +640,7 @@ const WorktreeCheckbox = forwardRef<HTMLButtonElement, WorktreeCheckboxProps>(
             </svg>
           )}
         </span>
-        <span>worktree</span>
+        <span>new worktree</span>
       </button>
     );
   },
@@ -625,7 +661,8 @@ function AttachChip({
   if (!value && !expanded) {
     return (
       <ChipButton onClick={() => setExpanded(true)} data-testid="attach-chip-picker">
-        🔗 attach
+        <span aria-hidden>🔗</span>
+        <span>attach</span>
       </ChipButton>
     );
   }
@@ -685,10 +722,10 @@ function DraftToggle({
       disabled={disabled}
       aria-pressed={checked}
       data-testid="draft-toggle"
-      className={`px-2 py-1 border text-[11px] font-mono ${
+      className={`focus-ring rounded-full border px-3 py-1 text-[11px] font-mono transition-colors disabled:opacity-40 ${
         checked
-          ? 'border-primary bg-primary/10 text-primary'
-          : 'border-border text-muted-foreground'
+          ? 'border-primary/40 bg-primary/10 text-primary'
+          : 'border-white/[0.15] bg-white/[0.03] text-muted-foreground hover:text-foreground'
       }`}
     >
       📝 draft
@@ -703,7 +740,7 @@ function ChipButton({ children, onClick, ...rest }: React.ButtonHTMLAttributes<H
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 border border-border px-2 py-1 text-[11px] font-mono text-muted-foreground hover:text-foreground hover:bg-muted/40"
+      className="focus-ring inline-flex items-center gap-1.5 rounded-full border border-white/[0.15] bg-white/[0.03] px-3 py-1 text-[11px] font-mono text-muted-foreground hover:text-foreground hover:bg-white/[0.08]"
       {...rest}
     >
       {children}
@@ -727,14 +764,14 @@ function ChipRemovable({
     <div
       {...rest}
       title={title}
-      className="inline-flex items-center gap-1 border border-border px-2 py-1 text-[11px] font-mono"
+      className="inline-flex items-center gap-1 rounded-full border border-white/[0.15] bg-white/[0.06] px-3 py-1 text-[11px] font-mono"
     >
       <button
         ref={buttonRef}
         type="button"
         onClick={onRemove}
         aria-label="Remove"
-        className="inline-flex items-center gap-1 text-foreground hover:text-muted-foreground"
+        className="focus-ring inline-flex items-center gap-1.5 text-foreground hover:text-muted-foreground"
       >
         <span>{label}</span>
         <span className="text-muted-foreground">×</span>

--- a/src/components/DiffFileTree.tsx
+++ b/src/components/DiffFileTree.tsx
@@ -17,6 +17,10 @@ export function ignoredGroupKey(taskId: string): string {
   return `octomux:diff-ignored-open:${taskId}`;
 }
 
+export function topGroupKey(taskId: string, group: string): string {
+  return `octomux:diff-group-open:${taskId}:${group}`;
+}
+
 interface Node {
   name: string;
   fullPath: string;
@@ -65,6 +69,9 @@ function TreeRow({
   onSelect,
   reviewed,
   onToggleReview,
+  collapsible,
+  openGroups,
+  onToggleGroup,
 }: {
   node: Node;
   depth: number;
@@ -72,6 +79,9 @@ function TreeRow({
   onSelect: (path: string) => void;
   reviewed?: Set<string>;
   onToggleReview?: (path: string) => void;
+  collapsible?: boolean;
+  openGroups?: Record<string, boolean>;
+  onToggleGroup?: (path: string) => void;
 }) {
   if (node.isFile && node.file) {
     const f = node.file;
@@ -89,11 +99,14 @@ function TreeRow({
         type="button"
         data-testid={`diff-file-row-${f.path}`}
         data-reviewed={isReviewed ? 'true' : undefined}
+        data-active={active ? 'true' : undefined}
         onClick={() => onSelect(f.path)}
         onKeyDown={handleKey}
         className={cn(
-          'flex w-full items-center gap-2 px-2 py-1 text-left text-xs hover:bg-accent',
-          active && 'bg-accent',
+          'flex w-full items-center gap-2 px-2 py-1 text-left text-xs',
+          active
+            ? 'border border-[#3B82F666] bg-[#3B82F61F] text-[#3B82F6]'
+            : 'border border-transparent hover:bg-[#FFFFFF0A]',
           isReviewed && 'opacity-50',
         )}
         style={{ paddingLeft: `${depth * 12 + 8}px` }}
@@ -138,28 +151,49 @@ function TreeRow({
     if (a.isFile !== b.isFile) return a.isFile ? 1 : -1;
     return a.name.localeCompare(b.name);
   });
+  const isGroupCollapsible = Boolean(node.name && collapsible);
+  const groupOpen = isGroupCollapsible ? (openGroups?.[node.fullPath] ?? true) : true;
   return (
     <>
-      {node.name && (
-        <div
-          data-testid={`diff-group-${node.fullPath}`}
-          className="px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
-          style={{ paddingLeft: `${depth * 12 + 8}px` }}
-        >
-          {node.name}
-        </div>
-      )}
-      {children.map((child) => (
-        <TreeRow
-          key={child.fullPath}
-          node={child}
-          depth={node.name ? depth + 1 : depth}
-          selected={selected}
-          onSelect={onSelect}
-          reviewed={reviewed}
-          onToggleReview={onToggleReview}
-        />
-      ))}
+      {node.name &&
+        (isGroupCollapsible ? (
+          <button
+            type="button"
+            data-testid={`diff-group-${node.fullPath}`}
+            aria-expanded={groupOpen}
+            onClick={() => onToggleGroup?.(node.fullPath)}
+            className="flex w-full items-center gap-1.5 px-2 py-1 text-left font-mono text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-[#FFFFFF0A]"
+            style={{ paddingLeft: `${depth * 12 + 8}px` }}
+          >
+            <span aria-hidden className="inline-block w-3 font-mono">
+              {groupOpen ? '▾' : '▸'}
+            </span>
+            <span>{node.name}</span>
+          </button>
+        ) : (
+          <div
+            data-testid={`diff-group-${node.fullPath}`}
+            className="px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground"
+            style={{ paddingLeft: `${depth * 12 + 8}px` }}
+          >
+            {node.name}
+          </div>
+        ))}
+      {groupOpen &&
+        children.map((child) => (
+          <TreeRow
+            key={child.fullPath}
+            node={child}
+            depth={node.name ? depth + 1 : depth}
+            selected={selected}
+            onSelect={onSelect}
+            reviewed={reviewed}
+            onToggleReview={onToggleReview}
+            collapsible={collapsible}
+            openGroups={openGroups}
+            onToggleGroup={onToggleGroup}
+          />
+        ))}
     </>
   );
 }
@@ -179,6 +213,7 @@ export function DiffFileTree({
   const ignoredTree = useMemo(() => buildTree(ignored), [ignored]);
 
   const [ignoredOpen, setIgnoredOpen] = useState(false);
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   useEffect(() => {
     if (!taskId) return;
     try {
@@ -187,6 +222,41 @@ export function DiffFileTree({
       // localStorage unavailable (SSR, privacy mode, etc.) — keep default closed.
     }
   }, [taskId]);
+
+  const toggleGroup = (path: string) => {
+    setOpenGroups((prev) => {
+      const current = prev[path] ?? true;
+      const next = { ...prev, [path]: !current };
+      if (taskId) {
+        try {
+          localStorage.setItem(topGroupKey(taskId, path), String(!current));
+        } catch {
+          // ignore
+        }
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!taskId) return;
+    const next: Record<string, boolean> = {};
+    const walk = (node: Node) => {
+      if (node.name) {
+        try {
+          const stored = localStorage.getItem(topGroupKey(taskId, node.fullPath));
+          if (stored !== null) next[node.fullPath] = stored === 'true';
+        } catch {
+          // ignore
+        }
+      }
+      if (node.children) {
+        for (const c of node.children.values()) walk(c);
+      }
+    };
+    walk(changedTree);
+    setOpenGroups(next);
+  }, [taskId, changedTree]);
 
   const toggleIgnored = () => {
     setIgnoredOpen((prev) => {
@@ -207,7 +277,7 @@ export function DiffFileTree({
   }
 
   return (
-    <div className="overflow-y-auto">
+    <div className="flex-1 overflow-y-auto p-1">
       {changed.length > 0 ? (
         <TreeRow
           node={changedTree}
@@ -216,15 +286,18 @@ export function DiffFileTree({
           onSelect={onSelect}
           reviewed={reviewed}
           onToggleReview={onToggleReview}
+          collapsible
+          openGroups={openGroups}
+          onToggleGroup={toggleGroup}
         />
       ) : null}
       {ignored.length > 0 ? (
-        <div className="border-t border-border">
+        <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)' }}>
           <button
             type="button"
             onClick={toggleIgnored}
             aria-expanded={ignoredOpen}
-            className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left font-mono text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent"
+            className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left font-mono text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-[#FFFFFF0A]"
           >
             <span aria-hidden className="inline-block w-3 font-mono">
               {ignoredOpen ? '▾' : '▸'}

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -234,8 +234,11 @@ export function DiffViewer({ taskId, isRunning }: Props) {
   }
 
   return (
-    <div className="flex h-full min-h-0" style={{ background: '#0B0C0F' }}>
-      <aside className="w-[280px] shrink-0 border-r border-border">
+    <div className="flex h-full min-h-0 gap-3 p-3">
+      <aside
+        data-testid="diff-file-list"
+        className="bg-glass-l1 glass-blur-l1 flex w-[260px] shrink-0 flex-col overflow-hidden border border-glass-edge"
+      >
         {summaryLoading && files.length === 0 ? (
           <div className="p-4 text-xs text-muted-foreground">Loading diff...</div>
         ) : (
@@ -250,11 +253,21 @@ export function DiffViewer({ taskId, isRunning }: Props) {
           />
         )}
       </aside>
-      <main className="flex min-w-0 flex-1 flex-col">
-        <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-1.5">
+      <main
+        data-testid="diff-pane"
+        className="flex min-w-0 flex-1 flex-col overflow-hidden border border-glass-edge"
+        style={{
+          background: '#0B0C0F',
+          boxShadow: '0 8px 24px -6px rgba(0,0,0,0.5)',
+        }}
+      >
+        <div
+          className="flex items-center justify-between gap-3 px-4 py-[10px]"
+          style={{ background: '#101217', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+        >
           <span className="flex min-w-0 items-center gap-3">
             {showToolbar && selected ? (
-              <span className="truncate text-xs text-muted-foreground">{selected}</span>
+              <span className="truncate font-mono text-[11px] text-[#B5B5BD]">{selected}</span>
             ) : null}
           </span>
           <span className="flex shrink-0 items-center gap-2">

--- a/src/components/PrSheet.tsx
+++ b/src/components/PrSheet.tsx
@@ -16,7 +16,7 @@ const SHEET_STYLE: React.CSSProperties = {
 };
 
 const BACKDROP_STYLE: React.CSSProperties = {
-  backgroundColor: 'rgba(0,0,0,0.44)',
+  backgroundColor: 'rgba(0,0,0,0.48)',
   backdropFilter: 'blur(20px)',
   WebkitBackdropFilter: 'blur(20px)',
 };

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Task } from '../../server/types';
 import { GlassPanel } from '@/components/ui/glass-panel';
@@ -7,7 +7,6 @@ import { useInbox } from '@/lib/inbox';
 import { useTasksContextOptional } from '@/lib/tasks-context';
 import { timeAgo } from '@/lib/time';
 import { repoName } from '@/lib/utils';
-import { cn } from '@/lib/utils';
 import { CircleCheckIcon } from '@/components/icons';
 
 type RowKind = 'awaiting_reply' | 'errored' | 'activity';
@@ -49,7 +48,7 @@ function ReplyButton({ taskId }: { taskId: string }) {
         e.stopPropagation();
         navigate(`/?add_agent=${taskId}`);
       }}
-      className="shrink-0 px-2.5 py-1 text-[11px] font-bold tracking-wider uppercase text-[#1f1300] transition-colors hover:brightness-110"
+      className="shrink-0 rounded-[10px] px-3 py-1.5 text-[11px] font-bold tracking-wider uppercase text-[#1f1300] transition-colors hover:brightness-110"
       style={{
         backgroundColor: '#FFB800',
         boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.35), 0 0 16px 0 rgba(255, 184, 0, 0.35)',
@@ -60,12 +59,37 @@ function ReplyButton({ taskId }: { taskId: string }) {
   );
 }
 
-function InboxRow({ task, kind }: { task: Task; kind: RowKind }) {
+// Per-mockup: awaiting_reply cards carry amber tint in border + a specular
+// top-edge; errored cards use red-tinted border; activity rows stay L1 glass.
+function cardStyleFor(kind: RowKind): { style: CSSProperties; className: string } {
+  if (kind === 'awaiting_reply') {
+    return {
+      className: 'border-[#FFB80040]',
+      style: {
+        backgroundColor: 'rgba(255, 255, 255, 0.10)',
+        boxShadow:
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.22), 0 12px 30px -8px rgba(0, 0, 0, 0.55)',
+      },
+    };
+  }
+  return {
+    className: 'border-[#EF444440]',
+    style: {
+      backgroundColor: 'rgba(255, 255, 255, 0.10)',
+      boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.22), 0 12px 30px -8px rgba(0, 0, 0, 0.55)',
+    },
+  };
+}
+
+function InboxCard({ task, kind }: { task: Task; kind: RowKind }) {
   const navigate = useNavigate();
+  const { style, className } = cardStyleFor(kind);
   return (
-    <div
+    <GlassPanel
+      level={2}
       data-testid={`inbox-row-${task.id}`}
-      className="group flex w-full items-center gap-3 border border-transparent px-3 py-2 transition-colors hover:border-[#2f2f2f] hover:bg-[#141414]"
+      className={`group flex items-center gap-3 rounded-[16px] px-5 py-4 transition-colors hover:bg-glass-l3 ${className}`}
+      style={style}
     >
       <button
         type="button"
@@ -73,16 +97,45 @@ function InboxRow({ task, kind }: { task: Task; kind: RowKind }) {
         className="flex min-w-0 flex-1 items-center gap-3 text-left"
       >
         <StatusGlyph status={glyphStatusFor(kind)} size={12} />
-        <span className="flex min-w-0 flex-1 items-baseline gap-2">
-          <span className="truncate text-sm font-medium text-foreground">{task.title}</span>
-          <span className="truncate text-xs text-muted-foreground">{subtitleFor(task, kind)}</span>
-        </span>
-        <span className="shrink-0 text-[11px] text-[#6a6a6a]">
-          {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="flex items-baseline gap-2">
+            <span className="truncate text-sm font-semibold text-foreground">{task.title}</span>
+            <span className="truncate text-xs text-muted-foreground">
+              {subtitleFor(task, kind)}
+            </span>
+          </span>
+          <span className="font-mono text-[11px] text-[#8a8a8a]">
+            {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
+          </span>
         </span>
       </button>
       {kind === 'awaiting_reply' && <ReplyButton taskId={task.id} />}
-    </div>
+    </GlassPanel>
+  );
+}
+
+function ActivityRow({ task }: { task: Task }) {
+  const navigate = useNavigate();
+  return (
+    <GlassPanel
+      level={1}
+      data-testid={`inbox-row-${task.id}`}
+      className="group flex items-center gap-4 rounded-[12px] px-4 py-2.5 transition-colors hover:bg-glass-l2"
+    >
+      <button
+        type="button"
+        onClick={() => navigate(`/tasks/${task.id}`)}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <StatusGlyph status="closed" size={10} />
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#B5B5BD]">
+          {task.title}
+        </span>
+        <span className="shrink-0 font-mono text-[11px] text-[#6a6a6a]">
+          {repoName(task.repo_path)} · closed · {timeAgo(task.updated_at)}
+        </span>
+      </button>
+    </GlassPanel>
   );
 }
 
@@ -101,8 +154,8 @@ function Section({
 }) {
   if (tasks.length === 0) return null;
   return (
-    <section data-testid={testId} className="flex flex-col gap-1">
-      <h3 className="flex items-baseline gap-2 px-3 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
+    <section data-testid={testId} className="flex flex-col gap-3">
+      <h3 className="flex items-baseline gap-2 px-1 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
         {eyebrow && (
           <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
             {eyebrow}
@@ -110,9 +163,9 @@ function Section({
         )}
         <span>{title}</span>
       </h3>
-      <div className="flex flex-col">
+      <div className="flex flex-col gap-3">
         {tasks.map((t) => (
-          <InboxRow key={t.id} task={t} kind={kind} />
+          <InboxCard key={t.id} task={t} kind={kind} />
         ))}
       </div>
     </section>
@@ -126,16 +179,18 @@ function ActivitySection({ tasks }: { tasks: Task[] }) {
   const visible = collapsed ? tasks.slice(0, ACTIVITY_COLLAPSED_LIMIT) : tasks;
   const hidden = tasks.length - visible.length;
   return (
-    <section data-testid="inbox-section-activity" className="flex flex-col gap-1">
-      <h3 className="flex items-baseline gap-2 px-3 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
+    <section data-testid="inbox-section-activity" className="flex flex-col gap-2">
+      <div
+        className="flex items-baseline gap-2 border-t border-[#FFFFFF14] px-1 pt-4 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]"
+      >
         <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
           //
         </span>
         <span>Activity</span>
-      </h3>
-      <div className="flex flex-col">
+      </div>
+      <div className="flex flex-col gap-2">
         {visible.map((t) => (
-          <InboxRow key={t.id} task={t} kind="activity" />
+          <ActivityRow key={t.id} task={t} />
         ))}
       </div>
       {tasks.length > ACTIVITY_COLLAPSED_LIMIT && (
@@ -143,7 +198,7 @@ function ActivitySection({ tasks }: { tasks: Task[] }) {
           type="button"
           data-testid="inbox-activity-toggle"
           onClick={() => setExpanded((v) => !v)}
-          className="self-start px-3 py-1 text-[11px] font-medium text-[#8a8a8a] hover:text-foreground"
+          className="self-start px-1 py-1 text-[11px] font-medium text-[#8a8a8a] hover:text-foreground"
         >
           {collapsed ? `Tap to expand (${hidden} more)` : 'Collapse'}
         </button>
@@ -174,14 +229,8 @@ export function SessionsInbox() {
   const isInboxZero = !loading && !isEmpty && awaitingReply.length === 0 && errored.length === 0;
 
   return (
-    <GlassPanel
-      level={1}
-      specular
-      data-testid="sessions-inbox"
-      className={cn('flex flex-col gap-5 p-4')}
-      style={{ borderRadius: '14px' }}
-    >
-      <div className="flex items-baseline justify-between px-3">
+    <div data-testid="sessions-inbox" className="flex flex-col gap-6">
+      <div className="flex items-baseline justify-between px-1">
         <h2 className="font-display text-sm font-bold uppercase tracking-wider text-[#6a6a6a]">
           Sessions
         </h2>
@@ -198,7 +247,7 @@ export function SessionsInbox() {
       </div>
 
       {error && (
-        <p data-testid="inbox-error" className="px-3 text-xs text-destructive">
+        <p data-testid="inbox-error" className="px-1 text-xs text-destructive">
           {error}
         </p>
       )}
@@ -206,7 +255,7 @@ export function SessionsInbox() {
       {isEmpty ? (
         <p
           data-testid="inbox-empty"
-          className="px-3 py-8 text-center text-sm text-muted-foreground"
+          className="px-1 py-8 text-center text-sm text-muted-foreground"
         >
           You&rsquo;re all caught up
         </p>
@@ -215,7 +264,7 @@ export function SessionsInbox() {
           {isInboxZero ? (
             <div
               data-testid="inbox-zero"
-              className="bg-glass-l2 glass-blur-l2 mx-3 flex flex-col items-center gap-3 rounded-xl border border-glass-edge px-6 py-8 text-center"
+              className="bg-glass-l2 glass-blur-l2 flex flex-col items-center gap-3 rounded-[16px] border border-glass-edge px-6 py-8 text-center"
             >
               <div
                 className="flex h-12 w-12 items-center justify-center rounded-full border border-[#22C55E66] bg-[#22C55E1F]"
@@ -252,6 +301,6 @@ export function SessionsInbox() {
           <ActivitySection tasks={activity} />
         </>
       )}
-    </GlassPanel>
+    </div>
   );
 }

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type CSSProperties } from 'react';
 
 import { StatusGlyph } from './ui/status-glyph';
 
@@ -24,9 +24,51 @@ const colors: Record<string, string> = {
   done: 'text-[#22C55E]',
 };
 
-export const StatusBadge = memo(function StatusBadge({ status }: { status: string }) {
+type PillTone = 'green' | 'amber' | 'red' | 'grey';
+
+const toneByStatus: Record<string, PillTone> = {
+  running: 'green',
+  working: 'green',
+  done: 'green',
+  setting_up: 'amber',
+  needs_attention: 'amber',
+  error: 'red',
+  draft: 'grey',
+  closed: 'grey',
+};
+
+const pillStyles: Record<PillTone, CSSProperties> = {
+  green: { backgroundColor: 'rgba(34, 197, 94, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(34, 197, 94, 0.24)' },
+  amber: { backgroundColor: 'rgba(255, 184, 0, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(255, 184, 0, 0.24)' },
+  red: { backgroundColor: 'rgba(239, 68, 68, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(239, 68, 68, 0.28)' },
+  grey: { backgroundColor: 'rgba(255, 255, 255, 0.04)', boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.08)' },
+};
+
+export const StatusBadge = memo(function StatusBadge({
+  status,
+  variant = 'text',
+}: {
+  status: string;
+  variant?: 'text' | 'pill';
+}) {
   const label = labels[status] || 'UNKNOWN';
   const colorClass = colors[status] || 'text-[#6a6a6a]';
+
+  if (variant === 'pill') {
+    const tone = toneByStatus[status] ?? 'grey';
+    return (
+      <span
+        data-status={status}
+        data-variant="pill"
+        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[10px] font-bold tracking-wider uppercase ${colorClass}`}
+        style={pillStyles[tone]}
+      >
+        <StatusGlyph status={status} size={8} />
+        <span>{label}</span>
+      </span>
+    );
+  }
+
   return (
     <span
       data-status={status}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -186,7 +186,7 @@ export const TaskCard = memo(function TaskCard({
         {/* Right: status pill + timestamp + actions + arrow */}
         <div className="flex shrink-0 flex-col items-end gap-2">
           <div className="flex items-center gap-2">
-            <StatusBadge status={displayStatus} />
+            <StatusBadge status={displayStatus} variant="pill" />
             <span className="text-xs tabular-nums whitespace-nowrap text-muted-foreground">
               {timeAgo(task.created_at)}
             </span>

--- a/src/components/TaskFilterBar.tsx
+++ b/src/components/TaskFilterBar.tsx
@@ -145,7 +145,7 @@ export const TaskFilterBar = memo(function TaskFilterBar({
       level={1}
       specular
       data-testid="task-filter-bar"
-      className="my-3 flex items-center justify-between px-2 py-1.5"
+      className="my-3 flex items-center justify-between gap-2 rounded-[14px] px-2 py-1.5"
     >
       <div className="flex items-center gap-1">
         {STATUS_CHIPS.map((chip) => (
@@ -160,7 +160,14 @@ export const TaskFilterBar = memo(function TaskFilterBar({
       </div>
       <div className="flex items-center gap-2">
         {repos.length > 1 && (
-          <RepoFilterDropdown repos={repos} activeRepo={activeRepo} onRepoChange={onRepoChange} />
+          <>
+            <span
+              aria-hidden
+              className="h-5 w-px"
+              style={{ backgroundColor: 'rgba(255, 255, 255, 0.08)' }}
+            />
+            <RepoFilterDropdown repos={repos} activeRepo={activeRepo} onRepoChange={onRepoChange} />
+          </>
         )}
       </div>
     </GlassPanel>

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -81,12 +81,12 @@ describe('UniversalSidebar nav', () => {
     expect(screen.getByLabelText('Settings (Cmd+,)')).toBeInTheDocument();
   });
 
-  it('active nav row carries the cyan-tinted stroke', async () => {
+  it('active nav row carries the cyan tint + 2px left accent bar', async () => {
     renderSidebar('/tasks');
     const row = await screen.findByTestId('sidebar-nav-tasks');
     expect(row).toHaveAttribute('data-active', 'true');
-    expect(row.style.backgroundColor).toBe('rgba(59, 130, 246, 0.12)');
-    expect(row.style.border).toContain('rgba(59, 130, 246, 0.4)');
+    expect(row.style.backgroundColor).toBe('rgba(59, 130, 246, 0.14)');
+    expect(row.style.borderLeft).toBe('2px solid rgb(59, 130, 246)');
   });
 });
 

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -48,8 +48,9 @@ const FOCUS_RING = 'focus-ring';
 const CYAN_ACTIVE_FG = '#7DD3FC';
 const NAV_INACTIVE_FG = 'rgba(255,255,255,0.65)';
 const NAV_MUTED_FG = 'rgba(255,255,255,0.45)';
-const ACTIVE_FILL = 'rgba(59,130,246,0.12)';
-const ACTIVE_STROKE = 'rgba(59,130,246,0.4)';
+// Mockup spec (PsSGN/uReOg): active row = 14% cyan fill + 2px left accent bar.
+const ACTIVE_FILL = 'rgba(59,130,246,0.14)';
+const ACTIVE_ACCENT = '#3B82F6';
 const SIDEBAR_EXPANDED_WIDTH = 240;
 const SIDEBAR_COLLAPSED_WIDTH = 56;
 const RAIL_TILE_SIZE = 36;
@@ -219,9 +220,9 @@ function Keycap({ children, active }: { children: ReactNode; active: boolean }) 
         fontSize: 10,
         fontWeight: 500,
         letterSpacing: 0.2,
-        backgroundColor: active ? 'rgba(59,130,246,0.16)' : 'rgba(255,255,255,0.04)',
-        color: active ? CYAN_ACTIVE_FG : NAV_MUTED_FG,
-        border: active ? '1px solid rgba(59,130,246,0.3)' : '1px solid rgba(255,255,255,0.06)',
+        backgroundColor: active ? 'rgba(59,130,246,0.12)' : 'rgba(255,255,255,0.04)',
+        color: active ? ACTIVE_ACCENT : NAV_MUTED_FG,
+        border: active ? '1px solid rgba(59,130,246,0.25)' : '1px solid rgba(255,255,255,0.06)',
       }}
       aria-hidden="true"
     >
@@ -893,11 +894,12 @@ function ExpandedNavRow({
         className={`flex items-center hover:bg-white/[0.04] ${FOCUS_RING}`}
         style={{
           padding: '8px 10px',
+          paddingLeft: isActive ? 8 : 10,
           gap: 10,
           borderRadius: 10,
           backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-          border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
-          color: isActive ? '#3B82F6' : NAV_INACTIVE_FG,
+          borderLeft: `2px solid ${isActive ? ACTIVE_ACCENT : 'transparent'}`,
+          color: isActive ? ACTIVE_ACCENT : NAV_INACTIVE_FG,
           fontWeight: isActive ? 600 : 500,
           fontSize: 13,
         }}
@@ -951,7 +953,7 @@ function CollapsedNavTile({
           height: RAIL_TILE_SIZE,
           borderRadius: 10,
           backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-          border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
+          border: `1px solid ${isActive ? 'rgba(59,130,246,0.4)' : 'transparent'}`,
         }}
       >
         <Icon color={iconColor} />
@@ -1174,7 +1176,6 @@ function SessionRow({
             height: 28,
             borderRadius: 8,
             backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-            border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
           }}
         >
           <StatusIcon item={item} />
@@ -1195,7 +1196,6 @@ function SessionRow({
           gap: 8,
           borderRadius: 8,
           backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-          border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
         }}
       >
         <StatusIcon item={item} />
@@ -1352,11 +1352,12 @@ function MoreSection({ collapsed, activePath }: { collapsed: boolean; activePath
                 className={`flex items-center hover:bg-white/[0.04] ${FOCUS_RING}`}
                 style={{
                   padding: '8px 10px',
+                  paddingLeft: isActive ? 8 : 10,
                   gap: 10,
                   borderRadius: 10,
                   backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-                  border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
-                  color: isActive ? '#3B82F6' : NAV_INACTIVE_FG,
+                  borderLeft: `2px solid ${isActive ? ACTIVE_ACCENT : 'transparent'}`,
+                  color: isActive ? ACTIVE_ACCENT : NAV_INACTIVE_FG,
                   fontWeight: isActive ? 600 : 500,
                   fontSize: 12,
                 }}
@@ -1433,8 +1434,7 @@ function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePat
                   height: RAIL_TILE_SIZE,
                   borderRadius: 10,
                   backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-                  border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
-                  color: isActive ? '#3B82F6' : NAV_INACTIVE_FG,
+                  color: isActive ? ACTIVE_ACCENT : NAV_INACTIVE_FG,
                 }}
               >
                 💬
@@ -1451,7 +1451,6 @@ function ChatsSection({ collapsed, activePath }: { collapsed: boolean; activePat
                 gap: 8,
                 borderRadius: 8,
                 backgroundColor: isActive ? ACTIVE_FILL : 'transparent',
-                border: `1px solid ${isActive ? ACTIVE_STROKE : 'transparent'}`,
               }}
             >
               <Link

--- a/src/components/fields/BranchPickerField.tsx
+++ b/src/components/fields/BranchPickerField.tsx
@@ -11,6 +11,8 @@ interface BranchPickerFieldProps {
   disabled?: boolean;
   /** Optional ref to the trigger button (used by ⌘B to open the picker). */
   triggerRef?: React.Ref<HTMLButtonElement>;
+  /** Override trigger button className — e.g. to blend into a chip pill. */
+  triggerClassName?: string;
 }
 
 export function BranchPickerField({
@@ -20,6 +22,7 @@ export function BranchPickerField({
   onBranchesLoaded,
   disabled,
   triggerRef,
+  triggerClassName,
 }: BranchPickerFieldProps) {
   const [branches, setBranches] = useState<string[]>([]);
   const [branchSearch, setBranchSearch] = useState('');
@@ -75,7 +78,10 @@ export function BranchPickerField({
               ref={triggerRef}
               type="button"
               disabled={disabled || branches.length === 0}
-              className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className={
+                triggerClassName ??
+                'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+              }
             >
               <span className={value ? 'font-mono text-xs' : 'text-muted-foreground'}>
                 {value || 'Select base branch...'}

--- a/src/index.css
+++ b/src/index.css
@@ -52,11 +52,15 @@
   /* Glass material system */
   --glass-l0: #0a0a0b;
   --glass-l1: rgba(255, 255, 255, 0.08);
-  --glass-l2: rgba(255, 255, 255, 0.12);
-  --glass-l3: rgba(255, 255, 255, 0.18);
+  --glass-l2: rgba(255, 255, 255, 0.14);
+  --glass-l3: rgba(255, 255, 255, 0.22);
   --glass-edge: rgba(255, 255, 255, 0.14);
   --glass-edge-strong: rgba(255, 255, 255, 0.26);
   --glass-specular: rgba(255, 255, 255, 0.22);
+
+  /* Ambient tint blobs (content canvas only — not terminal panes) */
+  --ambient-cyan: rgba(59, 130, 246, 0.18);
+  --ambient-purple: rgba(124, 58, 237, 0.12);
 }
 
 /* Dark-only app — no light theme. Keep .dark for shadcn compatibility. */
@@ -140,6 +144,8 @@
   --color-glass-edge: var(--glass-edge);
   --color-glass-edge-strong: var(--glass-edge-strong);
   --color-glass-specular: var(--glass-specular);
+  --color-ambient-cyan: var(--ambient-cyan);
+  --color-ambient-purple: var(--ambient-purple);
   --radius-sm: 0;
   --radius-md: 0;
   --radius-lg: 0;
@@ -182,6 +188,43 @@
     box-shadow:
       0 0 0 2px #07080b,
       0 0 0 4px #60a5fae6;
+  }
+}
+
+/*
+ * Ambient tint backdrop — cyan top-right, purple bottom-left gradient blobs
+ * sitting behind content so backdrop-blur panels have something to blur
+ * through. Must never sit behind a terminal pane (terminal rule).
+ */
+@utility ambient-tint-backdrop {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(120px);
+  }
+
+  &::before {
+    width: 900px;
+    height: 900px;
+    top: -200px;
+    right: -150px;
+    background: radial-gradient(circle, var(--ambient-cyan) 0%, transparent 70%);
+  }
+
+  &::after {
+    width: 700px;
+    height: 700px;
+    bottom: -200px;
+    left: -150px;
+    background: radial-gradient(circle, var(--ambient-purple) 0%, transparent 70%);
   }
 }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -43,9 +43,9 @@ export default function HomePage() {
   const isFirstRun = !loading && tasks.length === 0;
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="relative flex h-full flex-col">
       <div className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-4xl px-8 py-12">
+        <div className="mx-auto max-w-4xl px-8 pt-12 pb-[280px]">
           <div className="flex flex-col gap-2">
             <span
               data-testid="page-eyebrow"
@@ -66,7 +66,19 @@ export default function HomePage() {
           </div>
         </div>
       </div>
-      <Composer />
+      <div
+        data-testid="composer-dock"
+        className="pointer-events-none absolute inset-x-0 bottom-6 flex justify-center"
+      >
+        <div
+          className="pointer-events-auto w-[90%] max-w-[1056px]"
+          style={{
+            filter: 'drop-shadow(0 24px 60px rgba(0, 0, 0, 0.56))',
+          }}
+        >
+          <Composer />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/ParallelGridPage.tsx
+++ b/src/pages/ParallelGridPage.tsx
@@ -15,14 +15,29 @@ function hasAttention(task: Task): boolean {
   return d === 'needs_attention' || task.status === 'error';
 }
 
+function formatElapsed(startedAt: string): string {
+  const ms = Date.now() - new Date(startedAt + 'Z').getTime();
+  const secs = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
 function MiniPane({ task, onOpen }: MiniPaneProps) {
   const agents = task.agents ?? [];
   const activeAgent = agents.find((a) => a.status === 'running') || agents[0];
-  const lines: string[] = [
-    `branch: ${task.branch ?? '—'}`,
-    `agents: ${agents.length}`,
-    activeAgent ? `label: ${activeAgent.label}` : '',
-    activeAgent?.hook_activity ? `activity: ${activeAgent.hook_activity}` : '',
+  const running = agents.filter((a) => a.status === 'running').length;
+  const bodyLines: string[] = [
+    `$ branch ${task.branch ?? '—'}`,
+    `  status ${task.derived_status || task.status}`,
+    `  agents ${agents.length} (${running} running)`,
+    activeAgent ? `  active ${activeAgent.label}` : '',
+    activeAgent?.hook_activity ? `  hook   ${activeAgent.hook_activity}` : '',
+    task.error ? `! error  ${task.error.split('\n')[0]}` : '',
+    task.updated_at ? `  last   ${task.updated_at.replace('T', ' ').slice(0, 19)}` : '',
+    '  ⏎ open detail',
   ].filter(Boolean);
   const attention = hasAttention(task);
   return (
@@ -30,15 +45,12 @@ function MiniPane({ task, onOpen }: MiniPaneProps) {
       type="button"
       data-testid={`grid-pane-${task.id}`}
       onClick={onOpen}
-      className="group flex h-[260px] flex-col overflow-hidden rounded-xl border border-glass-edge bg-[#0B0C0F] text-left shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)] transition hover:border-[#3B82F666]"
+      className="focus-ring group flex h-[260px] flex-col overflow-hidden rounded-xl border border-glass-edge bg-[#0B0C0F] text-left shadow-[0_8px_20px_-6px_rgba(0,0,0,0.5)] transition hover:border-[#3B82F666] active:translate-y-px disabled:opacity-40"
+      style={attention ? { borderLeft: '2px solid #FFB800' } : undefined}
     >
       <header
         className="flex items-center gap-2 border-b bg-[#FFFFFF08] px-3 py-2"
-        style={
-          attention
-            ? { borderBottomColor: 'rgba(255,255,255,0.08)', borderLeft: '2px solid #FFB800' }
-            : { borderBottomColor: 'rgba(255,255,255,0.08)' }
-        }
+        style={{ borderBottomColor: 'rgba(255,255,255,0.08)' }}
       >
         <span
           className="flex-1 truncate font-mono text-[11px] font-medium text-white"
@@ -49,7 +61,7 @@ function MiniPane({ task, onOpen }: MiniPaneProps) {
         <StatusGlyph status={task.derived_status || task.status} size={10} />
       </header>
       <div className="flex-1 overflow-hidden px-4 py-3 font-mono text-[11px] leading-snug text-[#8a8a8a]">
-        {lines.map((line, idx) => (
+        {bodyLines.map((line, idx) => (
           <div key={idx} className="truncate">
             {line}
           </div>
@@ -57,10 +69,12 @@ function MiniPane({ task, onOpen }: MiniPaneProps) {
       </div>
       <footer className="flex items-center gap-2 border-t border-[#FFFFFF0A] bg-[#FFFFFF05] px-3 py-1.5 font-mono text-[10px] text-[#8a8a8a]">
         <span>opus-4.7</span>
+        <span className="text-[#3a3a3a]">·</span>
+        <span>412k/1M</span>
+        <span className="text-[#3a3a3a]">·</span>
+        <span>$2.14</span>
         <div className="flex-1" />
-        <span className="text-[#B5B5BD]">
-          {agents.length} agent{agents.length === 1 ? '' : 's'}
-        </span>
+        <span className="text-[#B5B5BD]">{formatElapsed(task.created_at)}</span>
       </footer>
     </button>
   );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -41,7 +41,7 @@ function ToggleSwitch({ checked, onChange }: { checked: boolean; onChange: (v: b
       type="button"
       role="switch"
       aria-checked={checked}
-      className="relative h-5 w-9 transition-colors"
+      className="focus-ring relative h-5 w-9 transition-colors disabled:opacity-40"
       style={checked ? TOGGLE_ON_STYLE : TOGGLE_OFF_STYLE}
       onClick={() => onChange(!checked)}
     >
@@ -162,7 +162,10 @@ function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
       {error && (
         <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
           <span className="text-sm text-red-400">{error}</span>
-          <button className="text-xs text-[#3B82F6] hover:text-[#60a5fa]" onClick={refresh}>
+          <button
+            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
+            onClick={refresh}
+          >
             Retry
           </button>
         </div>
@@ -209,13 +212,13 @@ function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
           />
           <div className="flex justify-end gap-2">
             <button
-              className="px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
+              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
               onClick={() => setShowCreate(false)}
             >
               Cancel
             </button>
             <button
-              className="bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] disabled:opacity-50"
+              className="focus-ring bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
               onClick={handleCreate}
               disabled={creating || !newName.trim()}
             >
@@ -288,7 +291,10 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
       {error && (
         <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
           <span className="text-sm text-red-400">{error}</span>
-          <button className="text-xs text-[#3B82F6] hover:text-[#60a5fa]" onClick={refresh}>
+          <button
+            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
+            onClick={refresh}
+          >
             Retry
           </button>
         </div>
@@ -298,7 +304,7 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
         <div className="py-8 text-center text-sm text-[#8a8a8a]">
           No skills installed.{' '}
           <button
-            className="text-[#3B82F6] hover:text-[#60a5fa]"
+            className="focus-ring text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
             onClick={() => setShowCreate(true)}
           >
             Create your first skill
@@ -320,7 +326,7 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
                 {skill.description && <p className="text-xs text-[#b5b5bd]">{skill.description}</p>}
               </div>
               <button
-                className="text-xs text-[#8a8a8a] opacity-0 group-hover:opacity-100 hover:text-red-400"
+                className="focus-ring text-xs text-[#8a8a8a] opacity-0 transition-opacity group-hover:opacity-100 hover:text-red-400 focus-visible:opacity-100"
                 onClick={(e) => {
                   e.stopPropagation();
                   setDeleteTarget(skill.name);
@@ -349,13 +355,13 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
           />
           <div className="flex justify-end gap-2">
             <button
-              className="px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
+              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
               onClick={() => setShowCreate(false)}
             >
               Cancel
             </button>
             <button
-              className="bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] disabled:opacity-50"
+              className="focus-ring bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
               onClick={handleCreate}
               disabled={creating || !newName.trim()}
             >
@@ -381,13 +387,13 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
           </DialogHeader>
           <div className="flex justify-end gap-2">
             <button
-              className="px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
+              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
               onClick={() => setDeleteTarget(null)}
             >
               Cancel
             </button>
             <button
-              className="bg-red-600 px-3 py-1.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
+              className="focus-ring bg-red-600 px-3 py-1.5 text-xs text-white hover:bg-red-700 active:bg-red-800 disabled:opacity-40"
               onClick={handleDelete}
               disabled={deleting}
             >
@@ -405,7 +411,7 @@ function AddChip({ label, onClick }: { label: string; onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="focus-ring inline-flex items-center gap-1 border border-[#3B82F6]/40 bg-[#3B82F6]/12 px-2.5 py-1 text-xs font-medium text-[#60a5fa] hover:bg-[#3B82F6]/20"
+      className="focus-ring inline-flex items-center gap-1 rounded-md border border-[#3B82F6]/40 px-2.5 py-1 text-xs font-medium text-[#60a5fa] transition-colors hover:bg-[#3B82F6]/20 active:bg-[#3B82F6]/30 disabled:opacity-40"
       style={{ backgroundColor: 'rgba(59,130,246,0.12)' }}
     >
       {label}
@@ -433,7 +439,7 @@ function RepoRow({ config, onEditClick }: { config: RepoConfig; onEditClick: () 
           type="button"
           aria-label={`Actions for ${repoName(config.repo_path)}`}
           data-testid={`repo-overflow-${repoName(config.repo_path)}`}
-          className="text-[#8a8a8a] opacity-0 group-hover:opacity-100 hover:text-white focus:opacity-100"
+          className="focus-ring text-[#8a8a8a] opacity-0 transition-opacity group-hover:opacity-100 hover:text-white focus-visible:opacity-100"
           onClick={() => setShowMenu((v) => !v)}
         >
           ⋯
@@ -446,7 +452,7 @@ function RepoRow({ config, onEditClick }: { config: RepoConfig; onEditClick: () 
           >
             <button
               type="button"
-              className="block w-full px-3 py-1.5 text-left text-white hover:bg-glass-l1"
+              className="focus-ring block w-full px-3 py-1.5 text-left text-white hover:bg-glass-l1"
               onClick={() => {
                 setShowMenu(false);
                 onEditClick();
@@ -456,7 +462,7 @@ function RepoRow({ config, onEditClick }: { config: RepoConfig; onEditClick: () 
             </button>
             <button
               type="button"
-              className="block w-full px-3 py-1.5 text-left text-red-400 hover:bg-red-400/10"
+              className="focus-ring block w-full px-3 py-1.5 text-left text-red-400 hover:bg-red-400/10"
               onClick={() => {
                 setShowMenu(false);
                 navigate(`/?repo=${encodeURIComponent(config.repo_path)}`);
@@ -537,7 +543,10 @@ function RepoConfigsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
       {error && (
         <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
           <span className="text-sm text-red-400">{error}</span>
-          <button className="text-xs text-[#3B82F6] hover:text-[#60a5fa]" onClick={refresh}>
+          <button
+            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
+            onClick={refresh}
+          >
             Retry
           </button>
         </div>
@@ -592,14 +601,14 @@ function RepoConfigsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
           <div className="flex justify-end gap-2 pt-1">
             <button
               onClick={() => setEditingPath(null)}
-              className="px-3 py-1 text-xs text-[#b5b5bd] hover:text-white"
+              className="focus-ring px-3 py-1 text-xs text-[#b5b5bd] hover:text-white"
             >
               Cancel
             </button>
             <button
               onClick={handleSave}
               disabled={saving}
-              className="bg-[#3B82F6] px-3 py-1 text-xs text-white disabled:opacity-50"
+              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
             >
               {saving ? 'Saving...' : 'Save'}
             </button>
@@ -656,7 +665,7 @@ function EditorSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
         <select
           value={editor}
           onChange={(e) => handleChange(e.target.value)}
-          className="bg-[#0B0C0F] border border-glass-edge px-3 py-1 text-xs text-white outline-none focus:border-[#3B82F6]"
+          className="focus-ring bg-[#0B0C0F] border border-glass-edge px-3 py-1 text-xs text-white outline-none focus:border-[#3B82F6]"
         >
           <option value="nvim">Neovim</option>
           <option value="vscode">VS Code</option>
@@ -769,7 +778,7 @@ function ClaudeLaunchFlagsSection({ scrollRef }: { scrollRef: (el: HTMLElement |
             <button
               onClick={saveFlags}
               disabled={!isDirty || saving}
-              className="bg-[#3B82F6] px-3 py-1 text-xs text-white disabled:opacity-50"
+              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
             >
               {saving ? 'Saving...' : 'Save'}
             </button>
@@ -911,7 +920,7 @@ function OrchestratorPromptSection() {
           <button
             onClick={save}
             disabled={!isDirty || saving}
-            className="bg-[#3B82F6] px-3 py-1 text-xs text-white disabled:opacity-50"
+            className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
           >
             {saving ? 'Saving...' : 'Save'}
           </button>
@@ -926,7 +935,10 @@ function OrchestratorPromptSection() {
         />
         <div className="mt-2 flex items-center gap-3">
           {data?.isCustom && (
-            <button onClick={reset} className="text-xs text-red-400 hover:text-red-300">
+            <button
+              onClick={reset}
+              className="focus-ring text-xs text-red-400 hover:text-red-300 active:text-red-500"
+            >
               Reset to Default
             </button>
           )}
@@ -956,7 +968,7 @@ function OrchestratorSection({ scrollRef }: { scrollRef: (el: HTMLElement | null
               showToast('error', 'ERROR', err instanceof Error ? err.message : 'Failed to restart');
             }
           }}
-          className="border border-glass-edge bg-glass-l1 px-3 py-1 text-xs text-white hover:bg-glass-l2"
+          className="focus-ring border border-glass-edge bg-glass-l1 px-3 py-1 text-xs text-white transition-colors hover:bg-glass-l2 active:bg-glass-l3 disabled:opacity-40"
         >
           Restart
         </button>

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -307,16 +307,16 @@ export default function TaskDetail() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* L1 glass header — compact 12px vertical padding */}
+      {/* L1 glass header — 18px vertical / 24px horizontal padding, 17px title */}
       <div
         data-testid="task-detail-header"
-        className="bg-glass-l1 glass-blur-l1 flex items-center justify-between gap-3 border-b border-glass-edge px-4 py-3"
+        className="bg-glass-l1 glass-blur-l1 flex items-center justify-between gap-3 border-b border-glass-edge px-6 py-[18px]"
       >
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2.5">
           <h1
             title={task.title}
             aria-label={task.title}
-            className="truncate text-[15px] font-semibold leading-none"
+            className="truncate text-[17px] font-semibold leading-none tracking-tight"
           >
             {task.title}
           </h1>
@@ -372,9 +372,11 @@ export default function TaskDetail() {
             <Button
               variant="outline"
               size="sm"
+              data-testid="diff-toggle"
+              data-active={mode === 'diff' ? 'true' : undefined}
               className={
                 mode === 'diff'
-                  ? 'border-[#2f2f2f] text-[#3B82F6]'
+                  ? 'border-[#3B82F666] bg-[#3B82F61F] text-[#3B82F6] hover:bg-[#3B82F633] hover:text-[#3B82F6]'
                   : 'border-[#2f2f2f] text-[#8a8a8a]'
               }
               onClick={() => setMode(mode === 'diff' ? 'agents' : 'diff')}
@@ -430,14 +432,16 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Thin metadata bar — L1 lighter (5% white + 30px blur), 6px vertical padding */}
+      {/* Thin metadata bar — L1 lighter (5% white + 30px blur), 10/24 padding, 10% bottom stroke */}
       {!isScratch && (
         <div
-          className="flex items-center gap-5 border-b border-glass-edge px-6 py-[6px]"
+          data-testid="task-detail-meta"
+          className="flex items-center gap-5 px-6 py-[10px]"
           style={{
             background: 'rgba(255,255,255,0.05)',
             backdropFilter: 'blur(30px)',
             WebkitBackdropFilter: 'blur(30px)',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
           }}
         >
           {task.repo_path && (


### PR DESCRIPTION
## Summary

Five parallel audit passes against `design/glass-redesign.pen` to close remaining drift after the T1–T7 glass redesign series (PRs #106–#112) shipped. Each pass re-read its assigned pen frames, diffed against the current implementation, and landed targeted fixes.

Orchestrated via 5 concurrent octomux agents, each on its own worktree, rebased and merged into `feat/glass-redesign` via `scripts/rollup-to-feat.sh`.

## What changed

| Pass | Frames | Summary |
|------|--------|---------|
| **T1** Foundation + shell | `PsSGN` + embedded sidebars | L2/L3 tint tokens corrected (0.12→0.14, 0.18→0.22), ambient-tint blobs mounted on `<main>` only (terminals stay opaque), sidebar active-row swapped to 2px left accent bar, keycap active color fixed |
| **T2** Home + Tasks | `9VzuO`, `TF8jb` | Sessions split into per-item L2 cards (amber needs-you / red errored borders), `StatusBadge` end-pill variant, Composer promoted to floating L3 dock (`bottom-6 w-[90%] max-w-[1056px]`) |
| **T3** Task Detail + Diff + PR sheet | `y3FOS`, `Ykdgp`, `h3PJl` | Header bumped to 17px, DIFF toggle = pressed cyan glass, diff sidebar rebuilt as 260px L1 glass panel, all top-level dir groups collapsible w/ localStorage persistence, PR sheet scrim 0.44→0.48 |
| **T4** Composer + Palette | `zqZ33`, `ldkwq`, `CsQvc` | Repo chip = cyan-tinted glass pill, prompt textarea + footer moved into single opaque `#0B0C0F` terminal inset, palette scrim → 48% black + 20px blur, keycap primitive gets edge stroke + specular, focus-rings everywhere |
| **T5** Orch + Settings + States + Grid | `cN3Ko`, `1NGJ5`, `NozRm`, `7CAFr`, `UrAU4`, `Scp7l` | `:focus-visible` rings added across ~15 Settings controls, Parallel Agent Grid full-pane 2px amber left stroke for attention/error panes, telemetry footer layout frozen to mockup |

## Files touched (source only)

- `src/App.tsx`, `src/index.css` — ambient tint tokens + backdrop utility
- `src/components/UniversalSidebar.tsx` (+test) — active-row left-accent treatment
- `src/components/CommandPalette.tsx` — scrim + keycap + group-header count chip
- `src/components/Composer.tsx` + `BranchPickerField.tsx` — cyan chip pills, terminal-rule prompt inset
- `src/components/SessionsInbox.tsx`, `StatusBadge.tsx`, `TaskCard.tsx`, `TaskFilterBar.tsx` — L2 card split, end-pill variant, unified filter bar
- `src/components/DiffViewer.tsx`, `DiffFileTree.tsx`, `PrSheet.tsx` — L1 file-list panel, collapsible dir groups, scrim
- `src/pages/HomePage.tsx`, `TaskDetail.tsx`, `SettingsPage.tsx`, `ParallelGridPage.tsx` — composer dock, header typography, focus rings, attention stroke

Also includes tooling committed to the branch:
- `design/glass-redesign.pen`, `design/README.md`, `design/task-backlog.md` — reference mockups for future iterations
- `scripts/rollup-to-feat.sh` — parallel-task rollup helper
- `.octomux/rollup/t{1..5}-*.md` — per-pass rollup summaries

## Known gaps (flagged for follow-up, not blocking)

1. Pen is missing a standalone `uReOg` **Sidebar Variants** frame; collapsed-rail tile sizing was inferred from embedded usages.
2. README and page frames disagree on sidebar active-row shape (README says 1px stroke, frames show 2px left accent bar). Agent followed the frames — confirm intent.
3. Composer still mounted inline in `HomePage` rather than as a true L3 modal sheet — restructuring would break Composer tests + URL hydration, deferred.
4. Orchestrator cadence hint + Parallel Grid tokens/cost footer are placeholders — no backend route yet. Layouts frozen, wiring deferred.

## Test plan

- [x] `bun run typecheck` — clean on each pass and after final rollup
- [x] `bun run lint` — 0 new errors (24 pre-existing warnings unchanged)
- [x] `bun run test` — 1263/1263 passing after final rollup
- [ ] Eyeball `/`, `/tasks`, `/tasks/:id`, `/tasks/:id/diff`, composer, `⌘K` palette, `/settings`, `/orchestrator`, `/orchestrator/grid` against the pen mockups
- [ ] Verify ambient tints render on content canvas but NOT on terminal panes
- [ ] Verify focus-visible rings on keyboard-tab through all surfaces