### PR TITLE
refactor(ui): align home/sessions-inbox to glass-redesign mockups

### DIFF
--- a/.octomux/rollup/t1-foundation-shell.md
+++ b/.octomux/rollup/t1-foundation-shell.md
@@ -15,7 +15,7 @@ sidebar was cross-verified against all six page frames instead.
 2. **Ambient tint blobs missing** — content canvas had no cyan/purple
    backdrop, so L1/L2/L3 glass had nothing to blur through. Added
    `--ambient-cyan` / `--ambient-purple` tokens + an `ambient-tint-
-   backdrop` utility; mounted on `<main>` only in `src/App.tsx` so
+backdrop` utility; mounted on `<main>` only in `src/App.tsx` so
    terminal panes (`<TerminalView>` inside `<main>` still renders on
    top of its own opaque `#0B0C0F` fill) stay opaque.
 3. **Sidebar nav active row shape drift** — code used a 1px all-around

--- a/.octomux/rollup/t2-home-tasks.md
+++ b/.octomux/rollup/t2-home-tasks.md
@@ -26,7 +26,7 @@ pen frames `9VzuO` (Home) + `TF8jb` (Tasks).
   implicit gap with the `fbSep` rule in the pen).
 - **Composer dock.** Home now renders the Composer as a floating
   L3 dock: absolute-positioned at `bottom-6`, centered, `w-[90%]
-  max-w-[1056px]`, with a drop-shadow filter for lift. Scroll body
+max-w-[1056px]`, with a drop-shadow filter for lift. Scroll body
   gets `pb-[280px]` so inbox content no longer slides under the
   dock. Composer itself now has an explicit `rounded-[20px]` outer
   radius to match the pen.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,28 +164,31 @@ export function AppShell() {
         <main className="relative isolate flex min-h-0 min-w-0 flex-1 flex-col">
           <div className="ambient-tint-backdrop" aria-hidden="true" />
           <div className="relative z-10 flex min-h-0 flex-1 flex-col">
-          <Suspense
-            fallback={
-              <div className="flex h-full items-center justify-center text-muted-foreground">
-                Loading...
-              </div>
-            }
-          >
-            <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/tasks" element={<TasksPage />} />
-              <Route path="/tasks/grid" element={<ParallelGridPage />} />
-              <Route path="/orchestrator/grid" element={<ParallelGridPage />} />
-              <Route path="/tasks/:id" element={<TaskDetail />} />
-              <Route path="/orchestrator" element={<Navigate to="/chats/orchestrator" replace />} />
-              <Route path="/settings" element={<SettingsPage />} />
-              <Route path="/skills/:name" element={<SkillEditor />} />
-              <Route path="/agents/:name" element={<AgentEditor />} />
-              <Route path="/chats/:id" element={<ChatPage />} />
-              <Route path="/workspaces" element={<WorkspacesPage />} />
-              <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
-            </Routes>
-          </Suspense>
+            <Suspense
+              fallback={
+                <div className="flex h-full items-center justify-center text-muted-foreground">
+                  Loading...
+                </div>
+              }
+            >
+              <Routes>
+                <Route path="/" element={<HomePage />} />
+                <Route path="/tasks" element={<TasksPage />} />
+                <Route path="/tasks/grid" element={<ParallelGridPage />} />
+                <Route path="/orchestrator/grid" element={<ParallelGridPage />} />
+                <Route path="/tasks/:id" element={<TaskDetail />} />
+                <Route
+                  path="/orchestrator"
+                  element={<Navigate to="/chats/orchestrator" replace />}
+                />
+                <Route path="/settings" element={<SettingsPage />} />
+                <Route path="/skills/:name" element={<SkillEditor />} />
+                <Route path="/agents/:name" element={<AgentEditor />} />
+                <Route path="/chats/:id" element={<ChatPage />} />
+                <Route path="/workspaces" element={<WorkspacesPage />} />
+                <Route path="/workspaces/:id" element={<WorkspaceDetailPage />} />
+              </Routes>
+            </Suspense>
           </div>
         </main>
         <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,12 @@ export function AppShell() {
     setPaletteOpen(true);
   });
 
+  useEffect(() => {
+    const handler = () => setPaletteOpen(true);
+    window.addEventListener('open-command-palette', handler);
+    return () => window.removeEventListener('open-command-palette', handler);
+  }, []);
+
   useGlobalShortcut({ key: 'g', mod: true, shift: true }, (e) => {
     e.preventDefault();
     navigate('/tasks/grid');

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -180,9 +180,7 @@ function ActivitySection({ tasks }: { tasks: Task[] }) {
   const hidden = tasks.length - visible.length;
   return (
     <section data-testid="inbox-section-activity" className="flex flex-col gap-2">
-      <div
-        className="flex items-baseline gap-2 border-t border-[#FFFFFF14] px-1 pt-4 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]"
-      >
+      <div className="flex items-baseline gap-2 border-t border-[#FFFFFF14] px-1 pt-4 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
         <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
           //
         </span>

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useMemo, useState, type CSSProperties } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Task } from '../../server/types';
@@ -7,7 +8,7 @@ import { useInbox } from '@/lib/inbox';
 import { useTasksContextOptional } from '@/lib/tasks-context';
 import { timeAgo } from '@/lib/time';
 import { repoName } from '@/lib/utils';
-import { CircleCheckIcon } from '@/components/icons';
+import { ActivityIcon, CircleCheckIcon, TriangleAlertIcon } from '@/components/icons';
 
 type RowKind = 'awaiting_reply' | 'errored' | 'activity';
 
@@ -139,30 +140,64 @@ function ActivityRow({ task }: { task: Task }) {
   );
 }
 
+function SectionHeader({
+  accent,
+  icon,
+  title,
+  count,
+  meta,
+}: {
+  accent: string;
+  icon: React.ReactNode;
+  title: string;
+  count?: string | number;
+  meta?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 px-1 py-1">
+      <span className="flex items-center justify-center" style={{ color: accent }} aria-hidden>
+        {icon}
+      </span>
+      <span
+        className="font-mono text-[11px] font-bold"
+        style={{ color: accent, letterSpacing: '1.5px' }}
+      >
+        {title}
+      </span>
+      {count !== undefined && (
+        <span className="font-mono text-[11px] font-bold text-[#6a6a6a]">{count}</span>
+      )}
+      {meta && (
+        <span className="font-mono text-[11px] font-medium text-[#6a6a6a]">{meta}</span>
+      )}
+      <span
+        className="ml-1 h-px flex-1"
+        style={{ backgroundColor: `${accent}22` }}
+        aria-hidden
+      />
+    </div>
+  );
+}
+
 function Section({
   title,
   tasks,
   kind,
   testId,
-  eyebrow,
+  accent,
+  icon,
 }: {
   title: string;
   tasks: Task[];
   kind: RowKind;
   testId: string;
-  eyebrow?: string;
+  accent: string;
+  icon: React.ReactNode;
 }) {
   if (tasks.length === 0) return null;
   return (
     <section data-testid={testId} className="flex flex-col gap-3">
-      <h3 className="flex items-baseline gap-2 px-1 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
-        {eyebrow && (
-          <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
-            {eyebrow}
-          </span>
-        )}
-        <span>{title}</span>
-      </h3>
+      <SectionHeader accent={accent} icon={icon} title={title} count={tasks.length} />
       <div className="flex flex-col gap-3">
         {tasks.map((t) => (
           <InboxCard key={t.id} task={t} kind={kind} />
@@ -172,20 +207,26 @@ function Section({
   );
 }
 
-function ActivitySection({ tasks }: { tasks: Task[] }) {
+function ActivitySection({ tasks, runningCount }: { tasks: Task[]; runningCount: number }) {
   const [expanded, setExpanded] = useState(false);
   if (tasks.length === 0) return null;
   const collapsed = !expanded && tasks.length > ACTIVITY_COLLAPSED_LIMIT;
   const visible = collapsed ? tasks.slice(0, ACTIVITY_COLLAPSED_LIMIT) : tasks;
   const hidden = tasks.length - visible.length;
+  const meta =
+    runningCount > 0
+      ? `${runningCount} running  ·  tap to expand`
+      : tasks.length > ACTIVITY_COLLAPSED_LIMIT
+        ? 'tap to expand'
+        : undefined;
   return (
     <section data-testid="inbox-section-activity" className="flex flex-col gap-2">
-      <div className="flex items-baseline gap-2 border-t border-[#FFFFFF14] px-1 pt-4 text-[10px] font-bold uppercase tracking-wider text-[#B5B5BD]">
-        <span className="font-mono text-[#6a6a6a]" style={{ letterSpacing: '1.5px' }}>
-          //
-        </span>
-        <span>Activity</span>
-      </div>
+      <SectionHeader
+        accent="#22C55E"
+        icon={<ActivityIcon size={14} />}
+        title="ACTIVITY"
+        meta={meta}
+      />
       <div className="flex flex-col gap-2">
         {visible.map((t) => (
           <ActivityRow key={t.id} task={t} />
@@ -227,12 +268,9 @@ export function SessionsInbox() {
   const isInboxZero = !loading && !isEmpty && awaitingReply.length === 0 && errored.length === 0;
 
   return (
-    <div data-testid="sessions-inbox" className="flex flex-col gap-6">
-      <div className="flex items-baseline justify-between px-1">
-        <h2 className="font-display text-sm font-bold uppercase tracking-wider text-[#6a6a6a]">
-          Sessions
-        </h2>
-        {(awaitingReply.length > 0 || errored.length > 0 || activity.length > 0) && (
+    <div data-testid="sessions-inbox" className="flex flex-col gap-8">
+      {(awaitingReply.length > 0 || errored.length > 0 || activity.length > 0) && (
+        <div className="flex items-baseline justify-end px-1">
           <button
             type="button"
             data-testid="inbox-mark-all-read"
@@ -241,8 +279,8 @@ export function SessionsInbox() {
           >
             Mark all read
           </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {error && (
         <p data-testid="inbox-error" className="px-1 text-xs text-destructive">
@@ -281,22 +319,24 @@ export function SessionsInbox() {
           ) : (
             <>
               <Section
-                title="Awaiting reply"
+                title="AWAITING REPLY"
                 tasks={awaitingReply}
                 kind="awaiting_reply"
                 testId="inbox-section-awaiting_reply"
-                eyebrow="//"
+                accent="#FFB800"
+                icon={<TriangleAlertIcon size={14} />}
               />
               <Section
-                title="Errored"
+                title="ERRORED"
                 tasks={errored}
                 kind="errored"
                 testId="inbox-section-errored"
-                eyebrow="//"
+                accent="#EF4444"
+                icon={<TriangleAlertIcon size={14} />}
               />
             </>
           )}
-          <ActivitySection tasks={activity} />
+          <ActivitySection tasks={activity} runningCount={runningCount} />
         </>
       )}
     </div>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -38,10 +38,22 @@ const toneByStatus: Record<string, PillTone> = {
 };
 
 const pillStyles: Record<PillTone, CSSProperties> = {
-  green: { backgroundColor: 'rgba(34, 197, 94, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(34, 197, 94, 0.24)' },
-  amber: { backgroundColor: 'rgba(255, 184, 0, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(255, 184, 0, 0.24)' },
-  red: { backgroundColor: 'rgba(239, 68, 68, 0.08)', boxShadow: 'inset 0 0 0 1px rgba(239, 68, 68, 0.28)' },
-  grey: { backgroundColor: 'rgba(255, 255, 255, 0.04)', boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.08)' },
+  green: {
+    backgroundColor: 'rgba(34, 197, 94, 0.08)',
+    boxShadow: 'inset 0 0 0 1px rgba(34, 197, 94, 0.24)',
+  },
+  amber: {
+    backgroundColor: 'rgba(255, 184, 0, 0.08)',
+    boxShadow: 'inset 0 0 0 1px rgba(255, 184, 0, 0.24)',
+  },
+  red: {
+    backgroundColor: 'rgba(239, 68, 68, 0.08)',
+    boxShadow: 'inset 0 0 0 1px rgba(239, 68, 68, 0.28)',
+  },
+  grey: {
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+    boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.08)',
+  },
 };
 
 export const StatusBadge = memo(function StatusBadge({

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -82,6 +82,14 @@ export function TerminalRectIcon({ size = 48, strokeWidth = 1.5, ...props }: Ico
   );
 }
 
+export function ActivityIcon({ size = 14, ...props }: IconProps) {
+  return (
+    <svg {...baseProps(size)} {...props}>
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+    </svg>
+  );
+}
+
 export function TriangleAlertIcon({ size = 14, ...props }: IconProps) {
   return (
     <svg {...baseProps(size)} {...props}>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -52,10 +52,11 @@ describe('HomePage', () => {
     expect(screen.getByTestId('sessions-inbox-slot')).toBeInTheDocument();
   });
 
-  it('renders the // INBOX eyebrow above the H1', () => {
+  it('renders the ⌘K jump affordance next to the H1', () => {
     renderHome('/');
-    const eyebrow = screen.getByTestId('page-eyebrow');
-    expect(eyebrow).toHaveTextContent('// INBOX');
+    const jump = screen.getByTestId('home-jump-palette');
+    expect(jump).toHaveTextContent(/⌘\s*K/);
+    expect(jump).toHaveTextContent(/jump/);
     const h1 = screen.getByRole('heading', { level: 1 });
     expect(h1).toHaveClass('text-[32px]');
   });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,20 @@
 import { Composer } from '@/components/Composer';
 import { SessionsInbox } from '@/components/SessionsInbox';
+import { useInbox } from '@/lib/inbox';
 import { useTasksContext } from '@/lib/tasks-context';
 import { RocketIcon } from '@/components/icons';
+
+function todayLabel(): string {
+  const d = new Date();
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'short' });
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  const day = d.getDate();
+  return `${weekday} · ${month} ${day}`;
+}
+
+function openPalette() {
+  window.dispatchEvent(new CustomEvent('open-command-palette'));
+}
 
 function FirstRunEmptyState() {
   const focusComposer = () => {
@@ -40,26 +53,44 @@ function FirstRunEmptyState() {
 
 export default function HomePage() {
   const { tasks, loading } = useTasksContext();
+  const { needsYou } = useInbox();
   const isFirstRun = !loading && tasks.length === 0;
+  const needsCount = needsYou.length;
 
   return (
     <div className="relative flex h-full flex-col">
       <div className="flex-1 overflow-auto">
         <div className="mx-auto max-w-4xl px-8 pt-12 pb-[280px]">
-          <div className="flex flex-col gap-2">
-            <span
-              data-testid="page-eyebrow"
-              className="font-mono text-[11px] font-bold text-[#B5B5BD]"
-              style={{ letterSpacing: '1.5px' }}
+          <div className="flex items-end justify-between gap-4">
+            <div className="flex flex-col gap-1.5">
+              <h1
+                className="font-display text-[32px] font-bold leading-[1.1] tracking-tight"
+                style={{ letterSpacing: '-1.2px' }}
+              >
+                Welcome back
+              </h1>
+              <p className="text-[14px] leading-snug text-[#8a8a8a]">
+                {todayLabel()}
+                {needsCount > 0 ? (
+                  <>
+                    {' · '}
+                    <span className="text-[#FFB800]">
+                      {needsCount} session{needsCount === 1 ? '' : 's'} want
+                      {needsCount === 1 ? 's' : ''} your attention
+                    </span>
+                  </>
+                ) : null}
+              </p>
+            </div>
+            <button
+              type="button"
+              data-testid="home-jump-palette"
+              onClick={openPalette}
+              className="focus-ring inline-flex items-center gap-1.5 rounded-lg border border-[#FFFFFF14] bg-[#FFFFFF0A] px-3 py-2 text-[12px] text-[#8a8a8a] transition-colors hover:bg-[#FFFFFF14] hover:text-white"
             >
-              // INBOX
-            </span>
-            <h1
-              className="font-display text-[32px] font-bold leading-[1.1] tracking-tight"
-              style={{ letterSpacing: '-0.5px' }}
-            >
-              Welcome back
-            </h1>
+              <span className="font-mono font-semibold text-[#D0D0D0]">⌘ K</span>
+              <span className="text-[#8a8a8a]">jump</span>
+            </button>
           </div>
           <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8">
             {isFirstRun ? <FirstRunEmptyState /> : <SessionsInbox />}


### PR DESCRIPTION
## Summary
- Replace `// INBOX` eyebrow with greeting row (`Welcome back`, `Fri · Apr 24 · N sessions want your attention`) and a right-aligned `⌘ K jump` pill that opens the command palette — matches frame `9VzuO` in `glass-redesign.pen`
- Section headers adopt per-kind color + icon: AWAITING REPLY (amber, triangle-alert), ERRORED (red), ACTIVITY (green, activity icon) with tinted rules; drops the plain "SESSIONS" heading
- Wire a window `open-command-palette` custom event in `AppShell` and add `ActivityIcon`

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` — 1263/1263 passing
- [x] Visual compare vs Pencil export for frames `9VzuO`, `TF8jb`, `y3FOS`, `Ykdgp`, `zqZ33`, `CsQvc`, `cN3Ko`, `1NGJ5`, `h3PJl`, `Scp7l` in `/Users/shreypaharia/Downloads/glass-redesign.pen`
- [ ] Eyeball Home: greeting copy, amber attention highlight when needs-you > 0, ⌘K pill opens palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)