### PR TITLE
refactor(ui): blend glass inputs and enable radius tokens

### DIFF
--- a/src/components/DraftEditForm.tsx
+++ b/src/components/DraftEditForm.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { GlassPanel } from '@/components/ui/glass-panel';
 import { api } from '@/lib/api';
 import type { Task } from '../../server/types';
 import { RepoPickerField } from './fields/RepoPickerField';
@@ -62,7 +63,11 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
 
   return (
     <div className="mx-auto max-w-2xl p-6">
-      <div className="flex flex-col gap-5">
+      <GlassPanel
+        level={2}
+        specular
+        className="flex flex-col gap-5 rounded-2xl p-6 shadow-[0_12px_32px_-12px_rgba(0,0,0,0.55)]"
+      >
         <div className="flex flex-col gap-2">
           <Label htmlFor="edit-title">Title</Label>
           <Input
@@ -156,7 +161,7 @@ export function DraftEditForm({ task, onSaved, onStart }: DraftEditFormProps) {
           </Button>
           {saved && <span className="font-mono text-xs text-[#22C55E]">SAVED</span>}
         </div>
-      </div>
+      </GlassPanel>
     </div>
   );
 }

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -167,14 +167,8 @@ function SectionHeader({
       {count !== undefined && (
         <span className="font-mono text-[11px] font-bold text-[#6a6a6a]">{count}</span>
       )}
-      {meta && (
-        <span className="font-mono text-[11px] font-medium text-[#6a6a6a]">{meta}</span>
-      )}
-      <span
-        className="ml-1 h-px flex-1"
-        style={{ backgroundColor: `${accent}22` }}
-        aria-hidden
-      />
+      {meta && <span className="font-mono text-[11px] font-medium text-[#6a6a6a]">{meta}</span>}
+      <span className="ml-1 h-px flex-1" style={{ backgroundColor: `${accent}22` }} aria-hidden />
     </div>
   );
 }

--- a/src/components/fields/BranchPickerField.tsx
+++ b/src/components/fields/BranchPickerField.tsx
@@ -80,7 +80,7 @@ export function BranchPickerField({
               disabled={disabled || branches.length === 0}
               className={
                 triggerClassName ??
-                'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                'flex h-9 w-full items-center justify-between rounded-lg border border-glass-edge bg-glass-l1 px-3 py-1 text-sm transition-colors hover:bg-glass-l2 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
               }
             >
               <span className={value ? 'font-mono text-xs' : 'text-muted-foreground'}>
@@ -94,30 +94,35 @@ export function BranchPickerField({
           align="start"
           side="bottom"
           sideOffset={4}
-          className="w-[--trigger-width] p-0"
+          className="w-[--trigger-width] gap-1 p-1.5"
         >
-          <div className="flex flex-col">
-            <div className="border-b border-border px-3 py-2">
-              <input
-                type="text"
-                placeholder="Search branches..."
-                className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                value={branchSearch}
-                onChange={(e) => setBranchSearch(e.target.value)}
-                autoFocus
-              />
-            </div>
-            <div className="max-h-[200px] overflow-y-auto">
-              {filteredBranches.length === 0 && (
-                <div className="px-3 py-3 text-center text-xs text-muted-foreground">
-                  {branches.length === 0 ? 'Select a repository first' : 'No matching branches'}
-                </div>
-              )}
-              {filteredBranches.map((b) => (
+          <div className="border-b border-glass-edge px-2 pb-2">
+            <input
+              type="text"
+              placeholder="Search branches..."
+              className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              value={branchSearch}
+              onChange={(e) => setBranchSearch(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="max-h-[220px] overflow-y-auto py-1">
+            {filteredBranches.length === 0 && (
+              <div className="px-3 py-3 text-center text-xs text-muted-foreground">
+                {branches.length === 0 ? 'Select a repository first' : 'No matching branches'}
+              </div>
+            )}
+            {filteredBranches.map((b) => {
+              const selected = b === value;
+              return (
                 <button
                   key={b}
                   type="button"
-                  className={`flex w-full items-center px-3 py-1.5 text-left text-sm hover:bg-muted transition-colors ${b === value ? 'bg-muted font-medium' : ''}`}
+                  className={`flex w-full items-center rounded-md px-2.5 py-1.5 text-left text-sm transition-colors ${
+                    selected
+                      ? 'border border-[#3B82F666] bg-[#3B82F61F] font-medium text-foreground'
+                      : 'border border-transparent hover:bg-glass-l2'
+                  }`}
                   onClick={() => {
                     onChange(b);
                     setBranchSearch('');
@@ -126,8 +131,8 @@ export function BranchPickerField({
                 >
                   <span className="font-mono text-xs truncate">{b}</span>
                 </button>
-              ))}
-            </div>
+              );
+            })}
           </div>
         </PopoverContent>
       </Popover>

--- a/src/components/fields/RepoPickerField.tsx
+++ b/src/components/fields/RepoPickerField.tsx
@@ -173,7 +173,12 @@ export function RepoPickerField({ value, onChange, onValidationChange }: RepoPic
               </Button>
             }
           />
-          <PopoverContent align="end" side="bottom" sideOffset={4} className="w-[420px] p-0">
+          <PopoverContent
+            align="end"
+            side="bottom"
+            sideOffset={4}
+            className="w-[420px] gap-0 p-0 overflow-hidden"
+          >
             <FolderBrowser
               data={browseData}
               loading={browseLoading}
@@ -195,12 +200,12 @@ export function RepoPickerField({ value, onChange, onValidationChange }: RepoPic
       {!value.trim() && recentRepos.length > 0 && (
         <div className="flex flex-col gap-1">
           <span className="text-xs text-muted-foreground font-medium">Recent</span>
-          <div className="rounded-md border border-border overflow-hidden">
+          <div className="flex flex-col gap-1 rounded-lg border border-glass-edge bg-glass-l1 p-1">
             {recentRepos.slice(0, 5).map((repo) => (
               <button
                 key={repo.repo_path}
                 type="button"
-                className="flex w-full items-center justify-between px-3 py-1.5 text-left text-sm hover:bg-muted transition-colors"
+                className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-sm transition-colors hover:bg-glass-l2"
                 onClick={() => onChange(repo.repo_path)}
               >
                 <span className="font-mono text-xs truncate mr-3">{repo.repo_path}</span>
@@ -240,11 +245,11 @@ function FolderBrowser({
   return (
     <div className="flex flex-col">
       {/* Header: back + current path */}
-      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+      <div className="flex items-center gap-2 border-b border-glass-edge px-3 py-2">
         <button
           type="button"
           disabled={!data.parent}
-          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30 disabled:hover:bg-transparent"
+          className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-glass-l2 hover:text-foreground disabled:opacity-30 disabled:hover:bg-transparent"
           onClick={() => data.parent && onNavigate(data.parent)}
         >
           <ChevronLeftIcon />
@@ -255,7 +260,7 @@ function FolderBrowser({
       </div>
 
       {/* Directory list */}
-      <div className="max-h-[280px] overflow-y-auto">
+      <div className="max-h-[280px] overflow-y-auto p-1">
         {data.entries.length === 0 && (
           <div className="px-3 py-4 text-center text-xs text-muted-foreground">
             No subdirectories
@@ -265,7 +270,7 @@ function FolderBrowser({
           <button
             key={entry.path}
             type="button"
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-muted transition-colors"
+            className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors hover:bg-glass-l2"
             onClick={() => onNavigate(entry.path)}
             onDoubleClick={() => entry.isGit && onSelect(entry.path)}
           >
@@ -297,7 +302,7 @@ function FolderBrowser({
       </div>
 
       {/* Footer: Select button */}
-      <div className="flex items-center justify-between border-t border-border px-3 py-2">
+      <div className="flex items-center justify-between border-t border-glass-edge px-3 py-2">
         <span className="font-mono text-[10px] text-muted-foreground truncate mr-2">
           {data.current}
         </span>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -66,7 +66,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 bg-[#0A0A0A] border border-border p-4 text-sm duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'bg-glass-l3 glass-blur-l3 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-glass-edge-strong p-5 text-sm shadow-[0_24px_64px_-16px_rgba(0,0,0,0.7)] duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'h-8 w-full min-w-0 border border-border bg-[#0A0A0A] px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'h-9 w-full min-w-0 rounded-lg border border-glass-edge bg-glass-l1 px-3 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -32,7 +32,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 bg-[#141414] border border-border p-2.5 text-sm text-popover-foreground outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'bg-glass-l3 glass-blur-l3 z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-xl border border-glass-edge-strong p-2.5 text-sm text-popover-foreground shadow-[0_12px_32px_-8px_rgba(0,0,0,0.6)] outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className,
           )}
           {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'flex field-sizing-content min-h-16 w-full border border-border bg-[#0A0A0A] px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        'flex field-sizing-content min-h-16 w-full rounded-lg border border-glass-edge bg-glass-l1 px-3 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,7 @@
   --chart-3: #ffb800;
   --chart-4: #ef4444;
   --chart-5: #8a8a8a;
-  --radius: 0;
+  --radius: 0.5rem;
   --sidebar: #080808;
   --sidebar-foreground: #ffffff;
   --sidebar-primary: #3b82f6;
@@ -146,13 +146,13 @@
   --color-glass-specular: var(--glass-specular);
   --color-ambient-cyan: var(--ambient-cyan);
   --color-ambient-purple: var(--ambient-purple);
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
-  --radius-xl: 0;
-  --radius-2xl: 0;
-  --radius-3xl: 0;
-  --radius-4xl: 0;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-3xl: 20px;
+  --radius-4xl: 24px;
 }
 
 @layer base {


### PR DESCRIPTION
## What

Finishes the glass-redesign pass for places that still felt "old":

- Global radius tokens (`--radius-*`) were all `0`, so 46+ `rounded-lg` /
  `rounded-xl` / `rounded-2xl` call sites across the codebase were
  rendering as squares. Now set to `4px → 24px`.
- Core `Input`, `Textarea`, `Button`, `Popover`, `Dialog` primitives
  replaced hard `bg-[#0A0A0A]` / `bg-[#141414]` with glass tint +
  glass-edge border + rounded corners.
- Draft edit form wrapped in a level-2 GlassPanel so inputs blend into
  a visible surface instead of sitting on the raw page canvas.
- Branch / Repo picker popovers: rounded pill rows, cyan-tinted
  "selected" state matching the command palette.

## Why

The glass-redesign landed in #113 / #114 but skipped the base primitives
and forgot to flip the radius tokens. The user flagged that the draft
input screen still had solid-black inputs and that many blocks/buttons
were square instead of rounded — root cause was the two gaps above.

## Testing

- \`bun run typecheck\` — clean
- \`bun run lint\` — 0 errors (warnings pre-existing)
- \`bunx vitest run\` over UI primitives + fields + DraftEditForm: 32/32 pass
- Manual: verified Home, Tasks, Settings, and Draft edit pages in browser
  at 1440×900 — fields blend into glass panel, corners rounded everywhere