### PR TITLE
fix(ui): drop false-positive stall overlay on idle terminals

### DIFF
--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -199,6 +199,41 @@ describe('TerminalView', () => {
     expect(closeSpy).toHaveBeenCalled();
   });
 
+  it('does NOT show the disconnect overlay when an OPEN ws is idle for 10+ seconds', async () => {
+    // Regression test: previously a 5s data-silence window would trip a stall
+    // timer and show the "Server unreachable" overlay on any idle terminal
+    // (shell at prompt, Claude waiting for input). Data silence is not a
+    // disconnect signal — only ws.onclose should surface that overlay.
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    const { queryByTestId } = render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws = MockWebSocket.instances[0];
+    act(() => ws._open());
+
+    // Simulate a long idle window with zero terminal output.
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(ws.readyState).toBe(MockWebSocket.OPEN);
+    expect(queryByTestId('terminal-disconnected-overlay')).toBeNull();
+  });
+
+  it('shows the disconnect overlay when the ws closes with a non-normal code', async () => {
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    const { queryByTestId } = render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws = MockWebSocket.instances[0];
+    act(() => ws._open());
+    // Non-normal close code (1005 = no status received) triggers the reconnect
+    // path and the overlay.
+    act(() => ws._close(1005));
+
+    expect(queryByTestId('terminal-disconnected-overlay')).not.toBeNull();
+  });
+
   it('does not reconnect a replaced WebSocket after it closes', async () => {
     // This is the core bug guard: once we switch tabs, the old WS's onclose
     // must NOT trigger a reconnect via the stale closure.

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -14,7 +14,6 @@ interface TerminalViewProps {
 
 const MAX_RECONNECT_DELAY = 10_000;
 const INITIAL_RECONNECT_DELAY = 1_000;
-const STALL_THRESHOLD_MS = 5_000;
 
 export function TerminalView({
   taskId,
@@ -29,10 +28,14 @@ export function TerminalView({
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectDelay = useRef(INITIAL_RECONNECT_DELAY);
   const unmounted = useRef(false);
-  const stallTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const [disconnected, setDisconnected] = useState(false);
   const [retrySecs, setRetrySecs] = useState<number>(0);
+
+  // Belt-and-suspenders: never show the overlay while the ws is actually OPEN,
+  // even if some stale state flipped `disconnected` to true.
+  const showOverlay =
+    disconnected && (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN);
 
   const getWsUrl = useCallback(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -60,20 +63,6 @@ export function TerminalView({
     }
   }, []);
 
-  const clearStallTimer = useCallback(() => {
-    if (stallTimer.current) {
-      clearTimeout(stallTimer.current);
-      stallTimer.current = null;
-    }
-  }, []);
-
-  const armStallTimer = useCallback(() => {
-    clearStallTimer();
-    stallTimer.current = setTimeout(() => {
-      setDisconnected(true);
-    }, STALL_THRESHOLD_MS);
-  }, [clearStallTimer]);
-
   const connectWs = useCallback(
     (term: Terminal) => {
       if (unmounted.current) return;
@@ -87,7 +76,6 @@ export function TerminalView({
           clearInterval(countdownTimer.current);
           countdownTimer.current = null;
         }
-        armStallTimer();
         // Re-fit now that we know layout is settled (WS connect takes a few ms,
         // guaranteeing the browser has completed layout), then send correct dimensions.
         fitAndSendResize(ws);
@@ -98,7 +86,6 @@ export function TerminalView({
       };
 
       ws.onmessage = (event) => {
-        armStallTimer();
         term.write(event.data);
       };
 
@@ -131,7 +118,7 @@ export function TerminalView({
 
       wsRef.current = ws;
     },
-    [getWsUrl, fitAndSendResize, armStallTimer],
+    [getWsUrl, fitAndSendResize],
   );
 
   const connect = useCallback(() => {
@@ -227,9 +214,6 @@ export function TerminalView({
       if (reconnectTimer.current) {
         clearTimeout(reconnectTimer.current);
       }
-      if (stallTimer.current) {
-        clearTimeout(stallTimer.current);
-      }
       if (countdownTimer.current) {
         clearInterval(countdownTimer.current);
       }
@@ -282,9 +266,9 @@ export function TerminalView({
       <div
         ref={containerRef}
         className="h-full w-full overflow-hidden rounded-lg bg-[#09090b] transition-opacity"
-        style={{ opacity: disconnected ? 0.7 : 1 }}
+        style={{ opacity: showOverlay ? 0.7 : 1 }}
       />
-      {disconnected && (
+      {showOverlay && (
         <div
           data-testid="terminal-disconnected-overlay"
           role="alert"


### PR DESCRIPTION
## Summary

`TerminalView` surfaced the amber "Server unreachable — reconnecting in Ns…" overlay whenever no terminal output arrived for 5 seconds (`STALL_THRESHOLD_MS`). This fired on any idle terminal (shell at prompt, Claude waiting for input) even though the WebSocket was perfectly healthy — data silence is not a disconnect signal.

## Before / After

- **Before:** Idle terminals constantly flashed the disconnect warning after 5s of silence, regardless of actual WebSocket health.
- **After:** The overlay appears only when `ws.onclose` fires with a non-normal close code. Belt-and-suspenders: the overlay is also gated on `ws.readyState !== OPEN` so any stale `disconnected=true` state cannot render it.

## Changes

- `src/components/TerminalView.tsx` — remove `STALL_THRESHOLD_MS`, `stallTimer`, `armStallTimer`, `clearStallTimer` and their callsites in `ws.onopen` / `ws.onmessage`. Add `showOverlay` guard on `wsRef.current?.readyState`.
- `src/components/TerminalView.test.tsx` — regression test: an OPEN ws idle for 10s does NOT show the overlay. New test: ws closing with a non-normal code DOES show the overlay.

## Test plan

- [x] `bun run test` — 1265 tests pass (incl. 7 in `TerminalView.test.tsx`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings
- [x] `bun run format:check` — clean
- [ ] Manual: open a task, let it sit at the Claude prompt for 30+ seconds → no overlay should appear
- [ ] Manual: kill the server while a terminal is open → overlay appears with countdown