### PR TITLE
feat(home): match glass-redesign pencil spec

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -277,9 +277,14 @@ export function Composer({ onSubmitted }: Props = {}) {
   return (
     <GlassPanel
       level={3}
-      specular
       className="flex flex-col gap-2 rounded-[20px] px-4 py-3"
       data-testid="composer"
+      style={{
+        backgroundColor: 'rgba(255, 255, 255, 0.078)',
+        borderColor: 'rgba(255, 255, 255, 0.15)',
+        boxShadow:
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.25), 0 24px 60px -12px rgba(0, 0, 0, 0.56)',
+      }}
     >
       <IntentHeader
         state={state}

--- a/src/components/SessionsInbox.tsx
+++ b/src/components/SessionsInbox.tsx
@@ -49,10 +49,11 @@ function ReplyButton({ taskId }: { taskId: string }) {
         e.stopPropagation();
         navigate(`/?add_agent=${taskId}`);
       }}
-      className="shrink-0 rounded-[10px] px-3 py-1.5 text-[11px] font-bold tracking-wider uppercase text-[#1f1300] transition-colors hover:brightness-110"
+      className="shrink-0 rounded-[10px] text-[12px] font-bold text-[#0A0A0B] transition-[filter] hover:brightness-110"
       style={{
         backgroundColor: '#FFB800',
-        boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.35), 0 0 16px 0 rgba(255, 184, 0, 0.35)',
+        padding: '8px 14px',
+        boxShadow: '0 4px 16px -2px rgba(255, 184, 0, 0.4)',
       }}
     >
       Reply →
@@ -60,50 +61,49 @@ function ReplyButton({ taskId }: { taskId: string }) {
   );
 }
 
-// Per-mockup: awaiting_reply cards carry amber tint in border + a specular
-// top-edge; errored cards use red-tinted border; activity rows stay L1 glass.
-function cardStyleFor(kind: RowKind): { style: CSSProperties; className: string } {
+// Card materials per pen frame lBhOV (awaiting) / MYKbE (errored):
+// awaiting is the "hot" card — brighter fill, top specular highlight;
+// errored dims to L2-low without the specular edge.
+function cardStyleFor(kind: RowKind): { style: CSSProperties; borderColor: string } {
   if (kind === 'awaiting_reply') {
     return {
-      className: 'border-[#FFB80040]',
+      borderColor: 'rgba(255, 255, 255, 0.12)',
       style: {
-        backgroundColor: 'rgba(255, 255, 255, 0.10)',
+        backgroundColor: 'rgba(255, 255, 255, 0.0625)',
         boxShadow:
-          'inset 0 1px 0 0 rgba(255, 255, 255, 0.22), 0 12px 30px -8px rgba(0, 0, 0, 0.55)',
+          'inset 0 1px 0 0 rgba(255, 255, 255, 0.18), 0 20px 40px -10px rgba(0, 0, 0, 0.38)',
       },
     };
   }
   return {
-    className: 'border-[#EF444440]',
+    borderColor: 'rgba(255, 255, 255, 0.08)',
     style: {
-      backgroundColor: 'rgba(255, 255, 255, 0.10)',
-      boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.22), 0 12px 30px -8px rgba(0, 0, 0, 0.55)',
+      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+      boxShadow: '0 20px 40px -10px rgba(0, 0, 0, 0.38)',
     },
   };
 }
 
 function InboxCard({ task, kind }: { task: Task; kind: RowKind }) {
   const navigate = useNavigate();
-  const { style, className } = cardStyleFor(kind);
+  const { style, borderColor } = cardStyleFor(kind);
   return (
     <GlassPanel
       level={2}
       data-testid={`inbox-row-${task.id}`}
-      className={`group flex items-center gap-3 rounded-[16px] px-5 py-4 transition-colors hover:bg-glass-l3 ${className}`}
-      style={style}
+      className="group flex items-center gap-4 rounded-[16px] px-[22px] py-[18px] transition-colors"
+      style={{ ...style, borderColor }}
     >
       <button
         type="button"
         onClick={() => navigate(`/tasks/${task.id}`)}
         className="flex min-w-0 flex-1 items-center gap-3 text-left"
       >
-        <StatusGlyph status={glyphStatusFor(kind)} size={12} />
-        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <StatusGlyph status={glyphStatusFor(kind)} size={14} />
+        <span className="flex min-w-0 flex-1 flex-col gap-1.5">
           <span className="flex items-baseline gap-2">
-            <span className="truncate text-sm font-semibold text-foreground">{task.title}</span>
-            <span className="truncate text-xs text-muted-foreground">
-              {subtitleFor(task, kind)}
-            </span>
+            <span className="truncate text-[15px] font-semibold text-white">{task.title}</span>
+            <span className="truncate text-xs text-[#8a8a8a]">{subtitleFor(task, kind)}</span>
           </span>
           <span className="font-mono text-[11px] text-[#8a8a8a]">
             {repoName(task.repo_path)} · {timeAgo(task.updated_at)}
@@ -115,25 +115,42 @@ function InboxCard({ task, kind }: { task: Task; kind: RowKind }) {
   );
 }
 
+function activityStatusKey(task: Task): string {
+  if (task.status === 'running') return 'running';
+  if (task.status === 'setting_up') return 'setting_up';
+  if (task.status === 'error') return 'error';
+  return 'closed';
+}
+
 function ActivityRow({ task }: { task: Task }) {
   const navigate = useNavigate();
+  const statusKey = activityStatusKey(task);
+  const isClosed = statusKey === 'closed';
   return (
     <GlassPanel
       level={1}
       data-testid={`inbox-row-${task.id}`}
-      className="group flex items-center gap-4 rounded-[12px] px-4 py-2.5 transition-colors hover:bg-glass-l2"
+      className="group flex items-center gap-3.5 rounded-[12px] px-[18px] py-3 transition-colors"
+      style={{
+        backgroundColor: 'rgba(255, 255, 255, 0.031)',
+        borderColor: 'rgba(255, 255, 255, 0.063)',
+      }}
     >
       <button
         type="button"
         onClick={() => navigate(`/tasks/${task.id}`)}
-        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+        className="flex min-w-0 flex-1 items-center gap-3.5 text-left"
       >
-        <StatusGlyph status="closed" size={10} />
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[#B5B5BD]">
+        <StatusGlyph status={statusKey} size={12} />
+        <span
+          className={`min-w-0 flex-1 truncate text-[13px] font-medium ${
+            isClosed ? 'text-[#8a8a8a]' : 'text-white'
+          }`}
+        >
           {task.title}
         </span>
-        <span className="shrink-0 font-mono text-[11px] text-[#6a6a6a]">
-          {repoName(task.repo_path)} · closed · {timeAgo(task.updated_at)}
+        <span className="shrink-0 font-mono text-[11px] text-[#8a8a8a]">
+          {repoName(task.repo_path)} · {statusKey.replace('_', ' ')} · {timeAgo(task.updated_at)}
         </span>
       </button>
     </GlassPanel>
@@ -142,19 +159,21 @@ function ActivityRow({ task }: { task: Task }) {
 
 function SectionHeader({
   accent,
+  lineColor,
   icon,
   title,
   count,
   meta,
 }: {
   accent: string;
+  lineColor?: string;
   icon: React.ReactNode;
   title: string;
   count?: string | number;
   meta?: string;
 }) {
   return (
-    <div className="flex items-center gap-2.5 px-1 py-1">
+    <div className="flex items-center gap-2.5 py-1">
       <span className="flex items-center justify-center" style={{ color: accent }} aria-hidden>
         {icon}
       </span>
@@ -168,7 +187,11 @@ function SectionHeader({
         <span className="font-mono text-[11px] font-bold text-[#6a6a6a]">{count}</span>
       )}
       {meta && <span className="font-mono text-[11px] font-medium text-[#6a6a6a]">{meta}</span>}
-      <span className="ml-1 h-px flex-1" style={{ backgroundColor: `${accent}22` }} aria-hidden />
+      <span
+        className="ml-1 h-px flex-1"
+        style={{ backgroundColor: lineColor ?? `${accent}22` }}
+        aria-hidden
+      />
     </div>
   );
 }
@@ -217,6 +240,7 @@ function ActivitySection({ tasks, runningCount }: { tasks: Task[]; runningCount:
     <section data-testid="inbox-section-activity" className="flex flex-col gap-2">
       <SectionHeader
         accent="#22C55E"
+        lineColor="rgba(34, 197, 94, 0.08)"
         icon={<ActivityIcon size={14} />}
         title="ACTIVITY"
         meta={meta}

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -61,6 +61,13 @@ describe('HomePage', () => {
     expect(h1).toHaveClass('text-[32px]');
   });
 
+  it('renders the // INBOX eyebrow above the welcome heading', () => {
+    renderHome('/');
+    const eyebrow = screen.getByTestId('home-eyebrow');
+    expect(eyebrow).toHaveTextContent(/\/\/ INBOX/);
+    expect(eyebrow).toHaveTextContent(/inbox zero|sessions? want/i);
+  });
+
   it('renders first-run CTA when there are no tasks', () => {
     renderHome('/', { tasks: [] });
     expect(screen.getByTestId('home-first-run')).toBeInTheDocument();

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ function todayLabel(): string {
   const weekday = d.toLocaleDateString('en-US', { weekday: 'short' });
   const month = d.toLocaleDateString('en-US', { month: 'short' });
   const day = d.getDate();
-  return `${weekday} · ${month} ${day}`;
+  return `${weekday} ${month} ${day}`;
 }
 
 function openPalette() {
@@ -57,30 +57,37 @@ export default function HomePage() {
   const isFirstRun = !loading && tasks.length === 0;
   const needsCount = needsYou.length;
 
+  const attentionMeta =
+    needsCount > 0
+      ? `${needsCount} session${needsCount === 1 ? '' : 's'} want${needsCount === 1 ? 's' : ''} your attention`
+      : 'inbox zero';
+
   return (
     <div className="relative flex h-full flex-col">
       <div className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-4xl px-8 pt-12 pb-[280px]">
+        <div className="flex flex-col gap-8 px-[72px] pt-12 pb-[160px]">
           <div className="flex items-end justify-between gap-4">
             <div className="flex flex-col gap-1.5">
+              <div
+                data-testid="home-eyebrow"
+                className="flex items-center gap-2 pb-0.5 font-mono text-[11px]"
+              >
+                <span className="font-bold text-[#B5B5BD]" style={{ letterSpacing: '1.5px' }}>
+                  // INBOX
+                </span>
+                <span className="text-[#6a6a6a]">·</span>
+                <span className="text-[#6a6a6a]">{todayLabel()}</span>
+                <span className="text-[#6a6a6a]">·</span>
+                <span className={needsCount > 0 ? 'text-[#FFB800]' : 'text-[#6a6a6a]'}>
+                  {attentionMeta}
+                </span>
+              </div>
               <h1
-                className="font-display text-[32px] font-bold leading-[1.1] tracking-tight"
+                className="font-display text-[32px] font-bold leading-[1.1] tracking-tight text-white"
                 style={{ letterSpacing: '-1.2px' }}
               >
                 Welcome back
               </h1>
-              <p className="text-[14px] leading-snug text-[#8a8a8a]">
-                {todayLabel()}
-                {needsCount > 0 ? (
-                  <>
-                    {' · '}
-                    <span className="text-[#FFB800]">
-                      {needsCount} session{needsCount === 1 ? '' : 's'} want
-                      {needsCount === 1 ? 's' : ''} your attention
-                    </span>
-                  </>
-                ) : null}
-              </p>
             </div>
             <button
               type="button"
@@ -92,21 +99,16 @@ export default function HomePage() {
               <span className="text-[#8a8a8a]">jump</span>
             </button>
           </div>
-          <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot" className="mt-8">
+          <div id="sessions-inbox-slot" data-testid="sessions-inbox-slot">
             {isFirstRun ? <FirstRunEmptyState /> : <SessionsInbox />}
           </div>
         </div>
       </div>
       <div
         data-testid="composer-dock"
-        className="pointer-events-none absolute inset-x-0 bottom-6 flex justify-center"
+        className="pointer-events-none absolute inset-x-0 bottom-10 flex justify-center px-[72px]"
       >
-        <div
-          className="pointer-events-auto w-[90%] max-w-[1056px]"
-          style={{
-            filter: 'drop-shadow(0 24px 60px rgba(0, 0, 0, 0.56))',
-          }}
-        >
+        <div className="pointer-events-auto w-full max-w-[1056px]">
           <Composer />
         </div>
       </div>


### PR DESCRIPTION
## What

Bring `/` (HomePage) in line with the pencil mockup "01 · Home — Sessions Inbox":

- Add `// INBOX · <date> · N sessions want your attention` eyebrow above the H1; drop the redundant date sub-line.
- Widen scroll padding to 72px sides (matches pen frame `tSz1n`).
- Move the composer-dock shadow off a `filter: drop-shadow(...)` ancestor (which was breaking descendant `backdrop-filter` on WebKit/Chromium) onto the GlassPanel via `box-shadow`. Tune composer fill/border to the pen's L3 material.
- Rework session cards (`AWAITING REPLY` vs `ERRORED`) and activity rows to the pen's L2/L1 materials — correct fills, borders, radii, padding, and top-specular highlight on awaiting cards.
- Tighten the `Reply →` button (amber `#FFB800`, radius 10, 8/14 padding, `0 4px 16px -2px` amber glow, `#0A0A0B` text).
- Drive activity-row status dots off real task state (running / setting_up / closed) instead of always rendering `closed`.

## Why

The home page material was visibly off the design spec — overbright glass tints on cards, a `filter: drop-shadow` wrapper around the composer that disabled `backdrop-filter` for descendants, and a missing `// INBOX` eyebrow row that anchors the page hierarchy in the mockup. This brings the rendered page in line with the pencil ground truth so the rest of the app's glass surfaces have a faithful reference.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean (no new warnings)
- `bun run test` — 67 files / 1265 tests passing; added an assertion that the `// INBOX` eyebrow renders in `HomePage.test.tsx`
- Manual: ran `bunx vite --port 5174` against this worktree and visually compared `/` to pen frame `9VzuO` via Playwright — eyebrow, H1, ⌘K pill, activity row, and composer dock all match