### PR TITLE
fix(preflight): correct none-mode same-branch vs different-branch logic

### DIFF
--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -527,15 +527,13 @@ describe('POST /api/tasks', () => {
   });
 
   it('allows run_mode=none with base_branch (new behavior)', async () => {
-    const res = await request(app)
-      .post('/api/tasks')
-      .send({
-        title: 't',
-        description: 'd',
-        run_mode: 'none',
-        repo_path: '/tmp/repo',
-        base_branch: 'feature-x',
-      });
+    const res = await request(app).post('/api/tasks').send({
+      title: 't',
+      description: 'd',
+      run_mode: 'none',
+      repo_path: '/tmp/repo',
+      base_branch: 'feature-x',
+    });
     // We allow the request to pass validation; downstream setup may still fail
     // when the repo path is fake. Accept any non-400 status.
     expect(res.status).not.toBe(400);
@@ -550,15 +548,13 @@ describe('POST /api/tasks', () => {
   });
 
   it('still rejects run_mode=none with worktree_path', async () => {
-    const res = await request(app)
-      .post('/api/tasks')
-      .send({
-        title: 't',
-        description: 'd',
-        run_mode: 'none',
-        repo_path: '/r',
-        worktree_path: '/r/.worktrees/x',
-      });
+    const res = await request(app).post('/api/tasks').send({
+      title: 't',
+      description: 'd',
+      run_mode: 'none',
+      repo_path: '/r',
+      worktree_path: '/r/.worktrees/x',
+    });
     expect(res.status).toBe(400);
   });
 
@@ -1885,9 +1881,7 @@ describe('POST /api/preflight/stash', () => {
   });
 
   it('400s when target_branch is missing', async () => {
-    const res = await request(app)
-      .post('/api/preflight/stash')
-      .send({ repo_path: '/r' });
+    const res = await request(app).post('/api/preflight/stash').send({ repo_path: '/r' });
     expect(res.status).toBe(400);
   });
 

--- a/server/preflight.test.ts
+++ b/server/preflight.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 });
 
 describe('preflightNoneMode', () => {
-  it('returns ok=true when current branch matches target and no conflicts', async () => {
+  it('returns ok=true when current branch matches target and no other tasks', async () => {
     mockedExec.mockImplementation((cmd: string, args: string[]) => {
       if (args.includes('rev-parse') && args.includes('--abbrev-ref')) {
         return Promise.resolve({ stdout: 'main\n', stderr: '' });
@@ -36,6 +36,7 @@ describe('preflightNoneMode', () => {
       currentBranch: 'main',
       targetBranch: 'main',
       conflicts: [],
+      warnings: [],
       dirty: null,
     });
   });
@@ -69,7 +70,7 @@ describe('preflightNoneMode', () => {
     expect(result.dirty).toBeNull();
   });
 
-  it('returns conflicts when active task uses the same repo+branch', async () => {
+  it('treats same-branch active none task as a non-blocking warning', async () => {
     const db = getDb();
     db.prepare(
       `INSERT INTO worktrees (id, path, repo_path, branch, base_branch, mode, status)
@@ -78,6 +79,32 @@ describe('preflightNoneMode', () => {
     db.prepare(
       `INSERT INTO tasks (id, title, description, status, worktree_id)
        VALUES ('t1', 'Other chat', '', 'running', 'wt1')`,
+    ).run();
+
+    mockedExec.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes('--abbrev-ref'))
+        return Promise.resolve({ stdout: 'feature-x\n', stderr: '' });
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    const result = await preflightNoneMode('/repo', 'feature-x');
+
+    expect(result.ok).toBe(true);
+    expect(result.conflicts).toEqual([]);
+    expect(result.warnings).toEqual([
+      { task_id: 't1', title: 'Other chat', status: 'running', branch: 'feature-x' },
+    ]);
+  });
+
+  it('treats different-branch active none task as a blocking conflict', async () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO worktrees (id, path, repo_path, branch, base_branch, mode, status)
+       VALUES ('wt-main', '/repo', '/repo', 'main', 'main', 'none', 'in_use')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, status, worktree_id)
+       VALUES ('t-main', 'main task', '', 'running', 'wt-main')`,
     ).run();
 
     mockedExec.mockImplementation((_cmd: string, args: string[]) => {
@@ -90,37 +117,71 @@ describe('preflightNoneMode', () => {
 
     expect(result.ok).toBe(false);
     expect(result.conflicts).toEqual([
-      { task_id: 't1', title: 'Other chat', status: 'running', branch: 'feature-x' },
+      { task_id: 't-main', title: 'main task', status: 'running', branch: 'main' },
     ]);
+    expect(result.warnings).toEqual([]);
   });
 
-  it('skips closed tasks and tasks on other branches', async () => {
+  it('skips closed tasks and ignores new-mode worktree tasks', async () => {
     const db = getDb();
+    // closed none-mode task → ignored
     db.prepare(
       `INSERT INTO worktrees (id, path, repo_path, branch, mode, status)
-       VALUES ('wt1', '/repo', '/repo', 'feature-x', 'none', 'available')`,
-    ).run();
-    db.prepare(
-      `INSERT INTO worktrees (id, path, repo_path, branch, mode, status)
-       VALUES ('wt2', '/repo', '/repo', 'main', 'none', 'in_use')`,
+       VALUES ('wt-closed', '/repo', '/repo', 'feature-x', 'none', 'available')`,
     ).run();
     db.prepare(
       `INSERT INTO tasks (id, title, description, status, worktree_id)
-       VALUES ('closed1', 'closed', '', 'closed', 'wt1')`,
+       VALUES ('closed1', 'closed', '', 'closed', 'wt-closed')`,
+    ).run();
+    // active 'new'-mode task on the same branch → ignored (its own worktree)
+    db.prepare(
+      `INSERT INTO worktrees (id, path, repo_path, branch, mode, status)
+       VALUES ('wt-new', '/repo/.worktrees/x', '/repo', 'feature-x', 'new', 'in_use')`,
     ).run();
     db.prepare(
       `INSERT INTO tasks (id, title, description, status, worktree_id)
-       VALUES ('main1', 'main task', '', 'running', 'wt2')`,
+       VALUES ('new1', 'new wt task', '', 'running', 'wt-new')`,
     ).run();
 
     mockedExec.mockImplementation((_cmd: string, args: string[]) => {
-      if (args.includes('--abbrev-ref')) return Promise.resolve({ stdout: 'main\n', stderr: '' });
-      if (args.includes('--porcelain=v1')) return Promise.resolve({ stdout: '', stderr: '' });
+      if (args.includes('--abbrev-ref'))
+        return Promise.resolve({ stdout: 'feature-x\n', stderr: '' });
       throw new Error(`unexpected git call: ${args.join(' ')}`);
     });
 
     const result = await preflightNoneMode('/repo', 'feature-x');
 
+    expect(result.ok).toBe(true);
     expect(result.conflicts).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('skips dirty check while a different-branch conflict is present', async () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO worktrees (id, path, repo_path, branch, mode, status)
+       VALUES ('wt-main', '/repo', '/repo', 'main', 'none', 'in_use')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, status, worktree_id)
+       VALUES ('t-main', 'main task', '', 'running', 'wt-main')`,
+    ).run();
+
+    let porcelainCalled = false;
+    mockedExec.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes('--abbrev-ref')) return Promise.resolve({ stdout: 'main\n', stderr: '' });
+      if (args.includes('--porcelain=v1')) {
+        porcelainCalled = true;
+        return Promise.resolve({ stdout: ' M a.ts\n', stderr: '' });
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    const result = await preflightNoneMode('/repo', 'feature-x');
+
+    expect(result.ok).toBe(false);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.dirty).toBeNull();
+    expect(porcelainCalled).toBe(false);
   });
 });

--- a/server/preflight.ts
+++ b/server/preflight.ts
@@ -18,7 +18,18 @@ export interface PreflightResult {
   ok: boolean;
   currentBranch: string;
   targetBranch: string;
+  /**
+   * Active none-mode tasks on the same root worktree but a *different* branch.
+   * These block creation because starting the new task would `git checkout`
+   * away from their branch and corrupt their working state.
+   */
   conflicts: PreflightConflict[];
+  /**
+   * Active none-mode tasks on the same root worktree on the *same* branch.
+   * They share the working tree, which is allowed but worth surfacing so the
+   * user can confirm before adding another agent that may step on the others.
+   */
+  warnings: PreflightConflict[];
   dirty: { count: number } | null;
 }
 
@@ -35,10 +46,33 @@ export async function preflightNoneMode(
   ]);
   const currentBranch = headOut.trim();
 
-  const conflicts: PreflightConflict[] = [];
-  let dirty: PreflightResult['dirty'] = null;
+  // Find every active task that is sharing this root worktree (mode='none').
+  // 'new'-mode tasks have their own dedicated worktrees and don't conflict.
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT t.id AS task_id, t.title, t.status, w.branch
+         FROM tasks t
+         INNER JOIN worktrees w ON t.worktree_id = w.id
+        WHERE t.status IN ('running', 'setting_up')
+          AND w.repo_path = ?
+          AND w.mode = 'none'`,
+    )
+    .all(repoPath) as PreflightConflict[];
 
-  if (currentBranch !== baseBranch) {
+  const conflicts: PreflightConflict[] = [];
+  const warnings: PreflightConflict[] = [];
+  for (const row of rows) {
+    if (row.branch === baseBranch) warnings.push(row);
+    else conflicts.push(row);
+  }
+
+  // Dirty matters only when a checkout will actually happen. If conflicts
+  // exist we won't get to the checkout anyway — the user will close those
+  // tasks first and we'll re-run preflight, at which point dirty (if still
+  // present) will be surfaced.
+  let dirty: PreflightResult['dirty'] = null;
+  if (currentBranch !== baseBranch && conflicts.length === 0) {
     const { stdout: statusOut } = await execFile('git', [
       '-C',
       repoPath,
@@ -49,20 +83,16 @@ export async function preflightNoneMode(
     if (lines.length > 0) dirty = { count: lines.length };
   }
 
-  const db = getDb();
-  const rows = db
-    .prepare(
-      `SELECT t.id AS task_id, t.title, t.status, w.branch
-         FROM tasks t
-         INNER JOIN worktrees w ON t.worktree_id = w.id
-        WHERE t.status IN ('running', 'setting_up')
-          AND w.repo_path = ?
-          AND w.branch = ?`,
-    )
-    .all(repoPath, baseBranch) as PreflightConflict[];
-  conflicts.push(...rows);
-
   const ok = conflicts.length === 0 && dirty === null;
-  logger.debug({ repoPath, baseBranch, ok, conflicts: conflicts.length }, 'preflight none mode');
-  return { ok, currentBranch, targetBranch: baseBranch, conflicts, dirty };
+  logger.debug(
+    {
+      repoPath,
+      baseBranch,
+      ok,
+      conflicts: conflicts.length,
+      warnings: warnings.length,
+    },
+    'preflight none mode',
+  );
+  return { ok, currentBranch, targetBranch: baseBranch, conflicts, warnings, dirty };
 }

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -466,52 +466,58 @@ describe('startTask', () => {
     describe('when current branch already equals base_branch', () => {
       beforeEach(() => {
         // Override --abbrev-ref to return 'feature-x' so currentBranch === target.
-        vi.mocked(execFile).mockImplementation(
-          ((_cmd: string, args: string[], optsOrCb: Function | object, maybeCb?: Function) => {
-            const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
-            if (args.includes('display-message')) {
-              cb(null, { stdout: String(nextWindowIndex), stderr: '' });
-            } else if (args.includes('list-windows')) {
-              cb(null, { stdout: String(nextWindowIndex), stderr: '' });
-            } else if (args.includes('new-window')) {
-              nextWindowIndex++;
-              cb(null, { stdout: '', stderr: '' });
-            } else if (args.includes('status') && args.some((a) => a.startsWith('--porcelain'))) {
-              cb(null, { stdout: '', stderr: '' });
-            } else if (args.includes('rev-parse') && args.includes('--abbrev-ref')) {
-              cb(null, { stdout: 'feature-x\n', stderr: '' });
-            } else if (args.includes('rev-parse')) {
-              cb(null, { stdout: 'abcdef0000000000000000000000000000000000\n', stderr: '' });
-            } else {
-              cb(null, { stdout: 'true', stderr: '' });
-            }
-          }) as never,
-        );
+        vi.mocked(execFile).mockImplementation(((
+          _cmd: string,
+          args: string[],
+          optsOrCb: Function | object,
+          maybeCb?: Function,
+        ) => {
+          const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
+          if (args.includes('display-message')) {
+            cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+          } else if (args.includes('list-windows')) {
+            cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+          } else if (args.includes('new-window')) {
+            nextWindowIndex++;
+            cb(null, { stdout: '', stderr: '' });
+          } else if (args.includes('status') && args.some((a) => a.startsWith('--porcelain'))) {
+            cb(null, { stdout: '', stderr: '' });
+          } else if (args.includes('rev-parse') && args.includes('--abbrev-ref')) {
+            cb(null, { stdout: 'feature-x\n', stderr: '' });
+          } else if (args.includes('rev-parse')) {
+            cb(null, { stdout: 'abcdef0000000000000000000000000000000000\n', stderr: '' });
+          } else {
+            cb(null, { stdout: 'true', stderr: '' });
+          }
+        }) as never);
       });
 
       afterEach(() => {
         // Restore the default mock so subsequent tests don't see 'feature-x' from --abbrev-ref.
-        vi.mocked(execFile).mockImplementation(
-          ((_cmd: string, args: string[], optsOrCb: Function | object, maybeCb?: Function) => {
-            const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
-            if (args.includes('display-message')) {
-              cb(null, { stdout: String(nextWindowIndex), stderr: '' });
-            } else if (args.includes('list-windows')) {
-              cb(null, { stdout: String(nextWindowIndex), stderr: '' });
-            } else if (args.includes('new-window')) {
-              nextWindowIndex++;
-              cb(null, { stdout: '', stderr: '' });
-            } else if (args.includes('status') && args.some((a) => a.startsWith('--porcelain'))) {
-              cb(null, { stdout: '', stderr: '' });
-            } else if (args.includes('rev-parse') && args.includes('--abbrev-ref')) {
-              cb(null, { stdout: 'main\n', stderr: '' });
-            } else if (args.includes('rev-parse')) {
-              cb(null, { stdout: 'abcdef0000000000000000000000000000000000\n', stderr: '' });
-            } else {
-              cb(null, { stdout: 'true', stderr: '' });
-            }
-          }) as never,
-        );
+        vi.mocked(execFile).mockImplementation(((
+          _cmd: string,
+          args: string[],
+          optsOrCb: Function | object,
+          maybeCb?: Function,
+        ) => {
+          const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
+          if (args.includes('display-message')) {
+            cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+          } else if (args.includes('list-windows')) {
+            cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+          } else if (args.includes('new-window')) {
+            nextWindowIndex++;
+            cb(null, { stdout: '', stderr: '' });
+          } else if (args.includes('status') && args.some((a) => a.startsWith('--porcelain'))) {
+            cb(null, { stdout: '', stderr: '' });
+          } else if (args.includes('rev-parse') && args.includes('--abbrev-ref')) {
+            cb(null, { stdout: 'main\n', stderr: '' });
+          } else if (args.includes('rev-parse')) {
+            cb(null, { stdout: 'abcdef0000000000000000000000000000000000\n', stderr: '' });
+          } else {
+            cb(null, { stdout: 'true', stderr: '' });
+          }
+        }) as never);
       });
 
       it('skips checkout when current branch equals base_branch', async () => {
@@ -538,17 +544,20 @@ describe('startTask', () => {
     it('errors when current==target but another active task is on the same branch', async () => {
       // Override mock so abbrev-ref returns feature-x (already on target)
       const originalImpl = vi.mocked(execFile).getMockImplementation();
-      vi.mocked(execFile).mockImplementation(
-        ((_cmd: string, args: string[], optsOrCb: Function | object, maybeCb?: Function) => {
-          const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
-          if (args.includes('--abbrev-ref')) {
-            cb(null, { stdout: 'feature-x\n', stderr: '' });
-            return;
-          }
-          // delegate to the original baseline for everything else
-          if (originalImpl) (originalImpl as Function)(_cmd, args, optsOrCb, maybeCb);
-        }) as never,
-      );
+      vi.mocked(execFile).mockImplementation(((
+        _cmd: string,
+        args: string[],
+        optsOrCb: Function | object,
+        maybeCb?: Function,
+      ) => {
+        const cb = typeof optsOrCb === 'function' ? optsOrCb : (maybeCb as Function);
+        if (args.includes('--abbrev-ref')) {
+          cb(null, { stdout: 'feature-x\n', stderr: '' });
+          return;
+        }
+        // delegate to the original baseline for everything else
+        if (originalImpl) (originalImpl as Function)(_cmd, args, optsOrCb, maybeCb);
+      }) as never);
 
       try {
         db.prepare(

--- a/server/task-runner.test.ts
+++ b/server/task-runner.test.ts
@@ -541,7 +541,7 @@ describe('startTask', () => {
       });
     });
 
-    it('errors when current==target but another active task is on the same branch', async () => {
+    it('succeeds when another active task shares the same branch (no checkout needed)', async () => {
       // Override mock so abbrev-ref returns feature-x (already on target)
       const originalImpl = vi.mocked(execFile).getMockImplementation();
       vi.mocked(execFile).mockImplementation(((
@@ -578,8 +578,9 @@ describe('startTask', () => {
         await startTask(noneTask);
 
         const updated = getTask(db, DEFAULTS.task.id)!;
-        expect(updated.status).toBe('error');
-        expect(updated.error).toMatch(/another chat is active on feature-x/);
+        expect(updated.status).toBe('running');
+        expect(updated.error).toBeNull();
+        // No checkout needed when current already equals target
         expect(
           findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['checkout', 'feature-x'] }),
         ).toBeUndefined();
@@ -588,11 +589,14 @@ describe('startTask', () => {
       }
     });
 
-    it('errors when another active task is on the same branch', async () => {
-      // Insert a conflicting active task directly into the DB
+    it('errors when another active task is on a different branch on the same root', async () => {
+      // Existing active task at /tmp/test-repo on 'main' (different branch).
+      // The default mock returns 'main' from --abbrev-ref, so the new task on
+      // feature-x would need to checkout — which would corrupt the running
+      // task's working state. Preflight must block this.
       db.prepare(
         `INSERT INTO worktrees (id, path, repo_path, branch, base_branch, mode, status)
-         VALUES ('wt-other', '/tmp/test-repo', '/tmp/test-repo', 'feature-x', 'feature-x', 'none', 'in_use')`,
+         VALUES ('wt-other', '/tmp/test-repo', '/tmp/test-repo', 'main', 'main', 'none', 'in_use')`,
       ).run();
       db.prepare(
         `INSERT INTO tasks (id, title, description, status, worktree_id)
@@ -609,7 +613,7 @@ describe('startTask', () => {
 
       const updated = getTask(db, DEFAULTS.task.id)!;
       expect(updated.status).toBe('error');
-      expect(updated.error).toMatch(/another chat is active on feature-x/);
+      expect(updated.error).toMatch(/another chat is active on a different branch/);
       expect(
         findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['checkout', 'feature-x'] }),
       ).toBeUndefined();

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -462,7 +462,9 @@ async function setupNone(task: Task): Promise<SetupResult> {
     const pre = await preflightNoneMode(task.repo_path, targetBranch);
     if (!pre.ok) {
       const reason = pre.conflicts.length
-        ? `another chat is active on ${targetBranch}: ${pre.conflicts.map((c) => c.task_id).join(', ')}`
+        ? `another chat is active on a different branch at ${task.repo_path}: ${pre.conflicts
+            .map((c) => `${c.task_id} (${c.branch ?? 'unknown'})`)
+            .join(', ')}`
         : `working tree at ${task.repo_path} has ${pre.dirty!.count} uncommitted changes`;
       throw new Error(`none mode preflight failed: ${reason}`);
     }

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -274,6 +274,7 @@ describe('Composer / submit', () => {
       currentBranch: 'feature-x',
       targetBranch: 'feature-x',
       conflicts: [],
+      warnings: [],
       dirty: null,
     });
     apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'none-1' }));
@@ -284,10 +285,11 @@ describe('Composer / submit', () => {
     expect(apiMock.createTask).toHaveBeenCalled();
   });
 
-  it('conflict dialog opens when preflight returns conflicts', async () => {
+  it('conflict dialog opens when another task is on a different branch', async () => {
     apiMock.preflightNoneMode.mockResolvedValueOnce({
       ok: false,
-      conflicts: [{ task_id: 't1', title: 'other', status: 'running', branch: 'feature-x' }],
+      conflicts: [{ task_id: 't1', title: 'other', status: 'running', branch: 'main' }],
+      warnings: [],
       dirty: null,
       currentBranch: 'main',
       targetBranch: 'feature-x',
@@ -299,10 +301,30 @@ describe('Composer / submit', () => {
     expect(apiMock.createTask).not.toHaveBeenCalled();
   });
 
+  it('shared-branch dialog warns (non-blocking) when another task is on the same branch', async () => {
+    apiMock.preflightNoneMode.mockResolvedValueOnce({
+      ok: true,
+      conflicts: [],
+      warnings: [{ task_id: 't1', title: 'other', status: 'running', branch: 'feature-x' }],
+      dirty: null,
+      currentBranch: 'feature-x',
+      targetBranch: 'feature-x',
+    });
+    apiMock.createTask.mockResolvedValueOnce(makeTask({ id: 'none-shared' }));
+    renderComposer('/?repo=%2Fr&mode=none&branch=feature-x');
+    await user.type(screen.getByTestId('composer-prompt'), 'do the thing');
+    await user.click(screen.getByTestId('composer-submit'));
+    await waitFor(() => expect(screen.getByText(/share the working tree/i)).toBeInTheDocument());
+    expect(apiMock.createTask).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /continue anyway/i }));
+    await waitFor(() => expect(apiMock.createTask).toHaveBeenCalled());
+  });
+
   it('dirty dialog opens when preflight returns dirty', async () => {
     apiMock.preflightNoneMode.mockResolvedValueOnce({
       ok: false,
       conflicts: [],
+      warnings: [],
       dirty: { count: 5 },
       currentBranch: 'main',
       targetBranch: 'feature-x',

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -26,6 +26,7 @@ import { useTasksContext } from '@/lib/tasks-context';
 import type { Task, Agent } from '../../server/types';
 import { NoneModeConflictDialog } from './NoneModeConflictDialog';
 import { NoneModeDirtyDialog } from './NoneModeDirtyDialog';
+import { NoneModeSharedBranchDialog } from './NoneModeSharedBranchDialog';
 
 /** POST /api/chats — create a standalone runtime agent. */
 async function createChatRequest(body: { label?: string; agent?: string | null }): Promise<Agent> {
@@ -200,7 +201,10 @@ export function Composer({ onSubmitted }: Props = {}) {
           // Preflight only for none-mode + base_branch
           if (state.mode === 'none' && state.branch) {
             const pre = await api.preflightNoneMode(state.repo, state.branch);
-            if (!pre.ok) {
+            // Conflicts (different-branch active task) and dirty both block
+            // creation. Same-branch warnings don't block but require an
+            // explicit confirmation.
+            if (!pre.ok || pre.warnings.length > 0) {
               setPreflightBlock({ result: pre, payload });
               return;
             }
@@ -411,7 +415,10 @@ export function Composer({ onSubmitted }: Props = {}) {
             setPreflightBlock({ result: next, payload: preflightBlock.payload });
           }}
           onResolved={async () => {
+            // Hand off to the dirty / shared-branch dialogs if those checks
+            // now apply — their conditional renders will pick up the flow.
             if (preflightBlock.result.dirty) return;
+            if (preflightBlock.result.warnings.length > 0) return;
             const created = await api.createTask(preflightBlock.payload);
             setPreflightBlock(null);
             refresh();
@@ -434,6 +441,24 @@ export function Composer({ onSubmitted }: Props = {}) {
                 preflightBlock.payload.repo_path!,
                 preflightBlock.payload.base_branch!,
               );
+              const created = await api.createTask(preflightBlock.payload);
+              setPreflightBlock(null);
+              refresh();
+              onSubmitted?.(created);
+              navigate(`/tasks/${created.id}`);
+            }}
+          />
+        )}
+      {preflightBlock &&
+        preflightBlock.result.conflicts.length === 0 &&
+        !preflightBlock.result.dirty &&
+        preflightBlock.result.warnings.length > 0 && (
+          <NoneModeSharedBranchDialog
+            open
+            warnings={preflightBlock.result.warnings}
+            targetBranch={preflightBlock.result.targetBranch}
+            onClose={() => setPreflightBlock(null)}
+            onConfirm={async () => {
               const created = await api.createTask(preflightBlock.payload);
               setPreflightBlock(null);
               refresh();

--- a/src/components/NoneModeConflictDialog.tsx
+++ b/src/components/NoneModeConflictDialog.tsx
@@ -52,8 +52,7 @@ export function NoneModeConflictDialog({
           {conflicts.map((c) => (
             <li key={c.task_id} className="flex items-center justify-between gap-2">
               <span className="truncate">
-                {c.title}{' '}
-                <span className="text-xs text-muted-foreground">({c.status})</span>
+                {c.title} <span className="text-xs text-muted-foreground">({c.status})</span>
               </span>
               <Button
                 size="sm"

--- a/src/components/NoneModeDirtyDialog.tsx
+++ b/src/components/NoneModeDirtyDialog.tsx
@@ -41,8 +41,8 @@ export function NoneModeDirtyDialog({
           <DialogTitle>Uncommitted changes</DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground">
-          You have {count} uncommitted change{count === 1 ? '' : 's'} on `{currentBranch}`.
-          Stash them to switch to `{targetBranch}`, or cancel and resolve manually.
+          You have {count} uncommitted change{count === 1 ? '' : 's'} on `{currentBranch}`. Stash
+          them to switch to `{targetBranch}`, or cancel and resolve manually.
         </p>
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
         <div className="mt-4 flex justify-end gap-2">

--- a/src/components/NoneModeSharedBranchDialog.tsx
+++ b/src/components/NoneModeSharedBranchDialog.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { PreflightConflict } from '@/lib/api';
+
+interface Props {
+  open: boolean;
+  warnings: PreflightConflict[];
+  targetBranch: string;
+  onClose: () => void;
+  onConfirm: () => Promise<void> | void;
+}
+
+export function NoneModeSharedBranchDialog({
+  open,
+  warnings,
+  targetBranch,
+  onClose,
+  onConfirm,
+}: Props) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onConfirm();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Other chats are using `{targetBranch}`</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          They share the working tree on this branch — concurrent edits may conflict. You can
+          continue, but the agents will see each other's changes.
+        </p>
+        <ul className="mt-4 space-y-1">
+          {warnings.map((w) => (
+            <li key={w.task_id} className="truncate text-sm">
+              {w.title} <span className="text-xs text-muted-foreground">({w.status})</span>
+            </li>
+          ))}
+        </ul>
+        {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={busy}>
+            {busy ? 'Starting…' : 'Continue anyway'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -122,7 +122,10 @@ export interface PreflightResult {
   ok: boolean;
   currentBranch: string;
   targetBranch: string;
+  /** Active none-mode tasks on the same root worktree, on a *different* branch. Blocks creation. */
   conflicts: PreflightConflict[];
+  /** Active none-mode tasks on the same root worktree, on the *same* branch. Non-blocking. */
+  warnings: PreflightConflict[];
   dirty: { count: number } | null;
 }
 

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -164,6 +164,7 @@ export function mockApi(overrides: Record<string, unknown> = {}) {
       currentBranch: 'main',
       targetBranch: 'main',
       conflicts: [],
+      warnings: [],
       dirty: null,
     }),
     stashRepo: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## What

The none-mode preflight check was inverted, causing two related bugs:

- **Same branch was blocked.** Creating a none-mode task on a branch that another active task was already using showed a conflict dialog and required closing the other task — even though both tasks would simply share the working tree (no checkout needed).
- **Different branch was silently allowed.** Creating a none-mode task on a *different* branch while another task was running on the root worktree was not flagged as a conflict, so task setup ran `git checkout <new-branch>` and corrupted the running task's working state.

This PR inverts the logic to match the actual semantics:

- Filter the conflict query to `mode='none'` (only root-worktree tasks share state — `new`-mode tasks have their own dedicated worktrees and don't conflict).
- Split active tasks into `conflicts` (different branch → block) and `warnings` (same branch → non-blocking confirmation).
- Skip the dirty check while a different-branch conflict is present; dirty is re-evaluated on the next preflight after the user closes the conflicting task.
- Add `NoneModeSharedBranchDialog` for the same-branch warning path with a "Continue anyway" affordance.
- Update the task-runner defense-in-depth error message to reflect that conflicts now mean a different branch.

## Why

The previous behavior blocked legitimate same-branch workflows while silently allowing the destructive different-branch case. Aligning `conflicts` with cases where `git checkout` would actually corrupt running state makes the dialogs match user expectations.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — no new errors
- `bun run format:check` — clean
- `bun run test` — 1228 tests across 64 files, all pass
- New tests cover: same-branch warning (non-blocking), different-branch conflict (blocks), `mode='none'` filter (ignores `new`-mode worktrees), dirty-check skip when conflicts present, and the Composer's shared-branch confirmation flow.