### PR TITLE
fix(chats): show scratch sessions in sidebar and pass initial prompt

### DIFF
--- a/server/api.review.test.ts
+++ b/server/api.review.test.ts
@@ -17,9 +17,7 @@ describe('POST/DELETE /api/tasks/:id/files/*path/reviewed', () => {
   });
 
   it('POST inserts a review-state row with current HEAD as commit', async () => {
-    const res = await request(app)
-      .post('/api/tasks/t1/files/src/foo.ts/reviewed')
-      .send();
+    const res = await request(app).post('/api/tasks/t1/files/src/foo.ts/reviewed').send();
     expect(res.status).toBe(204);
     const { listReviewState } = await import('./file-review-state.js');
     const rows = listReviewState('t1');
@@ -35,9 +33,7 @@ describe('POST/DELETE /api/tasks/:id/files/*path/reviewed', () => {
   });
 
   it('rejects path traversal', async () => {
-    const res = await request(app)
-      .post('/api/tasks/t1/files/..%2Fetc%2Fpasswd/reviewed')
-      .send();
+    const res = await request(app).post('/api/tasks/t1/files/..%2Fetc%2Fpasswd/reviewed').send();
     expect(res.status).toBe(400);
   });
 

--- a/server/api.ts
+++ b/server/api.ts
@@ -1225,7 +1225,12 @@ export function setupRoutes(app: Express): void {
   app.post('/api/chats', async (req: Request, res: Response) => {
     const body = (req.body ?? {}) as CreateChatRequest;
     try {
-      const chat = await createChat({ label: body.label, cwd: body.cwd, agent: body.agent });
+      const chat = await createChat({
+        label: body.label,
+        cwd: body.cwd,
+        agent: body.agent,
+        prompt: body.prompt,
+      });
       res.status(201).json(chat);
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -37,6 +37,11 @@ export interface CreateChatOptions {
   label?: string;
   cwd?: string;
   agent?: string | null;
+  prompt?: string | null;
+}
+
+function shellQuoteSingle(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
 /**
@@ -68,8 +73,25 @@ export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
 
     const flags = resolveClaudeFlags(await getSettings());
     const agentFlag = agent ? ` --agent ${agent}` : '';
-    const cmd = `claude${agentFlag} --session-id ${claudeSessionId}${flags}`;
+    let cmd = `claude${agentFlag} --session-id ${claudeSessionId}${flags}`;
+    let promptFile: string | null = null;
+    const initialPrompt = opts.prompt?.trim();
+    if (initialPrompt) {
+      promptFile = path.join(cwd, `.claude-prompt-${id}`);
+      fs.writeFileSync(promptFile, initialPrompt);
+      cmd += ` "$(cat ${shellQuoteSingle(promptFile)})"`;
+    }
     await execFile('tmux', ['send-keys', '-t', session, cmd, 'Enter']);
+    if (promptFile) {
+      const pf = promptFile;
+      setTimeout(() => {
+        try {
+          fs.unlinkSync(pf);
+        } catch {
+          // already removed
+        }
+      }, 30_000);
+    }
 
     logger.info(
       { chat_id: id, tmux_session: session, cwd, agent, operation: 'createChat' },
@@ -84,14 +106,14 @@ export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
   return db.prepare('SELECT * FROM agents WHERE id = ?').get(id) as Agent;
 }
 
-/** List all standalone agents (task_id IS NULL), pinned first. */
+/** List all standalone agents (task_id IS NULL), oldest first. */
 export function listChats(): Agent[] {
   const db = getDb();
   return db
     .prepare(
       `SELECT * FROM agents
          WHERE task_id IS NULL
-         ORDER BY pinned DESC, created_at ASC`,
+         ORDER BY created_at ASC`,
     )
     .all() as Agent[];
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -40,6 +40,7 @@ export interface CreateChatRequest {
   label?: string;
   cwd?: string;
   agent?: string;
+  prompt?: string;
 }
 
 export interface Task {

--- a/src/components/CommentQueueDrawer.tsx
+++ b/src/components/CommentQueueDrawer.tsx
@@ -21,10 +21,7 @@ export function CommentQueueDrawer({
       </header>
       <ul className="flex-1 overflow-auto">
         {comments.map((c) => (
-          <li
-            key={c.id}
-            className="p-3 border-b border-glass-border/50 flex gap-2 items-start"
-          >
+          <li key={c.id} className="p-3 border-b border-glass-border/50 flex gap-2 items-start">
             <button
               type="button"
               onClick={() => onJumpTo(c.filePath, c.line)}

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -29,7 +29,11 @@ import { NoneModeDirtyDialog } from './NoneModeDirtyDialog';
 import { NoneModeSharedBranchDialog } from './NoneModeSharedBranchDialog';
 
 /** POST /api/chats — create a standalone runtime agent. */
-async function createChatRequest(body: { label?: string; agent?: string | null }): Promise<Agent> {
+async function createChatRequest(body: {
+  label?: string;
+  agent?: string | null;
+  prompt?: string;
+}): Promise<Agent> {
   const res = await fetch('/api/chats', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -173,7 +177,9 @@ export function Composer({ onSubmitted }: Props = {}) {
           const chat = await createChatRequest({
             label: deriveTitleFromPrompt(trimmed),
             agent: pickedAgent,
+            prompt: trimmed,
           });
+          refresh();
           navigate(`/chats/${chat.id}`);
         } else if (state.mode !== 'empty') {
           const title = deriveTitleFromPrompt(trimmed);

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -314,12 +314,7 @@ describe('DiffViewer', () => {
       const user = userEvent.setup();
       const onAddComment = vi.fn();
       render(
-        <DiffViewer
-          oldContent="a"
-          newContent="aa"
-          path="src/foo.ts"
-          onAddComment={onAddComment}
-        />,
+        <DiffViewer oldContent="a" newContent="aa" path="src/foo.ts" onAddComment={onAddComment} />,
       );
       await user.click(screen.getByText('aa'));
       const input = screen.getByPlaceholderText(/leave a comment/i);
@@ -336,12 +331,7 @@ describe('DiffViewer', () => {
       const user = userEvent.setup();
       const onAddComment = vi.fn();
       render(
-        <DiffViewer
-          oldContent="a"
-          newContent="aa"
-          path="src/foo.ts"
-          onAddComment={onAddComment}
-        />,
+        <DiffViewer oldContent="a" newContent="aa" path="src/foo.ts" onAddComment={onAddComment} />,
       );
       await user.click(screen.getByText('aa'));
       const input = screen.getByPlaceholderText(/leave a comment/i);

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -86,11 +86,7 @@ export function DiffViewer(props: Props) {
 
   // Standalone / composer mode — renders the new-content lines as clickable
   // buttons with an inline comment composer. No taskId needed.
-  if (
-    standaloneNew !== undefined &&
-    standalonePath !== undefined &&
-    standaloneOld !== undefined
-  ) {
+  if (standaloneNew !== undefined && standalonePath !== undefined && standaloneOld !== undefined) {
     return (
       <InlineComposerDiff
         path={standalonePath}
@@ -156,9 +152,7 @@ function InlineComposerDiff({
     <div className="font-mono text-sm">
       {lines.map((lineText, idx) => {
         const lineNum = idx + 1; // 1-indexed
-        const pills = queuedComments.filter(
-          (c) => c.filePath === path && c.line === lineNum,
-        );
+        const pills = queuedComments.filter((c) => c.filePath === path && c.line === lineNum);
         return (
           <div key={lineNum} data-line={lineNum}>
             <button

--- a/src/hooks/useDiffKeyboardNav.test.ts
+++ b/src/hooks/useDiffKeyboardNav.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useDiffKeyboardNav, DIFF_KEYBINDS } from './useDiffKeyboardNav.js';
 
-function fire(key: string, mods: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean } = {}) {
+function fire(
+  key: string,
+  mods: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean } = {},
+) {
   window.dispatchEvent(new KeyboardEvent('keydown', { key, ...mods }));
 }
 

--- a/src/hooks/useReviewQueue.test.ts
+++ b/src/hooks/useReviewQueue.test.ts
@@ -56,7 +56,12 @@ describe('useReviewQueue', () => {
   it('format() emits the agent-message body', () => {
     const { result } = renderHook(() => useReviewQueue('t1'));
     act(() => {
-      result.current.add({ filePath: 'src/a.ts', line: 10, lineText: '> if (x) {', body: 'this is dead' });
+      result.current.add({
+        filePath: 'src/a.ts',
+        line: 10,
+        lineText: '> if (x) {',
+        body: 'this is dead',
+      });
       result.current.add({ filePath: 'src/b.ts', line: 5, lineText: '> y', body: 'rename y' });
     });
     const msg = result.current.format();

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -68,10 +68,7 @@ function DiffKeybindCheatSheet() {
           </div>
           <ul className="mt-2 space-y-1">
             {DIFF_KEYBINDS.map((b) => (
-              <li
-                key={b.keys}
-                className="flex items-center justify-between gap-3 text-xs"
-              >
+              <li key={b.keys} className="flex items-center justify-between gap-3 text-xs">
                 <kbd className="rounded border border-glass-edge bg-glass-l1 px-1.5 py-0.5 font-mono text-[10px]">
                   {b.keys}
                 </kbd>
@@ -230,9 +227,7 @@ export default function TaskDetail() {
   const moveActiveFile = useCallback(
     (delta: 1 | -1) => {
       if (visibleFiles.length === 0) return;
-      const idx = activeFilePath
-        ? visibleFiles.findIndex((f) => f.path === activeFilePath)
-        : -1;
+      const idx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
       const next = (idx + delta + visibleFiles.length) % visibleFiles.length;
       setActiveFilePath(visibleFiles[next].path);
     },
@@ -241,9 +236,7 @@ export default function TaskDetail() {
 
   const jumpToNextUnreviewed = useCallback(() => {
     if (visibleFiles.length === 0) return;
-    const startIdx = activeFilePath
-      ? visibleFiles.findIndex((f) => f.path === activeFilePath)
-      : -1;
+    const startIdx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
     for (let i = 1; i <= visibleFiles.length; i++) {
       const candidate = visibleFiles[(startIdx + i) % visibleFiles.length];
       if (!candidate.reviewed) {


### PR DESCRIPTION
## What

- Drop the `pinned DESC` clause from `listChats()` so `/api/chats` no longer throws after the migration that drops the `pinned` column.
- Plumb `prompt` through `CreateChatRequest` → `createChat()` and hand it to the spawned `claude` process via the same prompt-file pattern that `task-runner.sendClaudeCommand` uses, so the user's typed message is delivered as the agent's first input.
- `Composer` now sends the trimmed prompt when creating a scratch chat and refreshes the task list after navigation.

## Why

Two bugs reported together:

1. Scratch sessions (no repo selected) never appeared in the left sidebar. Root cause: `listChats` ordered by `pinned`, but `db.ts` drops that column on migration. The query threw, the API returned 500, and `ChatsSection` silently swallowed the fetch error, leaving chats invisible.
2. The first message typed into the composer was never delivered to the agent for scratch sessions — `createChatRequest` didn't pass the prompt, and `createChat` launched `claude` with no initial argument.

## Testing

- `bun run typecheck` — clean
- `bun run test -- chats Composer` — 209 passed
- Manual: create a scratch session from the home composer, verify it appears under `// CHATS` in the sidebar and that the typed prompt shows up as claude's first user message.