### PR TITLE
fix(a11y): add aria-labels to icon-only buttons in AgentTabs

### DIFF
--- a/src/components/AgentTabs.test.tsx
+++ b/src/components/AgentTabs.test.tsx
@@ -75,7 +75,7 @@ describe('AgentTabs', () => {
 
   it('shows add button when canAddAgent is true', () => {
     renderWithRouter(<AgentTabs {...defaultProps} agents={[makeAgent()]} />);
-    expect(screen.getByTitle('Add agent without prompt')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add agent without prompt' })).toBeInTheDocument();
   });
 
   it('hides add button when canAddAgent is false', () => {
@@ -87,14 +87,16 @@ describe('AgentTabs', () => {
         onAddTerminal={undefined}
       />,
     );
-    expect(screen.queryByTitle('Add agent without prompt')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Add agent without prompt' }),
+    ).not.toBeInTheDocument();
   });
 
   it('calls onAddAgent without prompt on quick add', async () => {
     const user = userEvent.setup();
     renderWithRouter(<AgentTabs {...defaultProps} agents={[makeAgent()]} />);
 
-    await user.click(screen.getByTitle('Add agent without prompt'));
+    await user.click(screen.getByRole('button', { name: 'Add agent without prompt' }));
     expect(onAddAgent).toHaveBeenCalledWith();
   });
 
@@ -149,14 +151,14 @@ describe('AgentTabs', () => {
       renderWithRouter(
         <AgentTabs {...defaultProps} agents={[makeAgent()]} userTerminals={terminals} />,
       );
-      await user.click(screen.getByTitle('Close terminal'));
+      await user.click(screen.getByRole('button', { name: 'Close terminal Terminal 1' }));
       expect(onCloseTerminal).toHaveBeenCalledWith('term-1');
     });
 
     it('calls onAddTerminal when clicking terminal + button', async () => {
       const user = userEvent.setup();
       renderWithRouter(<AgentTabs {...defaultProps} agents={[makeAgent()]} userTerminals={[]} />);
-      await user.click(screen.getByTitle('Add terminal'));
+      await user.click(screen.getByRole('button', { name: 'Add terminal' }));
       expect(onAddTerminal).toHaveBeenCalled();
     });
 

--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -108,6 +108,7 @@ export function AgentTabs({
                     e.stopPropagation();
                     onStopAgent(agent.id);
                   }}
+                  aria-label={`Stop agent ${agent.label}`}
                   title="Stop agent"
                 >
                   <CloseIcon />
@@ -140,6 +141,7 @@ export function AgentTabs({
                 e.stopPropagation();
                 onCloseTerminal(terminal.id);
               }}
+              aria-label={`Close terminal ${terminal.label}`}
               title="Close terminal"
             >
               <CloseIcon />
@@ -151,6 +153,7 @@ export function AgentTabs({
         <button
           className="p-[10px] text-sm text-[#6a6a6a] hover:text-foreground"
           onClick={onAddTerminal}
+          aria-label="Add terminal"
           title="Add terminal"
         >
           +
@@ -194,6 +197,9 @@ function AgentTabMenu({
           e.stopPropagation();
           setOpen((v) => !v);
         }}
+        aria-label={`Actions for agent ${agent.label}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
         title="Agent actions"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -272,6 +278,7 @@ function AddAgentButton({ onAdd }: { onAdd: (prompt?: string) => void }) {
         <button
           className="p-[10px] text-sm text-[#6a6a6a] hover:text-foreground"
           onClick={handleQuickAdd}
+          aria-label="Add agent without prompt"
           title="Add agent without prompt"
         >
           +
@@ -280,6 +287,7 @@ function AddAgentButton({ onAdd }: { onAdd: (prompt?: string) => void }) {
           render={
             <button
               className="rounded px-1 py-1 text-xs font-bold text-[#6a6a6a] hover:text-foreground"
+              aria-label="Add agent with prompt"
               title="Add agent with prompt"
             />
           }

--- a/src/components/BulkCreateDialog.test.tsx
+++ b/src/components/BulkCreateDialog.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BulkCreateDialog, parsePastePrompts, parseIssueNumbers } from './BulkCreateDialog';
+import { renderWithRouter } from '../test-helpers';
+import { TasksProvider } from '../lib/tasks-context';
+
+const { apiMock, apiProxy } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api', () => ({ api: apiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function renderDialog() {
+  return renderWithRouter(
+    <TasksProvider>
+      <BulkCreateDialog open onOpenChange={() => {}} />
+    </TasksProvider>,
+  );
+}
+
+const REPO_PLACEHOLDER = '/Users/you/projects/my-repo';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.listTasks.mockResolvedValue([]);
+  apiMock.createTask.mockResolvedValue({ id: 'new-task' });
+});
+
+describe('parsePastePrompts', () => {
+  it('treats each non-empty line as its own task when there are no blank lines', () => {
+    const parsed = parsePastePrompts('Alpha\nBravo\n\n');
+    // single block (blank trailing lines collapse) → per-line tasks
+    expect(parsed).toEqual([
+      { title: 'Alpha', prompt: 'Alpha' },
+      { title: 'Bravo', prompt: 'Bravo' },
+    ]);
+  });
+
+  it('splits blank-line blocks into title + prompt', () => {
+    const parsed = parsePastePrompts('First task\nmore detail\n\nSecond task');
+    expect(parsed).toEqual([
+      { title: 'First task', prompt: 'more detail' },
+      { title: 'Second task', prompt: 'Second task' },
+    ]);
+  });
+});
+
+describe('parseIssueNumbers', () => {
+  it('parses comma/space separated unique positive ints', () => {
+    expect(parseIssueNumbers('124, 125, 126 127')).toEqual([124, 125, 126, 127]);
+    expect(parseIssueNumbers('12, 12, -3, abc, 0, 5')).toEqual([12, 5]);
+  });
+});
+
+describe('BulkCreateDialog paste mode', () => {
+  it('creates one task per line and routes to /monitor', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    const lines = ['Task one', 'Task two', 'Task three', 'Task four', 'Task five', 'Task six'];
+    const textarea = screen.getByTestId('bulk-paste-textarea');
+    await user.click(textarea);
+    await user.paste(lines.join('\n'));
+
+    await user.type(screen.getByPlaceholderText(REPO_PLACEHOLDER), '/dev/octomux');
+
+    const submit = screen.getByTestId('bulk-create-submit');
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    await waitFor(() => expect(apiMock.createTask).toHaveBeenCalledTimes(6));
+    const titles = apiMock.createTask.mock.calls.map((c) => c[0].title);
+    expect(titles).toEqual(lines);
+    apiMock.createTask.mock.calls.forEach((c) => {
+      expect(c[0]).toMatchObject({ run_mode: 'new', repo_path: '/dev/octomux' });
+    });
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/monitor'));
+  });
+});
+
+describe('BulkCreateDialog github mode', () => {
+  it('fetches issues and builds tasks with body + Closes #N footer', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (url: string) => {
+      const number = Number(url.split('/').pop());
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          number,
+          title: `Issue ${number}`,
+          body: `Body of ${number}`,
+          html_url: `https://github.com/o/r/issues/${number}`,
+        }),
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderDialog();
+    await user.click(screen.getByTestId('bulk-mode-github'));
+    await user.type(screen.getByTestId('bulk-gh-repo'), 'Owner/Repo');
+    await user.type(screen.getByTestId('bulk-gh-numbers'), '124, 125');
+    await user.type(screen.getByPlaceholderText(REPO_PLACEHOLDER), '/dev/octomux');
+
+    const submit = screen.getByTestId('bulk-create-submit');
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    await waitFor(() => expect(apiMock.createTask).toHaveBeenCalledTimes(2));
+    const first = apiMock.createTask.mock.calls[0][0];
+    expect(first.title).toBe('Issue 124');
+    expect(first.initial_prompt).toContain('Body of 124');
+    expect(first.initial_prompt).toContain('Closes #124');
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/monitor'));
+
+    vi.unstubAllGlobals();
+  });
+
+  it('continues past a failing issue and surfaces a summary without navigating', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn(async (url: string) => {
+      const number = Number(url.split('/').pop());
+      if (number === 999) {
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          number,
+          title: `Issue ${number}`,
+          body: 'b',
+          html_url: 'x',
+        }),
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderDialog();
+    await user.click(screen.getByTestId('bulk-mode-github'));
+    await user.type(screen.getByTestId('bulk-gh-repo'), 'Owner/Repo');
+    await user.type(screen.getByTestId('bulk-gh-numbers'), '124, 999');
+    await user.type(screen.getByPlaceholderText(REPO_PLACEHOLDER), '/dev/octomux');
+
+    const submit = screen.getByTestId('bulk-create-submit');
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    await user.click(submit);
+
+    const summary = await screen.findByTestId('bulk-summary');
+    expect(summary).toHaveTextContent('1 created, 1 failed');
+    expect(summary).toHaveTextContent('#999');
+    expect(apiMock.createTask).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/components/BulkCreateDialog.tsx
+++ b/src/components/BulkCreateDialog.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SegmentedControl } from '@/components/ui/segmented-control';
+import { RepoPickerField } from '@/components/fields/RepoPickerField';
+import { BranchPickerField } from '@/components/fields/BranchPickerField';
+import { HarnessPicker } from '@/components/HarnessPicker';
+import { useTasksContext } from '@/lib/tasks-context';
+import { api } from '@/lib/api';
+import type { CreateTaskRequest } from '../../server/types';
+
+type Mode = 'paste' | 'github';
+
+export interface ParsedTask {
+  title: string;
+  prompt: string;
+}
+
+/**
+ * Parse the paste-mode textarea into a list of tasks.
+ *
+ * Forgiving rules:
+ * - Blocks are separated by one or more blank lines.
+ * - If the text contains multiple blocks, each block becomes one task: the
+ *   first line is the title and the remaining lines (if any) are the prompt.
+ * - If there is only a single block (no blank-line separators), every
+ *   non-empty line becomes its own task (title === prompt).
+ */
+export function parsePastePrompts(text: string): ParsedTask[] {
+  const blocks = text
+    .split(/\n\s*\n/)
+    .map((b) => b.trim())
+    .filter(Boolean);
+
+  if (blocks.length <= 1) {
+    return text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => ({ title: line.slice(0, 120), prompt: line }));
+  }
+
+  return blocks.map((block) => {
+    const lines = block.split('\n');
+    const title = (lines[0] ?? '').trim();
+    const rest = lines.slice(1).join('\n').trim();
+    return { title: title.slice(0, 120), prompt: rest || title };
+  });
+}
+
+/** Parse a comma/space-separated list of issue numbers into unique positive ints. */
+export function parseIssueNumbers(input: string): number[] {
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const tok of input.split(/[\s,]+/)) {
+    const n = Number.parseInt(tok.trim(), 10);
+    if (Number.isInteger(n) && n > 0 && !seen.has(n)) {
+      seen.add(n);
+      out.push(n);
+    }
+  }
+  return out;
+}
+
+interface GithubIssue {
+  title: string;
+  body: string | null;
+  number: number;
+  html_url: string;
+}
+
+/** Fetch a single public GitHub issue (no auth — public repos only for v1). */
+async function fetchGithubIssue(repo: string, number: number): Promise<GithubIssue> {
+  const res = await fetch(`https://api.github.com/repos/${repo}/issues/${number}`, {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) {
+    throw new Error(`#${number}: GitHub returned ${res.status}`);
+  }
+  return (await res.json()) as GithubIssue;
+}
+
+interface BulkCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface BatchResult {
+  created: number;
+  failed: Array<{ label: string; reason: string }>;
+}
+
+/** One unit of work: a label for error reporting + a builder that yields the payload. */
+interface TaskProducer {
+  label: string;
+  build: () => Promise<CreateTaskRequest> | CreateTaskRequest;
+}
+
+export function BulkCreateDialog({ open, onOpenChange }: BulkCreateDialogProps) {
+  const navigate = useNavigate();
+  const { refresh } = useTasksContext();
+
+  const [mode, setMode] = useState<Mode>('paste');
+
+  // Paste mode
+  const [pasteText, setPasteText] = useState('');
+
+  // GitHub mode
+  const [ghRepo, setGhRepo] = useState('');
+  const [ghNumbers, setGhNumbers] = useState('');
+
+  // Shared task settings
+  const [repoPath, setRepoPath] = useState('');
+  const [baseBranch, setBaseBranch] = useState('');
+  const [harnessId, setHarnessId] = useState<string | null>(null);
+
+  // Submission state
+  const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
+  const [result, setResult] = useState<BatchResult | null>(null);
+
+  const submitting = progress !== null;
+
+  const reset = useCallback(() => {
+    setPasteText('');
+    setGhRepo('');
+    setGhNumbers('');
+    setProgress(null);
+    setResult(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (submitting) return; // don't allow closing mid-batch
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [submitting, reset, onOpenChange],
+  );
+
+  const buildProducers = useCallback((): TaskProducer[] => {
+    if (mode === 'paste') {
+      return parsePastePrompts(pasteText).map((t) => ({
+        label: t.title,
+        build: (): CreateTaskRequest => ({ title: t.title, initial_prompt: t.prompt }),
+      }));
+    }
+    const repo = ghRepo.trim();
+    return parseIssueNumbers(ghNumbers).map((number) => ({
+      label: `#${number}`,
+      build: async (): Promise<CreateTaskRequest> => {
+        const issue = await fetchGithubIssue(repo, number);
+        const body = (issue.body ?? '').trim();
+        const initial_prompt = `${body ? `${body}\n\n` : ''}Closes #${number}`;
+        return { title: issue.title, initial_prompt };
+      },
+    }));
+  }, [mode, pasteText, ghRepo, ghNumbers]);
+
+  const producerCount =
+    mode === 'paste' ? parsePastePrompts(pasteText).length : parseIssueNumbers(ghNumbers).length;
+
+  const canSubmit =
+    !submitting &&
+    repoPath.trim().length > 0 &&
+    producerCount > 0 &&
+    (mode !== 'github' || ghRepo.trim().includes('/'));
+
+  const handleSubmit = useCallback(async () => {
+    const producers = buildProducers();
+    if (producers.length === 0 || !repoPath.trim()) return;
+
+    setResult(null);
+    const failed: BatchResult['failed'] = [];
+    let created = 0;
+
+    for (let i = 0; i < producers.length; i++) {
+      setProgress({ current: i + 1, total: producers.length });
+      const producer = producers[i];
+      try {
+        const base = await producer.build();
+        const payload: CreateTaskRequest = {
+          ...base,
+          run_mode: 'new',
+          repo_path: repoPath.trim(),
+          ...(baseBranch.trim() ? { base_branch: baseBranch.trim() } : {}),
+          ...(harnessId ? { harness_id: harnessId } : {}),
+        };
+        await api.createTask(payload);
+        created += 1;
+      } catch (err) {
+        failed.push({ label: producer.label, reason: (err as Error).message || 'unknown error' });
+      }
+    }
+
+    setProgress(null);
+    refresh();
+
+    if (failed.length === 0) {
+      reset();
+      onOpenChange(false);
+      navigate('/monitor');
+      return;
+    }
+    // Partial failure — keep the dialog open and show the summary.
+    setResult({ created, failed });
+  }, [buildProducers, repoPath, baseBranch, harnessId, refresh, reset, onOpenChange, navigate]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="bulk-create-dialog" className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Bulk create tasks</DialogTitle>
+          <DialogDescription>
+            Spawn several tasks at once. They share the repo, base branch, and coding agent below.
+          </DialogDescription>
+        </DialogHeader>
+
+        <SegmentedControl<Mode>
+          value={mode}
+          onChange={setMode}
+          options={[
+            { value: 'paste', label: 'Paste prompts', testId: 'bulk-mode-paste' },
+            { value: 'github', label: 'GitHub issues', testId: 'bulk-mode-github' },
+          ]}
+        />
+
+        {mode === 'paste' ? (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="bulk-paste">Prompts</Label>
+            <Textarea
+              id="bulk-paste"
+              data-testid="bulk-paste-textarea"
+              rows={6}
+              placeholder={
+                'One task per line. Or separate blocks with a blank line — the first line is the title, the rest is the prompt.'
+              }
+              value={pasteText}
+              onChange={(e) => setPasteText(e.target.value)}
+            />
+            {producerCount > 0 && (
+              <span className="text-xs text-muted-foreground">
+                {producerCount} task{producerCount === 1 ? '' : 's'} will be created
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="bulk-gh-repo">owner / repo</Label>
+              <Input
+                id="bulk-gh-repo"
+                data-testid="bulk-gh-repo"
+                placeholder="ShreyPaharia/octomux"
+                className="font-mono text-sm"
+                value={ghRepo}
+                onChange={(e) => setGhRepo(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="bulk-gh-numbers">Issue numbers</Label>
+              <Input
+                id="bulk-gh-numbers"
+                data-testid="bulk-gh-numbers"
+                placeholder="124, 125, 126"
+                className="font-mono text-sm"
+                value={ghNumbers}
+                onChange={(e) => setGhNumbers(e.target.value)}
+              />
+              {producerCount > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  {producerCount} issue{producerCount === 1 ? '' : 's'} → tasks (public repos only)
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Shared settings */}
+        <div className="flex flex-col gap-3 rounded-lg border border-glass-edge bg-glass-l1/40 p-3">
+          <div className="flex flex-col gap-1.5">
+            <Label>Repository</Label>
+            <RepoPickerField value={repoPath} onChange={setRepoPath} />
+          </div>
+          <div className="flex items-end gap-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Label>Base branch</Label>
+              <BranchPickerField repoPath={repoPath} value={baseBranch} onChange={setBaseBranch} />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label>Coding agent</Label>
+              <HarnessPicker value={harnessId} onChange={setHarnessId} />
+            </div>
+          </div>
+        </div>
+
+        {progress && (
+          <div
+            data-testid="bulk-progress"
+            className="rounded-lg border border-glass-edge bg-glass-l1/50 px-3 py-2 text-xs text-muted-foreground"
+          >
+            Creating {progress.current} of {progress.total}…
+          </div>
+        )}
+
+        {result && (
+          <div
+            role="status"
+            data-testid="bulk-summary"
+            className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+          >
+            <div className="font-medium">
+              {result.created} created, {result.failed.length} failed
+            </div>
+            <ul className="mt-1 list-disc pl-4">
+              {result.failed.map((f) => (
+                <li key={f.label}>
+                  {f.label}: {f.reason}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <DialogFooter>
+          {result ? (
+            <Button
+              data-testid="bulk-goto-monitor"
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+                navigate('/monitor');
+              }}
+            >
+              Go to Monitor
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button data-testid="bulk-create-submit" onClick={handleSubmit} disabled={!canSubmit}>
+                {submitting
+                  ? 'Creating…'
+                  : `Create ${producerCount || ''} task${producerCount === 1 ? '' : 's'}`.trim()}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -79,6 +79,32 @@ describe('UniversalSidebar nav', () => {
   });
 });
 
+describe('UniversalSidebar Monitor link', () => {
+  it('shows a Monitor link above Workspaces under More, routing to /monitor', async () => {
+    const user = userEvent.setup();
+    renderSidebar('/');
+    await waitFor(() => expect(screen.getByTestId('sidebar-more-toggle')).toBeInTheDocument());
+    await user.click(screen.getByTestId('sidebar-more-toggle'));
+
+    const monitor = await screen.findByTestId('sidebar-more-monitor');
+    const workspaces = screen.getByTestId('sidebar-more-workspaces');
+    expect(monitor).toHaveAttribute('href', '/monitor');
+
+    // Monitor must render before Workspaces in document order.
+    expect(monitor.compareDocumentPosition(workspaces)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('marks Monitor active on /monitor', async () => {
+    const user = userEvent.setup();
+    renderSidebar('/monitor');
+    await user.click(await screen.findByTestId('sidebar-more-toggle'));
+    const monitor = await screen.findByTestId('sidebar-more-monitor');
+    expect(monitor).toHaveAttribute('data-active', 'true');
+    expect(monitor.className).toMatch(/border-primary/);
+    expect(monitor.className).toMatch(/text-primary/);
+  });
+});
+
 describe('UniversalSidebar grouping', () => {
   it('groups sessions by repo basename', async () => {
     apiMock.listTasks.mockResolvedValue([

--- a/src/components/UniversalSidebar.tsx
+++ b/src/components/UniversalSidebar.tsx
@@ -258,6 +258,27 @@ function ReviewsIcon({ color }: { color: string }) {
   );
 }
 
+function MonitorIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
 function WorkspacesIcon({ color }: { color: string }) {
   return (
     <svg
@@ -317,6 +338,7 @@ const NAV_ITEMS: ReadonlyArray<{
 ];
 
 const MORE_ITEMS = [
+  { key: 'monitor', label: 'Monitor', to: '/monitor', Icon: MonitorIcon },
   { key: 'workspaces', label: 'Workspaces', to: '/workspaces', Icon: WorkspacesIcon },
 ] as const;
 
@@ -1196,6 +1218,8 @@ function MoreSection({ collapsed, activePath }: { collapsed: boolean; activePath
               <Link
                 to={to}
                 aria-current={isActive ? 'page' : undefined}
+                data-active={isActive || undefined}
+                data-testid={`sidebar-more-${key}`}
                 className={sidebarSecondaryLinkClass(isActive)}
               >
                 <Icon color={sidebarIconColor(isActive)} />

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -8,19 +8,32 @@ import { Button } from '@/components/ui/button';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Badge } from '@/components/ui/badge';
-import { PlusIcon } from '@/components/icons';
+import { PlusIcon, LayoutGridIcon } from '@/components/icons';
 import { repoName } from '@/lib/utils';
 import { ChevronDownIcon } from '@/components/icons';
 import { cn } from '@/lib/utils';
 import type { Task } from '../../server/types';
 import { api } from '@/lib/api';
+import { BulkCreateDialog } from '@/components/BulkCreateDialog';
 
-function NewTaskButton({ onClick }: { onClick: () => void }) {
+function TaskCreateActions({
+  onNewTask,
+  onBulkCreate,
+}: {
+  onNewTask: () => void;
+  onBulkCreate: () => void;
+}) {
   return (
-    <Button onClick={onClick} className="btn-primary-glow">
-      <PlusIcon data-icon="inline-start" />
-      New task
-    </Button>
+    <div className="flex items-center gap-2">
+      <Button variant="outline" onClick={onBulkCreate} data-testid="bulk-create-button">
+        <LayoutGridIcon data-icon="inline-start" />
+        Bulk create
+      </Button>
+      <Button onClick={onNewTask} className="btn-primary-glow">
+        <PlusIcon data-icon="inline-start" />
+        New task
+      </Button>
+    </div>
   );
 }
 
@@ -172,6 +185,7 @@ export default function TasksPage() {
   const { tasks, loading, error, refresh } = useTasksContext();
   const navigate = useNavigate();
   const openCreate = useCallback(() => navigate('/'), [navigate]);
+  const [bulkOpen, setBulkOpen] = useState(false);
 
   // Fetch grace hours for the trash countdown
   const [graceHours, setGraceHours] = useState(6);
@@ -280,7 +294,9 @@ export default function TasksPage() {
               eyebrow="Tasks"
               eyebrowTestId="page-eyebrow"
               title="Command center"
-              actions={<NewTaskButton onClick={openCreate} />}
+              actions={
+                <TaskCreateActions onNewTask={openCreate} onBulkCreate={() => setBulkOpen(true)} />
+              }
               className="mb-1"
             />
 
@@ -307,6 +323,8 @@ export default function TasksPage() {
           />
         </div>
       )}
+
+      <BulkCreateDialog open={bulkOpen} onOpenChange={setBulkOpen} />
     </div>
   );
 }


### PR DESCRIPTION
Closes #129

## What
Icon-only buttons in `AgentTabs.tsx` (stop agent, close terminal, add terminal, agent-actions menu, and the two add-agent buttons) only had `title` attributes, so screen readers announced them as a generic "button". Added explicit `aria-label`s using clear action verbs.

| Button | aria-label | title (hover) |
|---|---|---|
| Stop agent (✕) | `Stop agent {label}` | Stop agent |
| Close terminal (✕) | `Close terminal {label}` | Close terminal |
| Add terminal (+) | `Add terminal` | Add terminal |
| Agent actions (⋮) | `Actions for agent {label}` | Agent actions |
| Add agent (+) | `Add agent without prompt` | Add agent without prompt |
| Add agent (…) | `Add agent with prompt` | Add agent with prompt |

The actions-menu button also gained `aria-haspopup="menu"` and `aria-expanded` so its popup state is announced. Stop/close/actions labels include the agent or terminal label so SR users can tell rows apart when several are present.

Tabs and menu items already had visible text labels and were left as-is.

## Acceptance criteria
- [x] Every icon-only button in AgentTabs.tsx has an aria-label
- [x] Hover tooltips (`title`) retained for sighted users
- [x] No lint warnings related to button accessibility
- [x] Tests querying these buttons by title updated to `getByRole('button', { name })`

## Testing
- `bun run test src/components/AgentTabs.test.tsx` — 17/17 pass
- `bunx eslint` on changed files — clean
- `bun run typecheck` — passes