### PR TITLE
feat(board): add live duration label to BoardCard

### DIFF
--- a/src/components/BoardCard.test.tsx
+++ b/src/components/BoardCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { screen, act } from '@testing-library/react';
+import { BoardCard } from './BoardCard';
+import { makeTask, renderWithRouter } from '../test-helpers';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('BoardCard duration label', () => {
+  it('ticks every second for running tasks', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:14Z'));
+    const task = makeTask({ runtime_state: 'running', created_at: '2026-01-01 00:00:00' });
+
+    renderWithRouter(<BoardCard task={task} />);
+
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Running 1m 14s');
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Running 1m 15s');
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Running 1m 16s');
+  });
+
+  it('shows a static final duration for closed (idle) tasks', () => {
+    vi.setSystemTime(new Date('2026-01-01T02:00:00Z'));
+    const task = makeTask({
+      runtime_state: 'idle',
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:08:00',
+    });
+
+    renderWithRouter(<BoardCard task={task} />);
+
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Closed after 8m 0s');
+
+    // No ticking for terminal states.
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Closed after 8m 0s');
+  });
+
+  it('shows a static final duration for error tasks', () => {
+    vi.setSystemTime(new Date('2026-01-01T02:00:00Z'));
+    const task = makeTask({
+      runtime_state: 'error',
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:30',
+    });
+
+    renderWithRouter(<BoardCard task={task} />);
+
+    expect(screen.getByTestId('task-duration')).toHaveTextContent('Failed after 30s');
+  });
+});

--- a/src/components/BoardCard.tsx
+++ b/src/components/BoardCard.tsx
@@ -1,9 +1,10 @@
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import type { Task, WorkflowStatus } from '../../server/types';
 import { timeAgo } from '@/lib/time';
+import { formatDuration } from '@/lib/format-duration';
 import { cn, repoName } from '@/lib/utils';
 import { api } from '@/lib/api';
 import { TrashCountdown } from './TrashCountdown';
@@ -22,6 +23,45 @@ function RuntimeDot({ state }: { state: Task['runtime_state'] }) {
     default:
       return <span className="text-[#4a4a4a]">○</span>;
   }
+}
+
+// ─── Live duration label ──────────────────────────────────────────────────
+
+/**
+ * Shows time since the task started. Ticks every second while the task is
+ * active (running / setting_up); shows the final, static duration for
+ * terminal states (idle = closed, error).
+ */
+function TaskDuration({ task }: { task: Task }) {
+  const isActive = task.runtime_state === 'running' || task.runtime_state === 'setting_up';
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!isActive) return;
+    const t = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(t);
+  }, [isActive]);
+
+  const start = new Date(task.created_at + 'Z').getTime();
+  if (Number.isNaN(start)) return null;
+
+  const end = isActive ? now : new Date(task.updated_at + 'Z').getTime();
+  const label = formatDuration(end - start);
+
+  const prefix =
+    task.runtime_state === 'running'
+      ? 'Running'
+      : task.runtime_state === 'setting_up'
+        ? 'Setting up'
+        : task.runtime_state === 'error'
+          ? 'Failed after'
+          : 'Closed after';
+
+  return (
+    <span data-testid="task-duration" className="text-[10px] tabular-nums text-muted-soft">
+      {prefix} {label}
+    </span>
+  );
 }
 
 interface BoardCardProps {
@@ -147,6 +187,7 @@ export const BoardCard = memo(function BoardCard({
                 {task.agents.length} agent{task.agents.length !== 1 ? 's' : ''}
               </span>
             )}
+            <TaskDuration task={task} />
           </div>
           <span className="text-[10px] tabular-nums text-muted-soft">
             {timeAgo(task.updated_at)}

--- a/src/lib/format-duration.test.ts
+++ b/src/lib/format-duration.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatDuration } from './format-duration';
+
+describe('formatDuration', () => {
+  it.each([
+    [0, '0s'],
+    [999, '0s'],
+    [1_000, '1s'],
+    [59_000, '59s'],
+    [60_000, '1m 0s'],
+    [74_000, '1m 14s'],
+    [134_000, '2m 14s'],
+    [480_000, '8m 0s'],
+    [3_599_000, '59m 59s'],
+    [3_600_000, '1h 0m'],
+    [3_660_000, '1h 1m'],
+    [7_530_000, '2h 5m'],
+  ])('formats %ims as "%s"', (ms, expected) => {
+    expect(formatDuration(ms)).toBe(expected);
+  });
+
+  it('clamps negative input to 0s', () => {
+    expect(formatDuration(-5_000)).toBe('0s');
+  });
+});

--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,0 +1,19 @@
+/**
+ * Formats an elapsed duration (in milliseconds) into a compact human label.
+ *
+ *   <1m  -> "Ns"
+ *   <1h  -> "Nm Ss"
+ *   >=1h -> "Nh Nm"
+ *
+ * Negative inputs clamp to 0s.
+ */
+export function formatDuration(ms: number): string {
+  const totalSecs = Math.max(0, Math.floor(ms / 1000));
+  if (totalSecs < 60) return `${totalSecs}s`;
+
+  const totalMins = Math.floor(totalSecs / 60);
+  if (totalMins < 60) return `${totalMins}m ${totalSecs % 60}s`;
+
+  const hrs = Math.floor(totalMins / 60);
+  return `${hrs}h ${totalMins % 60}m`;
+}


### PR DESCRIPTION
## What

Adds a small duration label to each BoardCard showing time since the task started:
- Ticks every second for active tasks (`running` → "Running 2m 14s", `setting_up` → "Setting up …").
- Shows the final, static duration for terminal states (`idle` → "Closed after 8m 0s", `error` → "Failed after 30s").
- Format: `<1m → "Ns"`, `<1h → "Nm Ss"`, `>=1h → "Nh Nm"`.

Implemented as a new `formatDuration` helper (`src/lib/format-duration.ts`) plus a `<TaskDuration>` sub-component in `BoardCard`. Start time uses `created_at`; end time for terminal states uses `updated_at` (matching the existing UTC `+ 'Z'` timestamp convention).

## Why

Gives an at-a-glance sense of how long each task has been running or how long a finished task took, directly on the board card.

Resolves #126

## Testing

- `bun run test` → 2256 passed (incl. new `format-duration` unit tests and `BoardCard` live-update component tests)
- `bun run typecheck` → clean
- `bun run lint` → 0 errors (pre-existing warnings only)