### PR TITLE
feat(remote-auth): remote access over Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,33 @@ flowchart LR
 | `OCTOMUX_DB_PATH`         | Override task DB path            |
 | `OCTOMUX_GITHUB_LOGIN`    | Reviewer-request polling account |
 
+## Remote access over Tailscale
+
+octomux binds to `127.0.0.1` by default — reachable only from the host machine. To view
+and control sessions from your other devices (phone, second laptop), put them on a
+[Tailscale](https://tailscale.com) tailnet and enable remote mode:
+
+1. Install Tailscale on the host and each device; run `tailscale up` on each. Enable
+   MagicDNS so the host is reachable by name.
+2. Start octomux in remote mode:
+   ```bash
+   octomux start --bind 0.0.0.0
+   # or: OCTOMUX_BIND=0.0.0.0 octomux start
+   ```
+   On first start a random access token is generated and its file path is logged
+   (`~/.octomux/data/remote-token`). Override it with `OCTOMUX_REMOTE_TOKEN=<secret>`.
+3. (Optional) Restrict the accepted `Host` header to your tailnet name:
+   `OCTOMUX_ALLOWED_HOSTS=mybox.your-tailnet.ts.net`. The `100.64.0.0/10` tailnet IP range
+   is accepted automatically.
+4. From a device on the tailnet, open `http://<host-magicdns-name>:7777` and sign in once
+   with the token. Local (loopback) access never requires the token.
+
+**Security notes:** only devices on your tailnet can reach the port; the token is a second
+factor so a single compromised tailnet device cannot silently drive your agents. Binding
+`0.0.0.0` also exposes the port on any other LAN the host is on — the token gates those out,
+and you can add a host firewall rule limiting port 7777 to the `100.64.0.0/10` range for
+belt-and-suspenders. For HTTPS, front octomux with `tailscale serve`.
+
 ## FAQ
 
 **What's the difference between octomux and just running tmux + Claude Code?**

--- a/bin/octomux.js
+++ b/bin/octomux.js
@@ -37,6 +37,9 @@ async function runStart(startArgs) {
     if (startArgs[i] === '--port' && startArgs[i + 1]) {
       port = parseInt(startArgs[i + 1], 10);
       i++;
+    } else if (startArgs[i] === '--bind' && startArgs[i + 1]) {
+      process.env.OCTOMUX_BIND = startArgs[i + 1];
+      i++;
     } else if (startArgs[i] === '--no-open') {
       autoOpen = false;
     }
@@ -82,7 +85,8 @@ async function runStart(startArgs) {
   }
 
   checkNeovimVersion();
-  console.log('Open Setup in the dashboard to install dependencies and configure defaults.\n');
+  console.log('Open Setup in the dashboard to install dependencies and configure defaults.');
+  console.log('Tip: use --bind 0.0.0.0 to enable remote access over Tailscale.\n');
 
   // Start server
   process.env.NODE_ENV = 'production';

--- a/server/app.remote-auth.test.ts
+++ b/server/app.remote-auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { sessionCookieValue, COOKIE_NAME } from './remote-auth.js';
+
+describe('app remote-auth integration', () => {
+  afterEach(() => {
+    delete process.env.OCTOMUX_BIND;
+    delete process.env.OCTOMUX_REMOTE_TOKEN;
+  });
+
+  it('remote mode off: /login still serves and api is open (loopback)', async () => {
+    const app = createApp();
+    const login = await request(app).get('/login');
+    expect(login.status).toBe(200);
+  });
+
+  it('login with correct token sets the session cookie', async () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const app = createApp();
+    const res = await request(app).post('/login').type('form').send({ token: 'tok' });
+    expect(res.status).toBe(302);
+    expect(res.headers['set-cookie'][0]).toContain(`${COOKIE_NAME}=${sessionCookieValue('tok')}`);
+    expect(res.headers['set-cookie'][0]).toContain('HttpOnly');
+  });
+
+  it('login with wrong token returns 401 and sets no cookie', async () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const app = createApp();
+    const res = await request(app).post('/login').type('form').send({ token: 'nope' });
+    expect(res.status).toBe(401);
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('extended host allowlist accepts a configured tailscale host', async () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_ALLOWED_HOSTS = 'mybox.tailnet.ts.net';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const app = createApp();
+    const res = await request(app).get('/login').set('Host', 'mybox.tailnet.ts.net');
+    expect(res.status).toBe(200);
+    delete process.env.OCTOMUX_ALLOWED_HOSTS;
+  });
+
+  it('disallowed host is rejected with 403', async () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const app = createApp();
+    const res = await request(app).get('/login').set('Host', 'evil.example.com');
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/app.remote-auth.test.ts
+++ b/server/app.remote-auth.test.ts
@@ -7,6 +7,7 @@ describe('app remote-auth integration', () => {
   afterEach(() => {
     delete process.env.OCTOMUX_BIND;
     delete process.env.OCTOMUX_REMOTE_TOKEN;
+    delete process.env.OCTOMUX_ALLOWED_HOSTS;
   });
 
   it('remote mode off: /login still serves and api is open (loopback)', async () => {
@@ -41,7 +42,6 @@ describe('app remote-auth integration', () => {
     const app = createApp();
     const res = await request(app).get('/login').set('Host', 'mybox.tailnet.ts.net');
     expect(res.status).toBe(200);
-    delete process.env.OCTOMUX_ALLOWED_HOSTS;
   });
 
   it('disallowed host is rejected with 403', async () => {

--- a/server/app.remote-auth.test.ts
+++ b/server/app.remote-auth.test.ts
@@ -16,6 +16,15 @@ describe('app remote-auth integration', () => {
     expect(login.status).toBe(200);
   });
 
+  it('remote mode off: POST /login redirects to / without creating a token file', async () => {
+    // Remote mode is off (OCTOMUX_BIND defaults to 127.0.0.1), so POST /login must
+    // short-circuit before calling ensureToken() — no token file side effects.
+    const app = createApp();
+    const res = await request(app).post('/login').type('form').send({ token: 'any' });
+    expect(res.status).toBe(302);
+    expect(res.headers['location']).toBe('/');
+  });
+
   it('login with correct token sets the session cookie', async () => {
     process.env.OCTOMUX_BIND = '0.0.0.0';
     process.env.OCTOMUX_REMOTE_TOKEN = 'tok';

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,17 +2,39 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { setupRoutes } from './api.js';
 import { childLogger } from './logger.js';
+import { registerAuthRoutes, remoteAuthMiddleware, isRemoteMode } from './remote-auth.js';
 
 const logger = childLogger('app');
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost']);
+
+function isHostAllowed(host: string): boolean {
+  if (LOOPBACK_HOSTS.has(host)) return true;
+  if (!isRemoteMode()) return false;
+  const allowed = (process.env.OCTOMUX_ALLOWED_HOSTS ?? '')
+    .split(',')
+    .map((h) => h.trim())
+    .filter(Boolean);
+  if (allowed.includes(host)) return true;
+  // Tailscale CGNAT range 100.64.0.0/10
+  const m = host.match(/^100\.(\d+)\.\d+\.\d+$/);
+  if (m) {
+    const second = Number(m[1]);
+    if (second >= 64 && second <= 127) return true;
+  }
+  return false;
+}
 
 export function createApp(): express.Express {
   const app = express();
   app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ extended: false }));
 
-  // Host-header check (DNS-rebinding defense).
+  // Host-header check (DNS-rebinding defense). In remote mode, also allow
+  // configured Tailscale hosts and the 100.64.0.0/10 tailnet range.
   app.use((req, res, next) => {
     const host = (req.headers.host ?? '').split(':')[0];
-    if (host !== '127.0.0.1' && host !== 'localhost') {
+    if (!isHostAllowed(host)) {
       logger.warn({ host, ip: req.ip, path: req.path }, 'rejected: bad host header');
       return res.status(403).send();
     }
@@ -39,6 +61,9 @@ export function createApp(): express.Express {
     }
     next();
   });
+
+  registerAuthRoutes(app);
+  app.use(remoteAuthMiddleware);
 
   setupRoutes(app);
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -119,7 +119,15 @@ const HOST = getBindHost();
 server.listen(Number(PORT), HOST, () => {
   logger.info({ port: PORT, host: HOST }, `octomux listening on ${HOST}`);
   if (isRemoteMode()) {
-    ensureToken(); // generate + log the token file path on first remote start
+    try {
+      ensureToken(); // generate + log the token file path on first remote start
+    } catch (err) {
+      logger.error(
+        { err },
+        'remote mode: failed to read/create remote-access token — set OCTOMUX_REMOTE_TOKEN or fix permissions on the token dir',
+      );
+      process.exit(1);
+    }
     logger.warn(
       { host: HOST },
       'remote access ENABLED — clients must present the token at /login (see remote-token file or OCTOMUX_REMOTE_TOKEN)',

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { createApp } from './app.js';
+import { getBindHost, isRemoteMode, isUpgradeAuthorized, ensureToken } from './remote-auth.js';
 import {
   setupTerminalWebSocket,
   handleTerminalUpgrade,
@@ -37,6 +38,10 @@ setupTerminalWebSocket();
 setupEventWebSocket();
 
 server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+  if (!isUpgradeAuthorized(req)) {
+    socket.destroy();
+    return;
+  }
   if (handleTerminalUpgrade(req, socket, head)) return;
   if (handleEventUpgrade(req, socket, head)) return;
   socket.destroy();
@@ -110,8 +115,16 @@ server.on('error', (err: NodeJS.ErrnoException) => {
   throw err;
 });
 
-server.listen(Number(PORT), '127.0.0.1', () => {
-  logger.info({ port: PORT }, 'octomux listening on 127.0.0.1');
+const HOST = getBindHost();
+server.listen(Number(PORT), HOST, () => {
+  logger.info({ port: PORT, host: HOST }, `octomux listening on ${HOST}`);
+  if (isRemoteMode()) {
+    ensureToken(); // generate + log the token file path on first remote start
+    logger.warn(
+      { host: HOST },
+      'remote access ENABLED — clients must present the token at /login (see remote-token file or OCTOMUX_REMOTE_TOKEN)',
+    );
+  }
 });
 
 // ─── Graceful Shutdown ──────────────────────────────────────────────────────

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
 import { ensureToken, tokenFilePath } from './remote-auth.js';
+import { sessionCookieValue, parseCookies, validSessionCookie, COOKIE_NAME } from './remote-auth.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -87,5 +88,28 @@ describe('remote-auth token', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(tokenFilePath(), token, {
       mode: 0o600,
     });
+  });
+});
+
+describe('remote-auth cookies', () => {
+  it('sessionCookieValue is a stable 64-char hex HMAC of the token', () => {
+    const v = sessionCookieValue('tok');
+    expect(v).toMatch(/^[0-9a-f]{64}$/);
+    expect(sessionCookieValue('tok')).toBe(v); // deterministic
+    expect(sessionCookieValue('other')).not.toBe(v); // keyed by token
+  });
+
+  it('parseCookies extracts name/value pairs', () => {
+    expect(parseCookies(`a=1; ${COOKIE_NAME}=xyz; b=2`)[COOKIE_NAME]).toBe('xyz');
+    expect(parseCookies(undefined)).toEqual({});
+    expect(parseCookies('')).toEqual({});
+  });
+
+  it('validSessionCookie accepts the matching signed value only', () => {
+    const good = sessionCookieValue('tok');
+    expect(validSessionCookie(good, 'tok')).toBe(true);
+    expect(validSessionCookie('deadbeef', 'tok')).toBe(false);
+    expect(validSessionCookie('', 'tok')).toBe(false);
+    expect(validSessionCookie(undefined, 'tok')).toBe(false);
   });
 });

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
 import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
+import { ensureToken, tokenFilePath } from './remote-auth.js';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const mocked = {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => ''),
+  };
+  return { ...mocked, default: mocked };
+});
 
 describe('remote-auth config', () => {
   afterEach(() => {
@@ -38,5 +52,40 @@ describe('remote-auth config', () => {
     [undefined, false],
   ])('isLoopbackAddress(%s) → %s', (addr, expected) => {
     expect(isLoopbackAddress(addr)).toBe(expected);
+  });
+});
+
+describe('remote-auth token', () => {
+  afterEach(() => {
+    delete process.env.OCTOMUX_REMOTE_TOKEN;
+    vi.mocked(fs.existsSync).mockReset();
+    vi.mocked(fs.readFileSync).mockReset();
+    vi.mocked(fs.mkdirSync).mockReset();
+    vi.mocked(fs.writeFileSync).mockReset();
+  });
+
+  it('returns OCTOMUX_REMOTE_TOKEN when set, without touching fs', () => {
+    process.env.OCTOMUX_REMOTE_TOKEN = 'env-token-123';
+    expect(ensureToken()).toBe('env-token-123');
+    expect(vi.mocked(fs.readFileSync)).not.toHaveBeenCalled();
+  });
+
+  it('reads an existing token file', () => {
+    delete process.env.OCTOMUX_REMOTE_TOKEN;
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('file-token-abc');
+    expect(ensureToken()).toBe('file-token-abc');
+  });
+
+  it('generates and persists a token (mode 0600) when none exists', () => {
+    delete process.env.OCTOMUX_REMOTE_TOKEN;
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined as unknown as string);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    const token = ensureToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(tokenFilePath(), token, {
+      mode: 0o600,
+    });
   });
 });

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
+
+describe('remote-auth config', () => {
+  afterEach(() => {
+    delete process.env.OCTOMUX_BIND;
+    vi.unstubAllEnvs();
+  });
+
+  it('getBindHost defaults to 127.0.0.1', () => {
+    expect(getBindHost()).toBe('127.0.0.1');
+  });
+
+  it('getBindHost honors OCTOMUX_BIND', () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    expect(getBindHost()).toBe('0.0.0.0');
+  });
+
+  it.each([
+    [undefined, false],
+    ['127.0.0.1', false],
+    ['localhost', false],
+    ['::1', false],
+    ['0.0.0.0', true],
+    ['100.64.1.2', true],
+  ])('isRemoteMode with OCTOMUX_BIND=%s → %s', (bind, expected) => {
+    if (bind === undefined) delete process.env.OCTOMUX_BIND;
+    else process.env.OCTOMUX_BIND = bind;
+    expect(isRemoteMode()).toBe(expected);
+  });
+
+  it.each([
+    ['127.0.0.1', true],
+    ['::1', true],
+    ['::ffff:127.0.0.1', true],
+    ['100.64.1.2', false],
+    ['192.168.1.5', false],
+    [undefined, false],
+  ])('isLoopbackAddress(%s) → %s', (addr, expected) => {
+    expect(isLoopbackAddress(addr)).toBe(expected);
+  });
+});

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs';
-import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
-import { ensureToken, tokenFilePath } from './remote-auth.js';
-import { sessionCookieValue, parseCookies, validSessionCookie, COOKIE_NAME } from './remote-auth.js';
-import { authorizeRequest, authorizeUpgrade, sessionCookieValue as sig } from './remote-auth.js';
-import { isUpgradeAuthorized } from './remote-auth.js';
+import {
+  getBindHost,
+  isRemoteMode,
+  isLoopbackAddress,
+  ensureToken,
+  tokenFilePath,
+  sessionCookieValue,
+  sessionCookieValue as sig,
+  parseCookies,
+  validSessionCookie,
+  validToken,
+  COOKIE_NAME,
+  authorizeRequest,
+  authorizeUpgrade,
+  isUpgradeAuthorized,
+} from './remote-auth.js';
 import type { IncomingMessage } from 'http';
 
 vi.mock('fs', async (importOriginal) => {
@@ -117,6 +128,16 @@ describe('remote-auth cookies', () => {
   });
 });
 
+describe('validToken', () => {
+  it.each([
+    ['correct-token', 'correct-token', true],
+    ['wrong-token', 'correct-token', false],
+    ['', 'correct-token', false],
+  ])('validToken(%s, %s) → %s', (provided, token, expected) => {
+    expect(validToken(provided, token)).toBe(expected);
+  });
+});
+
 describe('authorizeRequest (pure)', () => {
   const token = 'tok';
   const cookie = `${COOKIE_NAME}=${sig(token)}`;
@@ -147,7 +168,13 @@ describe('authorizeRequest (pure)', () => {
 
   it.each(['/login', '/logout', '/api/hooks/permission'])('exempts %s', (p) => {
     expect(
-      authorizeRequest({ remoteMode: true, isLoopback: false, path: p, cookieHeader: undefined, token }),
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: false,
+        path: p,
+        cookieHeader: undefined,
+        token,
+      }),
     ).toBe('allow');
   });
 
@@ -197,9 +224,9 @@ describe('authorizeUpgrade (pure)', () => {
     [{ remoteMode: true, isLoopback: false, cookieHeader: `${COOKIE_NAME}=${sig('tok')}` }, true],
     [{ remoteMode: true, isLoopback: false, cookieHeader: `${COOKIE_NAME}=bad` }, false],
   ])('%o → %s', (input, expected) => {
-    expect(
-      authorizeUpgrade({ ...input, token } as Parameters<typeof authorizeUpgrade>[0]),
-    ).toBe(expected);
+    expect(authorizeUpgrade({ ...input, token } as Parameters<typeof authorizeUpgrade>[0])).toBe(
+      expected,
+    );
   });
 });
 

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
 import { ensureToken, tokenFilePath } from './remote-auth.js';
 import { sessionCookieValue, parseCookies, validSessionCookie, COOKIE_NAME } from './remote-auth.js';
+import { authorizeRequest, authorizeUpgrade, sessionCookieValue as sig } from './remote-auth.js';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -111,5 +112,91 @@ describe('remote-auth cookies', () => {
     expect(validSessionCookie('deadbeef', 'tok')).toBe(false);
     expect(validSessionCookie('', 'tok')).toBe(false);
     expect(validSessionCookie(undefined, 'tok')).toBe(false);
+  });
+});
+
+describe('authorizeRequest (pure)', () => {
+  const token = 'tok';
+  const cookie = `${COOKIE_NAME}=${sig(token)}`;
+
+  it('allows everything when remote mode is off', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: false,
+        isLoopback: false,
+        path: '/api/tasks',
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('allow');
+  });
+
+  it('allows loopback requests without a cookie', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: true,
+        path: '/api/tasks',
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('allow');
+  });
+
+  it.each(['/login', '/logout', '/api/hooks/permission'])('exempts %s', (p) => {
+    expect(
+      authorizeRequest({ remoteMode: true, isLoopback: false, path: p, cookieHeader: undefined, token }),
+    ).toBe('allow');
+  });
+
+  it('allows a remote request with a valid cookie', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: false,
+        path: '/api/tasks',
+        cookieHeader: cookie,
+        token,
+      }),
+    ).toBe('allow');
+  });
+
+  it('returns "unauthorized" for an API path without a cookie', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: false,
+        path: '/api/tasks',
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('unauthorized');
+  });
+
+  it('returns "redirect" for a non-API path without a cookie', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: false,
+        path: '/tasks/abc',
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('redirect');
+  });
+});
+
+describe('authorizeUpgrade (pure)', () => {
+  const token = 'tok';
+  it.each([
+    [{ remoteMode: false, isLoopback: false, cookieHeader: undefined }, true],
+    [{ remoteMode: true, isLoopback: true, cookieHeader: undefined }, true],
+    [{ remoteMode: true, isLoopback: false, cookieHeader: undefined }, false],
+    [{ remoteMode: true, isLoopback: false, cookieHeader: `${COOKIE_NAME}=${sig('tok')}` }, true],
+    [{ remoteMode: true, isLoopback: false, cookieHeader: `${COOKIE_NAME}=bad` }, false],
+  ])('%o → %s', (input, expected) => {
+    expect(
+      authorizeUpgrade({ ...input, token } as Parameters<typeof authorizeUpgrade>[0]),
+    ).toBe(expected);
   });
 });

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -166,12 +166,36 @@ describe('authorizeRequest (pure)', () => {
     ).toBe('allow');
   });
 
-  it.each(['/login', '/logout', '/api/hooks/permission'])('exempts %s', (p) => {
+  it.each(['/login', '/logout'])('exempts %s from auth in remote mode', (p) => {
     expect(
       authorizeRequest({
         remoteMode: true,
         isLoopback: false,
         path: p,
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('allow');
+  });
+
+  it('rejects /api/hooks/install from non-loopback in remote mode (admin route now protected)', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: false,
+        path: '/api/hooks/install',
+        cookieHeader: undefined,
+        token,
+      }),
+    ).toBe('unauthorized');
+  });
+
+  it('allows /api/hooks/permission-request from loopback in remote mode (real harness callback)', () => {
+    expect(
+      authorizeRequest({
+        remoteMode: true,
+        isLoopback: true,
+        path: '/api/hooks/permission-request',
         cookieHeader: undefined,
         token,
       }),

--- a/server/remote-auth.test.ts
+++ b/server/remote-auth.test.ts
@@ -4,6 +4,8 @@ import { getBindHost, isRemoteMode, isLoopbackAddress } from './remote-auth.js';
 import { ensureToken, tokenFilePath } from './remote-auth.js';
 import { sessionCookieValue, parseCookies, validSessionCookie, COOKIE_NAME } from './remote-auth.js';
 import { authorizeRequest, authorizeUpgrade, sessionCookieValue as sig } from './remote-auth.js';
+import { isUpgradeAuthorized } from './remote-auth.js';
+import type { IncomingMessage } from 'http';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -198,5 +200,40 @@ describe('authorizeUpgrade (pure)', () => {
     expect(
       authorizeUpgrade({ ...input, token } as Parameters<typeof authorizeUpgrade>[0]),
     ).toBe(expected);
+  });
+});
+
+describe('isUpgradeAuthorized wrapper', () => {
+  afterEach(() => {
+    delete process.env.OCTOMUX_BIND;
+    delete process.env.OCTOMUX_REMOTE_TOKEN;
+  });
+
+  it('allows when remote mode is off regardless of address', () => {
+    const req = {
+      socket: { remoteAddress: '100.64.1.2' },
+      headers: {},
+    } as unknown as IncomingMessage;
+    expect(isUpgradeAuthorized(req)).toBe(true);
+  });
+
+  it('rejects a remote upgrade without a valid cookie', () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const req = {
+      socket: { remoteAddress: '100.64.1.2' },
+      headers: {},
+    } as unknown as IncomingMessage;
+    expect(isUpgradeAuthorized(req)).toBe(false);
+  });
+
+  it('allows a loopback upgrade in remote mode', () => {
+    process.env.OCTOMUX_BIND = '0.0.0.0';
+    process.env.OCTOMUX_REMOTE_TOKEN = 'tok';
+    const req = {
+      socket: { remoteAddress: '127.0.0.1' },
+      headers: {},
+    } as unknown as IncomingMessage;
+    expect(isUpgradeAuthorized(req)).toBe(true);
   });
 });

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -157,7 +157,8 @@ export function isUpgradeAuthorized(req: IncomingMessage): boolean {
     cookieHeader: req.headers.cookie,
     token: ensureToken(),
   });
-  if (!ok) logger.warn({ url: req.url, addr: req.socket.remoteAddress }, 'remote-auth: rejected upgrade');
+  if (!ok)
+    logger.warn({ url: req.url, addr: req.socket.remoteAddress }, 'remote-auth: rejected upgrade');
   return ok;
 }
 
@@ -176,12 +177,14 @@ export function registerAuthRoutes(app: import('express').Express): void {
     res.type('html').send(LOGIN_PAGE);
   });
   app.post('/login', (req, res) => {
+    // requires express.urlencoded() to be registered in app.ts (the login form posts urlencoded)
     const provided = (req.body?.token ?? '') as string;
-    if (!validToken(provided, ensureToken())) {
+    const token = ensureToken();
+    if (!validToken(provided, token)) {
       res.status(401).type('html').send(LOGIN_PAGE);
       return;
     }
-    const value = sessionCookieValue(ensureToken());
+    const value = sessionCookieValue(token);
     res.setHeader(
       'Set-Cookie',
       `${COOKIE_NAME}=${value}; HttpOnly; SameSite=Lax; Path=/; Max-Age=2592000`,

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -58,3 +58,41 @@ export function ensureToken(): string {
   logger.info({ tokenFile: file }, 'generated new remote-access token');
   return token;
 }
+
+export const COOKIE_NAME = 'octomux_session';
+
+/** Constant-time compare of two strings (hashes first to avoid length leaks/throws). */
+function safeEqual(a: string, b: string): boolean {
+  const ha = crypto.createHash('sha256').update(a).digest();
+  const hb = crypto.createHash('sha256').update(b).digest();
+  return crypto.timingSafeEqual(ha, hb);
+}
+
+/**
+ * Derive the session cookie value from the token. The cookie never contains the
+ * raw token; only a holder of the token at login time could have obtained it.
+ */
+export function sessionCookieValue(token: string): string {
+  return crypto.createHmac('sha256', token).update('octomux-session-v1').digest('hex');
+}
+
+/** True if `provided` equals the real token (constant-time). */
+export function validToken(provided: string, token: string): boolean {
+  return provided.length > 0 && safeEqual(provided, token);
+}
+
+/** True if a presented cookie value matches the derived session value. */
+export function validSessionCookie(value: string | undefined, token: string): boolean {
+  return value !== undefined && value.length > 0 && safeEqual(value, sessionCookieValue(token));
+}
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    out[part.slice(0, idx).trim()] = part.slice(idx + 1).trim();
+  }
+  return out;
+}

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -97,7 +97,11 @@ export function parseCookies(header: string | undefined): Record<string, string>
   return out;
 }
 
-const EXEMPT_PREFIXES = ['/login', '/logout', '/api/hooks'];
+// Harness hook callbacks always originate from loopback (hookBaseUrl() → http://127.0.0.1:<port>)
+// so they are already allowed by the isLoopback check above. Listing '/api/hooks' here would
+// additionally exempt admin routes like POST /api/hooks/install and GET /api/hooks/registry
+// from authentication in remote mode — so it must NOT appear here.
+const EXEMPT_PREFIXES = ['/login', '/logout'];
 
 export type AuthDecision = 'allow' | 'redirect' | 'unauthorized';
 
@@ -180,6 +184,10 @@ export function registerAuthRoutes(app: import('express').Express): void {
   });
   app.post('/login', (req, res) => {
     // requires express.urlencoded() to be registered in app.ts (the login form posts urlencoded)
+    if (!isRemoteMode()) {
+      res.redirect('/');
+      return;
+    }
     const provided = (req.body?.token ?? '') as string;
     const token = ensureToken();
     if (!validToken(provided, token)) {

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -96,3 +96,37 @@ export function parseCookies(header: string | undefined): Record<string, string>
   }
   return out;
 }
+
+const EXEMPT_PREFIXES = ['/login', '/logout', '/api/hooks'];
+
+export type AuthDecision = 'allow' | 'redirect' | 'unauthorized';
+
+export function authorizeRequest(input: {
+  remoteMode: boolean;
+  isLoopback: boolean;
+  path: string;
+  cookieHeader: string | undefined;
+  token: string;
+}): AuthDecision {
+  const { remoteMode, isLoopback, path: p, cookieHeader, token } = input;
+  if (!remoteMode) return 'allow';
+  if (isLoopback) return 'allow';
+  if (EXEMPT_PREFIXES.some((pre) => p === pre || p.startsWith(pre + '/'))) return 'allow';
+
+  const cookie = parseCookies(cookieHeader)[COOKIE_NAME];
+  if (validSessionCookie(cookie, token)) return 'allow';
+
+  return p.startsWith('/api/') ? 'unauthorized' : 'redirect';
+}
+
+export function authorizeUpgrade(input: {
+  remoteMode: boolean;
+  isLoopback: boolean;
+  cookieHeader: string | undefined;
+  token: string;
+}): boolean {
+  const { remoteMode, isLoopback, cookieHeader, token } = input;
+  if (!remoteMode) return true;
+  if (isLoopback) return true;
+  return validSessionCookie(parseCookies(cookieHeader)[COOKIE_NAME], token);
+}

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -133,12 +133,13 @@ export function authorizeUpgrade(input: {
 
 /** Express middleware: enforce the auth decision. No-op when remote mode is off. */
 export function remoteAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const remoteMode = isRemoteMode();
   const decision = authorizeRequest({
-    remoteMode: isRemoteMode(),
+    remoteMode,
     isLoopback: isLoopbackAddress(req.socket.remoteAddress),
     path: req.path,
     cookieHeader: req.headers.cookie,
-    token: ensureToken(),
+    token: remoteMode ? ensureToken() : '',
   });
   if (decision === 'allow') return next();
   if (decision === 'unauthorized') {
@@ -151,11 +152,12 @@ export function remoteAuthMiddleware(req: Request, res: Response, next: NextFunc
 
 /** Wrapper around authorizeUpgrade that reads from a raw IncomingMessage. */
 export function isUpgradeAuthorized(req: IncomingMessage): boolean {
+  const remoteMode = isRemoteMode();
   const ok = authorizeUpgrade({
-    remoteMode: isRemoteMode(),
+    remoteMode,
     isLoopback: isLoopbackAddress(req.socket.remoteAddress),
     cookieHeader: req.headers.cookie,
-    token: ensureToken(),
+    token: remoteMode ? ensureToken() : '',
   });
   if (!ok)
     logger.warn({ url: req.url, addr: req.socket.remoteAddress }, 'remote-auth: rejected upgrade');

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -27,3 +27,34 @@ export function isRemoteMode(): boolean {
 export function isLoopbackAddress(addr: string | undefined): boolean {
   return addr !== undefined && LOOPBACK_ADDRS.has(addr);
 }
+
+/** Directory mirrors server/db.ts: ~/.octomux/data (prod) or ./data (dev). */
+function dataDir(): string {
+  return process.env.NODE_ENV === 'production'
+    ? path.join(os.homedir(), '.octomux', 'data')
+    : path.join(__dirname, '..', 'data');
+}
+
+export function tokenFilePath(): string {
+  return path.join(dataDir(), 'remote-token');
+}
+
+/**
+ * Resolve the shared remote token. Precedence:
+ *   1. OCTOMUX_REMOTE_TOKEN env var
+ *   2. existing token file
+ *   3. freshly generated 32-byte hex token, persisted at mode 0600
+ */
+export function ensureToken(): string {
+  const fromEnv = process.env.OCTOMUX_REMOTE_TOKEN;
+  if (fromEnv && fromEnv !== '') return fromEnv;
+
+  const file = tokenFilePath();
+  if (fs.existsSync(file)) return fs.readFileSync(file, 'utf8').trim();
+
+  const token = crypto.randomBytes(32).toString('hex');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, token, { mode: 0o600 });
+  logger.info({ tokenFile: file }, 'generated new remote-access token');
+  return token;
+}

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -130,3 +130,66 @@ export function authorizeUpgrade(input: {
   if (isLoopback) return true;
   return validSessionCookie(parseCookies(cookieHeader)[COOKIE_NAME], token);
 }
+
+/** Express middleware: enforce the auth decision. No-op when remote mode is off. */
+export function remoteAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const decision = authorizeRequest({
+    remoteMode: isRemoteMode(),
+    isLoopback: isLoopbackAddress(req.socket.remoteAddress),
+    path: req.path,
+    cookieHeader: req.headers.cookie,
+    token: ensureToken(),
+  });
+  if (decision === 'allow') return next();
+  if (decision === 'unauthorized') {
+    logger.warn({ ip: req.ip, path: req.path }, 'remote-auth: rejected request');
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  res.redirect('/login');
+}
+
+/** Wrapper around authorizeUpgrade that reads from a raw IncomingMessage. */
+export function isUpgradeAuthorized(req: IncomingMessage): boolean {
+  const ok = authorizeUpgrade({
+    remoteMode: isRemoteMode(),
+    isLoopback: isLoopbackAddress(req.socket.remoteAddress),
+    cookieHeader: req.headers.cookie,
+    token: ensureToken(),
+  });
+  if (!ok) logger.warn({ url: req.url, addr: req.socket.remoteAddress }, 'remote-auth: rejected upgrade');
+  return ok;
+}
+
+const LOGIN_PAGE = `<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>octomux login</title>
+<body style="font-family:system-ui;max-width:24rem;margin:4rem auto;padding:0 1rem">
+<h1>🐙 octomux</h1>
+<form method="post" action="/login">
+<label>Access token<br><input name="token" type="password" autofocus style="width:100%;padding:.5rem;margin:.5rem 0"></label>
+<button type="submit" style="padding:.5rem 1rem">Sign in</button>
+</form></body>`;
+
+/** Register /login and /logout. Call BEFORE remoteAuthMiddleware so they stay reachable. */
+export function registerAuthRoutes(app: import('express').Express): void {
+  app.get('/login', (_req, res) => {
+    res.type('html').send(LOGIN_PAGE);
+  });
+  app.post('/login', (req, res) => {
+    const provided = (req.body?.token ?? '') as string;
+    if (!validToken(provided, ensureToken())) {
+      res.status(401).type('html').send(LOGIN_PAGE);
+      return;
+    }
+    const value = sessionCookieValue(ensureToken());
+    res.setHeader(
+      'Set-Cookie',
+      `${COOKIE_NAME}=${value}; HttpOnly; SameSite=Lax; Path=/; Max-Age=2592000`,
+    );
+    res.redirect('/');
+  });
+  app.post('/logout', (_req, res) => {
+    res.setHeader('Set-Cookie', `${COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0`);
+    res.redirect('/login');
+  });
+}

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -1,0 +1,29 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import type { IncomingMessage } from 'http';
+import type { Request, Response, NextFunction } from 'express';
+import { childLogger } from './logger.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const logger = childLogger('remote-auth');
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+const LOOPBACK_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+/** The interface octomux binds to. Default loopback-only (unchanged behavior). */
+export function getBindHost(): string {
+  return process.env.OCTOMUX_BIND || '127.0.0.1';
+}
+
+/** Remote mode is on when bound to a non-loopback interface. */
+export function isRemoteMode(): boolean {
+  return !LOOPBACK_HOSTS.has(getBindHost());
+}
+
+/** True when a socket's remoteAddress is the local machine. */
+export function isLoopbackAddress(addr: string | undefined): boolean {
+  return addr !== undefined && LOOPBACK_ADDRS.has(addr);
+}


### PR DESCRIPTION
## Summary

Adds **opt-in remote access** so octomux can be viewed and controlled from the owner's other devices (phone, second laptop) over a [Tailscale](https://tailscale.com) tailnet — without exposing a code-execution surface to the public internet.

- **Configurable bind** (`OCTOMUX_BIND`, default `127.0.0.1` — unchanged): bind `0.0.0.0` to enable remote mode. New `--bind` flag on `octomux start`.
- **Shared-token auth** in a new `server/remote-auth.ts`: token login → HMAC-signed `HttpOnly`/`SameSite=Lax` session cookie. Constant-time comparison; the cookie never contains the raw token.
- **Auth on both layers** — Express middleware for HTTP routes/SPA, and an explicit gate on the WebSocket `upgrade` so an unauthenticated tailnet device can never open a terminal into tmux.
- **Loopback is always exempt**, so local use and harness hook callbacks (which POST to `127.0.0.1`) are completely unaffected. `/api/hooks` admin routes are *not* blanket-exempted — they require auth in remote mode (only the real loopback callbacks pass).
- **Host allowlist** extended for the Tailscale `100.64.0.0/10` range and `OCTOMUX_ALLOWED_HOSTS`, keeping the DNS-rebinding guard.
- README section documenting setup.

**Default-off guarantee:** with no `OCTOMUX_BIND`, behavior is byte-for-byte unchanged — loopback-only, no auth, no token file created.

Design and architecture rationale (incl. why Tailscale over a tunnel/relay) were captured in a design spec + implementation plan before coding.

## Test Plan

- [x] 39 unit tests for `remote-auth` (config, token persistence, HMAC cookie, pure `authorizeRequest`/`authorizeUpgrade` branch logic, loopback exemption, `/api/hooks` admin-route protection)
- [x] Supertest integration for app wiring (login flow, cookie, host allowlist, default-off passthrough)
- [x] Full suite green (2323 tests), typecheck / lint / format clean
- [ ] Manual: `octomux start --bind 0.0.0.0` on a tailnet host; sign in from a phone with the token; open a terminal; confirm loopback hook callbacks still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)