### PR TITLE
fix(tmux): make build-tmux.sh actually produce a working static binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ docs/superpowers
 designs/
 octomux.pen
 .DS_Store
+
+# Prebuilt tmux binaries + terminfo are produced by scripts/build-tmux.sh in CI
+# and published from there — never commit the build artifacts (keep the .gitkeep
+# placeholders so the empty dirs stay tracked).
+packages/*/bin/*
+!packages/*/bin/.gitkeep
+packages/*/share/terminfo/*
+!packages/*/share/terminfo/.gitkeep

--- a/scripts/build-tmux.sh
+++ b/scripts/build-tmux.sh
@@ -67,6 +67,12 @@ fetch_and_extract "$NCURSES_URL" "$NCURSES_SRC"
 
 (
   cd "$NCURSES_SRC"
+  # Install the terminfo DB into the build prefix (writable). The original
+  # --with-default-terminfo-dir=/usr/share/terminfo made `make install` try to
+  # write the DB into the root-owned system dir → "permission denied" and the
+  # whole build aborted (on CI runners too). We point the install/default dir at
+  # the prefix, but keep the system dirs in the compiled-in RUNTIME search path
+  # so the shipped binary still finds terminfo before TERMINFO_DIRS is set.
   ./configure \
     --prefix="$INSTALL_PREFIX" \
     --without-shared \
@@ -75,7 +81,8 @@ fetch_and_extract "$NCURSES_URL" "$NCURSES_SRC"
     --without-tests \
     --enable-widec \
     --disable-stripping \
-    --with-default-terminfo-dir=/usr/share/terminfo
+    --with-default-terminfo-dir="$INSTALL_PREFIX/share/terminfo" \
+    --with-terminfo-dirs="/usr/share/terminfo:/etc/terminfo:/lib/terminfo:/usr/lib/terminfo:$INSTALL_PREFIX/share/terminfo"
   make -j"$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
   make install
 )
@@ -112,18 +119,32 @@ fetch_and_extract "$TMUX_URL" "$TMUX_SRC"
   LDFLAGS="-L${INSTALL_PREFIX}/lib"
   LIBS="-lncursesw"
 
+  # Static-linking strategy differs by platform:
+  #   Linux  — fully static (-static + --enable-static): libevent, ncurses AND
+  #            libc are all linked in, giving a distro-portable binary.
+  #   macOS  — Apple does not support statically linking libSystem, and tmux's
+  #            configure HARD-ERRORS on --enable-static. So we omit it: tmux
+  #            links the libevent/ncurses *.a archives from our prefix (only
+  #            static libs exist there — we built them --disable-shared) while
+  #            libSystem stays dynamic. That's the standard "static enough" mac
+  #            binary that runs on any machine of the same arch.
+  # Single token, no spaces — safe to leave unquoted below (and empty-expands
+  # cleanly under `set -u`, unlike an empty array on macOS bash 3.2).
+  STATIC_FLAG=""
   if [ "$PLATFORM" = "linux" ]; then
-    # On Linux we can fully static-link (libSystem equivalent is glibc musl).
     LDFLAGS="$LDFLAGS -static"
+    STATIC_FLAG="--enable-static"
   fi
 
+  # shellcheck disable=SC2086 # STATIC_FLAG is a deliberate single optional flag
   PKG_CONFIG_PATH="$INSTALL_PREFIX/lib/pkgconfig" \
     CFLAGS="$CFLAGS" \
     LDFLAGS="$LDFLAGS" \
     LIBS="$LIBS" \
     ./configure \
       --prefix="$INSTALL_PREFIX" \
-      --enable-static
+      --disable-utf8proc \
+      $STATIC_FLAG
   make -j"$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
   make install
 )
@@ -134,26 +155,27 @@ echo "==> Compiling terminfo entries ..."
 TERMINFO_DIR="$BUILD_DIR/terminfo"
 mkdir -p "$TERMINFO_DIR"
 
-# tic ships with ncurses; use the just-built one if available.
+# Use the just-built ncurses 6.5 tic/infocmp, with TERMINFO pointed at the DB
+# we just installed into the prefix — that DB ships tmux-256color even though
+# the macOS system ncurses does not. infocmp regenerates the source, tic
+# compiles it into our bundle dir. (The previous version piped infocmp through
+# `head -1 | awk` and passed a capability string to tic as if it were a
+# filename, so nothing was ever compiled.)
 TIC_BIN="$INSTALL_PREFIX/bin/tic"
-if [ ! -x "$TIC_BIN" ]; then
-  TIC_BIN="$(command -v tic)"
-fi
+[ -x "$TIC_BIN" ] || TIC_BIN="$(command -v tic)"
+INFOCMP_BIN="$INSTALL_PREFIX/bin/infocmp"
+[ -x "$INFOCMP_BIN" ] || INFOCMP_BIN="$(command -v infocmp)"
 
 for term in tmux-256color screen-256color xterm-256color; do
-  # Compile from the system terminfo source (works on both macOS + Linux).
-  if "$TIC_BIN" -x -o "$TERMINFO_DIR" "$(infocmp -x "$term" 2>/dev/null | head -1 | awk '{print $1}' || true)" 2>/dev/null; then
-    echo "  ✓ $term (from infocmp)"
+  src="$BUILD_DIR/${term}.terminfo"
+  if TERMINFO="$INSTALL_PREFIX/share/terminfo" "$INFOCMP_BIN" -x "$term" >"$src" 2>/dev/null && [ -s "$src" ]; then
+    if "$TIC_BIN" -x -o "$TERMINFO_DIR" "$src" 2>/dev/null; then
+      echo "  ✓ $term"
+    else
+      echo "  ⚠  $term: tic failed to compile"
+    fi
   else
-    # Fallback: compile from /usr/share/terminfo source file if present.
-    for src_dir in /usr/share/terminfo /lib/terminfo /etc/terminfo; do
-      first_char="${term:0:1}"
-      src_file="$src_dir/$first_char/$term"
-      if [ -f "$src_file" ]; then
-        TERMINFO="$TERMINFO_DIR" tic -x -o "$TERMINFO_DIR" "$src_file" 2>/dev/null && \
-          echo "  ✓ $term (from $src_file)" && break || true
-      fi
-    done
+    echo "  ⚠  $term: not found in source terminfo DB"
   fi
 done
 


### PR DESCRIPTION
## What

Fix `scripts/build-tmux.sh` so it actually produces a working statically-linked `tmux`. I validated the release machinery by **running the script on darwin/arm64** — it failed in **five distinct ways**, each of which would also have broken the CI build matrix. None were caught earlier because the binaries are only ever built in CI.

## The five bugs (all fixed)

1. **ncurses install wrote to the system terminfo dir** — `--with-default-terminfo-dir=/usr/share/terminfo` made `make install` try to write into root-owned `/usr/share/terminfo` → `permission denied`, aborting the build before any tmux binary existed. Now installs into the build prefix; system dirs stay in the compiled-in **runtime** search path.
2. **`--enable-static` on macOS** — tmux's configure hard-errors (`static linking is not supported on macOS`). Made it Linux-only; macOS statically links the libevent/ncurses `.a` archives with libSystem dynamic (the standard portable-mac approach).
3. **Missing utf8proc choice** — tmux 3.5a's configure requires `--enable-utf8proc` or `--disable-utf8proc`. Added `--disable-utf8proc` (we don't vendor utf8proc).
4. **terminfo never compiled** — the step piped `infocmp` through `head -1 | awk` and handed a capability string to `tic` as a filename. Rewritten to regenerate source via the freshly-built `infocmp` against the ncurses 6.5 DB (which ships `tmux-256color`, unlike macOS's system ncurses) and `tic` it in.
5. **bash 3.2 safety** — avoided an empty-array-under-`set -u` crash.

Also **gitignore the CI-built artifacts** (`packages/*/bin/*`, `packages/*/share/terminfo/*`) so binaries are never committed; `.gitkeep` placeholders stay tracked.

## Verified on darwin/arm64
- Working `tmux 3.5a`; `bash -n` clean.
- libevent statically baked in; smoke test (`new-session` + `capture-pane` round-trip) passes.
- All three terminfo entries (`tmux-256color`, `screen-256color`, `xterm-256color`) bundle correctly.
- **End-to-end**: octomux's resolver picks up the bundled package — `source: "bundled"`, `verified: true`, private socket + `TERMINFO_DIRS` wired.

## Known follow-ups (not in this PR)
- **macOS linkage**: locally (no `pkg-config`) tmux linked the *system* `libncurses.5.4.dylib` rather than our static `ncursesw`. It still runs on any macOS (that dylib is always present), but it's not the clean static link intended. CI installs `pkg-config` + sets `PKG_CONFIG_PATH`, which should make it link our static `ncursesw` — worth confirming on a CI run, or hardening the script to force it.
- **node-pty prebuilds** built in the workflow are uploaded as artifacts but never published/consumed — the "node-pty has no Linux prebuild" gap isn't closed yet.
- The binaries workflow triggers on `main`/PRs-to-`main`, not `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
