### PR TITLE
feat(electron): isolate desktop app (own data dir + tmux socket)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@
 import { app, BrowserWindow } from 'electron';
 import path from 'path';
 import net from 'net';
+import os from 'os';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -128,6 +129,19 @@ app.on('activate', () => {
 let _serverPort: number | null = null;
 
 app.whenReady().then(async () => {
+  // 0. Isolate the desktop app from the CLI BEFORE importing the server.
+  //    Its own data dir → own SQLite DB, own tmux socket, own logs — so it never
+  //    collides with the CLI's ~/.octomux (which also avoids the bundled-tmux vs
+  //    system-tmux version clash on a shared socket). NODE_ENV=production is
+  //    required for the server to honor OCTOMUX_DATA_DIR (the dev branch ignores
+  //    it). HOME can be empty under a GUI/Finder launch, which broke ~/.claude
+  //    paths (mkdir '/.claude') — pin it.
+  if (!process.env.NODE_ENV) process.env.NODE_ENV = 'production';
+  if (!process.env.OCTOMUX_DATA_DIR) {
+    process.env.OCTOMUX_DATA_DIR = path.join(app.getPath('userData'), 'data');
+  }
+  if (!process.env.HOME) process.env.HOME = os.homedir();
+
   // 1. Pick a free port and tell the server to use it.
   const port = await findFreePort();
   _serverPort = port;

--- a/server/agents.ts
+++ b/server/agents.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { fileURLToPath } from 'url';
+import { octomuxRoot } from './octomux-root.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -23,7 +23,7 @@ function builtInDir(): string {
 }
 
 function customDir(): string {
-  return process.env.OCTOMUX_AGENTS_DIR || path.join(os.homedir(), '.octomux', 'agents');
+  return process.env.OCTOMUX_AGENTS_DIR || path.join(octomuxRoot(), 'agents');
 }
 
 function parseFrontmatter(content: string): { name: string; description: string } {

--- a/server/api.ts
+++ b/server/api.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
+import { octomuxRoot } from './octomux-root.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { getDb } from './db.js';
 import { childLogger } from './logger.js';
@@ -2867,7 +2868,7 @@ export function setupRoutes(app: Express): void {
 
   const isProduction = process.env.NODE_ENV === 'production';
   const hooksLogsDir = isProduction
-    ? path.join(os.homedir(), '.octomux', 'logs', 'hooks')
+    ? path.join(octomuxRoot(), 'logs', 'hooks')
     : path.join(__dirname, '..', 'data', 'logs', 'hooks');
 
   interface HookRegistryEntry {
@@ -3005,7 +3006,7 @@ export function setupRoutes(app: Express): void {
     });
 
     // Global hooks: ~/.octomux/hooks/
-    const globalHooksBase = path.join(os.homedir(), '.octomux', 'hooks');
+    const globalHooksBase = path.join(octomuxRoot(), 'hooks');
     entries.push(...discoverHookScripts(globalHooksBase, 'global'));
 
     // Repo hooks: collect from every active task's repo_path

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import path from 'path';
-import os from 'os';
 import fs from 'fs';
+import { octomuxRoot } from './octomux-root.js';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
 import { getSettings } from './settings.js';
@@ -22,7 +22,7 @@ const logger = childLogger('chats');
 
 /** Root directory for chat scratch working dirs. */
 export function chatRoot(): string {
-  return path.join(os.homedir(), '.octomux', 'chats');
+  return path.join(octomuxRoot(), 'chats');
 }
 
 export function chatDirFor(id: string): string {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,16 +1,16 @@
 import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import { nanoid } from 'nanoid';
 import { fileURLToPath } from 'url';
 import { childLogger } from './logger.js';
+import { octomuxRoot } from './octomux-root.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const logger = childLogger('db');
 const isProduction = process.env.NODE_ENV === 'production';
 
-const PROD_DB_DIR = path.join(os.homedir(), '.octomux', 'data');
+const PROD_DB_DIR = path.join(octomuxRoot(), 'data');
 const DEV_DB_DIR = path.join(__dirname, '..', 'data');
 const DB_DIR = isProduction ? PROD_DB_DIR : DEV_DB_DIR;
 /** Override for docs screenshots / isolated demo data (`scripts/seed-docs-demo.ts`). */

--- a/server/hook-dispatcher.ts
+++ b/server/hook-dispatcher.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import os from 'os';
 import { fileURLToPath } from 'url';
 import { childLogger } from './logger.js';
+import { octomuxRoot } from './octomux-root.js';
 import { getDb } from './db.js';
 import type { HookEventName, HookEnvelope } from './hook-types.js';
 
@@ -60,7 +61,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 function resolveHooksLogsDir(): string {
   return isProduction
-    ? path.join(os.homedir(), '.octomux', 'logs', 'hooks')
+    ? path.join(octomuxRoot(), 'logs', 'hooks')
     : path.join(__dirname, '..', 'data', 'logs', 'hooks');
 }
 
@@ -68,7 +69,7 @@ function resolveHookDirs(event: HookEventName, taskRepoPath?: string): string[] 
   const dirs: string[] = [];
 
   // Global hooks dir
-  const globalDir = path.join(os.homedir(), '.octomux', 'hooks', `${event}.d`);
+  const globalDir = path.join(octomuxRoot(), 'hooks', `${event}.d`);
   dirs.push(globalDir);
 
   // Repo-local hooks dir
@@ -477,7 +478,7 @@ export async function fireHook(event: HookEventName, envelope: HookEnvelope): Pr
     const cwd = worktreePath ?? taskRepoPath ?? os.homedir();
     const logsDir = resolveHooksLogsDir();
 
-    const globalHooksBase = path.join(os.homedir(), '.octomux', 'hooks');
+    const globalHooksBase = path.join(octomuxRoot(), 'hooks');
     const hookDirs = resolveHookDirs(event, taskRepoPath);
     // Track which dir each script came from so we can build the correct scope.
     const scriptsWithScope: Array<{ script: string; scope: string }> = [];

--- a/server/hooks-install.ts
+++ b/server/hooks-install.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { fileURLToPath } from 'url';
 import { childLogger } from './logger.js';
+import { octomuxRoot } from './octomux-root.js';
 
 const logger = childLogger('hooks-install');
 
@@ -38,7 +38,7 @@ export function listHookTemplates(): string[] {
 
 export function isHookTemplateInstalled(
   template: string,
-  hooksBase = path.join(os.homedir(), '.octomux', 'hooks'),
+  hooksBase = path.join(octomuxRoot(), 'hooks'),
 ): boolean {
   const manifest = readTemplateManifest(template);
   if (!manifest) return false;
@@ -60,7 +60,7 @@ function readTemplateManifest(template: string): TemplateManifest | null {
 /** Install a hook template into ~/.octomux/hooks (or hooksBase). Returns installed file paths. */
 export function installHookTemplate(
   template: string,
-  hooksBase = path.join(os.homedir(), '.octomux', 'hooks'),
+  hooksBase = path.join(octomuxRoot(), 'hooks'),
 ): string[] {
   const templatesBase = resolveTemplatesHooksDir();
   const templateDir = path.join(templatesBase, template);

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,8 +1,8 @@
 import pino, { type Logger, type TransportTargetOptions } from 'pino';
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import { fileURLToPath } from 'url';
+import { octomuxRoot } from './octomux-root.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isProduction = process.env.NODE_ENV === 'production';
@@ -11,7 +11,7 @@ const isTest = process.env.NODE_ENV === 'test';
 /** Resolve the log directory lazily so mocked fs/os in tests don't fail at module load. */
 function resolveLogDir(): string {
   return isProduction
-    ? path.join(os.homedir(), '.octomux', 'logs')
+    ? path.join(octomuxRoot(), 'logs')
     : path.join(__dirname, '..', 'data', 'logs');
 }
 

--- a/server/octomux-root.ts
+++ b/server/octomux-root.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+import os from 'os';
+
+/**
+ * Base octomux state directory (the "~/.octomux" equivalent).
+ * OCTOMUX_DATA_DIR overrides it — the Electron app sets this to an app-private
+ * path so it never shares the CLI's ~/.octomux (DB + tmux socket + logs, etc.).
+ */
+export function octomuxRoot(): string {
+  return process.env.OCTOMUX_DATA_DIR ?? path.join(os.homedir(), '.octomux');
+}

--- a/server/remote-auth.ts
+++ b/server/remote-auth.ts
@@ -1,8 +1,8 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { fileURLToPath } from 'url';
+import { octomuxRoot } from './octomux-root.js';
 import type { IncomingMessage } from 'http';
 import type { Request, Response, NextFunction } from 'express';
 import { childLogger } from './logger.js';
@@ -31,7 +31,7 @@ export function isLoopbackAddress(addr: string | undefined): boolean {
 /** Directory mirrors server/db.ts: ~/.octomux/data (prod) or ./data (dev). */
 function dataDir(): string {
   return process.env.NODE_ENV === 'production'
-    ? path.join(os.homedir(), '.octomux', 'data')
+    ? path.join(octomuxRoot(), 'data')
     : path.join(__dirname, '..', 'data');
 }
 

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { childLogger } from './logger.js';
+import { octomuxRoot } from './octomux-root.js';
 
 const logger = childLogger('settings');
 
@@ -39,7 +39,7 @@ export const DEFAULT_SETTINGS: OctomuxSettings = {
 const VALID_EDITORS: EditorChoice[] = ['nvim', 'vscode', 'cursor'];
 
 function settingsPath(): string {
-  return path.join(os.homedir(), '.octomux', 'settings.json');
+  return path.join(octomuxRoot(), 'settings.json');
 }
 
 let _deprecatedWarnEmitted = false;

--- a/server/task-runner.ts
+++ b/server/task-runner.ts
@@ -2,8 +2,8 @@ import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import crypto from 'crypto';
 import path from 'path';
-import os from 'os';
 import fs from 'fs';
+import { octomuxRoot } from './octomux-root.js';
 import { nanoid } from 'nanoid';
 import { getDb } from './db.js';
 import { getSettings } from './settings.js';
@@ -30,7 +30,7 @@ const execFile = promisify(execFileCb);
 
 /** Root directory for scratch-mode task working dirs. */
 export function scratchRoot(): string {
-  return path.join(os.homedir(), '.octomux', 'scratch');
+  return path.join(octomuxRoot(), 'scratch');
 }
 
 export function scratchDirFor(taskId: string): string {

--- a/server/tmux-bin.ts
+++ b/server/tmux-bin.ts
@@ -15,11 +15,11 @@ import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { createRequire } from 'module';
 import path from 'path';
-import os from 'os';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { probeBinary } from './binary-check.js';
 import { childLogger } from './logger.js';
+import { octomuxRoot } from './octomux-root.js';
 
 const logger = childLogger('tmux-bin');
 const execFileProm = promisify(execFileCb);
@@ -29,7 +29,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ─── Data directory (same logic as db.ts) ─────────────────────────────────────
 
 const isProduction = process.env.NODE_ENV === 'production';
-const PROD_DATA_DIR = path.join(os.homedir(), '.octomux');
+const PROD_DATA_DIR = octomuxRoot();
 const DEV_DATA_DIR = path.join(__dirname, '..', 'data');
 const DATA_DIR = isProduction ? PROD_DATA_DIR : DEV_DATA_DIR;
 


### PR DESCRIPTION
## What
Make the **Electron desktop app run fully isolated** from the CLI, fixing the cascade of issues we hit: white panes, failed task restarts, and the poller closing live tasks.

## Root cause
The desktop app shared `~/.octomux` (same SQLite DB **and** same tmux socket) with the CLI. Two backends fought over it, and critically the app's **bundled tmux 3.5a collided with the system tmux 3.6a** that owned the shared socket → `has-session`/`new-session` errored → which surfaced as:
- blank window (server crashed/stalled on boot recovery),
- restart failing (`new-session ... server exited unexpectedly`),
- the **poller marking live tasks dead** (a `has-session` error reads as "dead" → flips them to idle).

## Fix
- **`server/octomux-root.ts`** — `octomuxRoot()` returns `OCTOMUX_DATA_DIR ?? ~/.octomux`. Behavior-preserving when unset.
- Routed every `~/.octomux` path (DB, tmux socket, logs, settings, scratch, hooks, agents, chats — ~11 files) through it. `.claude` paths intentionally untouched (they target the user's real Claude config).
- **`electron/main.ts`** — before importing the server, sets `OCTOMUX_DATA_DIR = app.getPath('userData')/data` (+ `NODE_ENV=production` so the override is honored, + pins `HOME` which GUI launches can leave empty, fixing the `mkdir '/.claude'` error).

Result: the app gets its own DB + its own tmux socket and runs **its bundled tmux on that private socket** — no version clash, no contention with the CLI, and an empty DB means fast boot (no recovering the CLI's tasks → no white pane).

## Verified
- `OCTOMUX_DATA_DIR` run uses the isolated dir (`data/`, `logs/`, `run/`), serves **HTTP 200**, and **never touches `~/.octomux`**.
- `bun run typecheck` 0 errors · `bun run lint` 0 errors · `bun run test` **2442 pass** · electron tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
