### PR TITLE
fix(orchestrator): rehydrate pending cards on ws (re)connect (SHR-161)

### DIFF
--- a/server/orchestrator/stream.test.ts
+++ b/server/orchestrator/stream.test.ts
@@ -18,14 +18,24 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../app.js';
 import { createTestDb } from '../test-helpers.js';
-import { createConversation, getConversation, listMessages, appendMessage } from './store.js';
+import {
+  createConversation,
+  getConversation,
+  listMessages,
+  appendMessage,
+  createCard,
+  resolveCard,
+} from './store.js';
 import {
   dispatchUserTurn,
   persistAndPush,
   setupOrchestratorWebSocket,
   handleOrchestratorUpgrade,
   chatEventToWsEvent,
+  cardRowToWsEvent,
+  replayConnectionState,
 } from './stream.js';
+import type { ActionCard } from './store.js';
 import type { ChatEvent } from './transcript.js';
 import type { IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
@@ -400,5 +410,102 @@ describe('handleOrchestratorUpgrade', () => {
       result = true;
     }
     expect(result).toBe(true);
+  });
+});
+
+// ─── Card rehydration on (re)connect (SHR-161 follow-up) ──────────────────────
+
+describe('cardRowToWsEvent', () => {
+  const base = {
+    id: 'c1',
+    conversation_id: 'conv',
+    status: 'pending',
+    result: null,
+    created_at: '',
+    decided_at: null,
+  };
+
+  it('reconstructs an approve-plan card with an artifact_url pointer', () => {
+    const card: ActionCard = {
+      ...base,
+      tool_use_id: 'relay-1',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: 't1', plan_path: 'plan.json' }),
+    };
+    const ev = cardRowToWsEvent(card);
+    expect(ev).toMatchObject({ type: 'card', id: 'c1', command: 'approve-plan' });
+    expect(ev?.args.task_id).toBe('t1');
+    expect(ev?.args.plan_path).toBe('plan.json');
+    expect(String(ev?.args.artifact_url)).toContain('task=t1');
+    expect(String(ev?.args.artifact_url)).toContain('path=plan.json');
+  });
+
+  it('reconstructs a view-spec card', () => {
+    const card: ActionCard = {
+      ...base,
+      tool_use_id: 'spec-1',
+      tool_name: 'view-spec',
+      input: JSON.stringify({ task_id: 't1', spec_path: 'spec.md' }),
+    };
+    const ev = cardRowToWsEvent(card);
+    expect(ev).toMatchObject({ type: 'card', command: 'view-spec' });
+    expect(ev?.args.spec_path).toBe('spec.md');
+  });
+
+  it('falls back to a generic action card (command = tool_name, args = input)', () => {
+    const card: ActionCard = {
+      ...base,
+      tool_use_id: 'g1',
+      tool_name: 'create-task',
+      input: JSON.stringify({ title: 'X', repo_path: '/r' }),
+    };
+    const ev = cardRowToWsEvent(card);
+    expect(ev).toMatchObject({ type: 'card', command: 'create-task' });
+    expect(ev?.args).toMatchObject({ title: 'X', repo_path: '/r' });
+  });
+});
+
+describe('replayConnectionState', () => {
+  let convId: string;
+  beforeEach(() => {
+    createTestDb();
+    convId = createConversation({ title: 'c' });
+  });
+
+  it('replays persisted messages and pending cards to a connecting client', () => {
+    appendMessage({
+      conversation_id: convId,
+      role: 'assistant',
+      content: JSON.stringify([{ type: 'text', text: 'plan ready' }]),
+    });
+    createCard({
+      conversation_id: convId,
+      tool_use_id: 'relay-1',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: 't1', plan_path: 'plan.json' }),
+    });
+
+    const pushed: string[] = [];
+    replayConnectionState(convId, (m) => pushed.push(m));
+    const events = pushed.map((m) => JSON.parse(m) as { type: string; command?: string });
+
+    expect(events.some((e) => e.type === 'message')).toBe(true);
+    // The pending plan card is re-surfaced so the approval gate isn't lost on reload.
+    expect(events.some((e) => e.type === 'card' && e.command === 'approve-plan')).toBe(true);
+  });
+
+  it('does NOT replay resolved cards', () => {
+    const cardId = createCard({
+      conversation_id: convId,
+      tool_use_id: 'relay-1',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: 't1', plan_path: 'plan.json' }),
+    });
+    resolveCard(cardId, 'executed', null);
+
+    const pushed: string[] = [];
+    replayConnectionState(convId, (m) => pushed.push(m));
+    const events = pushed.map((m) => JSON.parse(m) as { type: string });
+    expect(events.some((e) => e.type === 'card')).toBe(false);
   });
 });

--- a/server/orchestrator/stream.ts
+++ b/server/orchestrator/stream.ts
@@ -30,7 +30,8 @@ import { WebSocketServer, WebSocket } from 'ws';
 import type { IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import { childLogger } from '../logger.js';
-import { getConversation, appendMessage, listMessages } from './store.js';
+import { getConversation, appendMessage, listMessages, listPendingCards } from './store.js';
+import type { ActionCard } from './store.js';
 import { sendTurn } from './runner.js';
 import { tailTranscript } from './transcript.js';
 import type { ChatEvent } from './transcript.js';
@@ -218,6 +219,96 @@ export function chatEventToWsEvent(event: ChatEvent): OrchestratorWsEvent | null
   }
 }
 
+// ─── Card rehydration on (re)connect (SHR-161 follow-up) ───────────────────────
+
+/**
+ * Reconstruct the `card` ws event for a persisted pending action_cards row, so a
+ * client that (re)connects or reloads re-renders the card instead of losing it.
+ *
+ * Cards are otherwise pushed exactly once, live, at phase-complete time — a
+ * page reload or a silent ws auto-reconnect (SHR-162) would drop them, leaving
+ * the run wedged on an invisible approval gate. Returns null only if a row can't
+ * be mapped (never expected for known tool_names).
+ */
+export function cardRowToWsEvent(card: ActionCard): WsCardEvent | null {
+  let input: Record<string, unknown> = {};
+  try {
+    input = JSON.parse(card.input) as Record<string, unknown>;
+  } catch {
+    input = {};
+  }
+  const taskId = typeof input.task_id === 'string' ? input.task_id : '';
+  const artifactUrl = (path: string) =>
+    taskId
+      ? `/api/orchestrator/artifact?task=${encodeURIComponent(taskId)}&path=${encodeURIComponent(path)}`
+      : '';
+
+  if (card.tool_name === 'approve-plan') {
+    const planPath = typeof input.plan_path === 'string' ? input.plan_path : 'plan.json';
+    return {
+      type: 'card',
+      id: card.id,
+      command: 'approve-plan',
+      args: { task_id: taskId, plan_path: planPath, artifact_url: artifactUrl(planPath) },
+    };
+  }
+  if (card.tool_name === 'view-spec') {
+    const specPath = typeof input.spec_path === 'string' ? input.spec_path : 'spec.md';
+    return {
+      type: 'card',
+      id: card.id,
+      command: 'view-spec',
+      args: { task_id: taskId, spec_path: specPath, artifact_url: artifactUrl(specPath) },
+    };
+  }
+  // Gated write-command card → render as a generic ActionCard (command = tool_name).
+  return { type: 'card', id: card.id, command: card.tool_name, args: input };
+}
+
+/**
+ * Send the durable conversation state to a (re)connecting client: persisted
+ * messages first, then any still-pending cards. Idempotent on the client — card
+ * ids are stable, so a live session that already has a card de-dupes the replay.
+ */
+export function replayConnectionState(convId: string, push: PushFn): void {
+  // Persisted messages
+  try {
+    const history = listMessages(convId);
+    for (const msg of history) {
+      const contentBlocks = (() => {
+        try {
+          return JSON.parse(msg.content) as Array<{ type: string; text?: string }>;
+        } catch {
+          return [{ type: 'text', text: msg.content }];
+        }
+      })();
+      const text = contentBlocks
+        .filter((b) => b.type === 'text')
+        .map((b) => b.text ?? '')
+        .join('');
+      const histEvent: WsMessageEvent = {
+        type: 'message',
+        role: msg.role as 'user' | 'assistant',
+        text,
+        id: msg.id,
+      };
+      push(JSON.stringify(histEvent));
+    }
+  } catch (err) {
+    logger.warn({ conversation_id: convId, err }, 'stream: failed to replay history');
+  }
+
+  // Pending cards (so a reload / reconnect re-surfaces the approval gate)
+  try {
+    for (const card of listPendingCards(convId)) {
+      const ev = cardRowToWsEvent(card);
+      if (ev) push(JSON.stringify(ev));
+    }
+  } catch (err) {
+    logger.warn({ conversation_id: convId, err }, 'stream: failed to replay pending cards');
+  }
+}
+
 // ─── startTranscriptTail ──────────────────────────────────────────────────────
 
 /**
@@ -356,32 +447,8 @@ export function handleOrchestratorUpgrade(
       return;
     }
 
-    // Replay persisted messages to the new client
-    try {
-      const history = listMessages(convId);
-      for (const msg of history) {
-        const contentBlocks = (() => {
-          try {
-            return JSON.parse(msg.content) as Array<{ type: string; text?: string }>;
-          } catch {
-            return [{ type: 'text', text: msg.content }];
-          }
-        })();
-        const text = contentBlocks
-          .filter((b) => b.type === 'text')
-          .map((b) => b.text ?? '')
-          .join('');
-        const histEvent: WsMessageEvent = {
-          type: 'message',
-          role: msg.role as 'user' | 'assistant',
-          text,
-          id: msg.id,
-        };
-        push(JSON.stringify(histEvent));
-      }
-    } catch (err) {
-      logger.warn({ conversation_id: convId, err }, 'stream: failed to replay history');
-    }
+    // Replay persisted messages AND pending cards to the (re)connecting client.
+    replayConnectionState(convId, push);
 
     // Start tailing the transcript if we have a path
     if (conv.transcript_path) {


### PR DESCRIPTION
## What

Replay pending `action_cards` to the client on every WebSocket (re)connect, so
spec/plan/action cards survive a page reload, a fresh conversation open, and a
silent auto-reconnect — instead of being shown live exactly once and then lost.

- `stream.ts`: extract `replayConnectionState(convId, push)` (persisted messages
  + pending cards) and call it from `handleOrchestratorUpgrade`.
- `stream.ts`: add `cardRowToWsEvent(card)` to reconstruct the `card` ws event
  from a persisted row (`approve-plan` / `view-spec` / generic action card).
  Card ids are stable, so a live session de-dupes the replay.

## Why

Follow-up to #144 / #145. Spec/plan/action cards were pushed over the ws once,
at phase-complete time. The connect handler replayed persisted *messages* but
not pending cards, and the client only re-fetches messages on open. So a reload
— or a silent SHR-162 auto-reconnect — dropped the cards, leaving the run wedged
on an invisible approval gate (the plan card couldn't be seen or approved).

Reproduced live: a workflow task fired `phase_complete(spec)` and
`phase_complete(plan)`, both relay notes persisted and the `approve-plan` card
row sat `pending`, but the UI showed only the text notes — the plan card was
gone after a reconnect/reload.

Note: spec cards have no DB row today (informational, live-only), so this
rehydrates the actionable plan/action cards — the approval gate. Durable spec
cards can be a separate follow-up.

## Testing

- 5 new tests: `cardRowToWsEvent` reconstruction (approve-plan/view-spec/generic);
  `replayConnectionState` includes pending cards and excludes resolved ones.
- Full suite 3009 pass; `bun run typecheck` clean; `bun run build` succeeds.
- No client change needed — the client already handles incoming `card` events
  and de-dupes by id.