### PR TITLE
feat(api): add GET /api/health endpoint

### DIFF
--- a/server/api.health.test.ts
+++ b/server/api.health.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import type Database from 'better-sqlite3';
+import { createTestDb, insertTask } from './test-helpers.js';
+import { setDb } from './db.js';
+import { createApp } from './app.js';
+
+describe('GET /api/health', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('returns 200 with a healthy report and all five fields', async () => {
+    const res = await request(createApp()).get('/api/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.db).toEqual({ ok: true });
+    expect(typeof res.body.uptime).toBe('number');
+    expect(Number.isInteger(res.body.running_tasks)).toBe(true);
+    expect(typeof res.body.data_dir).toBe('string');
+    expect(res.body.data_dir.length).toBeGreaterThan(0);
+  });
+
+  it('counts only tasks in running runtime_state', async () => {
+    insertTask(db, { id: 'r1', runtime_state: 'running' });
+    insertTask(db, { id: 'r2', runtime_state: 'running' });
+    insertTask(db, { id: 'r3', runtime_state: 'running' });
+    insertTask(db, { id: 'i1', runtime_state: 'idle' });
+    insertTask(db, { id: 'e1', runtime_state: 'error' });
+
+    const res = await request(createApp()).get('/api/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.running_tasks).toBe(3);
+  });
+
+  describe('when the database is unreachable', () => {
+    afterEach(() => {
+      // Restore a working in-memory DB for any later tests.
+      createTestDb();
+    });
+
+    it('returns 503 with a degraded report', async () => {
+      const failing = {
+        prepare: vi.fn(() => {
+          throw new Error('database is locked');
+        }),
+      } as unknown as Database.Database;
+      setDb(failing);
+
+      const res = await request(createApp()).get('/api/health');
+
+      expect(res.status).toBe(503);
+      expect(res.body.status).toBe('degraded');
+      expect(res.body.db.ok).toBe(false);
+      expect(typeof res.body.db.error).toBe('string');
+      expect(res.body.db.error.length).toBeGreaterThan(0);
+      expect(res.body.running_tasks).toBe(0);
+    });
+  });
+});

--- a/server/api.ts
+++ b/server/api.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { octomuxRoot } from './octomux-root.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-import { getDb } from './db.js';
+import { getDb, getDataDir } from './db.js';
 import { childLogger } from './logger.js';
 import { getNeedsYou, getActivity } from './inbox.js';
 import { execFile as execFileCb } from 'child_process';
@@ -130,6 +130,7 @@ import { fireHook, getTaskHookExecutions } from './hook-dispatcher.js';
 
 const execFile = promisify(execFileCb);
 const apiLogger = childLogger('api');
+const healthLogger = childLogger('health');
 
 const TERMINALS_BY_TASK_SQL =
   'SELECT * FROM user_terminals WHERE task_id = ? ORDER BY window_index';
@@ -270,6 +271,38 @@ function augmentDashboardSettings(settings: OctomuxSettings): OctomuxSettings & 
 export function setupRoutes(app: Express): void {
   app.use('/api/hooks', hookRoutes);
   mountArtifactEndpoint(app);
+
+  // GET /api/health — readiness probe: DB reachability, uptime, running tasks
+  app.get('/api/health', (_req: Request, res: Response) => {
+    const uptime = process.uptime();
+    const data_dir = getDataDir();
+
+    let db: { ok: true } | { ok: false; error: string };
+    let running_tasks = 0;
+    try {
+      const dbInstance = getDb();
+      dbInstance.prepare('SELECT 1 AS ok').get();
+      db = { ok: true };
+      const row = dbInstance
+        .prepare(`SELECT COUNT(*) AS n FROM tasks WHERE runtime_state = 'running'`)
+        .get() as { n: number };
+      running_tasks = row.n;
+    } catch (err) {
+      db = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    const status = db.ok ? 'ok' : 'degraded';
+    if (db.ok) {
+      healthLogger.info({ operation: 'health', status, db_ok: true, running_tasks }, 'health check');
+    } else {
+      healthLogger.warn(
+        { operation: 'health', status, db_ok: false, error: db.error },
+        'health check degraded',
+      );
+    }
+
+    res.status(db.ok ? 200 : 503).json({ status, uptime, db, running_tasks, data_dir });
+  });
 
   // GET /api/harnesses — list registered harness implementations
   app.get('/api/harnesses', (_req: Request, res: Response) => {

--- a/server/db.ts
+++ b/server/db.ts
@@ -19,6 +19,16 @@ const DB_PATH = process.env.OCTOMUX_DB_PATH ?? path.join(DB_DIR, 'tasks.db');
 /** Path to the old package-relative database (for migration detection). */
 const OLD_DB_PATH = path.join(__dirname, '..', 'data', 'tasks.db');
 
+/**
+ * Absolute path to the octomux data directory (the directory holding the SQLite
+ * file). Resolved from the same logic as the DB path so prod (`~/.octomux/data`),
+ * dev (`./data`), and `OCTOMUX_DB_PATH` overrides all agree. Single source of
+ * truth for consumers that need to report or locate the data dir.
+ */
+export function getDataDir(): string {
+  return path.dirname(DB_PATH);
+}
+
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS worktrees (
     id            TEXT PRIMARY KEY,


### PR DESCRIPTION
## What

Adds a `GET /api/health` readiness endpoint to the Express server. It returns a structured JSON report:

- `status` — `"ok"` or `"degraded"`
- `uptime` — server process uptime in seconds
- `db` — `{ ok: true }` or `{ ok: false, error }` from a trivial `SELECT 1`
- `running_tasks` — count of tasks in `running` runtime_state
- `data_dir` — resolved absolute octomux data directory

Returns HTTP **200** when the DB is reachable, **503** otherwise. Also exposes `getDataDir()` from `server/db.ts` as the single source of truth for the data directory path.

## Why

Operators and monitoring systems need one unauthenticated URL to check whether the server is up, the database is reachable, and the system is usable — machine-readable and using conventional HTTP health-check semantics.

## Testing

- New `server/api.health.test.ts` (supertest against `createApp()`): healthy 200 + response shape, `running_tasks` count, and DB-failure → 503/degraded.
- `bun run test` — full suite green
- `bun run lint` — 0 errors
- `bun run typecheck` — clean