### PR TITLE
refactor(diff): collapse DiffViewer to API-only + rename CommentsContext [SHR-183]

### DIFF
--- a/src/components/CommentsSidePanel.test.tsx
+++ b/src/components/CommentsSidePanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { CommentsSidePanel } from './CommentsSidePanel';
-import { TaskCommentsContext, type TaskCommentsState } from '@/hooks/useTaskComments';
+import { CommentsContext, type CommentsState } from '@/hooks/useTaskComments';
 import type { InlineCommentWithOutdated } from '@/lib/api';
 
 function comment(o: Partial<InlineCommentWithOutdated> = {}): InlineCommentWithOutdated {
@@ -21,7 +21,7 @@ function comment(o: Partial<InlineCommentWithOutdated> = {}): InlineCommentWithO
   };
 }
 
-function makeContext(initial: InlineCommentWithOutdated[]): TaskCommentsState {
+function makeContext(initial: InlineCommentWithOutdated[]): CommentsState {
   const byId = new Map(initial.map((c) => [c.id, c]));
   return {
     byId,
@@ -52,14 +52,14 @@ function renderPanel(opts: {
   const ctx = makeContext(opts.comments);
   const onJumpTo = opts.onJumpTo ?? vi.fn();
   render(
-    <TaskCommentsContext.Provider value={ctx}>
+    <CommentsContext.Provider value={ctx}>
       <CommentsSidePanel
         agents={[]}
         filesInDiff={opts.filesInDiff ?? new Set(opts.comments.map((c) => c.file_path))}
         rangeIsBase={opts.rangeIsBase ?? true}
         onJumpTo={onJumpTo}
       />
-    </TaskCommentsContext.Provider>,
+    </CommentsContext.Provider>,
   );
   return { ctx, onJumpTo };
 }
@@ -141,14 +141,14 @@ describe('CommentsSidePanel', () => {
 
   it('renders Outdated chip on base range only', () => {
     const { unmount } = render(
-      <TaskCommentsContext.Provider value={makeContext([comment({ id: 'c1', outdated: true })])}>
+      <CommentsContext.Provider value={makeContext([comment({ id: 'c1', outdated: true })])}>
         <CommentsSidePanel
           agents={[]}
           filesInDiff={new Set(['src/foo.ts'])}
           rangeIsBase={false}
           onJumpTo={vi.fn()}
         />
-      </TaskCommentsContext.Provider>,
+      </CommentsContext.Provider>,
     );
     // Pill button still says "Outdated" but no chip should appear inside the row.
     const row = screen.getByTestId('side-panel-comment-c1');
@@ -156,14 +156,14 @@ describe('CommentsSidePanel', () => {
     unmount();
 
     render(
-      <TaskCommentsContext.Provider value={makeContext([comment({ id: 'c1', outdated: true })])}>
+      <CommentsContext.Provider value={makeContext([comment({ id: 'c1', outdated: true })])}>
         <CommentsSidePanel
           agents={[]}
           filesInDiff={new Set(['src/foo.ts'])}
           rangeIsBase={true}
           onJumpTo={vi.fn()}
         />
-      </TaskCommentsContext.Provider>,
+      </CommentsContext.Provider>,
     );
     const row2 = screen.getByTestId('side-panel-comment-c1');
     expect(within(row2).getByText('Outdated')).toBeInTheDocument();

--- a/src/components/CommentsSidePanel.tsx
+++ b/src/components/CommentsSidePanel.tsx
@@ -5,7 +5,7 @@ import { DIFF_FILTER_ACTIVE } from '@/lib/design-tokens';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { timeAgo } from '@/lib/time';
 import { authorLabel } from '@/lib/comment-format';
-import { useTaskCommentsContext } from '@/hooks/useTaskComments';
+import { useCommentsContext } from '@/hooks/useTaskComments';
 import type { InlineCommentWithOutdated } from '@/lib/api';
 import type { Agent } from '../../server/types';
 
@@ -33,7 +33,7 @@ export function CommentsSidePanel({
   onClose,
   className,
 }: CommentsSidePanelProps) {
-  const ctx = useTaskCommentsContext();
+  const ctx = useCommentsContext();
   const [filter, setFilter] = useState<FilterMode>('all');
 
   const all = useMemo(() => Array.from(ctx.byId.values()), [ctx.byId]);

--- a/src/components/DiffFileRow.tsx
+++ b/src/components/DiffFileRow.tsx
@@ -10,7 +10,7 @@ import { ClampedExplainer } from '@/components/review/ClampedExplainer';
 import { useDiffEditorHostSize } from '@/hooks/useDiffEditorHostSize';
 import { useDiffEditorLayout } from '@/hooks/useDiffEditorLayout';
 import { useInlineCommentZones } from '@/hooks/useInlineCommentZones';
-import { useTaskCommentsContext } from '@/hooks/useTaskComments';
+import { useCommentsContext } from '@/hooks/useTaskComments';
 
 const MonacoDiff = lazy(() =>
   import('@monaco-editor/react').then((mod) => ({ default: mod.DiffEditor })),
@@ -302,7 +302,7 @@ function CommentZonePortals({
   agents: Agent[];
   rangeIsBase: boolean;
 }) {
-  const ctx = useTaskCommentsContext();
+  const ctx = useCommentsContext();
   const fileComments = useMemo(() => ctx.byFile(filePath), [ctx, filePath]);
 
   const portals = useInlineCommentZones({

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -433,69 +433,6 @@ describe('DiffViewer', () => {
     });
   });
 
-  // ─── Inline comment composer ────────────────────────────────────────────
-
-  describe('inline comment composer', () => {
-    it('clicking a line opens the composer below it', async () => {
-      const user = userEvent.setup();
-      const onAddComment = vi.fn();
-      render(
-        <DiffViewer
-          oldContent={'a\nb\nc'}
-          newContent={'a\nbb\nc'}
-          path="src/foo.ts"
-          onAddComment={onAddComment}
-        />,
-      );
-      await user.click(screen.getByText('bb'));
-      expect(screen.getByPlaceholderText(/leave a comment/i)).toBeInTheDocument();
-    });
-
-    it('Enter saves the comment with file path, line, and line text', async () => {
-      const user = userEvent.setup();
-      const onAddComment = vi.fn();
-      render(
-        <DiffViewer oldContent="a" newContent="aa" path="src/foo.ts" onAddComment={onAddComment} />,
-      );
-      await user.click(screen.getByText('aa'));
-      const input = screen.getByPlaceholderText(/leave a comment/i);
-      await user.type(input, 'rename pls{Enter}');
-      expect(onAddComment).toHaveBeenCalledWith({
-        filePath: 'src/foo.ts',
-        line: 1,
-        lineText: 'aa',
-        body: 'rename pls',
-      });
-    });
-
-    it('Esc discards without calling onAddComment', async () => {
-      const user = userEvent.setup();
-      const onAddComment = vi.fn();
-      render(
-        <DiffViewer oldContent="a" newContent="aa" path="src/foo.ts" onAddComment={onAddComment} />,
-      );
-      await user.click(screen.getByText('aa'));
-      const input = screen.getByPlaceholderText(/leave a comment/i);
-      await user.type(input, 'wip{Escape}');
-      expect(onAddComment).not.toHaveBeenCalled();
-    });
-
-    it('shows existing queued comments as pills under the line', () => {
-      render(
-        <DiffViewer
-          oldContent="a"
-          newContent="aa"
-          path="src/foo.ts"
-          onAddComment={() => {}}
-          queuedComments={[
-            { id: '1', filePath: 'src/foo.ts', line: 1, lineText: 'aa', body: 'rename' },
-          ]}
-        />,
-      );
-      expect(screen.getByText('rename')).toBeInTheDocument();
-    });
-  });
-
   it('reads stored expandedAll on mount and passes hideUnchangedRegions=false', async () => {
     apiMock.getTaskDiffSummary.mockResolvedValue({
       files: [{ path: 'src/a.ts', status: 'M', additions: 2, deletions: 1 }],

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -8,26 +8,9 @@ import { DiffFileList, type DiffFileListHandle } from './DiffFileList';
 
 const POLL_INTERVAL_MS = 2000;
 
-export interface QueuedReviewComment {
-  id: string;
-  filePath: string;
-  line: number;
-  lineText: string;
-  body: string;
-}
-
 interface Props {
-  taskId?: string;
+  taskId: string;
   isRunning?: boolean;
-  // Controlled / standalone-content mode (used by the review composer).
-  // When `oldContent`/`newContent`/`path` are passed directly, the component
-  // renders a simple line-by-line view of the new content with an inline
-  // comment composer per line, instead of fetching diff data via the API.
-  oldContent?: string;
-  newContent?: string;
-  path?: string;
-  onAddComment?: (c: { filePath: string; line: number; lineText: string; body: string }) => void;
-  queuedComments?: QueuedReviewComment[];
   // Optional notifier so a parent (e.g. TaskDetail's review cockpit) can mirror
   // the currently-active file path for keyboard nav and the review banner.
   onSelectionChange?: (path: string | null) => void;
@@ -42,8 +25,8 @@ interface Props {
   /** Forward an imperative handle for programmatic scroll/reveal — used by the
    *  comments side panel. */
   listRef?: RefObject<DiffFileListHandle | null>;
-  /** Opt-in to inline comment threads (uses TaskCommentsContext). When true,
-   *  callers must wrap with <TaskCommentsContext.Provider>. */
+  /** Opt-in to inline comment threads (uses CommentsContext). When true,
+   *  callers must wrap with <CommentsContext.Provider>. */
   enableComments?: boolean;
   agents?: Agent[];
   /** Notifier fired whenever the list of files in the diff changes. The host
@@ -61,147 +44,9 @@ interface Props {
   groups?: import('@/lib/review-file-groups').RenderGroup[];
 }
 
-export function DiffViewer(props: Props) {
-  const {
-    taskId,
-    isRunning,
-    oldContent: standaloneOld,
-    newContent: standaloneNew,
-    path: standalonePath,
-    onAddComment,
-    queuedComments,
-    onSelectionChange,
-    onSummaryLoaded,
-    onToggleReviewed,
-    range,
-    listRef,
-    enableComments,
-    agents,
-    onFilesChange,
-    hideFileTree,
-    fileOrder,
-    groups,
-  } = props;
-
-  // Standalone / composer mode — renders the new-content lines as clickable
-  // buttons with an inline comment composer. No taskId needed.
-  if (standaloneNew !== undefined && standalonePath !== undefined && standaloneOld !== undefined) {
-    return (
-      <InlineComposerDiff
-        path={standalonePath}
-        newContent={standaloneNew}
-        onAddComment={onAddComment}
-        queuedComments={queuedComments ?? []}
-      />
-    );
-  }
-
-  if (taskId === undefined) {
-    return null;
-  }
-
-  return (
-    <ApiDiffViewer
-      taskId={taskId}
-      isRunning={isRunning ?? false}
-      onSelectionChange={onSelectionChange}
-      onSummaryLoaded={onSummaryLoaded}
-      onToggleReviewed={onToggleReviewed}
-      range={range}
-      listRef={listRef}
-      enableComments={enableComments}
-      agents={agents}
-      onFilesChange={onFilesChange}
-      hideFileTree={hideFileTree}
-      fileOrder={fileOrder}
-      groups={groups}
-    />
-  );
-}
-
-interface InlineComposerDiffProps {
-  path: string;
-  newContent: string;
-  onAddComment?: (c: { filePath: string; line: number; lineText: string; body: string }) => void;
-  queuedComments: QueuedReviewComment[];
-}
-
-function InlineComposerDiff({
-  path,
-  newContent,
-  onAddComment,
-  queuedComments,
-}: InlineComposerDiffProps) {
-  const [activeLine, setActiveLine] = useState<number | null>(null);
-  const [draft, setDraft] = useState('');
-  const lines = newContent.split('\n');
-
-  const openComposer = (line: number) => {
-    setActiveLine(line);
-    setDraft('');
-  };
-
-  const close = () => {
-    setActiveLine(null);
-    setDraft('');
-  };
-
-  const save = (line: number, lineText: string) => {
-    if (!onAddComment) {
-      close();
-      return;
-    }
-    onAddComment({ filePath: path, line, lineText, body: draft });
-    close();
-  };
-
-  return (
-    <div className="font-mono text-sm">
-      {lines.map((lineText, idx) => {
-        const lineNum = idx + 1; // 1-indexed
-        const pills = queuedComments.filter((c) => c.filePath === path && c.line === lineNum);
-        return (
-          <div key={lineNum} data-line={lineNum}>
-            <button
-              type="button"
-              className="block w-full text-left hover:bg-accent/30"
-              onClick={() => openComposer(lineNum)}
-            >
-              {lineText}
-            </button>
-            {pills.map((c) => (
-              <div key={c.id} className="text-xs italic">
-                {c.body}
-              </div>
-            ))}
-            {activeLine === lineNum ? (
-              <input
-                autoFocus
-                placeholder="Leave a comment"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    save(lineNum, lineText);
-                  } else if (e.key === 'Escape') {
-                    e.preventDefault();
-                    close();
-                  }
-                }}
-                className="block w-full border border-glass-edge bg-glass-l1 px-2 py-1 text-sm"
-              />
-            ) : null}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function ApiDiffViewer({
+export function DiffViewer({
   taskId,
-  isRunning,
+  isRunning = false,
   onSelectionChange,
   onSummaryLoaded,
   onToggleReviewed: onToggleReviewedProp,
@@ -213,21 +58,7 @@ function ApiDiffViewer({
   hideFileTree = false,
   fileOrder,
   groups,
-}: {
-  taskId: string;
-  isRunning: boolean;
-  onSelectionChange?: (path: string | null) => void;
-  onSummaryLoaded?: (summary: import('@/lib/api').DiffSummaryResponse) => void;
-  onToggleReviewed?: (path: string, currentlyReviewed: boolean) => void;
-  range?: DiffRange;
-  listRef?: RefObject<DiffFileListHandle | null>;
-  enableComments?: boolean;
-  agents?: Agent[];
-  onFilesChange?: (paths: string[]) => void;
-  hideFileTree?: boolean;
-  fileOrder?: string[];
-  groups?: import('@/lib/review-file-groups').RenderGroup[];
-}) {
+}: Props) {
   const isBaseRange = !range || range.kind === 'base';
   const [files, setFiles] = useState<DiffFileEntry[]>([]);
   const [ignoredTruncated, setIgnoredTruncated] = useState(false);

--- a/src/hooks/useTaskComments.ts
+++ b/src/hooks/useTaskComments.ts
@@ -23,7 +23,7 @@ export interface QueueDraftInput {
   lineText: string;
 }
 
-export interface TaskCommentsState {
+export interface CommentsState {
   byId: Map<string, InlineCommentWithOutdated>;
   byFile: (path: string) => InlineCommentWithOutdated[];
   byFileLineSide: (path: string, line: number, side: 'old' | 'new') => InlineCommentWithOutdated[];
@@ -55,7 +55,7 @@ function indexBy(rows: InlineCommentWithOutdated[]): Map<string, InlineCommentWi
 export function useTaskComments(
   taskId: string | undefined,
   opts?: { onError?: (msg: string) => void; onQueueDraft?: (draft: QueueDraftInput) => void },
-): TaskCommentsState {
+): CommentsState {
   const [byId, setById] = useState<Map<string, InlineCommentWithOutdated>>(() => new Map());
   const [outdatedUnavailable, setOutdatedUnavailable] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -263,12 +263,12 @@ export function useTaskComments(
   };
 }
 
-export const TaskCommentsContext = createContext<TaskCommentsState | null>(null);
+export const CommentsContext = createContext<CommentsState | null>(null);
 
-export function useTaskCommentsContext(): TaskCommentsState {
-  const ctx = useContext(TaskCommentsContext);
+export function useCommentsContext(): CommentsState {
+  const ctx = useContext(CommentsContext);
   if (!ctx) {
-    throw new Error('useTaskCommentsContext must be used inside <TaskCommentsContext.Provider>');
+    throw new Error('useCommentsContext must be used inside <CommentsContext.Provider>');
   }
   return ctx;
 }

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -11,7 +11,7 @@ import { PublishBar } from '../components/review/PublishBar';
 import { HeadAdvancedBanner } from '../components/review/HeadAdvancedBanner';
 import { DiffViewer } from '../components/DiffViewer';
 import { CommentsSidePanel } from '../components/CommentsSidePanel';
-import { TaskCommentsContext, useTaskComments } from '../hooks/useTaskComments';
+import { CommentsContext, useTaskComments } from '../hooks/useTaskComments';
 import type { DiffFileListHandle } from '../components/DiffFileList';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -162,7 +162,7 @@ export default function ReviewDetailPage() {
   );
 
   return (
-    <TaskCommentsContext.Provider value={taskComments}>
+    <CommentsContext.Provider value={taskComments}>
       <div className="flex h-full min-h-0 flex-col">
         <HeadAdvancedBanner taskId={id!} currentSha={detail.task.pr_head_sha} onRefresh={refresh} />
 
@@ -263,6 +263,6 @@ export default function ReviewDetailPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </TaskCommentsContext.Provider>
+    </CommentsContext.Provider>
   );
 }

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,7 +19,7 @@ import { CommentQueueDrawer } from '@/components/CommentQueueDrawer';
 import { CommentsSidePanel } from '@/components/CommentsSidePanel';
 import type { DiffFileListHandle } from '@/components/DiffFileList';
 import { useReviewQueue } from '@/hooks/useReviewQueue';
-import { useTaskComments, TaskCommentsContext } from '@/hooks/useTaskComments';
+import { useTaskComments, CommentsContext } from '@/hooks/useTaskComments';
 import { DIFF_KEYBINDS, useDiffKeyboardNav } from '@/hooks/useDiffKeyboardNav';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
@@ -869,7 +869,7 @@ export default function TaskDetail() {
 
       {/* Diff view — review cockpit */}
       {mode === 'diff' && canShowDiff && (
-        <TaskCommentsContext.Provider value={taskComments}>
+        <CommentsContext.Provider value={taskComments}>
           <div className="relative flex min-h-0 flex-1 flex-col">
             {diffSummary && diffSummary.base_ref ? (
               <ReviewBaseRefBanner
@@ -940,7 +940,7 @@ export default function TaskDetail() {
             </div>
             <DiffKeybindCheatSheet />
           </div>
-        </TaskCommentsContext.Provider>
+        </CommentsContext.Provider>
       )}
 
       {/* Editor view — only shown for nvim (external editors stay on agents view) */}


### PR DESCRIPTION
## What

Collapses `DiffViewer` to its API-diff core and renames the misleadingly-named comments context (SHR-183 / [Modular 08]).

- Deletes the dead controlled-diff branch (`InlineComposerDiff`, `QueuedReviewComment`, and the `oldContent`/`newContent`/`path`/`onAddComment`/`queuedComments` props) — it had zero production callers. The `ApiDiffViewer` body is promoted to be `DiffViewer` (named + default export preserved).
- Renames `TaskCommentsContext`/`TaskCommentsState`/`useTaskCommentsContext` → `CommentsContext`/`CommentsState`/`useCommentsContext` (source-honest; both TaskDetail and ReviewDetailPage share one model/endpoint). The `useTaskComments(taskId)` hook name is kept.
- Removes the orphaned inline-composer test block that covered the deleted dead code.

Net: ~140 LOC removed, no behavior change. The `onFilesChange` render-loop guard is preserved verbatim.

## Why

Phase 3 of the octomux modularization refactor. `DiffViewer` + `TaskCommentsContext` were the shared task/review seam; the dead controlled-diff branch and the task-flavored context name blocked a clean reviews-UI extraction. Scope was corrected by the plan's adversarial review — no primitives/wrappers/second context (the code contradicted that premise).

Resolves https://linear.app/shreypaharia/issue/SHR-183

## Testing

`bun run test` / `typecheck` / `lint` per the task brief (subtractive refactor; surviving API-mode DiffViewer tests retained, dead-code tests removed).