### PR TITLE
feat(octomux): repo-portable skills, agents, and saved files [SHR-184]

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -175,6 +175,14 @@ export interface OctomuxClient {
   listTeams(): Promise<
     Array<{ name: string; cron: string; enabled: number; last_run_at: string | null }>
   >;
+
+  listSavedFiles(repoPath: string): Promise<Array<{ path: string; size: number }>>;
+  getSavedFile(repoPath: string, relPath: string): Promise<{ path: string; content: string }>;
+  putSavedFile(
+    repoPath: string,
+    relPath: string,
+    content: string,
+  ): Promise<{ path: string; content: string }>;
 }
 
 function qs(params: Record<string, string | undefined>): string {
@@ -366,6 +374,25 @@ export function createClient(serverUrl: string): OctomuxClient {
       return request<
         Array<{ name: string; cron: string; enabled: number; last_run_at: string | null }>
       >(baseUrl, '/teams');
+    },
+    listSavedFiles(repoPath) {
+      return request<{ path: string; size: number }[]>(
+        baseUrl,
+        `/repos/${encodeURIComponent(repoPath)}/files`,
+      );
+    },
+    getSavedFile(repoPath, relPath) {
+      return request<{ path: string; content: string }>(
+        baseUrl,
+        `/repos/${encodeURIComponent(repoPath)}/files/content${qs({ path: relPath })}`,
+      );
+    },
+    putSavedFile(repoPath, relPath, content) {
+      return request<{ path: string; content: string }>(
+        baseUrl,
+        `/repos/${encodeURIComponent(repoPath)}/files/content${qs({ path: relPath })}`,
+        { method: 'PUT', body: JSON.stringify({ content }) },
+      );
     },
   };
 }

--- a/cli/src/commands/files.ts
+++ b/cli/src/commands/files.ts
@@ -1,0 +1,80 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import fs from 'fs';
+import { getContext } from '../action.js';
+import { outputJson, printTable, errorMessage } from '../format.js';
+
+interface FilesOptions {
+  repo?: string;
+}
+
+function repoPath(opts: FilesOptions): string {
+  return opts.repo ?? process.cwd();
+}
+
+export function registerFiles(program: Command): void {
+  const files = program
+    .command('files')
+    .description('List, read, and write repo-portable saved files under .octomux/files/');
+
+  files
+    .command('list')
+    .description('List saved files in <repo>/.octomux/files/')
+    .option('-r, --repo <path>', 'repository path (default: cwd)')
+    .action(async (opts: FilesOptions, cmd: Command) => {
+      const { client, json } = getContext(cmd);
+      const entries = await client.listSavedFiles(repoPath(opts));
+      if (json) {
+        outputJson(entries);
+        return;
+      }
+      if (entries.length === 0) {
+        console.log('No saved files.');
+        return;
+      }
+      printTable(
+        [
+          { header: 'PATH', width: 40, get: (e) => e.path },
+          { header: 'SIZE', width: 10, get: (e) => String(e.size) },
+        ],
+        entries,
+      );
+    });
+
+  files
+    .command('get <path>')
+    .description('Read a saved file')
+    .option('-r, --repo <path>', 'repository path (default: cwd)')
+    .action(async (filePath: string, opts: FilesOptions, cmd: Command) => {
+      const { client, json } = getContext(cmd);
+      const file = await client.getSavedFile(repoPath(opts), filePath);
+      if (json) {
+        outputJson(file);
+        return;
+      }
+      console.log(file.content);
+    });
+
+  files
+    .command('put <path>')
+    .description('Write a saved file (content from --content or stdin)')
+    .option('-r, --repo <path>', 'repository path (default: cwd)')
+    .option('-c, --content <text>', 'file content (default: read stdin)')
+    .action(async (filePath: string, opts: FilesOptions & { content?: string }, cmd: Command) => {
+      const { client, json } = getContext(cmd);
+      let content = opts.content;
+      if (content === undefined) {
+        if (process.stdin.isTTY) {
+          errorMessage('Provide --content or pipe content on stdin');
+          process.exit(1);
+        }
+        content = await fs.promises.readFile(0, 'utf-8');
+      }
+      const file = await client.putSavedFile(repoPath(opts), filePath, content);
+      if (json) {
+        outputJson(file);
+        return;
+      }
+      console.log(chalk.green(`Wrote ${file.path}`));
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,6 +30,7 @@ import { registerHooksList } from './commands/hooks-list.js';
 import { registerListIntegrations } from './commands/list-integrations.js';
 import { registerInit } from './commands/init.js';
 import { registerTeam } from './commands/team.js';
+import { registerFiles } from './commands/files.js';
 
 const program = new Command();
 
@@ -71,6 +72,7 @@ registerHooksList(program);
 registerListIntegrations(program);
 registerInit(program);
 registerTeam(program);
+registerFiles(program);
 
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();

--- a/server/agents.test.ts
+++ b/server/agents.test.ts
@@ -67,6 +67,22 @@ describe('agents', () => {
       expect(agent.isCustom).toBe(true);
     });
 
+    it('repo .octomux/agents overrides home and built-in', async () => {
+      const repoDir = path.join(os.tmpdir(), `octomux-agents-repo-${Date.now()}`);
+      fs.mkdirSync(path.join(repoDir, '.octomux', 'agents'), { recursive: true });
+      fs.writeFileSync(path.join(tmpDir, 'orchestrator.md'), 'Home prompt');
+      fs.writeFileSync(
+        path.join(repoDir, '.octomux', 'agents', 'orchestrator.md'),
+        'Repo prompt',
+      );
+
+      const agent = await getAgent('orchestrator', repoDir);
+      expect(agent.content).toBe('Repo prompt');
+      expect(agent.isCustom).toBe(true);
+
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    });
+
     it('throws for non-existent agent', async () => {
       await expect(getAgent('nonexistent')).rejects.toThrow();
     });

--- a/server/agents.ts
+++ b/server/agents.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-import { octomuxRoot } from './octomux-root.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import {
+  builtInAgentsDir,
+  homeAgentsDir,
+  repoAgentsDir,
+} from './octomux-paths.js';
 
 export interface AgentDefinition {
   name: string;
@@ -19,11 +20,11 @@ export interface AgentDetail {
 }
 
 function builtInDir(): string {
-  return path.resolve(__dirname, '..', 'agents');
+  return builtInAgentsDir();
 }
 
 function customDir(): string {
-  return process.env.OCTOMUX_AGENTS_DIR || path.join(octomuxRoot(), 'agents');
+  return homeAgentsDir();
 }
 
 function parseFrontmatter(content: string): { name: string; description: string } {
@@ -51,71 +52,77 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
-export async function listAgents(): Promise<AgentDefinition[]> {
-  const builtIn = builtInDir();
-  const custom = customDir();
+async function loadAgentsFromDir(
+  dir: string,
+  isCustom: boolean,
+  into: Map<string, AgentDefinition>,
+): Promise<void> {
+  if (!(await exists(dir))) return;
+  const entries = await fs.promises.readdir(dir);
+  for (const entry of entries) {
+    if (!entry.endsWith('.md')) continue;
+    const name = entry.replace('.md', '');
+    const content = await fs.promises.readFile(path.join(dir, entry), 'utf-8');
+    const fm = parseFrontmatter(content);
+    const existing = into.get(name);
+    into.set(name, {
+      name,
+      description: fm.description || existing?.description || '',
+      isCustom: isCustom || existing?.isCustom || false,
+    });
+  }
+}
+
+/** Loader precedence: repo → home → built-in (later sources override earlier). */
+export async function listAgents(repoPath?: string): Promise<AgentDefinition[]> {
   const agents = new Map<string, AgentDefinition>();
 
-  if (await exists(builtIn)) {
-    const entries = await fs.promises.readdir(builtIn);
-    for (const entry of entries) {
-      if (!entry.endsWith('.md')) continue;
-      const name = entry.replace('.md', '');
-      const content = await fs.promises.readFile(path.join(builtIn, entry), 'utf-8');
-      const fm = parseFrontmatter(content);
-      agents.set(name, { name, description: fm.description, isCustom: false });
-    }
-  }
-
-  if (await exists(custom)) {
-    const entries = await fs.promises.readdir(custom);
-    for (const entry of entries) {
-      if (!entry.endsWith('.md')) continue;
-      const name = entry.replace('.md', '');
-      const content = await fs.promises.readFile(path.join(custom, entry), 'utf-8');
-      const fm = parseFrontmatter(content);
-      const existing = agents.get(name);
-      agents.set(name, {
-        name,
-        description: fm.description || existing?.description || '',
-        isCustom: true,
-      });
-    }
+  await loadAgentsFromDir(builtInDir(), false, agents);
+  await loadAgentsFromDir(customDir(), true, agents);
+  if (repoPath) {
+    await loadAgentsFromDir(repoAgentsDir(repoPath), true, agents);
   }
 
   return Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function getAgent(name: string): Promise<AgentDetail> {
+export async function getAgent(name: string, repoPath?: string): Promise<AgentDetail> {
   const builtInPath = path.join(builtInDir(), `${name}.md`);
-  const customPath = path.join(customDir(), `${name}.md`);
+  const homePath = path.join(customDir(), `${name}.md`);
+  const repoPath_ = repoPath ? path.join(repoAgentsDir(repoPath), `${name}.md`) : null;
 
   const hasBuiltIn = await exists(builtInPath);
-  const hasCustom = await exists(customPath);
+  const hasHome = await exists(homePath);
+  const hasRepo = repoPath_ ? await exists(repoPath_) : false;
 
-  if (!hasBuiltIn && !hasCustom) {
+  if (!hasBuiltIn && !hasHome && !hasRepo) {
     throw new Error(`Agent not found: ${name}`);
   }
 
   const defaultContent = hasBuiltIn ? await fs.promises.readFile(builtInPath, 'utf-8') : '';
-  const customContent = hasCustom ? await fs.promises.readFile(customPath, 'utf-8') : null;
+  const homeContent = hasHome ? await fs.promises.readFile(homePath, 'utf-8') : null;
+  const repoContent = hasRepo && repoPath_ ? await fs.promises.readFile(repoPath_, 'utf-8') : null;
 
   return {
     name,
-    content: customContent ?? defaultContent,
+    content: repoContent ?? homeContent ?? defaultContent,
     defaultContent,
-    isCustom: hasCustom,
+    isCustom: hasRepo || hasHome,
   };
 }
 
-export async function saveAgent(name: string, content: string): Promise<void> {
-  const dir = customDir();
+function writeAgentsDir(repoPath?: string): string {
+  return repoPath ? repoAgentsDir(repoPath) : customDir();
+}
+
+export async function saveAgent(name: string, content: string, repoPath?: string): Promise<void> {
+  const dir = writeAgentsDir(repoPath);
   await fs.promises.mkdir(dir, { recursive: true });
   await fs.promises.writeFile(path.join(dir, `${name}.md`), content, 'utf-8');
 }
 
-export async function resetAgent(name: string): Promise<void> {
-  const customPath = path.join(customDir(), `${name}.md`);
+export async function resetAgent(name: string, repoPath?: string): Promise<void> {
+  const customPath = path.join(writeAgentsDir(repoPath), `${name}.md`);
   try {
     await fs.promises.unlink(customPath);
   } catch (err) {
@@ -124,16 +131,20 @@ export async function resetAgent(name: string): Promise<void> {
   }
 }
 
-export async function createAgent(name: string, content: string): Promise<void> {
-  const customPath = path.join(customDir(), `${name}.md`);
+export async function createAgent(
+  name: string,
+  content: string,
+  repoPath?: string,
+): Promise<void> {
+  const customPath = path.join(writeAgentsDir(repoPath), `${name}.md`);
   if (await exists(customPath)) {
     throw new Error(`Agent already exists: ${name}`);
   }
-  await saveAgent(name, content);
+  await saveAgent(name, content, repoPath);
 }
 
 /**
- * Sync effective agent files (custom override or built-in default) to
+ * Sync effective agent files (repo → home → built-in) to
  * `.claude/agents/` in `cwd` (defaults to process.cwd) so `claude --agent <name>`
  * resolves them when launched in that directory.
  */
@@ -142,12 +153,11 @@ export async function syncAgents(cwd?: string): Promise<void> {
   await claudeCodeHarness.syncAgents(cwd ?? process.cwd());
 }
 
-export async function deleteAgent(name: string): Promise<void> {
-  const builtInPath = path.join(builtInDir(), `${name}.md`);
-  if (await exists(builtInPath)) {
+export async function deleteAgent(name: string, repoPath?: string): Promise<void> {
+  if (!repoPath && (await exists(path.join(builtInDir(), `${name}.md`)))) {
     throw new Error(`Cannot delete built-in agent: ${name}. Use reset to restore defaults.`);
   }
-  const customPath = path.join(customDir(), `${name}.md`);
+  const customPath = path.join(writeAgentsDir(repoPath), `${name}.md`);
   if (!(await exists(customPath))) {
     throw new Error(`Agent not found: ${name}`);
   }

--- a/server/api.ts
+++ b/server/api.ts
@@ -7,6 +7,7 @@ import { hookRoutes } from './hooks.js';
 import { router as miscRouter } from './routes/misc.js';
 import { router as learningsRouter } from './routes/learnings.js';
 import { router as skillsRouter } from './routes/skills.js';
+import { router as savedFilesRouter } from './routes/saved-files.js';
 import { router as teamsRouter } from './routes/teams.js';
 import { router as setupRouter } from './routes/setup.js';
 import { router as settingsRouter } from './routes/settings.js';
@@ -34,6 +35,7 @@ export function setupRoutes(app: Express): void {
   app.use(miscRouter);
   app.use(learningsRouter);
   app.use(skillsRouter);
+  app.use(savedFilesRouter);
   app.use(teamsRouter);
   app.use(setupRouter);
   app.use(settingsRouter);

--- a/server/harnesses/claude-code.ts
+++ b/server/harnesses/claude-code.ts
@@ -95,9 +95,9 @@ export const claudeCodeHarness: Harness = {
     const targetDir = path.join(worktreePath, '.claude', 'agents');
     await fs.promises.mkdir(targetDir, { recursive: true });
 
-    const agents = await listAgents();
+    const agents = await listAgents(worktreePath);
     for (const def of agents) {
-      const agent = await getAgent(def.name);
+      const agent = await getAgent(def.name, worktreePath);
       await fs.promises.writeFile(path.join(targetDir, `${def.name}.md`), agent.content, 'utf-8');
     }
   },

--- a/server/harnesses/cursor.ts
+++ b/server/harnesses/cursor.ts
@@ -207,10 +207,10 @@ export const cursorHarness: Harness = {
     fs.mkdirSync(rulesDir, { recursive: true });
     pruneOctomuxCursorRules(rulesDir);
 
-    const defs = await listAgents();
+    const defs = await listAgents(worktreePath);
     for (const def of defs) {
       try {
-        const detail = await getAgent(def.name);
+        const detail = await getAgent(def.name, worktreePath);
         const raw = `${OCTOMUX_CURSOR_RULE_PREFIX}${def.name}.mdc`;
         const dest = path.join(rulesDir, raw);
         const next = agentMarkdownToCursorRule(def.name, detail.content);

--- a/server/multi-task-shared.test.ts
+++ b/server/multi-task-shared.test.ts
@@ -28,6 +28,14 @@ vi.mock('./hook-settings.js', () => ({
   installHookSettings: vi.fn(),
 }));
 
+vi.mock('./skills.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./skills.js')>();
+  return {
+    ...actual,
+    syncSkills: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 vi.mock('./harnesses/claude-code.js', async () => {
   const actual = await vi.importActual<typeof import('./harnesses/claude-code.js')>(
     './harnesses/claude-code.js',

--- a/server/octomux-paths.ts
+++ b/server/octomux-paths.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import { octomuxRoot } from './octomux-root.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-local octomux config root: `<repo>/.octomux/`. */
+export function repoOctomuxDir(repoPath: string): string {
+  return path.join(repoPath, '.octomux');
+}
+
+export function repoSkillsDir(repoPath: string): string {
+  return path.join(repoOctomuxDir(repoPath), 'skills');
+}
+
+export function repoAgentsDir(repoPath: string): string {
+  return path.join(repoOctomuxDir(repoPath), 'agents');
+}
+
+/** Repo-portable saved files: `<repo>/.octomux/files/`. */
+export function repoFilesDir(repoPath: string): string {
+  return path.join(repoOctomuxDir(repoPath), 'files');
+}
+
+export function homeSkillsDir(): string {
+  return path.join(os.homedir(), '.claude', 'skills');
+}
+
+export function homeAgentsDir(): string {
+  return process.env.OCTOMUX_AGENTS_DIR || path.join(octomuxRoot(), 'agents');
+}
+
+export function builtInSkillsDir(): string {
+  return path.resolve(__dirname, '..', 'skills');
+}
+
+export function builtInAgentsDir(): string {
+  return path.resolve(__dirname, '..', 'agents');
+}

--- a/server/routes/agent-defs.ts
+++ b/server/routes/agent-defs.ts
@@ -14,11 +14,16 @@ import { sendDomainError } from './_shared.js';
 
 export const router = express.Router();
 
+function repoPathFromQuery(req: Request): string | undefined {
+  const repoPath = req.query.repo_path as string | undefined;
+  return repoPath || undefined;
+}
+
 // ─── Agents ──────────────────────────────────────────────────────────────────
 
-router.get('/api/agents', async (_req: Request, res: Response) => {
+router.get('/api/agents', async (req: Request, res: Response) => {
   try {
-    const agents = await listAgents();
+    const agents = await listAgents(repoPathFromQuery(req));
     res.json(agents);
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
@@ -27,7 +32,7 @@ router.get('/api/agents', async (_req: Request, res: Response) => {
 
 router.get('/api/agents/:name', async (req: Request, res: Response) => {
   try {
-    const agent = await getAgent(req.params.name as string);
+    const agent = await getAgent(req.params.name as string, repoPathFromQuery(req));
     res.json(agent);
   } catch (err) {
     sendDomainError(res, err);
@@ -40,10 +45,11 @@ router.put('/api/agents/:name', async (req: Request, res: Response) => {
     res.status(400).json({ error: 'content is required' });
     return;
   }
+  const repoPath = repoPathFromQuery(req);
   try {
-    await saveAgent(req.params.name as string, content);
-    await syncAgents();
-    const agent = await getAgent(req.params.name as string);
+    await saveAgent(req.params.name as string, content, repoPath);
+    await syncAgents(repoPath);
+    const agent = await getAgent(req.params.name as string, repoPath);
     res.json(agent);
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
@@ -51,14 +57,15 @@ router.put('/api/agents/:name', async (req: Request, res: Response) => {
 });
 
 router.delete('/api/agents/:name', async (req: Request, res: Response) => {
+  const name = req.params.name as string;
+  const repoPath = repoPathFromQuery(req);
   try {
-    const name = req.params.name as string;
     if (isBuiltInAgent(name)) {
-      await resetAgent(name);
+      await resetAgent(name, repoPath);
     } else {
-      await deleteAgent(name);
+      await deleteAgent(name, repoPath);
     }
-    await syncAgents();
+    await syncAgents(repoPath);
     res.json({ ok: true });
   } catch (err) {
     sendDomainError(res, err);
@@ -71,10 +78,11 @@ router.post('/api/agents', async (req: Request, res: Response) => {
     res.status(400).json({ error: 'name and content are required' });
     return;
   }
+  const repoPath = repoPathFromQuery(req);
   try {
-    await createAgent(name, content);
-    await syncAgents();
-    const agent = await getAgent(name);
+    await createAgent(name, content, repoPath);
+    await syncAgents(repoPath);
+    const agent = await getAgent(name, repoPath);
     res.status(201).json(agent);
   } catch (err) {
     sendDomainError(res, err);

--- a/server/routes/saved-files.ts
+++ b/server/routes/saved-files.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import { listSavedFiles, getSavedFile, putSavedFile } from '../saved-files.js';
+import { sendDomainError } from './_shared.js';
+
+export const router = express.Router();
+
+function decodeRepoPath(req: Request): string {
+  return decodeURIComponent((req.params as Record<string, string>).repoPath);
+}
+
+// GET /api/repos/:repoPath/files — list saved files under .octomux/files/
+router.get('/api/repos/:repoPath/files', async (req: Request, res: Response) => {
+  const repoPath = decodeRepoPath(req);
+  try {
+    const files = await listSavedFiles(repoPath);
+    res.json(files);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+// GET /api/repos/:repoPath/files/content?path=<rel> — read a saved file
+router.get('/api/repos/:repoPath/files/content', async (req: Request, res: Response) => {
+  const repoPath = decodeRepoPath(req);
+  const relPath = req.query.path as string | undefined;
+  if (!relPath) {
+    res.status(400).json({ error: 'path query parameter is required' });
+    return;
+  }
+  try {
+    const file = await getSavedFile(repoPath, relPath);
+    res.json(file);
+  } catch (err) {
+    sendDomainError(res, err);
+  }
+});
+
+// PUT /api/repos/:repoPath/files/content?path=<rel> — write a saved file
+router.put('/api/repos/:repoPath/files/content', async (req: Request, res: Response) => {
+  const repoPath = decodeRepoPath(req);
+  const relPath = req.query.path as string | undefined;
+  if (!relPath) {
+    res.status(400).json({ error: 'path query parameter is required' });
+    return;
+  }
+  const { content } = req.body as { content?: string };
+  if (content === undefined || content === null) {
+    res.status(400).json({ error: 'content is required' });
+    return;
+  }
+  try {
+    const file = await putSavedFile(repoPath, relPath, content);
+    res.json(file);
+  } catch (err) {
+    sendDomainError(res, err);
+  }
+});

--- a/server/routes/skills.ts
+++ b/server/routes/skills.ts
@@ -1,13 +1,25 @@
 import express from 'express';
 import type { Request, Response } from 'express';
-import { listSkills, getSkill, createSkill, updateSkill, deleteSkill } from '../skills.js';
+import {
+  listSkills,
+  getSkill,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  type SkillsOptions,
+} from '../skills.js';
 import { sendDomainError } from './_shared.js';
 
 export const router = express.Router();
 
-router.get('/api/skills', async (_req: Request, res: Response) => {
+function skillsOpts(req: Request): SkillsOptions | undefined {
+  const repoPath = req.query.repo_path as string | undefined;
+  return repoPath ? { repoPath } : undefined;
+}
+
+router.get('/api/skills', async (req: Request, res: Response) => {
   try {
-    const skills = await listSkills();
+    const skills = await listSkills(skillsOpts(req));
     res.json(skills);
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
@@ -16,7 +28,7 @@ router.get('/api/skills', async (_req: Request, res: Response) => {
 
 router.get('/api/skills/:name', async (req: Request, res: Response) => {
   try {
-    const skill = await getSkill(req.params.name as string);
+    const skill = await getSkill(req.params.name as string, skillsOpts(req));
     res.json(skill);
   } catch (err) {
     sendDomainError(res, err);
@@ -30,7 +42,7 @@ router.post('/api/skills', async (req: Request, res: Response) => {
     return;
   }
   try {
-    const skill = await createSkill(name, content || '');
+    const skill = await createSkill(name, content || '', skillsOpts(req));
     res.status(201).json(skill);
   } catch (err) {
     sendDomainError(res, err);
@@ -44,7 +56,7 @@ router.put('/api/skills/:name', async (req: Request, res: Response) => {
     return;
   }
   try {
-    const skill = await updateSkill(req.params.name as string, content);
+    const skill = await updateSkill(req.params.name as string, content, skillsOpts(req));
     res.json(skill);
   } catch (err) {
     sendDomainError(res, err);
@@ -53,7 +65,7 @@ router.put('/api/skills/:name', async (req: Request, res: Response) => {
 
 router.delete('/api/skills/:name', async (req: Request, res: Response) => {
   try {
-    await deleteSkill(req.params.name as string);
+    await deleteSkill(req.params.name as string, skillsOpts(req));
     res.status(204).send();
   } catch (err) {
     sendDomainError(res, err);

--- a/server/saved-files.test.ts
+++ b/server/saved-files.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  listSavedFiles,
+  getSavedFile,
+  putSavedFile,
+  resolveSavedFilePath,
+} from './saved-files.js';
+import { repoFilesDir } from './octomux-paths.js';
+
+describe('saved-files', () => {
+  const tmpDir = path.join(os.tmpdir(), `octomux-saved-files-${Date.now()}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('listSavedFiles returns [] when directory missing', async () => {
+    expect(await listSavedFiles(tmpDir)).toEqual([]);
+  });
+
+  it('put/get round-trip writes under .octomux/files/', async () => {
+    await putSavedFile(tmpDir, 'notes/todo.md', '# Todo\n- item');
+    const file = await getSavedFile(tmpDir, 'notes/todo.md');
+    expect(file.content).toBe('# Todo\n- item');
+    expect(fs.existsSync(path.join(repoFilesDir(tmpDir), 'notes', 'todo.md'))).toBe(true);
+  });
+
+  it('listSavedFiles returns nested files', async () => {
+    await putSavedFile(tmpDir, 'a.md', 'a');
+    await putSavedFile(tmpDir, 'dir/b.md', 'b');
+    const files = await listSavedFiles(tmpDir);
+    expect(files.map((f) => f.path)).toEqual(['a.md', 'dir/b.md']);
+  });
+
+  it('rejects path traversal', () => {
+    expect(resolveSavedFilePath(tmpDir, '../etc/passwd')).toEqual({
+      rejected: 'path traversal detected',
+    });
+  });
+
+  it('rejects disallowed extension', () => {
+    expect(resolveSavedFilePath(tmpDir, 'evil.exe')).toEqual({
+      rejected: 'extension ".exe" is not allowed; allowed: .md, .txt, .json, .yaml, .yml, .csv, .html',
+    });
+  });
+
+  it('getSavedFile throws for missing file', async () => {
+    await expect(getSavedFile(tmpDir, 'missing.md')).rejects.toThrow('File not found');
+  });
+});

--- a/server/saved-files.ts
+++ b/server/saved-files.ts
@@ -1,0 +1,164 @@
+import fs from 'fs';
+import path from 'path';
+import { childLogger } from './logger.js';
+import { repoFilesDir } from './octomux-paths.js';
+
+const logger = childLogger('saved-files');
+
+const MAX_FILE_BYTES = 1024 * 1024;
+
+const ALLOWED_EXTENSIONS = new Set([
+  '.md',
+  '.txt',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.csv',
+  '.html',
+]);
+
+export interface SavedFileEntry {
+  path: string;
+  size: number;
+}
+
+export interface SavedFileDetail {
+  path: string;
+  content: string;
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.promises.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate and resolve a relative path under `<repo>/.octomux/files/`.
+ * Rejects absolute paths, traversal, symlinks, and disallowed extensions.
+ */
+export function resolveSavedFilePath(
+  repoPath: string,
+  relPath: string,
+): { resolved: string; normalized: string } | { rejected: string } {
+  if (path.isAbsolute(relPath)) {
+    return { rejected: 'path must be relative, not absolute' };
+  }
+
+  const normalized = path.normalize(relPath).split(path.sep).join('/');
+  if (normalized.startsWith('..') || normalized.startsWith('/')) {
+    return { rejected: 'path traversal detected' };
+  }
+  if (!normalized) {
+    return { rejected: 'path is required' };
+  }
+
+  const ext = path.extname(normalized).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.has(ext)) {
+    return {
+      rejected: `extension "${ext}" is not allowed; allowed: ${[...ALLOWED_EXTENSIONS].join(', ')}`,
+    };
+  }
+
+  const root = repoFilesDir(repoPath);
+  const segments = normalized.split('/').filter(Boolean);
+  let current = root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        return { rejected: `symlink detected at path component "${segment}"` };
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') break;
+      throw err;
+    }
+  }
+
+  const resolved = path.join(root, ...segments);
+  const containmentBase = root.endsWith(path.sep) ? root : root + path.sep;
+  if (!resolved.startsWith(containmentBase) && resolved !== root) {
+    return { rejected: 'path escapes saved-files directory' };
+  }
+
+  return { resolved, normalized };
+}
+
+async function walkFiles(dir: string, prefix: string, out: SavedFileEntry[]): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const abs = path.join(dir, entry.name);
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      await walkFiles(abs, rel, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const stat = await fs.promises.stat(abs);
+    out.push({ path: rel, size: stat.size });
+  }
+}
+
+export async function listSavedFiles(repoPath: string): Promise<SavedFileEntry[]> {
+  const root = repoFilesDir(repoPath);
+  if (!(await exists(root))) return [];
+  const files: SavedFileEntry[] = [];
+  await walkFiles(root, '', files);
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export async function getSavedFile(repoPath: string, relPath: string): Promise<SavedFileDetail> {
+  const resolution = resolveSavedFilePath(repoPath, relPath);
+  if ('rejected' in resolution) {
+    throw new Error(resolution.rejected);
+  }
+
+  let content: string;
+  try {
+    content = await fs.promises.readFile(resolution.resolved, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw Object.assign(new Error(`File not found: ${relPath}`), { code: 'ENOENT' });
+    }
+    throw err;
+  }
+
+  if (Buffer.byteLength(content, 'utf-8') > MAX_FILE_BYTES) {
+    throw new Error(`File too large (max ${MAX_FILE_BYTES} bytes): ${relPath}`);
+  }
+
+  return { path: resolution.normalized, content };
+}
+
+export async function putSavedFile(
+  repoPath: string,
+  relPath: string,
+  content: string,
+): Promise<SavedFileDetail> {
+  if (Buffer.byteLength(content, 'utf-8') > MAX_FILE_BYTES) {
+    throw new Error(`Content too large (max ${MAX_FILE_BYTES} bytes)`);
+  }
+
+  const resolution = resolveSavedFilePath(repoPath, relPath);
+  if ('rejected' in resolution) {
+    throw new Error(resolution.rejected);
+  }
+
+  await fs.promises.mkdir(path.dirname(resolution.resolved), { recursive: true });
+  await fs.promises.writeFile(resolution.resolved, content, 'utf-8');
+  logger.info({ repo_path: repoPath, path: resolution.normalized }, 'saved file written');
+  return { path: resolution.normalized, content };
+}

--- a/server/skills.repo.test.ts
+++ b/server/skills.repo.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { listSkills, getSkill, syncSkills } from './skills.js';
+import { repoSkillsDir } from './octomux-paths.js';
+
+describe('skills repo precedence', () => {
+  const repoDir = path.join(os.tmpdir(), `octomux-skills-repo-${Date.now()}`);
+
+  beforeEach(() => {
+    fs.mkdirSync(path.join(repoDir, '.octomux', 'skills', 'repo-skill'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, '.octomux', 'skills', 'repo-skill', 'SKILL.md'),
+      '---\ndescription: From repo\n---\n# Repo skill',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('listSkills includes repo skills when repoPath is set', async () => {
+    const skills = await listSkills({ repoPath: repoDir });
+    expect(skills.some((s) => s.name === 'repo-skill')).toBe(true);
+    const repoSkill = skills.find((s) => s.name === 'repo-skill');
+    expect(repoSkill?.description).toBe('From repo');
+  });
+
+  it('getSkill reads repo skill without home copy', async () => {
+    const skill = await getSkill('repo-skill', { repoPath: repoDir });
+    expect(skill.content).toContain('# Repo skill');
+    expect(fs.existsSync(path.join(repoSkillsDir(repoDir), 'repo-skill', 'SKILL.md'))).toBe(true);
+  });
+
+  it('syncSkills mirrors effective skills into worktree .claude/skills', async () => {
+    const worktree = path.join(os.tmpdir(), `octomux-skills-wt-${Date.now()}`);
+    fs.mkdirSync(worktree, { recursive: true });
+    fs.mkdirSync(path.join(worktree, '.octomux', 'skills', 'repo-skill'), { recursive: true });
+    fs.writeFileSync(
+      path.join(worktree, '.octomux', 'skills', 'repo-skill', 'SKILL.md'),
+      '---\ndescription: Sync me\n---\n# Synced',
+    );
+
+    await syncSkills(worktree);
+
+    const synced = path.join(worktree, '.claude', 'skills', 'repo-skill', 'SKILL.md');
+    expect(fs.existsSync(synced)).toBe(true);
+    expect(fs.readFileSync(synced, 'utf-8')).toContain('# Synced');
+
+    fs.rmSync(worktree, { recursive: true, force: true });
+  });
+});

--- a/server/skills.test.ts
+++ b/server/skills.test.ts
@@ -190,7 +190,7 @@ describe('getSkill', () => {
   });
 
   it('throws on missing skill', async () => {
-    vi.mocked(fs.promises.access).mockRejectedValue(new Error('ENOENT'));
+    vi.mocked(fs.promises.readFile).mockRejectedValue(enoent());
 
     await expect(getSkill('nonexistent')).rejects.toThrow('Skill not found: nonexistent');
   });

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -1,7 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { childLogger } from './logger.js';
+import {
+  builtInSkillsDir,
+  homeSkillsDir,
+  repoSkillsDir,
+} from './octomux-paths.js';
 
 const logger = childLogger('skills');
 
@@ -15,11 +19,12 @@ export interface SkillDetail {
   content: string;
 }
 
-const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
-
-function skillsDir(): string {
-  return path.join(os.homedir(), '.claude', 'skills');
+export interface SkillsOptions {
+  /** When set, repo `.octomux/skills/` takes precedence over home and built-in. */
+  repoPath?: string;
 }
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 function validateName(name: string): void {
   if (name === '..' || name.includes('..') || !NAME_RE.test(name)) {
@@ -44,52 +49,88 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
-export async function listSkills(): Promise<Skill[]> {
-  const dir = skillsDir();
+function writeSkillsDir(opts?: SkillsOptions): string {
+  return opts?.repoPath ? repoSkillsDir(opts.repoPath) : homeSkillsDir();
+}
 
-  await fs.promises.mkdir(dir, { recursive: true });
-
+async function listSkillNamesInDir(dir: string): Promise<string[]> {
+  if (!(await exists(dir))) return [];
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
-  const skills: Skill[] = [];
-
+  const names: string[] = [];
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith('.')) continue;
-    const skillFile = path.join(dir, entry.name, 'SKILL.md');
-    try {
-      const content = await fs.promises.readFile(skillFile, 'utf-8');
-      skills.push({ name: entry.name, description: parseDescription(content) });
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT' || code === 'EISDIR') {
-        logger.warn({ skill: entry.name, code }, 'skipping dir without readable SKILL.md');
-        continue;
-      }
-      throw err;
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+    names.push(entry.name);
+  }
+  return names;
+}
+
+async function readSkillContent(skillsRoot: string, name: string): Promise<string | null> {
+  const skillFile = path.join(skillsRoot, name, 'SKILL.md');
+  try {
+    return await fs.promises.readFile(skillFile, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'EISDIR') {
+      logger.warn({ skill: name, code, skills_root: skillsRoot }, 'skipping dir without readable SKILL.md');
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** Loader precedence: repo → home → built-in (later sources override earlier). */
+function skillSourceDirs(opts?: SkillsOptions): string[] {
+  const dirs: string[] = [builtInSkillsDir(), homeSkillsDir()];
+  if (opts?.repoPath) dirs.push(repoSkillsDir(opts.repoPath));
+  return dirs;
+}
+
+export async function listSkills(opts?: SkillsOptions): Promise<Skill[]> {
+  const homeDir = homeSkillsDir();
+  if (!opts?.repoPath) {
+    await fs.promises.mkdir(homeDir, { recursive: true });
+  }
+
+  const byName = new Map<string, Skill>();
+  for (const dir of skillSourceDirs(opts)) {
+    for (const name of await listSkillNamesInDir(dir)) {
+      const content = await readSkillContent(dir, name);
+      if (content === null) continue;
+      byName.set(name, { name, description: parseDescription(content) });
     }
   }
 
-  return skills.sort((a, b) => a.name.localeCompare(b.name));
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function getSkill(name: string): Promise<SkillDetail> {
+async function resolveSkillContent(name: string, opts?: SkillsOptions): Promise<string | null> {
+  const dirs = [...skillSourceDirs(opts)].reverse();
+  for (const dir of dirs) {
+    const content = await readSkillContent(dir, name);
+    if (content !== null) return content;
+  }
+  return null;
+}
+
+export async function getSkill(name: string, opts?: SkillsOptions): Promise<SkillDetail> {
   validateName(name);
 
-  const dir = skillsDir();
-  const skillDir = path.join(dir, name);
-
-  if (!(await exists(skillDir))) {
+  const content = await resolveSkillContent(name, opts);
+  if (content === null) {
     throw new Error(`Skill not found: ${name}`);
   }
 
-  const content = await fs.promises.readFile(path.join(skillDir, 'SKILL.md'), 'utf-8');
   return { name, content };
 }
 
-export async function createSkill(name: string, content: string): Promise<SkillDetail> {
+export async function createSkill(
+  name: string,
+  content: string,
+  opts?: SkillsOptions,
+): Promise<SkillDetail> {
   validateName(name);
 
-  const dir = skillsDir();
+  const dir = writeSkillsDir(opts);
   const skillDir = path.join(dir, name);
 
   if (await exists(skillDir)) {
@@ -102,10 +143,14 @@ export async function createSkill(name: string, content: string): Promise<SkillD
   return { name, content };
 }
 
-export async function updateSkill(name: string, content: string): Promise<SkillDetail> {
+export async function updateSkill(
+  name: string,
+  content: string,
+  opts?: SkillsOptions,
+): Promise<SkillDetail> {
   validateName(name);
 
-  const dir = skillsDir();
+  const dir = writeSkillsDir(opts);
   const skillDir = path.join(dir, name);
 
   if (!(await exists(skillDir))) {
@@ -116,10 +161,10 @@ export async function updateSkill(name: string, content: string): Promise<SkillD
   return { name, content };
 }
 
-export async function deleteSkill(name: string): Promise<void> {
+export async function deleteSkill(name: string, opts?: SkillsOptions): Promise<void> {
   validateName(name);
 
-  const dir = skillsDir();
+  const dir = writeSkillsDir(opts);
   const skillDir = path.join(dir, name);
 
   if (!(await exists(skillDir))) {
@@ -127,4 +172,22 @@ export async function deleteSkill(name: string): Promise<void> {
   }
 
   await fs.promises.rm(skillDir, { recursive: true });
+}
+
+/**
+ * Mirror effective skills (repo → home → built-in) into `<worktree>/.claude/skills/`
+ * so Claude Code resolves them in the worktree without touching `~/.claude/skills`.
+ */
+export async function syncSkills(worktreePath: string): Promise<void> {
+  const targetDir = path.join(worktreePath, '.claude', 'skills');
+  await fs.promises.mkdir(targetDir, { recursive: true });
+
+  const opts: SkillsOptions = { repoPath: worktreePath };
+  const skills = await listSkills(opts);
+  for (const skill of skills) {
+    const detail = await getSkill(skill.name, opts);
+    const skillDir = path.join(targetDir, skill.name);
+    await fs.promises.mkdir(skillDir, { recursive: true });
+    await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), detail.content, 'utf-8');
+  }
 }

--- a/server/task-engine/lifecycle.ts
+++ b/server/task-engine/lifecycle.ts
@@ -15,6 +15,7 @@ import { broadcast } from '../events.js';
 import type { RepoConfig } from '../repositories/repo-config.js';
 import type { Task, Agent, RunMode, Worktree } from '../types.js';
 import { chatDirFor, chatSessionName } from '../chats.js';
+import { syncSkills } from '../skills.js';
 import {
   setRuntimeState,
   updateTaskFields,
@@ -208,6 +209,7 @@ async function prepareFirstAgentLaunch(
   const { sessionIdForDb, sessionIdForLaunch } = computeFreshSessionIds(harness);
 
   await harness.syncAgents(setup.worktreePath);
+  await syncSkills(setup.worktreePath);
   await harness.installHooks(setup.worktreePath, hookBaseUrl(), hookToken);
 
   // For orchestrator-managed tasks, write a worker mcp-config.json and append
@@ -415,6 +417,7 @@ export async function addAgent(task: Task, opts: AddAgentOpts = {}): Promise<Age
 
   // Hooks on disk before the window launches the harness (starts on pane create).
   await harness.syncAgents(task.worktree!);
+  await syncSkills(task.worktree!);
   await harness.installHooks(task.worktree!, hookBaseUrl(), hookToken);
 
   const baseCmd = harness.buildLaunchCommand({
@@ -550,6 +553,7 @@ export async function resumeTask(task: Task): Promise<void> {
     if (agents.length > 0) {
       const bootstrapHarness = getHarness(agents[0]!.harness_id);
       await bootstrapHarness.syncAgents(cwd);
+      await syncSkills(cwd);
       await bootstrapHarness.installHooks(cwd, hookBaseUrl(), agents[0]!.hook_token);
     } else {
       // No agents to recover, but recreate the session so callers that expect
@@ -694,6 +698,7 @@ export async function hopAgent(agent: Agent, targetTaskId: string | null): Promi
 
   // Hooks on disk before the window launches the harness (starts on pane create).
   await harness.syncAgents(cwd);
+  await syncSkills(cwd);
   await harness.installHooks(cwd, hookBaseUrl(), agent.hook_token);
 
   const baseCmd = prepareResumeLaunch({ agent, harness, flags, model: hopModel, cwd });

--- a/spec/repo-portable.md
+++ b/spec/repo-portable.md
@@ -1,0 +1,64 @@
+# Repo-portable skills, agents, and saved files (SHR-184)
+
+octomux stores repo-local configuration under `<repo>/.octomux/`. Skills and agents
+use a three-tier loader; saved files use a single documented directory with REST
+and CLI access.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `<repo>/.octomux/skills/<name>/SKILL.md` | Repo-portable skills (version-controlled) |
+| `<repo>/.octomux/agents/<name>.md` | Repo-portable agent definitions |
+| `<repo>/.octomux/files/**` | Saved files / lightweight memory (plain text) |
+
+Home and package defaults still apply:
+
+| Path | Purpose |
+|------|---------|
+| `~/.claude/skills/<name>/SKILL.md` | User-global skills |
+| `$OCTOMUX_AGENTS_DIR` or `~/.octomux/agents/<name>.md` | User-global agent overrides |
+| `<octomux-package>/skills/` | Built-in skills shipped with octomux |
+| `<octomux-package>/agents/` | Built-in agent definitions |
+
+## Loader precedence
+
+For both skills and agents:
+
+1. **Repo** — `<repo>/.octomux/...` (highest)
+2. **Home** — `~/.claude/skills` or `~/.octomux/agents`
+3. **Built-in** — package `skills/` and `agents/` dirs
+
+On task launch, effective skills are mirrored to `<worktree>/.claude/skills/` and
+agents to `<worktree>/.claude/agents/` (or Cursor rules) so harnesses resolve them
+without writing to `~/.claude`.
+
+Optional `repo_path` query parameter on skills/agents REST endpoints scopes reads and
+writes to the repo tier.
+
+## Saved files API
+
+**Location:** `<repo>/.octomux/files/` (created on first write).
+
+Allowed extensions: `.md`, `.txt`, `.json`, `.yaml`, `.yml`, `.csv`, `.html`.
+Max file size: 1 MiB. Paths must be relative; traversal and symlinks are rejected.
+
+### REST
+
+```
+GET  /api/repos/:repoPath/files
+GET  /api/repos/:repoPath/files/content?path=<rel>
+PUT  /api/repos/:repoPath/files/content?path=<rel>   body: { "content": "..." }
+```
+
+`:repoPath` is URL-encoded (same pattern as `/api/repos/:repoPath/learnings`).
+
+### CLI
+
+```
+octomux files list [-r <repo>]
+octomux files get <path> [-r <repo>]
+octomux files put <path> [-r <repo>] [-c <content>]
+```
+
+`-r` defaults to the current working directory.


### PR DESCRIPTION
## What

- Add repo → home → built-in loader precedence for skills (`.octomux/skills/`, `~/.claude/skills/`, package `skills/`) and agents (`.octomux/agents/`, home overrides, package `agents/`)
- Mirror effective skills into `<worktree>/.claude/skills/` on task launch so repo skills work without touching `~/.claude`
- Add saved-files API over `<repo>/.octomux/files/` — REST (`list` / `get` / `put`) and CLI (`octomux files list|get|put`)
- Document layout and API in `spec/repo-portable.md`

## Why

Skills, agents, and lightweight memory were fragmented across home dirs and on-demand discovery, which blocked version control and CI portability. SHR-184 (Modular 11) unifies these under repo-local `.octomux/` with a single documented files API.

Resolves SHR-184

## Testing

- `bun run test` — 3332 passed
- `bun run typecheck` — clean
- `bun run lint` — clean (pre-existing warnings only)