### PR TITLE
refactor(orchestrator): route conductor launch through harness

### DIFF
--- a/server/agents.test.ts
+++ b/server/agents.test.ts
@@ -71,10 +71,7 @@ describe('agents', () => {
       const repoDir = path.join(os.tmpdir(), `octomux-agents-repo-${Date.now()}`);
       fs.mkdirSync(path.join(repoDir, '.octomux', 'agents'), { recursive: true });
       fs.writeFileSync(path.join(tmpDir, 'orchestrator.md'), 'Home prompt');
-      fs.writeFileSync(
-        path.join(repoDir, '.octomux', 'agents', 'orchestrator.md'),
-        'Repo prompt',
-      );
+      fs.writeFileSync(path.join(repoDir, '.octomux', 'agents', 'orchestrator.md'), 'Repo prompt');
 
       const agent = await getAgent('orchestrator', repoDir);
       expect(agent.content).toBe('Repo prompt');

--- a/server/agents.ts
+++ b/server/agents.ts
@@ -1,10 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  builtInAgentsDir,
-  homeAgentsDir,
-  repoAgentsDir,
-} from './octomux-paths.js';
+import { builtInAgentsDir, homeAgentsDir, repoAgentsDir } from './octomux-paths.js';
 
 export interface AgentDefinition {
   name: string;
@@ -131,11 +127,7 @@ export async function resetAgent(name: string, repoPath?: string): Promise<void>
   }
 }
 
-export async function createAgent(
-  name: string,
-  content: string,
-  repoPath?: string,
-): Promise<void> {
+export async function createAgent(name: string, content: string, repoPath?: string): Promise<void> {
   const customPath = path.join(writeAgentsDir(repoPath), `${name}.md`);
   if (await exists(customPath)) {
     throw new Error(`Agent already exists: ${name}`);

--- a/server/orchestrator/conductor-flags.test.ts
+++ b/server/orchestrator/conductor-flags.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { claudeCodeHarness } from '../harnesses/claude-code.js';
+import {
+  buildOrchestratorConductorFlags,
+  ORCHESTRATOR_SYSTEM_PROMPT,
+} from './conductor-flags.js';
+
+describe('buildOrchestratorConductorFlags', () => {
+  it('includes --settings, --append-system-prompt, and optional MCP flags', () => {
+    const flags = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/orch/settings.local.json',
+      mcpConfigPath: '/tmp/orch/mcp-config.json',
+      extraFlags: '--verbose',
+    });
+
+    expect(flags).toContain('--settings');
+    expect(flags).toContain('/tmp/orch/settings.local.json');
+    expect(flags).toContain('--mcp-config');
+    expect(flags).toContain('--strict-mcp-config');
+    expect(flags).toContain('/tmp/orch/mcp-config.json');
+    expect(flags).toContain('--append-system-prompt');
+    expect(flags).toContain(ORCHESTRATOR_SYSTEM_PROMPT.slice(0, 40));
+    expect(flags).toContain('--verbose');
+  });
+
+  it('omits MCP flags when mcpConfigPath is null', () => {
+    const flags = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: null,
+    });
+
+    expect(flags).not.toContain('--mcp-config');
+    expect(flags).not.toContain('--strict-mcp-config');
+  });
+
+  it('routes through harness buildLaunchCommand with orchestrator flags', () => {
+    const flags = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: '/tmp/mcp-config.json',
+    });
+    const cmd = claudeCodeHarness.buildLaunchCommand({ sessionId: 'sess-1', flags });
+
+    expect(cmd).toBe(
+      `claude --session-id sess-1 --settings '/tmp/settings.local.json' --mcp-config '/tmp/mcp-config.json' --strict-mcp-config --append-system-prompt '${ORCHESTRATOR_SYSTEM_PROMPT.replace(/'/g, `'\\''`)}'`,
+    );
+  });
+
+  it('routes through harness buildResumeCommand with orchestrator flags', () => {
+    const flags = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: '/tmp/mcp-config.json',
+    });
+    const cmd = claudeCodeHarness.buildResumeCommand({ sessionId: 'sess-1', flags });
+
+    expect(cmd).toContain('claude --resume sess-1');
+    expect(cmd).toContain('--settings');
+    expect(cmd).toContain('--strict-mcp-config');
+    expect(cmd).toContain('--append-system-prompt');
+  });
+});

--- a/server/orchestrator/conductor-flags.ts
+++ b/server/orchestrator/conductor-flags.ts
@@ -1,0 +1,65 @@
+import { shellQuoteSingle } from '../shell-quote.js';
+
+/**
+ * The conductor's role, appended to the harness CLI via `--append-system-prompt`.
+ * Establishes the orchestrator as a thin coordination layer that DELEGATES work
+ * to octomux worker tasks rather than doing the work itself.
+ */
+export const ORCHESTRATOR_SYSTEM_PROMPT = [
+  'You are the octomux ORCHESTRATOR (the conductor). Your job is to COORDINATE work — never to do it yourself.',
+  '',
+  'HARD RULES:',
+  '- NEVER implement work yourself. Do not write code, edit files, run git, or modify anything. You have no Edit/Write tools by design — that is intentional.',
+  '- DELEGATE every task to an octomux worker using your MCP tools. Do NOT plan the implementation yourself — you have not read the code, so any step-by-step plan you write will be stale or wrong, and it duplicates the planning the worker will redo on the ground.',
+  '    Call mcp__octomux__create_task({ title, description, repo_path, base_branch?, kind? }) — it runs immediately (no approval) and returns the task id.',
+  '',
+  'WRITE A GOAL-ORIENTED BRIEF, NOT A PLAN. The task description tells the worker WHAT to achieve and WHY — never the HOW (no "step 1, step 2, edit file X"). A capable worker owns the implementation. Use this shape:',
+  '  ## Goal — 1-2 sentences: the outcome/capability that should exist when done.',
+  '  ## Why / Context — intent and how it fits, so the worker makes sound tradeoffs itself.',
+  '  ## Acceptance criteria — VERIFIABLE: passing tests / build+lint green / concrete example cases / an end-to-end check that proves it works, plus what evidence to show.',
+  "  ## Hard constraints — non-negotiables (don't break API X, no new deps, follow CLAUDE.md).",
+  '  ## Non-goals — explicitly what NOT to touch (prevents scope-creep).',
+  '  ## Pointers — orientation only: "follow the pattern in src/auth/" — NEVER a procedure.',
+  'Put your precision into the acceptance criteria, not into steps.',
+  '',
+  "- PLANNING is the WORKER's job, not yours. Choose the right kind for the work:",
+  '    kind:"workflow" — for non-trivial work (anything beyond a one-liner). The worker runs spec→plan→implement in ONE session with two human review gates: a read-only spec card (review, no decision needed — planning auto-starts), then a plan-approval card (approve to implement). Use this for features, refactors, or anything requiring thought.',
+  '    kind:"plan" — for plan-only or moderately ambiguous work where you just want to see the plan before implementation (same approval gate, but no separate spec phase).',
+  '    omit kind — for small/clear work (a one-sentence diff); the worker implements directly.',
+  '- All other actions are MCP tools too: mcp__octomux__send_message, mcp__octomux__set_task_status, mcp__octomux__add_agent, mcp__octomux__close_task, mcp__octomux__delete_task. Use them instead of any octomux CLI command.',
+  '- TRACK progress with your read tools only: mcp__octomux__list_tasks, mcp__octomux__get_task, mcp__octomux__monitor_status, mcp__octomux__get_task_output. Do not read or edit the repo directly — inspect tasks and their artifacts through these tools.',
+  '- KEEP THE USER INFORMED: when you create a task, tell them its id and the goal; when a worker finishes a phase, summarize the outcome and propose the next step.',
+  '',
+  'You are a thin coordination layer: set the goal, delegate, track it, report status. Never plan the implementation, never touch the code.',
+].join('\n');
+
+export interface OrchestratorConductorFlagsOpts {
+  settingsPath: string;
+  /** Path to the conductor mcp-config.json (octomux read tools), or null. */
+  mcpConfigPath?: string | null;
+  extraFlags?: string;
+}
+
+/**
+ * Build harness `flags` for orchestrator conductor launch/resume.
+ *
+ * Uses the DEFAULT config dir so the user's subscription OAuth applies — tool
+ * isolation is via `--settings <file>` (gate hook + read-only allowlist), not a
+ * separate config home. `--mcp-config` with `--strict-mcp-config` limits the
+ * session to ONLY the conductor's MCP servers.
+ */
+export function buildOrchestratorConductorFlags({
+  settingsPath,
+  mcpConfigPath,
+  extraFlags = '',
+}: OrchestratorConductorFlagsOpts): string {
+  let flags = ` --settings ${shellQuoteSingle(settingsPath)}`;
+  if (mcpConfigPath) {
+    flags += ` --mcp-config ${shellQuoteSingle(mcpConfigPath)} --strict-mcp-config`;
+  }
+  flags += ` --append-system-prompt ${shellQuoteSingle(ORCHESTRATOR_SYSTEM_PROMPT)}`;
+  if (extraFlags) {
+    flags += extraFlags.startsWith(' ') ? extraFlags : ` ${extraFlags}`;
+  }
+  return flags;
+}

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -35,6 +35,8 @@ import { execTmux } from '../tmux-bin.js';
 import { hookBaseUrl } from '../hook-base-url.js';
 import { octomuxRoot } from '../octomux-root.js';
 import { childLogger } from '../logger.js';
+import { DEFAULT_HARNESS_ID, getHarness } from '../harnesses/index.js';
+import { buildOrchestratorConductorFlags } from './conductor-flags.js';
 import {
   getConversation,
   updateConversation,
@@ -55,44 +57,6 @@ const CAPTURE_PANE_POLL_MS = 50;
 const PASTE_TO_ENTER_MIN_DELAY_MS = 50;
 /** Delay after --resume auto-turn before we allow real turns to be sent. */
 export const RESUME_QUIET_WINDOW_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
-
-// ─── Orchestrator role (system prompt) ──────────────────────────────────────
-
-/**
- * The conductor's role, appended to claude's default system prompt via
- * `--append-system-prompt`. It establishes the orchestrator as a thin
- * coordination layer that DELEGATES work to octomux worker tasks rather than
- * doing the work itself. Paired with the `permissions.deny` mutation block, this
- * fixes the conductor editing the repo directly instead of creating + tracking a
- * worker task.
- */
-const ORCHESTRATOR_SYSTEM_PROMPT = [
-  'You are the octomux ORCHESTRATOR (the conductor). Your job is to COORDINATE work — never to do it yourself.',
-  '',
-  'HARD RULES:',
-  '- NEVER implement work yourself. Do not write code, edit files, run git, or modify anything. You have no Edit/Write tools by design — that is intentional.',
-  '- DELEGATE every task to an octomux worker using your MCP tools. Do NOT plan the implementation yourself — you have not read the code, so any step-by-step plan you write will be stale or wrong, and it duplicates the planning the worker will redo on the ground.',
-  '    Call mcp__octomux__create_task({ title, description, repo_path, base_branch?, kind? }) — it runs immediately (no approval) and returns the task id.',
-  '',
-  'WRITE A GOAL-ORIENTED BRIEF, NOT A PLAN. The task description tells the worker WHAT to achieve and WHY — never the HOW (no "step 1, step 2, edit file X"). A capable worker owns the implementation. Use this shape:',
-  '  ## Goal — 1-2 sentences: the outcome/capability that should exist when done.',
-  '  ## Why / Context — intent and how it fits, so the worker makes sound tradeoffs itself.',
-  '  ## Acceptance criteria — VERIFIABLE: passing tests / build+lint green / concrete example cases / an end-to-end check that proves it works, plus what evidence to show.',
-  "  ## Hard constraints — non-negotiables (don't break API X, no new deps, follow CLAUDE.md).",
-  '  ## Non-goals — explicitly what NOT to touch (prevents scope-creep).',
-  '  ## Pointers — orientation only: "follow the pattern in src/auth/" — NEVER a procedure.',
-  'Put your precision into the acceptance criteria, not into steps.',
-  '',
-  "- PLANNING is the WORKER's job, not yours. Choose the right kind for the work:",
-  '    kind:"workflow" — for non-trivial work (anything beyond a one-liner). The worker runs spec→plan→implement in ONE session with two human review gates: a read-only spec card (review, no decision needed — planning auto-starts), then a plan-approval card (approve to implement). Use this for features, refactors, or anything requiring thought.',
-  '    kind:"plan" — for plan-only or moderately ambiguous work where you just want to see the plan before implementation (same approval gate, but no separate spec phase).',
-  '    omit kind — for small/clear work (a one-sentence diff); the worker implements directly.',
-  '- All other actions are MCP tools too: mcp__octomux__send_message, mcp__octomux__set_task_status, mcp__octomux__add_agent, mcp__octomux__close_task, mcp__octomux__delete_task. Use them instead of any octomux CLI command.',
-  '- TRACK progress with your read tools only: mcp__octomux__list_tasks, mcp__octomux__get_task, mcp__octomux__monitor_status, mcp__octomux__get_task_output. Do not read or edit the repo directly — inspect tasks and their artifacts through these tools.',
-  '- KEEP THE USER INFORMED: when you create a task, tell them its id and the goal; when a worker finishes a phase, summarize the outcome and propose the next step.',
-  '',
-  'You are a thin coordination layer: set the goal, delegate, track it, report status. Never plan the implementation, never touch the code.',
-].join('\n');
 
 // ─── Config dir ───────────────────────────────────────────────────────────────
 
@@ -331,15 +295,15 @@ export async function startConversation(
 
   const sessionName = orchestratorSessionName(convId);
 
-  // Generate a fresh session id for this new conversation
-  const sessionId = crypto.randomUUID();
-
-  const claudeCmd = buildLaunchCommand({
-    sessionId,
+  const harness = getHarness(DEFAULT_HARNESS_ID);
+  const sessionId = harness.newSessionId();
+  const flags = buildOrchestratorConductorFlags({
     settingsPath,
     mcpConfigPath,
     extraFlags: opts.extraFlags,
   });
+
+  const claudeCmd = harness.buildLaunchCommand({ sessionId, flags });
   const shell = process.env.SHELL || '/bin/sh';
   const script = `${claudeCmd}; exec ${shell} -i`;
   const startupCmd = `${shell} -ic '${script.replace(/'/g, "'\\''")}'`;
@@ -403,25 +367,22 @@ export async function resumeConversation(
 
   const sessionName = orchestratorSessionName(convId);
 
+  const harness = getHarness(DEFAULT_HARNESS_ID);
+  const flags = buildOrchestratorConductorFlags({
+    settingsPath,
+    mcpConfigPath,
+    extraFlags: opts.extraFlags,
+  });
+
   const claudeSessionId = opts.claudeSessionId ?? conv.claude_session_id;
 
   let claudeCmd: string;
   if (claudeSessionId) {
-    claudeCmd = buildResumeCommand({
-      sessionId: claudeSessionId,
-      settingsPath,
-      mcpConfigPath,
-      extraFlags: opts.extraFlags,
-    });
+    claudeCmd = harness.buildResumeCommand({ sessionId: claudeSessionId, flags });
   } else {
     // No session id → fresh start (fallback)
-    const newSessionId = crypto.randomUUID();
-    claudeCmd = buildLaunchCommand({
-      sessionId: newSessionId,
-      settingsPath,
-      mcpConfigPath,
-      extraFlags: opts.extraFlags,
-    });
+    const newSessionId = harness.newSessionId();
+    claudeCmd = harness.buildLaunchCommand({ sessionId: newSessionId, flags });
     updateConversation(convId, {
       claude_session_id: newSessionId,
       transcript_path: transcriptPathFor(cwd, newSessionId),
@@ -590,65 +551,6 @@ async function isConversationSessionAlive(conv: OrchestratorConversation): Promi
   }
 }
 
-interface LaunchOpts {
-  sessionId: string;
-  settingsPath: string;
-  /** Path to the conductor mcp-config.json (octomux read tools), or null. */
-  mcpConfigPath?: string | null;
-  extraFlags?: string;
-}
-
-interface ResumeOpts {
-  sessionId: string;
-  settingsPath: string;
-  /** Path to the conductor mcp-config.json (octomux read tools), or null. */
-  mcpConfigPath?: string | null;
-  extraFlags?: string;
-}
-
-/**
- * Build the `--mcp-config <file> --strict-mcp-config` flag fragment. `--strict`
- * limits the session to ONLY this config's servers (ignores the user's global
- * ~/.claude MCP servers) — the conductor gets exactly octomux's read tools.
- */
-function mcpConfigFlags(mcpConfigPath?: string | null): string {
-  if (!mcpConfigPath) return '';
-  return ` --mcp-config ${shellQuoteSingle(mcpConfigPath)} --strict-mcp-config`;
-}
-
-/**
- * Build the `claude --session-id <id>` launch command.
- *
- * Uses the DEFAULT config dir so the user's subscription OAuth applies — an
- * isolated `CLAUDE_CONFIG_DIR` logs the session out (verified end-to-end). Tool
- * isolation is via `--settings <file>` (gate hook + read-only allowlist), not a
- * separate config home. (`--config-dir` is not a real claude flag — it was
- * rejected with "unknown option".)
- */
-function buildLaunchCommand({
-  sessionId,
-  settingsPath,
-  mcpConfigPath,
-  extraFlags = '',
-}: LaunchOpts): string {
-  return `claude --session-id ${sessionId} --settings ${shellQuoteSingle(settingsPath)}${mcpConfigFlags(mcpConfigPath)}${orchestratorRoleFlag()}${extraFlags ? ` ${extraFlags}` : ''}`;
-}
-
-/** Build the `claude --resume <id>` command (default config dir + `--settings`). */
-function buildResumeCommand({
-  sessionId,
-  settingsPath,
-  mcpConfigPath,
-  extraFlags = '',
-}: ResumeOpts): string {
-  return `claude --resume ${sessionId} --settings ${shellQuoteSingle(settingsPath)}${mcpConfigFlags(mcpConfigPath)}${orchestratorRoleFlag()}${extraFlags ? ` ${extraFlags}` : ''}`;
-}
-
-/** The `--append-system-prompt` flag carrying the orchestrator role. */
-function orchestratorRoleFlag(): string {
-  return ` --append-system-prompt ${shellQuoteSingle(ORCHESTRATOR_SYSTEM_PROMPT)}`;
-}
-
 /**
  * Derive the transcript path Claude Code writes under the default config dir:
  * `~/.claude/projects/<cwd-with-non-alnum-as-dash>/<session-id>.jsonl`.
@@ -668,11 +570,6 @@ export function transcriptPathFor(cwd: string, sessionId: string): string {
   }
   const encoded = realCwd.replace(/[^a-zA-Z0-9]/g, '-');
   return path.join(home, '.claude', 'projects', encoded, `${sessionId}.jsonl`);
-}
-
-/** Single-quote a string safe for use inside a shell command. */
-function shellQuoteSingle(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 /**

--- a/server/saved-files.test.ts
+++ b/server/saved-files.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import {
-  listSavedFiles,
-  getSavedFile,
-  putSavedFile,
-  resolveSavedFilePath,
-} from './saved-files.js';
+import { listSavedFiles, getSavedFile, putSavedFile, resolveSavedFilePath } from './saved-files.js';
 import { repoFilesDir } from './octomux-paths.js';
 
 describe('saved-files', () => {
@@ -47,7 +42,8 @@ describe('saved-files', () => {
 
   it('rejects disallowed extension', () => {
     expect(resolveSavedFilePath(tmpDir, 'evil.exe')).toEqual({
-      rejected: 'extension ".exe" is not allowed; allowed: .md, .txt, .json, .yaml, .yml, .csv, .html',
+      rejected:
+        'extension ".exe" is not allowed; allowed: .md, .txt, .json, .yaml, .yml, .csv, .html',
     });
   });
 

--- a/server/saved-files.ts
+++ b/server/saved-files.ts
@@ -7,15 +7,7 @@ const logger = childLogger('saved-files');
 
 const MAX_FILE_BYTES = 1024 * 1024;
 
-const ALLOWED_EXTENSIONS = new Set([
-  '.md',
-  '.txt',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.csv',
-  '.html',
-]);
+const ALLOWED_EXTENSIONS = new Set(['.md', '.txt', '.json', '.yaml', '.yml', '.csv', '.html']);
 
 export interface SavedFileEntry {
   path: string;

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -1,11 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { childLogger } from './logger.js';
-import {
-  builtInSkillsDir,
-  homeSkillsDir,
-  repoSkillsDir,
-} from './octomux-paths.js';
+import { builtInSkillsDir, homeSkillsDir, repoSkillsDir } from './octomux-paths.js';
 
 const logger = childLogger('skills');
 
@@ -71,7 +67,10 @@ async function readSkillContent(skillsRoot: string, name: string): Promise<strin
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT' || code === 'EISDIR') {
-      logger.warn({ skill: name, code, skills_root: skillsRoot }, 'skipping dir without readable SKILL.md');
+      logger.warn(
+        { skill: name, code, skills_root: skillsRoot },
+        'skipping dir without readable SKILL.md',
+      );
       return null;
     }
     throw err;

--- a/spec/repo-portable.md
+++ b/spec/repo-portable.md
@@ -6,20 +6,20 @@ and CLI access.
 
 ## Layout
 
-| Path | Purpose |
-|------|---------|
-| `<repo>/.octomux/skills/<name>/SKILL.md` | Repo-portable skills (version-controlled) |
-| `<repo>/.octomux/agents/<name>.md` | Repo-portable agent definitions |
-| `<repo>/.octomux/files/**` | Saved files / lightweight memory (plain text) |
+| Path                                     | Purpose                                       |
+| ---------------------------------------- | --------------------------------------------- |
+| `<repo>/.octomux/skills/<name>/SKILL.md` | Repo-portable skills (version-controlled)     |
+| `<repo>/.octomux/agents/<name>.md`       | Repo-portable agent definitions               |
+| `<repo>/.octomux/files/**`               | Saved files / lightweight memory (plain text) |
 
 Home and package defaults still apply:
 
-| Path | Purpose |
-|------|---------|
-| `~/.claude/skills/<name>/SKILL.md` | User-global skills |
-| `$OCTOMUX_AGENTS_DIR` or `~/.octomux/agents/<name>.md` | User-global agent overrides |
-| `<octomux-package>/skills/` | Built-in skills shipped with octomux |
-| `<octomux-package>/agents/` | Built-in agent definitions |
+| Path                                                   | Purpose                              |
+| ------------------------------------------------------ | ------------------------------------ |
+| `~/.claude/skills/<name>/SKILL.md`                     | User-global skills                   |
+| `$OCTOMUX_AGENTS_DIR` or `~/.octomux/agents/<name>.md` | User-global agent overrides          |
+| `<octomux-package>/skills/`                            | Built-in skills shipped with octomux |
+| `<octomux-package>/agents/`                            | Built-in agent definitions           |
 
 ## Loader precedence
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,7 +4,9 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 import HomePage from './pages/HomePage';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('./test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('./test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/BulkCreateDialog.test.tsx
+++ b/src/components/BulkCreateDialog.test.tsx
@@ -5,7 +5,9 @@ import { BulkCreateDialog, parsePastePrompts, parseIssueNumbers } from './BulkCr
 import { renderWithRouter } from '../test-helpers';
 import { TasksProvider } from '../lib/tasks-context';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -7,7 +7,9 @@ import { CommandPalette } from './CommandPalette';
 import { makeTask } from '../test-helpers';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -10,7 +10,9 @@ import type { Task } from '../../server/types';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/DiffFileList.test.tsx
+++ b/src/components/DiffFileList.test.tsx
@@ -3,7 +3,9 @@ import { useRef } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/DiffFileList.tsx
+++ b/src/components/DiffFileList.tsx
@@ -8,7 +8,13 @@ import {
   useState,
 } from 'react';
 import type { editor } from 'monaco-editor';
-import { diffRangeToParam, taskApi, type DiffFileEntry, type DiffRange, type FileDiffResponse } from '@/lib/api/taskApi';
+import {
+  diffRangeToParam,
+  taskApi,
+  type DiffFileEntry,
+  type DiffRange,
+  type FileDiffResponse,
+} from '@/lib/api/taskApi';
 import type { Agent } from '../../server/types';
 import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
 import { findHunkLine } from '@/lib/diff-hunks';

--- a/src/components/DiffRangePicker.test.tsx
+++ b/src/components/DiffRangePicker.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -4,7 +4,9 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { diffExpandedKey, reviewedKey } from '@/lib/diff-state';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/DraftEditForm.test.tsx
+++ b/src/components/DraftEditForm.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/HarnessPicker.test.tsx
+++ b/src/components/HarnessPicker.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/MoveAgentDialog.test.tsx
+++ b/src/components/MoveAgentDialog.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));

--- a/src/components/PrSheet.test.tsx
+++ b/src/components/PrSheet.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { PrSheet } from './PrSheet';
 import { makeTask } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/SessionsInbox.test.tsx
+++ b/src/components/SessionsInbox.test.tsx
@@ -6,7 +6,9 @@ import { SessionsInbox } from './SessionsInbox';
 import { _resetInboxStore } from '@/lib/inbox';
 import { makeTask } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -10,7 +10,10 @@ export function SetupBanner() {
     let cancelled = false;
     (async () => {
       try {
-        const [settings, setup] = await Promise.all([configApi.getSettings(), configApi.getSetupStatus()]);
+        const [settings, setup] = await Promise.all([
+          configApi.getSettings(),
+          configApi.getSetupStatus(),
+        ]);
         if (cancelled) return;
         if (settings.onboardingCompletedAt) {
           setShow(false);

--- a/src/components/TaskActivityPanel.test.tsx
+++ b/src/components/TaskActivityPanel.test.tsx
@@ -4,7 +4,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskActivityPanel } from './TaskActivityPanel';
 import type { TaskUpdate } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskBoard.test.tsx
+++ b/src/components/TaskBoard.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 import { TaskBoard } from './TaskBoard';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskBoard.trash.test.tsx
+++ b/src/components/TaskBoard.trash.test.tsx
@@ -8,7 +8,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 import { TaskBoard } from './TaskBoard';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskHooksPanel.test.tsx
+++ b/src/components/TaskHooksPanel.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskHooksPanel } from './TaskHooksPanel';
 import type { HookExecution } from '@/lib/api/taskApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskRefsPanel.test.tsx
+++ b/src/components/TaskRefsPanel.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskRefsPanel } from './TaskRefsPanel';
 import type { TaskExternalRef } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -8,7 +8,9 @@ import { TasksProvider } from '../lib/tasks-context';
 import type { RunMode } from '../../server/types';
 import type { SidebarItem } from '@/lib/sidebar-utils';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/__tests__/DiffViewer-fileOrder.test.tsx
+++ b/src/components/__tests__/DiffViewer-fileOrder.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/fields/RepoPickerField.test.tsx
+++ b/src/components/fields/RepoPickerField.test.tsx
@@ -5,7 +5,9 @@ import { RepoPickerField } from './RepoPickerField';
 import { renderWithRouter } from '../../test-helpers';
 import type { RecentRepo } from '@/lib/api/taskApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/hooks/useTaskComments.test.tsx
+++ b/src/hooks/useTaskComments.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/hooks/useTaskComments.ts
+++ b/src/hooks/useTaskComments.ts
@@ -1,5 +1,12 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { taskApi, type InlineCommentRow, type InlineCommentWithOutdated, type ListCommentsResponse, type PostCommentInput, type UpdateCommentInput } from '@/lib/api/taskApi';
+import {
+  taskApi,
+  type InlineCommentRow,
+  type InlineCommentWithOutdated,
+  type ListCommentsResponse,
+  type PostCommentInput,
+  type UpdateCommentInput,
+} from '@/lib/api/taskApi';
 import { useResource } from '@/lib/use-resource';
 
 export interface OpenComposer {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -63,14 +63,20 @@ export function useTask(id: string) {
   // Content-dedup (inside useResource) keeps the task object reference stable
   // unless the data actually changed, so an unrelated event can't re-render the
   // TaskDetail tree and remount its terminals.
-  const { data, loading, error, refresh } = useResource<Task>(`task:${id}`, () => taskApi.getTask(id), {
-    events: (event) => event.payload.taskId === id,
-  });
+  const { data, loading, error, refresh } = useResource<Task>(
+    `task:${id}`,
+    () => taskApi.getTask(id),
+    {
+      events: (event) => event.payload.taskId === id,
+    },
+  );
   return { task: data, loading, error, refresh };
 }
 
 export function useSkills() {
-  const { data, loading, error, refresh } = useResource<Skill[]>('skills', () => configApi.listSkills());
+  const { data, loading, error, refresh } = useResource<Skill[]>('skills', () =>
+    configApi.listSkills(),
+  );
   return { skills: data ?? [], loading, error, refresh };
 }
 

--- a/src/pages/GridMonitor.test.tsx
+++ b/src/pages/GridMonitor.test.tsx
@@ -10,7 +10,9 @@ vi.mock('@/components/TerminalView', () => ({
   ),
 }));
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -7,7 +7,9 @@ import HomePage from './HomePage';
 import { makeTask } from '../test-helpers';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/pages/ReviewDetailPage.test.tsx
+++ b/src/pages/ReviewDetailPage.test.tsx
@@ -4,7 +4,9 @@ import ReviewDetailPage from './ReviewDetailPage';
 import { renderWithRouter } from '../test-helpers';
 import type { ReviewDetail, InlineCommentDTO } from '@/lib/api/reviewApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 const scrollToFileSpy = vi.hoisted(() => vi.fn());
 

--- a/src/pages/ReviewsPage.test.tsx
+++ b/src/pages/ReviewsPage.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import ReviewsPage from './ReviewsPage';
 import { renderWithRouter } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -190,9 +190,9 @@ function DefaultsForm({
 
 export default function SetupPage() {
   const [status, setStatus] = useState<SetupStatusResponse | null>(null);
-  const [settings, setSettings] = useState<Awaited<ReturnType<typeof configApi.getSettings>> | null>(
-    null,
-  );
+  const [settings, setSettings] = useState<Awaited<
+    ReturnType<typeof configApi.getSettings>
+  > | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [installing, setInstalling] = useState<string | null>(null);

--- a/src/pages/SkillEditor.test.tsx
+++ b/src/pages/SkillEditor.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import SkillEditor from './SkillEditor';
 import { renderWithRouter } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/TaskDetail.terminal-cache.test.tsx
+++ b/src/pages/TaskDetail.terminal-cache.test.tsx
@@ -18,7 +18,9 @@ vi.mock('@/lib/event-source', () => ({
   subscribeConnectionState: vi.fn(() => () => {}),
 }));
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -21,7 +21,9 @@ function simulateEvent(taskId = 'test-task-01') {
   for (const cb of eventCallbacks) cb(event);
 }
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -25,7 +25,12 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 import { useTask } from '@/lib/hooks';
 import { useTerminalCacheSize } from '@/lib/terminal-cache-settings';
-import { diffRangeToParam, taskApi, type DiffRange, type DiffSummaryResponse } from '@/lib/api/taskApi';
+import {
+  diffRangeToParam,
+  taskApi,
+  type DiffRange,
+  type DiffSummaryResponse,
+} from '@/lib/api/taskApi';
 import { reviewApi } from '@/lib/api/reviewApi';
 import { TaskDetailHeader } from '@/components/layout/task-detail-header';
 import { TaskDetailMeta } from '@/components/layout/task-detail-meta';

--- a/src/pages/TasksPage.test.tsx
+++ b/src/pages/TasksPage.test.tsx
@@ -5,7 +5,9 @@ import TasksPage from './TasksPage';
 import { renderWithRouter, makeTask } from '../test-helpers';
 import { TasksProvider } from '../lib/tasks-context';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/WorkspaceDetailPage.test.tsx
+++ b/src/pages/WorkspaceDetailPage.test.tsx
@@ -7,7 +7,9 @@ import type { WorktreeDetail } from '@/lib/api/taskApi';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));

--- a/src/pages/WorkspacesPage.test.tsx
+++ b/src/pages/WorkspacesPage.test.tsx
@@ -6,7 +6,9 @@ import type { WorktreeSummary } from '../../server/types';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));


### PR DESCRIPTION
## What

Remove the orchestrator runner's private `buildLaunchCommand` / `buildResumeCommand` helpers and route conductor launch/resume through the shared harness `buildLaunchCommand` / `buildResumeCommand`. Orchestrator-specific CLI flags (`--settings`, `--mcp-config --strict-mcp-config`, `--append-system-prompt`) are assembled by a new `buildOrchestratorConductorFlags` helper in `server/orchestrator/conductor-flags.ts`.

## Why

Command-string assembly for agent launch lived in two places: the harness abstraction and a hand-rolled copy in `server/orchestrator/runner.ts`. That duplication hard-wired the orchestrator to the `claude` binary and meant harness/flag changes had to be made twice. Centralizing launch through the harness keeps one source of truth and allows future harness swaps.

Resolves SHR-207

## Testing

- `bun run test server/orchestrator server/harnesses` — 523 passed
- `bun run typecheck` — passed
- `bun run lint` — passed (warnings only, pre-existing)
- `bun run test` — 3335/3337 passed; 2 unrelated UI tests (`Composer.test.tsx`, `HomePage.test.tsx`) flake under full-suite parallel load but pass in isolation