### PR TITLE
refactor(agent-session): route live task tmux launches through windowed substrate

### DIFF
--- a/server/agent-session/index.ts
+++ b/server/agent-session/index.ts
@@ -1,6 +1,17 @@
-export type { SpawnOptions, ProcessHandle, ProcessSubstrate } from './substrate.js';
+export type {
+  SpawnOptions,
+  ProcessHandle,
+  ProcessSubstrate,
+  TmuxWindowLaunchOptions,
+  TmuxWindowSubstrate,
+} from './substrate.js';
 export { ptySubstrate } from './substrate-pty.js';
 export { tmuxSubstrate } from './substrate-tmux.js';
+export {
+  tmuxWindowSubstrate,
+  getActiveWindowIndex,
+  getLastWindowIndex,
+} from './substrate-tmux-windowed.js';
 export {
   buildToolDefinition,
   handleSubmitResultCall,

--- a/server/agent-session/substrate-tmux-windowed.test.ts
+++ b/server/agent-session/substrate-tmux-windowed.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execFile } from 'child_process';
+import { findExecCall, countExecCalls } from '../test-helpers.js';
+import {
+  tmuxWindowSubstrate,
+  getActiveWindowIndex,
+  getLastWindowIndex,
+} from './substrate-tmux-windowed.js';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (
+      err: Error | null,
+      result: { stdout: string; stderr: string },
+    ) => void;
+    const argList = args[1] as string[];
+    if (argList.includes('display-message')) {
+      cb(null, { stdout: '0\n', stderr: '' });
+    } else if (argList.includes('list-windows')) {
+      cb(null, { stdout: '0\n1\n2\n', stderr: '' });
+    } else {
+      cb(null, { stdout: '', stderr: '' });
+    }
+    return undefined as never;
+  });
+});
+
+describe('tmuxWindowSubstrate.launchWindow', () => {
+  it('fresh=true emits new-session with the startup command', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'octomux-agent-test01',
+      cwd: '/wt',
+      startupCmd: 'bash -ic claude',
+      fresh: true,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-session'],
+    });
+    expect(call).toBeDefined();
+  });
+
+  it('fresh=true emits set-option aggressive-resize', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'octomux-agent-test01',
+      cwd: '/wt',
+      startupCmd: 'bash -ic claude',
+      fresh: true,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['set-option', 'aggressive-resize', 'on'],
+    });
+    expect(call).toBeDefined();
+  });
+
+  it('fresh=true queries active window index via display-message', async () => {
+    const idx = await tmuxWindowSubstrate.launchWindow({
+      session: 'octomux-agent-test01',
+      cwd: '/wt',
+      startupCmd: 'bash -ic claude',
+      fresh: true,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['display-message'],
+    });
+    expect(call).toBeDefined();
+    expect(typeof idx).toBe('number');
+  });
+
+  it('fresh=false emits new-window (not new-session)', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'octomux-agent-test01',
+      cwd: '/wt',
+      startupCmd: 'bash -ic claude',
+      fresh: false,
+    });
+
+    const newWindowCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-window'],
+    });
+    expect(newWindowCall).toBeDefined();
+
+    const newSessionCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-session'],
+    });
+    expect(newSessionCall).toBeUndefined();
+  });
+
+  it('fresh=false queries last window index via list-windows', async () => {
+    const idx = await tmuxWindowSubstrate.launchWindow({
+      session: 'octomux-agent-test01',
+      cwd: '/wt',
+      startupCmd: 'bash -ic claude',
+      fresh: false,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['list-windows'],
+    });
+    expect(call).toBeDefined();
+    expect(typeof idx).toBe('number');
+  });
+
+  it('fresh=true passes session and cwd to new-session', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'my-session',
+      cwd: '/my/worktree',
+      startupCmd: 'bash -ic claude',
+      fresh: true,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-session', '-s', 'my-session', '-c', '/my/worktree'],
+    });
+    expect(call).toBeDefined();
+  });
+
+  it('fresh=false passes session and cwd to new-window', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'my-session',
+      cwd: '/my/worktree',
+      startupCmd: 'bash -ic claude',
+      fresh: false,
+    });
+
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-window', '-t', 'my-session', '-c', '/my/worktree'],
+    });
+    expect(call).toBeDefined();
+  });
+
+  it('omits startup command when not provided', async () => {
+    await tmuxWindowSubstrate.launchWindow({
+      session: 'my-session',
+      cwd: '/my/worktree',
+      fresh: false,
+    });
+
+    expect(
+      countExecCalls(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['new-window'] }),
+    ).toBe(1);
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-window', '-t', 'my-session', '-c', '/my/worktree'],
+    });
+    expect(call).toBeDefined();
+    const args = call![1] as string[];
+    const subcommandIndex = args.indexOf('new-window');
+    expect(args.slice(subcommandIndex)).toEqual([
+      'new-window',
+      '-t',
+      'my-session',
+      '-c',
+      '/my/worktree',
+    ]);
+  });
+});
+
+describe('tmuxWindowSubstrate.createEmptySession', () => {
+  it('creates a detached session without a startup command', async () => {
+    await tmuxWindowSubstrate.createEmptySession({ session: 'octomux-agent-x', cwd: '/wt' });
+
+    const sessionCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['new-session', '-d', '-s', 'octomux-agent-x', '-c', '/wt'],
+    });
+    expect(sessionCall).toBeDefined();
+
+    const optionCall = findExecCall(vi.mocked(execFile), {
+      cmd: 'tmux',
+      argsInclude: ['set-option', 'aggressive-resize', 'on'],
+    });
+    expect(optionCall).toBeDefined();
+  });
+});
+
+describe('window index helpers', () => {
+  it('getActiveWindowIndex parses display-message output', async () => {
+    const idx = await getActiveWindowIndex('octomux-agent-test');
+    expect(idx).toBe(0);
+  });
+
+  it('getLastWindowIndex returns max window index', async () => {
+    const idx = await getLastWindowIndex('octomux-agent-test');
+    expect(idx).toBe(2);
+  });
+});

--- a/server/agent-session/substrate-tmux-windowed.ts
+++ b/server/agent-session/substrate-tmux-windowed.ts
@@ -1,0 +1,73 @@
+import { execTmux } from '../tmux-bin.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('agent-session/substrate-tmux-windowed');
+
+/** Get the active window index of a tmux session. */
+export async function getActiveWindowIndex(session: string): Promise<number> {
+  const { stdout } = await execTmux(['display-message', '-t', session, '-p', '#{window_index}']);
+  return parseInt(stdout.trim(), 10);
+}
+
+/** Get the index of the last window in a tmux session. */
+export async function getLastWindowIndex(session: string): Promise<number> {
+  const { stdout } = await execTmux(['list-windows', '-t', session, '-F', '#{window_index}']);
+  const indices = stdout.trim().split('\n').map(Number);
+  return Math.max(...indices);
+}
+
+export interface TmuxWindowLaunchOptions {
+  session: string;
+  cwd: string;
+  startupCmd?: string;
+  fresh: boolean;
+}
+
+/**
+ * Detached, multi-window tmux orchestration for the live dashboard task path.
+ *
+ * Creates or reuses a named session, adds windows without a parent-held pty, and
+ * returns a window index for external attach (xterm.js grouped viewer sessions).
+ * Distinct from `tmuxSubstrate` (spawn-and-hold-a-pty for headless `runAgentSession`).
+ */
+export interface TmuxWindowSubstrate {
+  readonly kind: 'tmux-windowed';
+  launchWindow(opts: TmuxWindowLaunchOptions): Promise<number>;
+  createEmptySession(opts: { session: string; cwd: string }): Promise<void>;
+}
+
+function appendStartupCmd(args: string[], startupCmd?: string): string[] {
+  if (startupCmd) args.push(startupCmd);
+  return args;
+}
+
+export const tmuxWindowSubstrate: TmuxWindowSubstrate = {
+  kind: 'tmux-windowed',
+
+  async launchWindow(opts: TmuxWindowLaunchOptions): Promise<number> {
+    const { session, cwd, startupCmd, fresh } = opts;
+
+    logger.debug(
+      { session, cwd, fresh, has_startup_cmd: Boolean(startupCmd) },
+      'launching tmux window',
+    );
+
+    if (fresh) {
+      await execTmux(
+        appendStartupCmd(['new-session', '-d', '-s', session, '-c', cwd], startupCmd),
+      );
+      await execTmux(['set-option', '-t', session, 'aggressive-resize', 'on']);
+      return getActiveWindowIndex(session);
+    }
+
+    await execTmux(appendStartupCmd(['new-window', '-t', session, '-c', cwd], startupCmd));
+    return getLastWindowIndex(session);
+  },
+
+  async createEmptySession(opts: { session: string; cwd: string }): Promise<void> {
+    const { session, cwd } = opts;
+    logger.debug({ session, cwd }, 'creating empty tmux session');
+    await execTmux(['new-session', '-d', '-s', session, '-c', cwd]);
+    await execTmux(['set-option', '-t', session, 'aggressive-resize', 'on']);
+  },
+};

--- a/server/agent-session/substrate.ts
+++ b/server/agent-session/substrate.ts
@@ -17,3 +17,5 @@ export interface ProcessSubstrate {
   readonly kind: 'pty' | 'tmux';
   spawn(opts: SpawnOptions): Promise<ProcessHandle>;
 }
+
+export type { TmuxWindowLaunchOptions, TmuxWindowSubstrate } from './substrate-tmux-windowed.js';

--- a/server/agents.test.ts
+++ b/server/agents.test.ts
@@ -71,10 +71,7 @@ describe('agents', () => {
       const repoDir = path.join(os.tmpdir(), `octomux-agents-repo-${Date.now()}`);
       fs.mkdirSync(path.join(repoDir, '.octomux', 'agents'), { recursive: true });
       fs.writeFileSync(path.join(tmpDir, 'orchestrator.md'), 'Home prompt');
-      fs.writeFileSync(
-        path.join(repoDir, '.octomux', 'agents', 'orchestrator.md'),
-        'Repo prompt',
-      );
+      fs.writeFileSync(path.join(repoDir, '.octomux', 'agents', 'orchestrator.md'), 'Repo prompt');
 
       const agent = await getAgent('orchestrator', repoDir);
       expect(agent.content).toBe('Repo prompt');

--- a/server/agents.ts
+++ b/server/agents.ts
@@ -1,10 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  builtInAgentsDir,
-  homeAgentsDir,
-  repoAgentsDir,
-} from './octomux-paths.js';
+import { builtInAgentsDir, homeAgentsDir, repoAgentsDir } from './octomux-paths.js';
 
 export interface AgentDefinition {
   name: string;
@@ -131,11 +127,7 @@ export async function resetAgent(name: string, repoPath?: string): Promise<void>
   }
 }
 
-export async function createAgent(
-  name: string,
-  content: string,
-  repoPath?: string,
-): Promise<void> {
+export async function createAgent(name: string, content: string, repoPath?: string): Promise<void> {
   const customPath = path.join(writeAgentsDir(repoPath), `${name}.md`);
   if (await exists(customPath)) {
     throw new Error(`Agent already exists: ${name}`);

--- a/server/saved-files.test.ts
+++ b/server/saved-files.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import {
-  listSavedFiles,
-  getSavedFile,
-  putSavedFile,
-  resolveSavedFilePath,
-} from './saved-files.js';
+import { listSavedFiles, getSavedFile, putSavedFile, resolveSavedFilePath } from './saved-files.js';
 import { repoFilesDir } from './octomux-paths.js';
 
 describe('saved-files', () => {
@@ -47,7 +42,8 @@ describe('saved-files', () => {
 
   it('rejects disallowed extension', () => {
     expect(resolveSavedFilePath(tmpDir, 'evil.exe')).toEqual({
-      rejected: 'extension ".exe" is not allowed; allowed: .md, .txt, .json, .yaml, .yml, .csv, .html',
+      rejected:
+        'extension ".exe" is not allowed; allowed: .md, .txt, .json, .yaml, .yml, .csv, .html',
     });
   });
 

--- a/server/saved-files.ts
+++ b/server/saved-files.ts
@@ -7,15 +7,7 @@ const logger = childLogger('saved-files');
 
 const MAX_FILE_BYTES = 1024 * 1024;
 
-const ALLOWED_EXTENSIONS = new Set([
-  '.md',
-  '.txt',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.csv',
-  '.html',
-]);
+const ALLOWED_EXTENSIONS = new Set(['.md', '.txt', '.json', '.yaml', '.yml', '.csv', '.html']);
 
 export interface SavedFileEntry {
   path: string;

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -1,11 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { childLogger } from './logger.js';
-import {
-  builtInSkillsDir,
-  homeSkillsDir,
-  repoSkillsDir,
-} from './octomux-paths.js';
+import { builtInSkillsDir, homeSkillsDir, repoSkillsDir } from './octomux-paths.js';
 
 const logger = childLogger('skills');
 
@@ -71,7 +67,10 @@ async function readSkillContent(skillsRoot: string, name: string): Promise<strin
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT' || code === 'EISDIR') {
-      logger.warn({ skill: name, code, skills_root: skillsRoot }, 'skipping dir without readable SKILL.md');
+      logger.warn(
+        { skill: name, code, skills_root: skillsRoot },
+        'skipping dir without readable SKILL.md',
+      );
       return null;
     }
     throw err;

--- a/server/task-engine/launch.ts
+++ b/server/task-engine/launch.ts
@@ -5,8 +5,7 @@ import { childLogger } from '../logger.js';
 import { mcpServerInvocation } from '../orchestrator/runner.js';
 import { isOrchestratorManaged } from '../orchestrator/store.js';
 import { shellQuoteSingle } from '../shell-quote.js';
-import { execTmux } from '../tmux-bin.js';
-import { getActiveWindowIndex, getLastWindowIndex } from './sessions.js';
+import { tmuxWindowSubstrate } from '../agent-session/substrate-tmux-windowed.js';
 import { setAgentHarnessSessionId } from '../repositories/index.js';
 import type { Harness } from '../harnesses/index.js';
 import type { Agent } from '../types.js';
@@ -155,15 +154,7 @@ export async function launchAgentWindow(opts: {
   startupCmd: string;
   fresh: boolean;
 }): Promise<number> {
-  const { session, cwd, startupCmd, fresh } = opts;
-  if (fresh) {
-    await execTmux(['new-session', '-d', '-s', session, '-c', cwd, startupCmd]);
-    await execTmux(['set-option', '-t', session, 'aggressive-resize', 'on']);
-    return getActiveWindowIndex(session);
-  } else {
-    await execTmux(['new-window', '-t', session, '-c', cwd, startupCmd]);
-    return getLastWindowIndex(session);
-  }
+  return tmuxWindowSubstrate.launchWindow(opts);
 }
 
 /**

--- a/server/task-engine/lifecycle.ts
+++ b/server/task-engine/lifecycle.ts
@@ -10,6 +10,7 @@ import { hookBaseUrl } from '../hook-base-url.js';
 import { getOrCreateRepoConfig } from '../repositories/repo-config.js';
 import { inferRefs } from '../ref-inference.js';
 import { childLogger } from '../logger.js';
+import { tmuxWindowSubstrate } from '../agent-session/substrate-tmux-windowed.js';
 import { execTmux } from '../tmux-bin.js';
 import { broadcast } from '../events.js';
 import type { RepoConfig } from '../repositories/repo-config.js';
@@ -558,8 +559,7 @@ export async function resumeTask(task: Task): Promise<void> {
     } else {
       // No agents to recover, but recreate the session so callers that expect
       // the task's tmux session to exist after resume still find it.
-      await execTmux(['new-session', '-d', '-s', session, '-c', cwd]);
-      await execTmux(['set-option', '-t', session, 'aggressive-resize', 'on']);
+      await tmuxWindowSubstrate.createEmptySession({ session, cwd });
     }
 
     let sessionCreated = false;

--- a/server/task-engine/sessions.ts
+++ b/server/task-engine/sessions.ts
@@ -1,5 +1,10 @@
 import { execTmux } from '../tmux-bin.js';
 
+export {
+  getActiveWindowIndex,
+  getLastWindowIndex,
+} from '../agent-session/substrate-tmux-windowed.js';
+
 /**
  * True when an execFile error stems from tmux reporting that a target
  * session/window/pane does not exist — which happens routinely during cleanup
@@ -8,19 +13,6 @@ import { execTmux } from '../tmux-bin.js';
 export function isTmuxTargetMissing(err: unknown): boolean {
   const stderr = (err as { stderr?: string } | null)?.stderr ?? '';
   return /can't find (?:session|window|pane):/i.test(stderr);
-}
-
-/** Get the active window index of a tmux session. */
-export async function getActiveWindowIndex(session: string): Promise<number> {
-  const { stdout } = await execTmux(['display-message', '-t', session, '-p', '#{window_index}']);
-  return parseInt(stdout.trim(), 10);
-}
-
-/** Get the index of the last window in a tmux session. */
-export async function getLastWindowIndex(session: string): Promise<number> {
-  const { stdout } = await execTmux(['list-windows', '-t', session, '-F', '#{window_index}']);
-  const indices = stdout.trim().split('\n').map(Number);
-  return Math.max(...indices);
 }
 
 /**

--- a/server/task-engine/terminals.ts
+++ b/server/task-engine/terminals.ts
@@ -1,5 +1,6 @@
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
+import { tmuxWindowSubstrate } from '../agent-session/substrate-tmux-windowed.js';
 import { execTmux } from '../tmux-bin.js';
 import { getSettings } from '../settings.js';
 import type { Task, UserTerminal } from '../types.js';
@@ -9,7 +10,6 @@ import {
   deleteUserTerminal,
   countUserTerminals,
 } from '../repositories/index.js';
-import { getLastWindowIndex } from './sessions.js';
 
 const execFile = promisify(execFileCb);
 
@@ -32,8 +32,11 @@ export async function createUserTerminal(task: Task): Promise<UserTerminalResult
     return { editor, windowIndex: task.user_window_index };
   }
 
-  await execTmux(['new-window', '-t', task.tmux_session!, '-c', task.worktree!]);
-  const windowIndex = await getLastWindowIndex(task.tmux_session!);
+  const windowIndex = await tmuxWindowSubstrate.launchWindow({
+    session: task.tmux_session!,
+    cwd: task.worktree!,
+    fresh: false,
+  });
 
   await execTmux(['send-keys', '-t', `${task.tmux_session}:${windowIndex}`, 'nvim .', 'Enter']);
 
@@ -43,8 +46,11 @@ export async function createUserTerminal(task: Task): Promise<UserTerminalResult
 }
 
 export async function createShellTerminal(task: Task): Promise<UserTerminal> {
-  await execTmux(['new-window', '-t', task.tmux_session!, '-c', task.worktree!]);
-  const windowIndex = await getLastWindowIndex(task.tmux_session!);
+  const windowIndex = await tmuxWindowSubstrate.launchWindow({
+    session: task.tmux_session!,
+    cwd: task.worktree!,
+    fresh: false,
+  });
 
   const count = countUserTerminals(task.id);
   const label = `Terminal ${count + 1}`;

--- a/spec/agent-session.md
+++ b/spec/agent-session.md
@@ -62,6 +62,12 @@ ptySubstrate  — spawn a shell + command under a local pty.
 tmuxSubstrate — create a named tmux session; attach via a pty.
                 Session survives parent exit; dispose() kills the tmux session.
                 Suitable for reattachable, long-running agents.
+
+tmuxWindowSubstrate — create-or-reuse a named detached tmux session and add
+                      windows without a parent-held pty. Returns a window
+                      index for external attach (dashboard grouped viewers).
+                      Used by the live task-engine path; distinct from the
+                      spawn-and-hold-a-pty model above.
 ```
 
 ### Capture seam (`CaptureStrategy<T>`)
@@ -95,15 +101,16 @@ and batch pipelines without any octomux infrastructure.
 
 ---
 
-## Deferred: live task-path swap
+## Live task-path tmux orchestration
 
-The interactive task dashboard path (`server/task-engine/launch.ts →
-launchAgentWindow`) is intentionally **not** routed through
-`runAgentSession` / the spawn-and-hold-a-pty substrate model.
+The interactive task dashboard path (`server/task-engine/launch.ts` →
+`launchAgentWindow`, `terminals.ts`, and empty-session recovery in
+`lifecycle.ts`) routes `new-session` / `new-window` orchestration through
+`tmuxWindowSubstrate` in `server/agent-session/substrate-tmux-windowed.ts`.
 
-**Why**: The live task path uses a fundamentally different model:
+**Model** (unchanged from before consolidation):
 
-| Dimension         | `runAgentSession` (pty/tmux substrates)   | Live task path                                                |
+| Dimension         | `runAgentSession` (pty/tmux substrates)   | Live task path (`tmuxWindowSubstrate`)                        |
 | ----------------- | ----------------------------------------- | ------------------------------------------------------------- |
 | Session ownership | Parent process holds the handle           | Named `octomux-agent-<id>` tmux session created independently |
 | Windows           | Single process / single session           | Multiple tmux windows (one per agent)                         |
@@ -111,15 +118,16 @@ launchAgentWindow`) is intentionally **not** routed through
 | Lifecycle         | dispose() kills everything                | `closeTask` / `deleteTask` with DB + git cleanup              |
 | Structured result | MCP submit_result capture                 | Not applicable (interactive streaming output)                 |
 
-Forcing the live path onto the spawn-and-attach tmux substrate would change
-dashboard behavior and violate the "no behavior change, suites stay green" rule.
+The live path is intentionally **not** routed through `runAgentSession` or the
+spawn-and-hold-a-pty `tmuxSubstrate`. Both paths share `execTmux` /
+`tmux-bin.ts` as a leaf utility.
 
-Both paths share `execTmux` / `tmux-bin.ts` as a leaf utility. A future ticket
-could introduce a windowed-substrate variant (multi-window, external-attach
-semantics) if unification is justified.
+**Files using `tmuxWindowSubstrate`:**
 
-**Files not modified by this ticket:**
+- `server/task-engine/launch.ts` — `launchAgentWindow`
+- `server/task-engine/terminals.ts` — user nvim/shell terminals
+- `server/task-engine/lifecycle.ts` — empty-session recovery on resume
 
-- `server/task-engine/*`
-- `server/task-runner.ts`
+**Files not modified (viewer attach model unchanged):**
+
 - `server/terminal.ts`

--- a/spec/repo-portable.md
+++ b/spec/repo-portable.md
@@ -6,20 +6,20 @@ and CLI access.
 
 ## Layout
 
-| Path | Purpose |
-|------|---------|
-| `<repo>/.octomux/skills/<name>/SKILL.md` | Repo-portable skills (version-controlled) |
-| `<repo>/.octomux/agents/<name>.md` | Repo-portable agent definitions |
-| `<repo>/.octomux/files/**` | Saved files / lightweight memory (plain text) |
+| Path                                     | Purpose                                       |
+| ---------------------------------------- | --------------------------------------------- |
+| `<repo>/.octomux/skills/<name>/SKILL.md` | Repo-portable skills (version-controlled)     |
+| `<repo>/.octomux/agents/<name>.md`       | Repo-portable agent definitions               |
+| `<repo>/.octomux/files/**`               | Saved files / lightweight memory (plain text) |
 
 Home and package defaults still apply:
 
-| Path | Purpose |
-|------|---------|
-| `~/.claude/skills/<name>/SKILL.md` | User-global skills |
-| `$OCTOMUX_AGENTS_DIR` or `~/.octomux/agents/<name>.md` | User-global agent overrides |
-| `<octomux-package>/skills/` | Built-in skills shipped with octomux |
-| `<octomux-package>/agents/` | Built-in agent definitions |
+| Path                                                   | Purpose                              |
+| ------------------------------------------------------ | ------------------------------------ |
+| `~/.claude/skills/<name>/SKILL.md`                     | User-global skills                   |
+| `$OCTOMUX_AGENTS_DIR` or `~/.octomux/agents/<name>.md` | User-global agent overrides          |
+| `<octomux-package>/skills/`                            | Built-in skills shipped with octomux |
+| `<octomux-package>/agents/`                            | Built-in agent definitions           |
 
 ## Loader precedence
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,7 +4,9 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 import HomePage from './pages/HomePage';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('./test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('./test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/BulkCreateDialog.test.tsx
+++ b/src/components/BulkCreateDialog.test.tsx
@@ -5,7 +5,9 @@ import { BulkCreateDialog, parsePastePrompts, parseIssueNumbers } from './BulkCr
 import { renderWithRouter } from '../test-helpers';
 import { TasksProvider } from '../lib/tasks-context';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -7,7 +7,9 @@ import { CommandPalette } from './CommandPalette';
 import { makeTask } from '../test-helpers';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -10,7 +10,9 @@ import type { Task } from '../../server/types';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/DiffFileList.test.tsx
+++ b/src/components/DiffFileList.test.tsx
@@ -3,7 +3,9 @@ import { useRef } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/DiffFileList.tsx
+++ b/src/components/DiffFileList.tsx
@@ -8,7 +8,13 @@ import {
   useState,
 } from 'react';
 import type { editor } from 'monaco-editor';
-import { diffRangeToParam, taskApi, type DiffFileEntry, type DiffRange, type FileDiffResponse } from '@/lib/api/taskApi';
+import {
+  diffRangeToParam,
+  taskApi,
+  type DiffFileEntry,
+  type DiffRange,
+  type FileDiffResponse,
+} from '@/lib/api/taskApi';
 import type { Agent } from '../../server/types';
 import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
 import { findHunkLine } from '@/lib/diff-hunks';

--- a/src/components/DiffRangePicker.test.tsx
+++ b/src/components/DiffRangePicker.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -4,7 +4,9 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { diffExpandedKey, reviewedKey } from '@/lib/diff-state';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/DraftEditForm.test.tsx
+++ b/src/components/DraftEditForm.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/HarnessPicker.test.tsx
+++ b/src/components/HarnessPicker.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/MoveAgentDialog.test.tsx
+++ b/src/components/MoveAgentDialog.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));

--- a/src/components/PrSheet.test.tsx
+++ b/src/components/PrSheet.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { PrSheet } from './PrSheet';
 import { makeTask } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/SessionsInbox.test.tsx
+++ b/src/components/SessionsInbox.test.tsx
@@ -6,7 +6,9 @@ import { SessionsInbox } from './SessionsInbox';
 import { _resetInboxStore } from '@/lib/inbox';
 import { makeTask } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/SetupBanner.tsx
+++ b/src/components/SetupBanner.tsx
@@ -10,7 +10,10 @@ export function SetupBanner() {
     let cancelled = false;
     (async () => {
       try {
-        const [settings, setup] = await Promise.all([configApi.getSettings(), configApi.getSetupStatus()]);
+        const [settings, setup] = await Promise.all([
+          configApi.getSettings(),
+          configApi.getSetupStatus(),
+        ]);
         if (cancelled) return;
         if (settings.onboardingCompletedAt) {
           setShow(false);

--- a/src/components/TaskActivityPanel.test.tsx
+++ b/src/components/TaskActivityPanel.test.tsx
@@ -4,7 +4,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskActivityPanel } from './TaskActivityPanel';
 import type { TaskUpdate } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskBoard.test.tsx
+++ b/src/components/TaskBoard.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 import { TaskBoard } from './TaskBoard';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskBoard.trash.test.tsx
+++ b/src/components/TaskBoard.trash.test.tsx
@@ -8,7 +8,9 @@ import { renderWithRouter, makeTask } from '../test-helpers';
 import { TaskBoard } from './TaskBoard';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskHooksPanel.test.tsx
+++ b/src/components/TaskHooksPanel.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskHooksPanel } from './TaskHooksPanel';
 import type { HookExecution } from '@/lib/api/taskApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/TaskRefsPanel.test.tsx
+++ b/src/components/TaskRefsPanel.test.tsx
@@ -5,7 +5,9 @@ import { renderWithRouter } from '../test-helpers';
 import { TaskRefsPanel } from './TaskRefsPanel';
 import type { TaskExternalRef } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/components/UniversalSidebar.test.tsx
+++ b/src/components/UniversalSidebar.test.tsx
@@ -8,7 +8,9 @@ import { TasksProvider } from '../lib/tasks-context';
 import type { RunMode } from '../../server/types';
 import type { SidebarItem } from '@/lib/sidebar-utils';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/components/__tests__/DiffViewer-fileOrder.test.tsx
+++ b/src/components/__tests__/DiffViewer-fileOrder.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;
   return { ...actual, taskApi: taskApiProxy };

--- a/src/components/fields/RepoPickerField.test.tsx
+++ b/src/components/fields/RepoPickerField.test.tsx
@@ -5,7 +5,9 @@ import { RepoPickerField } from './RepoPickerField';
 import { renderWithRouter } from '../../test-helpers';
 import type { RecentRepo } from '@/lib/api/taskApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/hooks/useTaskComments.test.tsx
+++ b/src/hooks/useTaskComments.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/hooks/useTaskComments.ts
+++ b/src/hooks/useTaskComments.ts
@@ -1,5 +1,12 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { taskApi, type InlineCommentRow, type InlineCommentWithOutdated, type ListCommentsResponse, type PostCommentInput, type UpdateCommentInput } from '@/lib/api/taskApi';
+import {
+  taskApi,
+  type InlineCommentRow,
+  type InlineCommentWithOutdated,
+  type ListCommentsResponse,
+  type PostCommentInput,
+  type UpdateCommentInput,
+} from '@/lib/api/taskApi';
 import { useResource } from '@/lib/use-resource';
 
 export interface OpenComposer {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -63,14 +63,20 @@ export function useTask(id: string) {
   // Content-dedup (inside useResource) keeps the task object reference stable
   // unless the data actually changed, so an unrelated event can't re-render the
   // TaskDetail tree and remount its terminals.
-  const { data, loading, error, refresh } = useResource<Task>(`task:${id}`, () => taskApi.getTask(id), {
-    events: (event) => event.payload.taskId === id,
-  });
+  const { data, loading, error, refresh } = useResource<Task>(
+    `task:${id}`,
+    () => taskApi.getTask(id),
+    {
+      events: (event) => event.payload.taskId === id,
+    },
+  );
   return { task: data, loading, error, refresh };
 }
 
 export function useSkills() {
-  const { data, loading, error, refresh } = useResource<Skill[]>('skills', () => configApi.listSkills());
+  const { data, loading, error, refresh } = useResource<Skill[]>('skills', () =>
+    configApi.listSkills(),
+  );
   return { skills: data ?? [], loading, error, refresh };
 }
 

--- a/src/pages/GridMonitor.test.tsx
+++ b/src/pages/GridMonitor.test.tsx
@@ -10,7 +10,9 @@ vi.mock('@/components/TerminalView', () => ({
   ),
 }));
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -7,7 +7,9 @@ import HomePage from './HomePage';
 import { makeTask } from '../test-helpers';
 import type { Task } from '../../server/types';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));

--- a/src/pages/ReviewDetailPage.test.tsx
+++ b/src/pages/ReviewDetailPage.test.tsx
@@ -4,7 +4,9 @@ import ReviewDetailPage from './ReviewDetailPage';
 import { renderWithRouter } from '../test-helpers';
 import type { ReviewDetail, InlineCommentDTO } from '@/lib/api/reviewApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 const scrollToFileSpy = vi.hoisted(() => vi.fn());
 

--- a/src/pages/ReviewsPage.test.tsx
+++ b/src/pages/ReviewsPage.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import ReviewsPage from './ReviewsPage';
 import { renderWithRouter } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -190,9 +190,9 @@ function DefaultsForm({
 
 export default function SetupPage() {
   const [status, setStatus] = useState<SetupStatusResponse | null>(null);
-  const [settings, setSettings] = useState<Awaited<ReturnType<typeof configApi.getSettings>> | null>(
-    null,
-  );
+  const [settings, setSettings] = useState<Awaited<
+    ReturnType<typeof configApi.getSettings>
+  > | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [installing, setInstalling] = useState<string | null>(null);

--- a/src/pages/SkillEditor.test.tsx
+++ b/src/pages/SkillEditor.test.tsx
@@ -4,7 +4,9 @@ import userEvent from '@testing-library/user-event';
 import SkillEditor from './SkillEditor';
 import { renderWithRouter } from '../test-helpers';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/TaskDetail.terminal-cache.test.tsx
+++ b/src/pages/TaskDetail.terminal-cache.test.tsx
@@ -18,7 +18,9 @@ vi.mock('@/lib/event-source', () => ({
   subscribeConnectionState: vi.fn(() => () => {}),
 }));
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -21,7 +21,9 @@ function simulateEvent(taskId = 'test-task-01') {
   for (const cb of eventCallbacks) cb(event);
 }
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', async () => {
   const actual = (await vi.importActual('@/lib/api/taskApi')) as Record<string, unknown>;

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -25,7 +25,12 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 import { useTask } from '@/lib/hooks';
 import { useTerminalCacheSize } from '@/lib/terminal-cache-settings';
-import { diffRangeToParam, taskApi, type DiffRange, type DiffSummaryResponse } from '@/lib/api/taskApi';
+import {
+  diffRangeToParam,
+  taskApi,
+  type DiffRange,
+  type DiffSummaryResponse,
+} from '@/lib/api/taskApi';
 import { reviewApi } from '@/lib/api/reviewApi';
 import { TaskDetailHeader } from '@/components/layout/task-detail-header';
 import { TaskDetailMeta } from '@/components/layout/task-detail-meta';

--- a/src/pages/TasksPage.test.tsx
+++ b/src/pages/TasksPage.test.tsx
@@ -5,7 +5,9 @@ import TasksPage from './TasksPage';
 import { renderWithRouter, makeTask } from '../test-helpers';
 import { TasksProvider } from '../lib/tasks-context';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));

--- a/src/pages/WorkspaceDetailPage.test.tsx
+++ b/src/pages/WorkspaceDetailPage.test.tsx
@@ -7,7 +7,9 @@ import type { WorktreeDetail } from '@/lib/api/taskApi';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));

--- a/src/pages/WorkspacesPage.test.tsx
+++ b/src/pages/WorkspacesPage.test.tsx
@@ -6,7 +6,9 @@ import type { WorktreeSummary } from '../../server/types';
 const { mockNavigate, routerMockFactory } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupRouterNavigateMock(),
 );
-const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupApiMock(),
+);
 
 vi.mock('react-router-dom', routerMockFactory);
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));


### PR DESCRIPTION
## What

Introduce `tmuxWindowSubstrate` — a detached, multi-window tmux orchestration primitive in `server/agent-session/substrate-tmux-windowed.ts` — and route the live dashboard task-engine `new-session` / `new-window` call sites through it:

- `launchAgentWindow` (`launch.ts`)
- User nvim/shell terminals (`terminals.ts`)
- Empty-session recovery on resume (`lifecycle.ts`)

Window index helpers (`getActiveWindowIndex`, `getLastWindowIndex`) move alongside the substrate; `sessions.ts` re-exports them for existing callers.

## Why

The same create-or-reuse named session / add window logic was duplicated across the live task path and the headless agent-session substrates. SHR-202 introduced `runAgentSession` with a spawn-and-hold-a-pty model; the dashboard intentionally uses a different model (named session, multiple windows, external xterm.js attach). This change consolidates the live path onto a shared primitive without altering viewer attach behavior.

Resolves SHR-204

## Testing

- `bun run typecheck` — pass
- `bun run lint` — pass (warnings only, pre-existing)
- `bun run test` — 3341+ tests pass; occasional unrelated flakes in `HomePage.test.tsx` / diff-engine git integration tests under full-suite load
- `bun run test server/agent-session server/task-engine` — 277/277 pass

Made with [Cursor](https://cursor.com)