### PR TITLE
refactor(server): centralize route error handling middleware

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -69,90 +69,86 @@ export function setupRoutes(app: Express): void {
      * deleteTask from accidentally removing the server's working directory.
      */
     app.post('/api/__test__/seed-review', (req: Request, res: Response) => {
-      try {
-        const body = req.body as {
-          task: {
-            id: string;
-            title: string;
-            pr_url: string;
-            pr_number: number;
-            pr_head_sha: string;
-          };
-          review_run: {
-            id: string;
-            walkthrough: string;
-          };
-          comments: Array<{
-            id: string;
-            file_path: string;
-            line: number;
-            side: 'old' | 'new';
-            body: string;
-            kind: 'comment' | 'suggestion';
-            severity?: string;
-            bucket?: string;
-            existing_code?: string | null;
-            suggested_code?: string | null;
-          }>;
+      const body = req.body as {
+        task: {
+          id: string;
+          title: string;
+          pr_url: string;
+          pr_number: number;
+          pr_head_sha: string;
         };
+        review_run: {
+          id: string;
+          walkthrough: string;
+        };
+        comments: Array<{
+          id: string;
+          file_path: string;
+          line: number;
+          side: 'old' | 'new';
+          body: string;
+          kind: 'comment' | 'suggestion';
+          severity?: string;
+          bucket?: string;
+          existing_code?: string | null;
+          suggested_code?: string | null;
+        }>;
+      };
 
-        inTransaction(() => {
-          const wtId = `wt-${body.task.id}`;
-          // `path` = server's cwd so git-show works; `repo_path` = non-existent so
-          // deleteTask's git-worktree-remove fails gracefully without deleting cwd.
-          insertWorktreeIfAbsent({
-            id: wtId,
-            path: process.cwd(),
-            repo_path: '/tmp/e2e-norepo',
-            branch: 'review/e2e',
-            base_branch: 'main',
-            mode: 'new',
-            status: 'available',
-          });
-
-          insertTaskIfAbsent({
-            id: body.task.id,
-            title: body.task.title,
-            description: '',
-            runtime_state: 'idle',
-            workflow_status: 'backlog',
-            source: 'auto_review',
-            worktree_id: wtId,
-            pr_url: body.task.pr_url,
-            pr_number: body.task.pr_number,
-            pr_head_sha: body.task.pr_head_sha,
-          });
-
-          seedReviewRun({
-            id: body.review_run.id,
-            task_id: body.task.id,
-            pr_head_sha: body.task.pr_head_sha,
-            walkthrough: body.review_run.walkthrough,
-          });
-
-          for (const c of body.comments) {
-            seedInlineComment({
-              id: c.id,
-              task_id: body.task.id,
-              review_run_id: body.review_run.id,
-              file_path: c.file_path,
-              line: c.line,
-              side: c.side,
-              original_commit_sha: body.task.pr_head_sha,
-              body: c.body,
-              kind: c.kind,
-              severity: c.severity ?? null,
-              bucket: c.bucket ?? null,
-              existing_code: c.existing_code ?? null,
-              suggested_code: c.suggested_code ?? null,
-            });
-          }
+      inTransaction(() => {
+        const wtId = `wt-${body.task.id}`;
+        // `path` = server's cwd so git-show works; `repo_path` = non-existent so
+        // deleteTask's git-worktree-remove fails gracefully without deleting cwd.
+        insertWorktreeIfAbsent({
+          id: wtId,
+          path: process.cwd(),
+          repo_path: '/tmp/e2e-norepo',
+          branch: 'review/e2e',
+          base_branch: 'main',
+          mode: 'new',
+          status: 'available',
         });
 
-        res.json({ task_id: body.task.id });
-      } catch (err) {
-        res.status(500).json({ error: (err as Error).message });
-      }
+        insertTaskIfAbsent({
+          id: body.task.id,
+          title: body.task.title,
+          description: '',
+          runtime_state: 'idle',
+          workflow_status: 'backlog',
+          source: 'auto_review',
+          worktree_id: wtId,
+          pr_url: body.task.pr_url,
+          pr_number: body.task.pr_number,
+          pr_head_sha: body.task.pr_head_sha,
+        });
+
+        seedReviewRun({
+          id: body.review_run.id,
+          task_id: body.task.id,
+          pr_head_sha: body.task.pr_head_sha,
+          walkthrough: body.review_run.walkthrough,
+        });
+
+        for (const c of body.comments) {
+          seedInlineComment({
+            id: c.id,
+            task_id: body.task.id,
+            review_run_id: body.review_run.id,
+            file_path: c.file_path,
+            line: c.line,
+            side: c.side,
+            original_commit_sha: body.task.pr_head_sha,
+            body: c.body,
+            kind: c.kind,
+            severity: c.severity ?? null,
+            bucket: c.bucket ?? null,
+            existing_code: c.existing_code ?? null,
+            suggested_code: c.suggested_code ?? null,
+          });
+        }
+      });
+
+      res.json({ task_id: body.task.id });
     });
   }
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,6 @@
 import express from 'express';
-import type { Request, Response, NextFunction } from 'express';
 import { setupRoutes } from './api.js';
+import { errorMiddleware } from './error-middleware.js';
 import { childLogger } from './logger.js';
 import { registerAuthRoutes, remoteAuthMiddleware, isRemoteMode } from './remote-auth.js';
 
@@ -67,11 +67,7 @@ export function createApp(): express.Express {
 
   setupRoutes(app);
 
-  // Error handler
-  app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
-    logger.error({ err, method: req.method, path: req.path }, `Unhandled error: ${err.message}`);
-    res.status(500).json({ error: err.message });
-  });
+  app.use(errorMiddleware);
 
   return app;
 }

--- a/server/error-middleware.test.ts
+++ b/server/error-middleware.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { ServiceError } from './services/errors.js';
+import express from 'express';
+
+describe('errorMiddleware', () => {
+  it('maps ServiceError to status + { error } JSON', async () => {
+    const app = express();
+    app.get('/test', () => {
+      throw new ServiceError('Task not found', 404);
+    });
+    const { errorMiddleware } = await import('./error-middleware.js');
+    app.use(errorMiddleware);
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Task not found' });
+  });
+
+  it('preserves custom error body on ServiceError', async () => {
+    const app = express();
+    app.get('/test', () => {
+      throw new ServiceError('config validation failed', 400, {
+        error: 'config validation failed',
+        details: ['name is required'],
+      });
+    });
+    const { errorMiddleware } = await import('./error-middleware.js');
+    app.use(errorMiddleware);
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: 'config validation failed',
+      details: ['name is required'],
+    });
+  });
+
+  it('maps loadTaskOrFail through createApp routes', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/tasks/nonexistent-id');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Task not found' });
+  });
+});

--- a/server/error-middleware.ts
+++ b/server/error-middleware.ts
@@ -1,0 +1,58 @@
+import type { Request, Response, NextFunction } from 'express';
+import { BaseBranchMissingError, BaseUnavailableError } from '@octomux/diff-engine';
+import { childLogger } from './logger.js';
+import { ServiceError } from './services/errors.js';
+
+const logger = childLogger('error-middleware');
+
+function taskIdFromRequest(req: Request): string | undefined {
+  const id = (req.params as Record<string, string | undefined>).id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+function errorBody(err: ServiceError): Record<string, unknown> {
+  return err.body ?? { error: err.message };
+}
+
+/** Express error-handling middleware — register last on the app. */
+export function errorMiddleware(
+  err: unknown,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  const taskId = taskIdFromRequest(req);
+  const baseLog = {
+    method: req.method,
+    path: req.path,
+    ...(taskId ? { task_id: taskId } : {}),
+  };
+
+  if (err instanceof ServiceError) {
+    const level = err.status >= 500 ? 'error' : 'warn';
+    logger[level]({ ...baseLog, err, status: err.status }, err.message);
+    res.status(err.status).json(errorBody(err));
+    return;
+  }
+
+  if (err instanceof BaseBranchMissingError) {
+    logger.warn({ ...baseLog, err }, err.message);
+    res.status(422).json({ error: 'base_branch_missing', message: err.message });
+    return;
+  }
+
+  if (err instanceof BaseUnavailableError) {
+    logger.warn({ ...baseLog, err }, err.message);
+    res.status(503).json({ error: 'base_unavailable', message: err.message });
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : 'Unknown error';
+  logger.error({ ...baseLog, err }, `Unhandled error: ${message}`);
+  res.status(500).json({ error: message });
+}

--- a/server/routes/_shared.ts
+++ b/server/routes/_shared.ts
@@ -2,7 +2,8 @@
  * Shared helpers used across multiple route modules.
  * This file MUST NOT import any router or api.ts.
  */
-import type { Request, Response } from 'express';
+import type { Request } from 'express';
+import { notFound, ServiceError } from '../services/errors.js';
 import { getTask as getTaskRepo, listAllAgents, listUserTerminals } from '../repositories/index.js';
 import { findReviewTaskByPrNumber, findReviewTaskBySource } from '../repositories/index.js';
 import { nanoid } from 'nanoid';
@@ -25,28 +26,21 @@ import {
   updateWorktreeFields,
 } from '../repositories/index.js';
 
-/** Load a task by :id param; respond 404 and return null if missing. */
-export function loadTaskOrFail(req: Request, res: Response): Task | null {
+/** Load a task by :id param; throw 404 if missing. */
+export function loadTaskOrFail(req: Request): Task {
   const task = getTaskRepo(req.params.id as string);
   if (!task) {
-    res.status(404).json({ error: 'Task not found' });
-    return null;
+    throw notFound('Task not found');
   }
   return task;
 }
 
-/** Map a thrown domain error to an HTTP response. */
-export function sendDomainError(res: Response, err: unknown): void {
-  const e = err as NodeJS.ErrnoException;
-  const msg = e.message || 'Unknown error';
-  if (e.code === 'ENOENT' || msg.includes('not found') || msg.includes('does not exist')) {
-    res.status(404).json({ error: msg });
-  } else if (msg.includes('already exists')) {
-    res.status(409).json({ error: msg });
-  } else if (msg.startsWith('Invalid') || msg.includes('required')) {
-    res.status(400).json({ error: msg });
-  } else {
-    res.status(500).json({ error: msg });
+/** Throw ServiceError from a validation helper result. */
+export function throwIfValidationError(
+  result: { status: number; message: string } | null,
+): asserts result is null {
+  if (result) {
+    throw new ServiceError(result.message, result.status);
   }
 }
 

--- a/server/routes/agent-defs.ts
+++ b/server/routes/agent-defs.ts
@@ -10,7 +10,7 @@ import {
   isBuiltInAgent,
   syncAgents,
 } from '../agents.js';
-import { sendDomainError } from './_shared.js';
+import { badRequest, toDomainServiceError } from '../services/errors.js';
 
 export const router = express.Router();
 
@@ -22,12 +22,8 @@ function repoPathFromQuery(req: Request): string | undefined {
 // ─── Agents ──────────────────────────────────────────────────────────────────
 
 router.get('/api/agents', async (req: Request, res: Response) => {
-  try {
-    const agents = await listAgents(repoPathFromQuery(req));
-    res.json(agents);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const agents = await listAgents(repoPathFromQuery(req));
+  res.json(agents);
 });
 
 router.get('/api/agents/:name', async (req: Request, res: Response) => {
@@ -35,25 +31,20 @@ router.get('/api/agents/:name', async (req: Request, res: Response) => {
     const agent = await getAgent(req.params.name as string, repoPathFromQuery(req));
     res.json(agent);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
 router.put('/api/agents/:name', async (req: Request, res: Response) => {
   const { content } = req.body as { content?: string };
   if (content === undefined || content === null) {
-    res.status(400).json({ error: 'content is required' });
-    return;
+    throw badRequest('content is required');
   }
   const repoPath = repoPathFromQuery(req);
-  try {
-    await saveAgent(req.params.name as string, content, repoPath);
-    await syncAgents(repoPath);
-    const agent = await getAgent(req.params.name as string, repoPath);
-    res.json(agent);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  await saveAgent(req.params.name as string, content, repoPath);
+  await syncAgents(repoPath);
+  const agent = await getAgent(req.params.name as string, repoPath);
+  res.json(agent);
 });
 
 router.delete('/api/agents/:name', async (req: Request, res: Response) => {
@@ -68,15 +59,14 @@ router.delete('/api/agents/:name', async (req: Request, res: Response) => {
     await syncAgents(repoPath);
     res.json({ ok: true });
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
 router.post('/api/agents', async (req: Request, res: Response) => {
   const { name, content } = req.body as { name?: string; content?: string };
   if (!name || !content) {
-    res.status(400).json({ error: 'name and content are required' });
-    return;
+    throw badRequest('name and content are required');
   }
   const repoPath = repoPathFromQuery(req);
   try {
@@ -85,6 +75,6 @@ router.post('/api/agents', async (req: Request, res: Response) => {
     const agent = await getAgent(name, repoPath);
     res.status(201).json(agent);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -8,67 +8,51 @@ import { getHarness } from '../harnesses/index.js';
 import { hopAgent } from '../task-engine/index.js';
 import { getAgent as getAgentRepo, getTask as getTaskRepo } from '../repositories/index.js';
 import type { CreateChatRequest, Task } from '../types.js';
+import { badRequest, conflict, notFound, ServiceError } from '../services/errors.js';
 
 const apiLogger = childLogger('api');
 
 export const router = express.Router();
 
 router.get('/api/chats', (_req: Request, res: Response) => {
-  try {
-    res.json(listChats());
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  res.json(listChats());
 });
 
 router.get('/api/chats/:id', (req: Request, res: Response) => {
   const chat = getChat(req.params.id as string);
   if (!chat) {
-    res.status(404).json({ error: 'Chat not found' });
-    return;
+    throw notFound('Chat not found');
   }
   res.json(chat);
 });
 
-/**
- * Move a runtime agent between task ids (or detach to a standalone chat
- * with task_id=null). Kills the old tmux window, opens a new one at the new
- * cwd, and resumes claude so transcript context survives.
- */
 router.patch('/api/agents/:id/task', async (req: Request, res: Response) => {
   const agent = getAgentRepo(req.params.id as string);
   if (!agent) {
-    res.status(404).json({ error: 'Agent not found' });
-    return;
+    throw notFound('Agent not found');
   }
   const body = (req.body ?? {}) as { task_id?: string | null };
   if (!('task_id' in body)) {
-    res.status(400).json({ error: 'task_id is required (string or null)' });
-    return;
+    throw badRequest('task_id is required (string or null)');
   }
   const targetTaskId = body.task_id;
   if (targetTaskId !== null && typeof targetTaskId !== 'string') {
-    res.status(400).json({ error: 'task_id must be a string or null' });
-    return;
+    throw badRequest('task_id must be a string or null');
   }
   if (targetTaskId === agent.task_id) {
-    res.status(400).json({ error: 'Agent is already on that task' });
-    return;
+    throw badRequest('Agent is already on that task');
   }
   if (targetTaskId !== null) {
     const targetTask = getTaskRepo(targetTaskId);
     if (!targetTask) {
-      res.status(404).json({ error: `Task not found: ${targetTaskId}` });
-      return;
+      throw notFound(`Task not found: ${targetTaskId}`);
     }
     const trs = (targetTask as Task).runtime_state;
     if (!(['setting_up', 'running'] as const).includes(trs as 'running')) {
-      res.status(409).json({ error: `Target task is not active (runtime_state=${trs})` });
-      return;
+      throw conflict(`Target task is not active (runtime_state=${trs})`);
     }
     if (!targetTask.worktree_id) {
-      res.status(409).json({ error: 'Target task has no worktree' });
-      return;
+      throw conflict('Target task has no worktree');
     }
   }
 
@@ -89,10 +73,9 @@ router.patch('/api/agents/:id/task', async (req: Request, res: Response) => {
       'task_hop: failed',
     );
     if (msg.includes('not found') || msg.includes('does not exist')) {
-      res.status(409).json({ error: msg });
-    } else {
-      res.status(500).json({ error: msg });
+      throw conflict(msg);
     }
+    throw new ServiceError(msg, 500);
   }
 });
 
@@ -103,8 +86,7 @@ router.post('/api/chats', async (req: Request, res: Response) => {
     try {
       validateAgentName(body.agent);
     } catch (err) {
-      res.status(400).json({ error: (err as Error).message });
-      return;
+      throw badRequest((err as Error).message);
     }
   }
 
@@ -112,62 +94,41 @@ router.post('/api/chats', async (req: Request, res: Response) => {
     try {
       getHarness(body.harness_id);
     } catch (err) {
-      res.status(400).json({ error: (err as Error).message });
-      return;
+      throw badRequest((err as Error).message);
     }
   }
 
-  try {
-    const chat = await createChat({
-      label: body.label,
-      cwd: body.cwd,
-      agent: body.agent,
-      prompt: body.prompt,
-      harnessId: body.harness_id,
-    });
-    res.status(201).json(chat);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const chat = await createChat({
+    label: body.label,
+    cwd: body.cwd,
+    agent: body.agent,
+    prompt: body.prompt,
+    harnessId: body.harness_id,
+  });
+  res.status(201).json(chat);
 });
 
-/**
- * Close a chat — stop the tmux session, mark the agent stopped.
- * Body: `{ status: 'stopped' }`. Preserves the row so history stays visible.
- */
 router.patch('/api/chats/:id', async (req: Request, res: Response) => {
   const chat = getChat(req.params.id as string);
   if (!chat) {
-    res.status(404).json({ error: 'Chat not found' });
-    return;
+    throw notFound('Chat not found');
   }
   const body = (req.body ?? {}) as { status?: string };
   if (body.status !== 'stopped') {
-    res.status(400).json({ error: "Only status='stopped' is supported" });
-    return;
+    throw badRequest("Only status='stopped' is supported");
   }
-  try {
-    await closeChat(chat);
-    const updated = getChat(chat.id);
-    broadcast({ type: 'chat:updated', payload: { chatId: chat.id } });
-    res.json(updated);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  await closeChat(chat);
+  const updated = getChat(chat.id);
+  broadcast({ type: 'chat:updated', payload: { chatId: chat.id } });
+  res.json(updated);
 });
 
-/** Delete a chat — kill tmux, remove scratch dir, delete DB row. */
 router.delete('/api/chats/:id', async (req: Request, res: Response) => {
   const chat = getChat(req.params.id as string);
   if (!chat) {
-    res.status(404).json({ error: 'Chat not found' });
-    return;
+    throw notFound('Chat not found');
   }
-  try {
-    await deleteChat(chat);
-    broadcast({ type: 'chat:deleted', payload: { chatId: chat.id } });
-    res.status(204).send();
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  await deleteChat(chat);
+  broadcast({ type: 'chat:deleted', payload: { chatId: chat.id } });
+  res.status(204).send();
 });

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -19,90 +19,73 @@ import {
 import { computeOutdated } from '../inline-comments-outdated.js';
 import { addLearning } from '../repositories/review-learnings.js';
 import { createInlineComment } from '../services/comment-service.js';
-import { ServiceError } from '../services/errors.js';
 import { loadTaskOrFail } from './_shared.js';
+import { badRequest, conflict, notFound } from '../services/errors.js';
 
 const execFile = promisify(execFileCb);
 const logger = childLogger('api:comments');
 
+function resolveRelPath(req: Request): string {
+  const params = req.params as Record<string, string | string[]>;
+  const rawPath = params.path ?? params['0'] ?? '';
+  return Array.isArray(rawPath) ? rawPath.join('/') : rawPath;
+}
+
+function assertValidPath(cwd: string, relPath: string): void {
+  try {
+    safeResolvePath(cwd, relPath);
+  } catch {
+    throw badRequest('Invalid path');
+  }
+}
+
 export const router = express.Router();
 
-// POST /api/tasks/:id/files/*path/reviewed — mark a file as reviewed
 router.post('/api/tasks/:id/files/*path/reviewed', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const cwd = taskWorkingDir(task);
   if (!cwd) {
-    res.status(400).json({ error: 'Task has no worktree' });
-    return;
+    throw badRequest('Task has no worktree');
   }
-  const params = req.params as Record<string, string | string[]>;
-  const rawPath = params.path ?? params['0'] ?? '';
-  const relPath = Array.isArray(rawPath) ? rawPath.join('/') : rawPath;
+  const relPath = resolveRelPath(req);
+  assertValidPath(cwd, relPath);
+
+  const { stdout } = await execFile('git', ['-C', cwd, 'rev-parse', 'HEAD']);
+  const headSha = stdout.trim();
+  let blobSha: string | null = null;
   try {
-    safeResolvePath(cwd, relPath);
+    const { stdout: bs } = await execFile('git', ['-C', cwd, 'hash-object', '--', relPath]);
+    blobSha = bs.trim() || null;
   } catch {
-    res.status(400).json({ error: 'Invalid path' });
-    return;
+    blobSha = null;
   }
-  try {
-    const { stdout } = await execFile('git', ['-C', cwd, 'rev-parse', 'HEAD']);
-    const headSha = stdout.trim();
-    // Capture the blob hash of the content actually reviewed (the working
-    // tree), so "changed since review" reacts to uncommitted edits too. Null
-    // when the file is gone (e.g. a reviewed deletion).
-    let blobSha: string | null = null;
-    try {
-      const { stdout: bs } = await execFile('git', ['-C', cwd, 'hash-object', '--', relPath]);
-      blobSha = bs.trim() || null;
-    } catch {
-      blobSha = null;
-    }
-    setReviewed(task.id, relPath, headSha, blobSha);
-    res.status(204).send();
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  setReviewed(task.id, relPath, headSha, blobSha);
+  res.status(204).send();
 });
 
-// DELETE /api/tasks/:id/files/*path/reviewed — unmark a file as reviewed
 router.delete('/api/tasks/:id/files/*path/reviewed', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const cwd = taskWorkingDir(task);
   if (!cwd) {
-    res.status(400).json({ error: 'Task has no worktree' });
-    return;
+    throw badRequest('Task has no worktree');
   }
-  const params = req.params as Record<string, string | string[]>;
-  const rawPath = params.path ?? params['0'] ?? '';
-  const relPath = Array.isArray(rawPath) ? rawPath.join('/') : rawPath;
-  try {
-    safeResolvePath(cwd, relPath);
-  } catch {
-    res.status(400).json({ error: 'Invalid path' });
-    return;
-  }
+  const relPath = resolveRelPath(req);
+  assertValidPath(cwd, relPath);
   clearReviewed(task.id, relPath);
   res.status(204).send();
 });
 
-// POST /api/tasks/:id/comments — create an inline review comment
 router.post('/api/tasks/:id/comments', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
+    throw badRequest('no repo for scratch task');
   }
   const cwd = taskWorkingDir(task);
   if (!cwd) {
-    res.status(400).json({ error: 'Task has no worktree' });
-    return;
+    throw badRequest('Task has no worktree');
   }
   if (!fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Worktree no longer exists on disk' });
-    return;
+    throw badRequest('Worktree no longer exists on disk');
   }
 
   const body = req.body as {
@@ -122,64 +105,43 @@ router.post('/api/tasks/:id/comments', async (req: Request, res: Response) => {
   const anchorRaw = body.anchor_commit_sha;
 
   if (!filePath) {
-    res.status(400).json({ error: 'file_path is required' });
-    return;
+    throw badRequest('file_path is required');
   }
   if (typeof lineRaw !== 'number' || !Number.isInteger(lineRaw) || lineRaw < 1) {
-    res.status(400).json({ error: 'line must be a positive integer' });
-    return;
+    throw badRequest('line must be a positive integer');
   }
   if (side !== 'old' && side !== 'new') {
-    res.status(400).json({ error: "side must be 'old' or 'new'" });
-    return;
+    throw badRequest("side must be 'old' or 'new'");
   }
   if (!commentBody.trim()) {
-    res.status(400).json({ error: 'body is required' });
-    return;
+    throw badRequest('body is required');
   }
   if (anchorRaw !== undefined && typeof anchorRaw !== 'string') {
-    res.status(400).json({ error: 'anchor_commit_sha must be a string' });
-    return;
+    throw badRequest('anchor_commit_sha must be a string');
   }
 
-  try {
-    safeResolvePath(cwd, filePath);
-  } catch {
-    res.status(400).json({ error: 'Invalid path' });
-    return;
-  }
+  assertValidPath(cwd, filePath);
 
   if (!task.base_sha) {
-    res.status(400).json({ error: 'base_sha not available for this task' });
-    return;
+    throw badRequest('base_sha not available for this task');
   }
 
-  try {
-    const row = await createInlineComment({
-      cwd,
-      task_id: task.id,
-      base_sha: task.base_sha,
-      file_path: filePath,
-      line: lineRaw as number,
-      side: side as 'old' | 'new',
-      body: commentBody,
-      agent_id: agentId,
-      anchor_commit_sha: anchorRaw as string | undefined,
-    });
-    res.status(201).json(row);
-  } catch (err) {
-    if (err instanceof ServiceError) {
-      res.status(err.status).json({ error: err.message });
-    } else {
-      res.status(500).json({ error: (err as Error).message });
-    }
-  }
+  const row = await createInlineComment({
+    cwd,
+    task_id: task.id,
+    base_sha: task.base_sha,
+    file_path: filePath,
+    line: lineRaw as number,
+    side: side as 'old' | 'new',
+    body: commentBody,
+    agent_id: agentId,
+    anchor_commit_sha: anchorRaw as string | undefined,
+  });
+  res.status(201).json(row);
 });
 
-// GET /api/tasks/:id/comments — list inline comments for a task
 router.get('/api/tasks/:id/comments', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const fileFilter = typeof req.query.file === 'string' ? req.query.file : undefined;
   const rows = listComments(task.id, fileFilter ? { file: fileFilter } : undefined);
@@ -212,22 +174,17 @@ router.get('/api/tasks/:id/comments', async (req: Request, res: Response) => {
   }
 });
 
-// PATCH /api/tasks/:id/comments/:cid — update a comment
 router.patch('/api/tasks/:id/comments/:cid', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const cid = (req.params as Record<string, string>).cid;
   const existing = getComment(cid);
   if (!existing || existing.task_id !== task.id) {
-    res.status(404).json({ error: 'Comment not found' });
-    return;
+    throw notFound('Comment not found');
   }
 
-  // Refuse updates on already-published comments
   if (existing.status === 'published') {
-    res.status(409).json({ error: 'Cannot update a published comment' });
-    return;
+    throw conflict('Cannot update a published comment');
   }
 
   const body = req.body as {
@@ -254,20 +211,16 @@ router.patch('/api/tasks/:id/comments/:cid', (req: Request, res: Response) => {
   const VALID_STATUSES = ['draft', 'accepted', 'rejected', 'stale'];
 
   if (!hasResolved && !hasBody && !hasStatus && !hasExtended) {
-    res.status(400).json({ error: 'no fields to update' });
-    return;
+    throw badRequest('no fields to update');
   }
   if (hasResolved && typeof body.resolved !== 'boolean') {
-    res.status(400).json({ error: 'resolved must be a boolean' });
-    return;
+    throw badRequest('resolved must be a boolean');
   }
   if (hasBody && (typeof body.body !== 'string' || !body.body.trim())) {
-    res.status(400).json({ error: 'body must be a non-empty string' });
-    return;
+    throw badRequest('body must be a non-empty string');
   }
   if (hasStatus && !VALID_STATUSES.includes(body.status as string)) {
-    res.status(400).json({ error: `status must be one of ${VALID_STATUSES.join(', ')}` });
-    return;
+    throw badRequest(`status must be one of ${VALID_STATUSES.join(', ')}`);
   }
 
   let row = existing;
@@ -296,7 +249,6 @@ router.patch('/api/tasks/:id/comments/:cid', (req: Request, res: Response) => {
     if (updated) row = updated;
   }
 
-  // Capture rejection learning if status='rejected' and rejection_why provided
   if (
     body.status === 'rejected' &&
     typeof body.rejection_why === 'string' &&
@@ -315,16 +267,13 @@ router.patch('/api/tasks/:id/comments/:cid', (req: Request, res: Response) => {
   res.json(row);
 });
 
-// DELETE /api/tasks/:id/comments/:cid — delete a comment
 router.delete('/api/tasks/:id/comments/:cid', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const cid = (req.params as Record<string, string>).cid;
   const existing = getComment(cid);
   if (!existing || existing.task_id !== task.id) {
-    res.status(404).json({ error: 'Comment not found' });
-    return;
+    throw notFound('Comment not found');
   }
 
   deleteComment(cid);

--- a/server/routes/diffs.ts
+++ b/server/routes/diffs.ts
@@ -2,15 +2,13 @@ import express from 'express';
 import type { Request, Response } from 'express';
 import fs from 'fs';
 import {
-  BaseBranchMissingError,
-  BaseUnavailableError,
-  clearDiffBaseCache,
-  getDiffSummary,
-  getFileDiff,
   parseDiffRange,
   resolveDiffBase,
   resolveRef,
   safeResolvePath,
+  getDiffSummary,
+  getFileDiff,
+  clearDiffBaseCache,
 } from '@octomux/diff-engine';
 import { childLogger } from '../logger.js';
 import { taskWorkingDir } from '../task-paths.js';
@@ -20,183 +18,119 @@ import { setWorktreeBase } from '../repositories/index.js';
 import { touchUpdatedAt, getTask as getTaskRepo } from '../repositories/index.js';
 import { broadcast } from '../events.js';
 import { loadTaskOrFail } from './_shared.js';
+import { badRequest, conflict } from '../services/errors.js';
 
 const logger = childLogger('api:diffs');
 const diffLogger = childLogger('diff');
 
+function requireDiffTask(req: Request) {
+  const task = loadTaskOrFail(req);
+  if (task.run_mode === 'scratch') {
+    throw badRequest('no repo for scratch task');
+  }
+  const cwd = taskWorkingDir(task);
+  if (!cwd) {
+    throw badRequest('Task has no worktree');
+  }
+  if (!task.base_sha) {
+    throw badRequest('base_sha not available for this task');
+  }
+  if (!fs.existsSync(cwd)) {
+    throw badRequest('Worktree no longer exists on disk');
+  }
+  return { task, cwd };
+}
+
+function requireUsableWorktree(req: Request) {
+  const task = loadTaskOrFail(req);
+  if (task.run_mode === 'scratch') {
+    throw badRequest('no repo for scratch task');
+  }
+  const cwd = taskWorkingDir(task);
+  if (!cwd || !fs.existsSync(cwd)) {
+    throw badRequest('Task has no usable worktree');
+  }
+  return { task, cwd };
+}
+
+function parseRangeOrThrow(queryRange: string | undefined) {
+  try {
+    return parseDiffRange(queryRange);
+  } catch (err) {
+    throw badRequest((err as Error).message);
+  }
+}
+
 export const router = express.Router();
 
-// GET /api/tasks/:id/diff — get diff summary for a task
 router.get('/api/tasks/:id/diff', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
-  if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
-  }
-  const cwd = taskWorkingDir(task);
-  if (!cwd) {
-    res.status(400).json({ error: 'Task has no worktree' });
-    return;
-  }
-  if (!task.base_sha) {
-    res.status(400).json({ error: 'base_sha not available for this task' });
-    return;
-  }
-  if (!fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Worktree no longer exists on disk' });
-    return;
-  }
-  let range;
-  try {
-    range = parseDiffRange(typeof req.query.range === 'string' ? req.query.range : undefined);
-  } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
-    return;
-  }
-  try {
-    const summary = await getDiffSummary({ target: task, range, logger: diffLogger });
-    const decorated = await decorateDiffSummaryWithReviewState(task.id, cwd, summary);
-    res.json(decorated);
-  } catch (err) {
-    if (err instanceof BaseBranchMissingError) {
-      res.status(422).json({ error: 'base_branch_missing', message: err.message });
-      return;
-    }
-    if (err instanceof BaseUnavailableError) {
-      res.status(503).json({ error: 'base_unavailable', message: err.message });
-      return;
-    }
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const { task, cwd } = requireDiffTask(req);
+  const range = parseRangeOrThrow(
+    typeof req.query.range === 'string' ? req.query.range : undefined,
+  );
+  const summary = await getDiffSummary({ target: task, range, logger: diffLogger });
+  const decorated = await decorateDiffSummaryWithReviewState(task.id, cwd, summary);
+  res.json(decorated);
 });
 
-// GET /api/tasks/:id/diff/*path — get per-file diff
 router.get('/api/tasks/:id/diff/*path', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
-  if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
-  }
-  const cwd = taskWorkingDir(task);
-  if (!cwd) {
-    res.status(400).json({ error: 'Task has no worktree' });
-    return;
-  }
-  if (!task.base_sha) {
-    res.status(400).json({ error: 'base_sha not available for this task' });
-    return;
-  }
-  if (!fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Worktree no longer exists on disk' });
-    return;
-  }
+  const { task, cwd } = requireDiffTask(req);
   const params = req.params as Record<string, string | string[]>;
   const rawPath = params.path ?? params['0'] ?? '';
   const relPath = Array.isArray(rawPath) ? rawPath.join('/') : rawPath;
   try {
     safeResolvePath(cwd, relPath);
   } catch {
-    res.status(400).json({ error: 'Invalid path' });
-    return;
+    throw badRequest('Invalid path');
   }
-  let range;
-  try {
-    range = parseDiffRange(typeof req.query.range === 'string' ? req.query.range : undefined);
-  } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
-    return;
-  }
-  try {
-    // Resolve the live base so the per-file diff agrees with the summary
-    // (both go through resolveDiffBase, which shares an in-process cache).
-    const resolved = await resolveDiffBase(task);
-    const diff = await getFileDiff({
-      worktree: cwd,
-      range,
-      taskBaseSha: resolved.sha,
-      relPath,
-    });
-    res.json(diff);
-  } catch (err) {
-    if (err instanceof BaseBranchMissingError) {
-      res.status(422).json({ error: 'base_branch_missing', message: err.message });
-      return;
-    }
-    if (err instanceof BaseUnavailableError) {
-      res.status(503).json({ error: 'base_unavailable', message: err.message });
-      return;
-    }
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const range = parseRangeOrThrow(
+    typeof req.query.range === 'string' ? req.query.range : undefined,
+  );
+  const resolved = await resolveDiffBase(task);
+  const diff = await getFileDiff({
+    worktree: cwd,
+    range,
+    taskBaseSha: resolved.sha,
+    relPath,
+  });
+  res.json(diff);
 });
 
-// GET /api/tasks/:id/branches — list branches in a task's worktree
 router.get('/api/tasks/:id/branches', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
-  if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
-  }
-  const cwd = taskWorkingDir(task);
-  if (!cwd || !fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Task has no usable worktree' });
-    return;
-  }
+  const { task, cwd } = requireUsableWorktree(req);
   try {
     const result = await listBranches(cwd);
     res.json(result);
   } catch (err) {
     logger.warn({ task_id: task.id, err: (err as Error).message }, 'listBranches failed');
-    res.status(500).json({ error: (err as Error).message });
+    throw err;
   }
 });
 
-// GET /api/tasks/:id/commits — list commits in a task's worktree
 router.get('/api/tasks/:id/commits', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
-  if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
-  }
-  const cwd = taskWorkingDir(task);
-  if (!cwd || !fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Task has no usable worktree' });
-    return;
-  }
+  const { task, cwd } = requireUsableWorktree(req);
 
-  // Determine the from/to refs. If `range=` is provided, derive from it; else
-  // default to base..HEAD when we have a base_sha, or just HEAD when we don't.
   let from: string | undefined;
   let to = 'HEAD';
   const rangeParam = typeof req.query.range === 'string' ? req.query.range : undefined;
   if (rangeParam) {
-    try {
-      const parsed = parseDiffRange(rangeParam);
-      switch (parsed.kind) {
-        case 'base':
-          from = task.base_sha ?? undefined;
-          to = 'HEAD';
-          break;
-        case 'commit':
-          from = `${parsed.sha}^`;
-          to = parsed.sha;
-          break;
-        case 'range':
-          from = parsed.from;
-          to = parsed.to;
-          break;
-        case 'working':
-          // No commits in a working-only range.
-          res.json({ commits: [], truncated: false });
-          return;
-      }
-    } catch (err) {
-      res.status(400).json({ error: (err as Error).message });
-      return;
+    const parsed = parseRangeOrThrow(rangeParam);
+    switch (parsed.kind) {
+      case 'base':
+        from = task.base_sha ?? undefined;
+        to = 'HEAD';
+        break;
+      case 'commit':
+        from = `${parsed.sha}^`;
+        to = parsed.sha;
+        break;
+      case 'range':
+        from = parsed.from;
+        to = parsed.to;
+        break;
+      case 'working':
+        res.json({ commits: [], truncated: false });
+        return;
     }
   } else if (task.base_sha) {
     from = task.base_sha;
@@ -210,36 +144,29 @@ router.get('/api/tasks/:id/commits', async (req: Request, res: Response) => {
     res.json(result);
   } catch (err) {
     logger.warn({ task_id: task.id, err: (err as Error).message }, 'listCommits failed');
-    res.status(500).json({ error: (err as Error).message });
+    throw err;
   }
 });
 
-// PATCH /api/tasks/:id/base — change base branch for a task
 router.patch('/api/tasks/:id/base', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   if (task.run_mode === 'scratch') {
-    res.status(400).json({ error: 'no repo for scratch task' });
-    return;
+    throw badRequest('no repo for scratch task');
   }
   if (task.runtime_state === 'idle') {
-    res.status(409).json({ error: 'cannot change base on a draft task' });
-    return;
+    throw conflict('cannot change base on a draft task');
   }
   if (!task.worktree_id) {
-    res.status(400).json({ error: 'task has no worktree row to update' });
-    return;
+    throw badRequest('task has no worktree row to update');
   }
   const cwd = taskWorkingDir(task);
   if (!cwd || !fs.existsSync(cwd)) {
-    res.status(400).json({ error: 'Task has no usable worktree' });
-    return;
+    throw badRequest('Task has no usable worktree');
   }
 
   const baseBranch = (req.body as { base_branch?: unknown }).base_branch;
   if (typeof baseBranch !== 'string' || !baseBranch.trim()) {
-    res.status(400).json({ error: 'base_branch is required' });
-    return;
+    throw badRequest('base_branch is required');
   }
 
   let sha: string;
@@ -250,17 +177,12 @@ router.patch('/api/tasks/:id/base', async (req: Request, res: Response) => {
       { task_id: task.id, base_branch: baseBranch, err: (err as Error).message },
       'resolveRef failed',
     );
-    res.status(400).json({ error: 'ref does not resolve' });
-    return;
+    throw badRequest('ref does not resolve');
   }
 
-  // Persist the new base on the joined worktrees row (Phase 2a moved these
-  // columns off `tasks`). Bump the task's updated_at separately.
   setWorktreeBase(task.worktree_id, baseBranch, sha);
   touchUpdatedAt(task.id);
 
-  // Invalidate any cached origin tip for old/new branch on this worktree so
-  // the next diff fetch resolves fresh.
   if (task.base_branch) clearDiffBaseCache(cwd, task.base_branch);
   clearDiffBaseCache(cwd, baseBranch);
 

--- a/server/routes/hooks-registry.ts
+++ b/server/routes/hooks-registry.ts
@@ -11,6 +11,7 @@ import {
   getHookEnabled as getHookEnabledRepo,
   upsertHookSetting,
 } from '../repositories/index.js';
+import { badRequest, ServiceError } from '../services/errors.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const apiLogger = childLogger('api');
@@ -140,30 +141,25 @@ function discoverHookScripts(
 }
 
 router.get('/api/hooks/templates', async (_req: Request, res: Response) => {
-  try {
-    const { listHookTemplates, isHookTemplateInstalled } = await import('../hooks-install.js');
-    const templates = listHookTemplates().map((id) => ({
-      id,
-      installed: isHookTemplateInstalled(id),
-    }));
-    res.json(templates);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const { listHookTemplates, isHookTemplateInstalled } = await import('../hooks-install.js');
+  const templates = listHookTemplates().map((id) => ({
+    id,
+    installed: isHookTemplateInstalled(id),
+  }));
+  res.json(templates);
 });
 
 router.post('/api/hooks/install', async (req: Request, res: Response) => {
   const { template } = req.body as { template?: string };
   if (!template || typeof template !== 'string') {
-    res.status(400).json({ error: 'body must contain { template: string }' });
-    return;
+    throw badRequest('body must contain { template: string }');
   }
   try {
     const { installHookTemplate } = await import('../hooks-install.js');
     const files = installHookTemplate(template);
     res.json({ ok: true, files });
   } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
+    throw badRequest((err as Error).message);
   }
 });
 
@@ -171,7 +167,6 @@ router.post('/api/hooks/install', async (req: Request, res: Response) => {
 router.get('/api/hooks/registry', (_req: Request, res: Response) => {
   const entries: HookRegistryEntry[] = [];
 
-  // Built-in: summarize-progress (defaults disabled)
   const builtinEnabled = getHookEnabled('builtin', 'summarize-progress', false);
   entries.push({
     scope: 'builtin',
@@ -186,11 +181,9 @@ router.get('/api/hooks/registry', (_req: Request, res: Response) => {
     last_exit_code: null,
   });
 
-  // Global hooks: ~/.octomux/hooks/
   const globalHooksBase = path.join(octomuxRoot(), 'hooks');
   entries.push(...discoverHookScripts(globalHooksBase, 'global'));
 
-  // Repo hooks: collect from every active task's repo_path
   try {
     const activeTasks = listActiveRepoPaths();
 
@@ -217,19 +210,15 @@ router.patch('/api/hooks/registry/:scope/:key', (req: Request, res: Response) =>
   const { enabled } = req.body as { enabled?: unknown };
 
   if (typeof enabled !== 'boolean') {
-    res.status(400).json({ error: 'body must contain { enabled: boolean }' });
-    return;
+    throw badRequest('body must contain { enabled: boolean }');
   }
 
   try {
     upsertHookSetting(scope, key, enabled);
-
-    // Invalidate dispatcher cache for this entry
     invalidateHookEnabledCache(scope, key);
-
     res.json({ scope, key, enabled });
   } catch (err) {
     apiLogger.warn({ scope, key, err }, 'failed to update hook_settings');
-    res.status(500).json({ error: 'failed to update hook setting' });
+    throw new ServiceError('failed to update hook setting', 500);
   }
 });

--- a/server/routes/integrations.ts
+++ b/server/routes/integrations.ts
@@ -9,6 +9,7 @@ import {
 } from '../integrations/store.js';
 import { listProviders, getProvider } from '../integrations/registry.js';
 import { maskIntegration, mergeMaskedConfig } from '../integrations/mask.js';
+import { badRequest, notFound, ServiceError } from '../services/errors.js';
 // Side-effect: ensure all providers are registered when the API is loaded.
 import '../integrations/index.js';
 
@@ -40,22 +41,21 @@ router.get('/api/integrations', (_req: Request, res: Response) => {
 router.post('/api/integrations', (req: Request, res: Response) => {
   const body = req.body as { kind?: string; name?: string; config?: unknown };
   if (!body.kind?.trim()) {
-    res.status(400).json({ error: 'kind is required' });
-    return;
+    throw badRequest('kind is required');
   }
   if (!body.name?.trim()) {
-    res.status(400).json({ error: 'name is required' });
-    return;
+    throw badRequest('name is required');
   }
   const provider = getProvider(body.kind);
   if (!provider) {
-    res.status(400).json({ error: `unknown integration kind: ${body.kind}` });
-    return;
+    throw badRequest(`unknown integration kind: ${body.kind}`);
   }
   const validation = provider.validate(body.config ?? {});
   if (!validation.ok) {
-    res.status(400).json({ error: 'config validation failed', details: validation.errors });
-    return;
+    throw new ServiceError('config validation failed', 400, {
+      error: 'config validation failed',
+      details: validation.errors,
+    });
   }
   const integration = createIntegration(body.kind, body.name, body.config ?? {});
   res.status(201).json(maskIntegration(integration, provider.configSchema));
@@ -66,8 +66,7 @@ router.patch('/api/integrations/:id', (req: Request, res: Response) => {
   const id = (req.params as Record<string, string>).id;
   const existing = getIntegration(id);
   if (!existing) {
-    res.status(404).json({ error: 'Integration not found' });
-    return;
+    throw notFound('Integration not found');
   }
   const provider = getProvider(existing.kind);
   const body = req.body as { name?: string; config?: unknown; enabled?: boolean };
@@ -82,19 +81,17 @@ router.patch('/api/integrations/:id', (req: Request, res: Response) => {
       : (body.config as Record<string, unknown>);
     const validation = provider ? provider.validate(mergedConfig) : { ok: true };
     if (!validation.ok) {
-      res.status(400).json({
+      throw new ServiceError('config validation failed', 400, {
         error: 'config validation failed',
         details: (validation as { errors?: string[] }).errors,
       });
-      return;
     }
     patch.config = mergedConfig;
   }
 
   const updated = updateIntegration(id, patch);
   if (!updated) {
-    res.status(404).json({ error: 'Integration not found' });
-    return;
+    throw notFound('Integration not found');
   }
   res.json(provider ? maskIntegration(updated, provider.configSchema) : updated);
 });
@@ -104,8 +101,7 @@ router.delete('/api/integrations/:id', (req: Request, res: Response) => {
   const id = (req.params as Record<string, string>).id;
   const existing = getIntegration(id);
   if (!existing) {
-    res.status(404).json({ error: 'Integration not found' });
-    return;
+    throw notFound('Integration not found');
   }
   deleteIntegration(id);
   res.status(204).send();
@@ -116,16 +112,14 @@ router.post('/api/integrations/linear/prefill', async (req: Request, res: Respon
   const body = req.body as { api_key?: string };
   const apiKey = body.api_key?.trim();
   if (!apiKey) {
-    res.status(400).json({ error: 'api_key is required' });
-    return;
+    throw badRequest('api_key is required');
   }
   try {
     const { prefillFromLinear } = await import('../integrations/linear/prefill.js');
     const result = await prefillFromLinear(apiKey);
     res.json(result);
   } catch (err) {
-    const message = (err as Error).message;
-    res.status(502).json({ error: message });
+    throw new ServiceError((err as Error).message, 502);
   }
 });
 
@@ -134,13 +128,11 @@ router.post('/api/integrations/:id/test', async (req: Request, res: Response) =>
   const id = (req.params as Record<string, string>).id;
   const existing = getIntegration(id);
   if (!existing) {
-    res.status(404).json({ error: 'Integration not found' });
-    return;
+    throw notFound('Integration not found');
   }
   const provider = getProvider(existing.kind);
   if (!provider) {
-    res.status(400).json({ error: `no provider for kind: ${existing.kind}` });
-    return;
+    throw badRequest(`no provider for kind: ${existing.kind}`);
   }
   if (!provider.test) {
     res.json({ ok: true, message: 'Provider does not support connection testing' });
@@ -150,6 +142,9 @@ router.post('/api/integrations/:id/test', async (req: Request, res: Response) =>
     const result = await provider.test(existing.config);
     res.json(result);
   } catch (err) {
-    res.status(500).json({ ok: false, message: (err as Error).message });
+    throw new ServiceError((err as Error).message, 500, {
+      ok: false,
+      message: (err as Error).message,
+    });
   }
 });

--- a/server/routes/learnings.ts
+++ b/server/routes/learnings.ts
@@ -7,20 +7,12 @@ export const router = express.Router();
 // GET /api/repos/:repoPath/learnings — list learnings for a repo
 router.get('/api/repos/:repoPath/learnings', (req: Request, res: Response) => {
   const repoPath = decodeURIComponent((req.params as Record<string, string>).repoPath);
-  try {
-    res.json(listLearningsForRepo(repoPath));
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  res.json(listLearningsForRepo(repoPath));
 });
 
 // DELETE /api/learnings/:id — delete a single learning
 router.delete('/api/learnings/:id', (req: Request, res: Response) => {
   const id = (req.params as Record<string, string>).id;
-  try {
-    deleteLearning(id);
-    res.status(204).send();
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  deleteLearning(id);
+  res.status(204).send();
 });

--- a/server/routes/misc.ts
+++ b/server/routes/misc.ts
@@ -9,13 +9,13 @@ import { getDataDir, pingDb } from '../db.js';
 import { childLogger } from '../logger.js';
 import { countRunningTasks, listRecentRepoPaths } from '../repositories/index.js';
 import { listHarnesses } from '../harnesses/index.js';
+import { badRequest, ServiceError } from '../services/errors.js';
 
 const execFile = promisify(execFileCb);
 const healthLogger = childLogger('health');
 
 export const router = express.Router();
 
-// GET /api/health — readiness probe: DB reachability, uptime, running tasks
 router.get('/api/health', (_req: Request, res: Response) => {
   const uptime = process.uptime();
   const data_dir = getDataDir();
@@ -43,7 +43,6 @@ router.get('/api/health', (_req: Request, res: Response) => {
   res.status(db.ok ? 200 : 503).json({ status, uptime, db, running_tasks, data_dir });
 });
 
-// GET /api/harnesses — list registered harness implementations
 router.get('/api/harnesses', (_req: Request, res: Response) => {
   res.json(
     listHarnesses().map(({ id, displayName, sessionIdMode }) => ({
@@ -54,19 +53,17 @@ router.get('/api/harnesses', (_req: Request, res: Response) => {
   );
 });
 
-// Browse directories for folder picker
 router.get('/api/browse', async (req: Request, res: Response) => {
   const dirPath = (req.query.path as string) || os.homedir();
 
   try {
     const stat = await fs.promises.stat(dirPath);
     if (!stat.isDirectory()) {
-      res.status(400).json({ error: 'Path is not a directory' });
-      return;
+      throw badRequest('Path is not a directory');
     }
-  } catch {
-    res.status(400).json({ error: 'Path does not exist' });
-    return;
+  } catch (err) {
+    if (err instanceof ServiceError) throw err;
+    throw badRequest('Path does not exist');
   }
 
   const dirEntries = await fs.promises.readdir(dirPath);
@@ -106,12 +103,10 @@ router.get('/api/browse', async (req: Request, res: Response) => {
   });
 });
 
-// List branches for a git repo
 router.get('/api/branches', async (req: Request, res: Response) => {
   const repoPath = req.query.repo_path as string;
   if (!repoPath) {
-    res.status(400).json({ error: 'repo_path is required' });
-    return;
+    throw badRequest('repo_path is required');
   }
 
   try {
@@ -127,38 +122,33 @@ router.get('/api/branches', async (req: Request, res: Response) => {
       .split('\n')
       .filter(Boolean)
       .map((b) => b.replace(/^origin\//, ''));
-    // Deduplicate (local + remote may overlap)
     const unique = [...new Set(branches)].filter((b) => b !== 'HEAD');
     res.json(unique);
   } catch {
-    res.status(400).json({ error: 'Failed to list branches' });
+    throw badRequest('Failed to list branches');
   }
 });
 
-// Preflight check for none-mode task creation
 router.get('/api/preflight/none-mode', async (req: Request, res: Response) => {
   const repoPath = String(req.query.repo_path ?? '');
   const baseBranch = String(req.query.base_branch ?? '');
   if (!repoPath || !baseBranch) {
-    res.status(400).json({ error: 'repo_path and base_branch are required' });
-    return;
+    throw badRequest('repo_path and base_branch are required');
   }
   try {
     const { preflightNoneMode } = await import('../preflight.js');
     const result = await preflightNoneMode(repoPath, baseBranch);
     res.json(result);
   } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
+    throw badRequest((err as Error).message);
   }
 });
 
-// Stash uncommitted changes before switching branch
 router.post('/api/preflight/stash', async (req: Request, res: Response) => {
   const repoPath = String(req.body?.repo_path ?? '');
   const targetBranch = String(req.body?.target_branch ?? '');
   if (!repoPath || !targetBranch) {
-    res.status(400).json({ error: 'repo_path and target_branch are required' });
-    return;
+    throw badRequest('repo_path and target_branch are required');
   }
   try {
     await execFile('git', [
@@ -172,16 +162,14 @@ router.post('/api/preflight/stash', async (req: Request, res: Response) => {
     ]);
     res.json({ ok: true });
   } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
+    throw badRequest((err as Error).message);
   }
 });
 
-// Get default branch for a git repo
 router.get('/api/default-branch', async (req: Request, res: Response) => {
   const repoPath = req.query.repo_path as string;
   if (!repoPath) {
-    res.status(400).json({ error: 'repo_path is required' });
-    return;
+    throw badRequest('repo_path is required');
   }
 
   try {
@@ -194,12 +182,10 @@ router.get('/api/default-branch', async (req: Request, res: Response) => {
     const branch = stdout.trim().replace('refs/remotes/origin/', '');
     res.json({ branch });
   } catch {
-    // Fallback to 'main'
     res.json({ branch: 'main' });
   }
 });
 
-// Recent repository paths from past tasks
 router.get('/api/recent-repos', (_req: Request, res: Response) => {
   res.json(listRecentRepoPaths(10));
 });

--- a/server/routes/orchestrator.ts
+++ b/server/routes/orchestrator.ts
@@ -12,6 +12,7 @@ import {
 } from '../orchestrator/store.js';
 import { startConversation } from '../orchestrator/runner.js';
 import { childLogger } from '../logger.js';
+import { badRequest, notFound } from '../services/errors.js';
 
 const apiLogger = childLogger('api');
 
@@ -21,14 +22,11 @@ export const router = express.Router();
 router.post('/api/orchestrator/conversations', async (req: Request, res: Response) => {
   const { title, cwd } = req.body as { title?: string; cwd?: string };
   if (!title?.trim()) {
-    res.status(400).json({ error: 'title is required' });
-    return;
+    throw badRequest('title is required');
   }
   try {
     const id = createConversation({ title: title.trim() });
-    // The conductor runs in a trusted cwd (default: the server's repo root).
     const convCwd = cwd?.trim() || process.cwd();
-    // Launch the interactive claude session for this conversation (tmux + transcript).
     await startConversation(id, convCwd);
     apiLogger.info(
       { conversation_id: id, operation: 'createConversation', cwd: convCwd },
@@ -41,106 +39,74 @@ router.post('/api/orchestrator/conversations', async (req: Request, res: Respons
       { err, operation: 'createConversation' },
       'failed to create orchestrator conversation',
     );
-    res.status(500).json({ error: (err as Error).message });
+    throw err;
   }
 });
 
 // GET /api/orchestrator/conversations — list all conversations
 router.get('/api/orchestrator/conversations', (_req: Request, res: Response) => {
-  try {
-    res.json(listConversations());
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  res.json(listConversations());
 });
 
 // GET /api/orchestrator/conversations/:id — get a single conversation
 router.get('/api/orchestrator/conversations/:id', (req: Request, res: Response) => {
-  try {
-    const conv = getConversation((req.params as Record<string, string>).id);
-    if (!conv) {
-      res.status(404).json({ error: 'Conversation not found' });
-      return;
-    }
-    res.json(conv);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
+  const conv = getConversation((req.params as Record<string, string>).id);
+  if (!conv) {
+    throw notFound('Conversation not found');
   }
+  res.json(conv);
 });
 
 // GET /api/orchestrator/conversations/:id/messages — list messages for a conversation
 router.get('/api/orchestrator/conversations/:id/messages', (req: Request, res: Response) => {
-  try {
-    const convId = (req.params as Record<string, string>).id;
-    const conv = getConversation(convId);
-    if (!conv) {
-      res.status(404).json({ error: 'Conversation not found' });
-      return;
-    }
-    res.json(listOrchestratorMessages(convId));
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
+  const convId = (req.params as Record<string, string>).id;
+  const conv = getConversation(convId);
+  if (!conv) {
+    throw notFound('Conversation not found');
   }
+  res.json(listOrchestratorMessages(convId));
 });
 
 // POST /api/orchestrator/conversations/:id/global-monitor — toggle global-monitor mode
-// Exactly one conversation may be in global-monitor mode at a time.
-// If the conversation is already the global monitor, clears it.
-// Otherwise, designates it as the global monitor (clearing the previous one).
 router.post('/api/orchestrator/conversations/:id/global-monitor', (req: Request, res: Response) => {
-  try {
-    const convId = (req.params as Record<string, string>).id;
-    const conv = getConversation(convId);
-    if (!conv) {
-      res.status(404).json({ error: 'Conversation not found' });
-      return;
-    }
-    // Toggle: if already global-monitor, clear; otherwise set
-    const currentMonitor = getGlobalMonitorConversation();
-    let isMonitor: boolean;
-    if (currentMonitor === convId) {
-      clearGlobalMonitor();
-      isMonitor = false;
-    } else {
-      setGlobalMonitor(convId);
-      isMonitor = true;
-    }
-    apiLogger.info(
-      { conversation_id: convId, is_global_monitor: isMonitor },
-      'orchestrator: global-monitor toggled',
-    );
-    res.json({ is_global_monitor: isMonitor });
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
+  const convId = (req.params as Record<string, string>).id;
+  const conv = getConversation(convId);
+  if (!conv) {
+    throw notFound('Conversation not found');
   }
+  const currentMonitor = getGlobalMonitorConversation();
+  let isMonitor: boolean;
+  if (currentMonitor === convId) {
+    clearGlobalMonitor();
+    isMonitor = false;
+  } else {
+    setGlobalMonitor(convId);
+    isMonitor = true;
+  }
+  apiLogger.info(
+    { conversation_id: convId, is_global_monitor: isMonitor },
+    'orchestrator: global-monitor toggled',
+  );
+  res.json({ is_global_monitor: isMonitor });
 });
 
 // GET /api/orchestrator/conversations/:id/usage — conductor-leanness stats (§6.7)
-// Returns tasks_spawned, tool_calls, started_at, last_activity_at.
-// Returns zeros when no usage row exists yet (conversation was created but no
-// write-actions have been dispatched).
 router.get('/api/orchestrator/conversations/:id/usage', (req: Request, res: Response) => {
-  try {
-    const convId = (req.params as Record<string, string>).id;
-    const conv = getConversation(convId);
-    if (!conv) {
-      res.status(404).json({ error: 'Conversation not found' });
-      return;
-    }
-    const usage = getConversationUsage(convId);
-    if (!usage) {
-      // No usage row yet — return zeros so the UI always gets a valid shape.
-      res.json({
-        conversation_id: convId,
-        tasks_spawned: 0,
-        tool_calls: 0,
-        started_at: conv.created_at,
-        last_activity_at: conv.updated_at,
-      });
-      return;
-    }
-    res.json(usage);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
+  const convId = (req.params as Record<string, string>).id;
+  const conv = getConversation(convId);
+  if (!conv) {
+    throw notFound('Conversation not found');
   }
+  const usage = getConversationUsage(convId);
+  if (!usage) {
+    res.json({
+      conversation_id: convId,
+      tasks_spawned: 0,
+      tool_calls: 0,
+      started_at: conv.created_at,
+      last_activity_at: conv.updated_at,
+    });
+    return;
+  }
+  res.json(usage);
 });

--- a/server/routes/review-runs.ts
+++ b/server/routes/review-runs.ts
@@ -4,32 +4,27 @@ import { getReviewRun, getCurrentRun, setWalkthrough } from '../repositories/rev
 import { listPublishedReviews } from '../repositories/published-reviews.js';
 import { triggerReviewRun } from '../services/review-service.js';
 import { loadTaskOrFail, deepMerge } from './_shared.js';
+import { badRequest, conflict, notFound } from '../services/errors.js';
 
 export const router = express.Router();
 
-// PATCH /api/tasks/:id/review-runs/:rid/walkthrough — deep-merge walkthrough
 router.patch('/api/tasks/:id/review-runs/:rid/walkthrough', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const params = req.params as Record<string, string>;
   const rid = params.rid;
 
   const run = getReviewRun(rid);
   if (!run || run.task_id !== task.id) {
-    res.status(404).json({ error: 'Review run not found' });
-    return;
+    throw notFound('Review run not found');
   }
 
-  // Refuse if a published_reviews row exists for this run's pr_head_sha
   const published = listPublishedReviews(task.id);
   const alreadyPublished = published.some((p) => p.head_sha === run.pr_head_sha);
   if (alreadyPublished) {
-    res.status(409).json({ error: 'Review already published for this head SHA' });
-    return;
+    throw conflict('Review already published for this head SHA');
   }
 
-  // Deep-merge incoming body into existing walkthrough JSON
   const existing = run.walkthrough ? JSON.parse(run.walkthrough) : {};
   const incoming = req.body as Record<string, unknown>;
   const merged = deepMerge(existing, incoming);
@@ -39,37 +34,26 @@ router.patch('/api/tasks/:id/review-runs/:rid/walkthrough', (req: Request, res: 
   res.json(updated);
 });
 
-// POST /api/tasks/:id/review-runs — trigger a manual re-review
 router.post('/api/tasks/:id/review-runs', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
-  // 409 if a run with status='running' already exists for this task
   const currentRun = getCurrentRun(task.id);
   if (currentRun?.status === 'running') {
-    res.status(409).json({ error: 'A review run is already in progress' });
-    return;
+    throw conflict('A review run is already in progress');
   }
 
-  try {
-    await triggerReviewRun(task);
-    res.status(202).json({ ok: true });
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  await triggerReviewRun(task);
+  res.status(202).json({ ok: true });
 });
 
-// POST /api/tasks/:id/publish-review — publish accepted draft comments to GitHub
 router.post('/api/tasks/:id/publish-review', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const body = req.body as { verdict?: unknown; review_body?: unknown };
   const verdict = body.verdict ?? 'COMMENT';
 
   if (!['COMMENT', 'APPROVE', 'REQUEST_CHANGES'].includes(verdict as string)) {
-    res.status(400).json({ error: 'verdict must be one of COMMENT, APPROVE, REQUEST_CHANGES' });
-    return;
+    throw badRequest('verdict must be one of COMMENT, APPROVE, REQUEST_CHANGES');
   }
 
   try {
@@ -83,9 +67,8 @@ router.post('/api/tasks/:id/publish-review', async (req: Request, res: Response)
   } catch (err) {
     const msg = (err as Error).message;
     if (msg.includes('No accepted comments')) {
-      res.status(400).json({ error: msg });
-    } else {
-      res.status(500).json({ error: msg });
+      throw badRequest(msg);
     }
+    throw err;
   }
 });

--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -12,54 +12,38 @@ import {
 } from '../repositories/index.js';
 import { createReviewTaskFromPr, createManualReview } from '../services/review-service.js';
 import { lookupExistingReviewId } from './_shared.js';
+import { badRequest, notFound, ServiceError } from '../services/errors.js';
 
 const execFile = promisify(execFileCb);
 const logger = childLogger('api:reviews');
 
 export const router = express.Router();
 
-// GET /api/reviews — list all auto_review tasks with aggregated counts
 router.get('/api/reviews', (_req: Request, res: Response) => {
-  try {
-    res.json(listReviewsInbox());
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  res.json(listReviewsInbox());
 });
 
-// GET /api/reviews/:id — full detail for a single review task
 router.get('/api/reviews/:id', (req: Request, res: Response) => {
-  try {
-    const detail = getReviewDetail((req.params as Record<string, string>).id);
-    if (!detail) {
-      res.status(404).json({ error: 'Review not found' });
-      return;
-    }
-    res.json(detail);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
+  const detail = getReviewDetail((req.params as Record<string, string>).id);
+  if (!detail) {
+    throw notFound('Review not found');
   }
+  res.json(detail);
 });
 
-// POST /api/reviews — create an auto_review task for a GitHub PR URL.
-// Idempotent: if a live (non-deleted, non-error) review task already exists
-// for the same repo+PR, returns that instead of creating a duplicate.
 router.post('/api/reviews', async (req: Request, res: Response) => {
   const body = req.body as { pr_url?: unknown; repo_path?: unknown };
   const prUrl = typeof body.pr_url === 'string' ? body.pr_url.trim() : '';
   const bodyRepoPath = typeof body.repo_path === 'string' ? body.repo_path.trim() : '';
 
-  // Parse GitHub PR URL
   const prMatch = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
   if (!prMatch) {
-    res.status(400).json({ error: 'invalid pr_url' });
-    return;
+    throw badRequest('invalid pr_url');
   }
   const [, owner, repo, numberStr] = prMatch;
   const number = parseInt(numberStr, 10);
   const ownerRepo = `${owner}/${repo}`;
 
-  // Resolve the local repo path
   let repoPath = bodyRepoPath;
   if (!repoPath) {
     const rows = listTrackedRepoPaths();
@@ -75,7 +59,6 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
           'origin',
         ]);
         const remoteUrl = stdout.trim();
-        // Handle both ssh (git@github.com:owner/repo.git) and https
         const sshMatch = remoteUrl.match(/git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
         const httpsMatch = remoteUrl.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/);
         const remoteOwnerRepo = (sshMatch?.[1] ?? httpsMatch?.[1] ?? '').toLowerCase();
@@ -90,13 +73,9 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
   }
 
   if (!repoPath) {
-    res.status(400).json({
-      error: `could not resolve a local repo for ${ownerRepo}; pass repo_path`,
-    });
-    return;
+    throw badRequest(`could not resolve a local repo for ${ownerRepo}; pass repo_path`);
   }
 
-  // Dedup: check for an existing live review task for this repo+PR
   const existing = findExistingReviewTask(repoPath, number);
 
   if (existing) {
@@ -104,7 +83,6 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
     return;
   }
 
-  // Fetch PR metadata via gh CLI
   let pr: {
     title: string;
     headRefOid: string;
@@ -129,16 +107,13 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
     );
     pr = JSON.parse(stdout) as typeof pr;
   } catch (err) {
-    res.status(400).json({ error: `failed to fetch PR metadata: ${(err as Error).message}` });
-    return;
+    throw badRequest(`failed to fetch PR metadata: ${(err as Error).message}`);
   }
 
   if (pr.state !== 'OPEN') {
-    res.status(400).json({ error: `PR #${number} is ${pr.state}` });
-    return;
+    throw badRequest(`PR #${number} is ${pr.state}`);
   }
 
-  // Create the review task (service owns the build+insert+broadcast+startTask tail).
   const { id } = await createReviewTaskFromPr({
     repo_path: repoPath,
     pr_number: number,
@@ -158,20 +133,15 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
   res.status(201).json({ id, reused: false });
 });
 
-// POST /api/tasks/:taskId/review — manually trigger a review for this task.
-// Creates an auto_review task pointing back at the source via review_of_task_id,
-// or returns the existing review when one is already present.
 router.post('/api/tasks/:taskId/review', async (req: Request, res: Response) => {
   const taskId = (req.params as Record<string, string>).taskId;
   const task = getTaskRepo(taskId);
   if (!task) {
-    res.status(404).json({ error: 'Task not found' });
-    return;
+    throw notFound('Task not found');
   }
 
   if (!task.branch || !task.worktree) {
-    res.status(400).json({ error: 'Start the task first' });
-    return;
+    throw badRequest('Start the task first');
   }
 
   const existingId = lookupExistingReviewId(task);
@@ -180,8 +150,6 @@ router.post('/api/tasks/:taskId/review', async (req: Request, res: Response) => 
     return;
   }
 
-  // PR-less source: capture the current HEAD of the source worktree so the
-  // review agent has a concrete sha to diff base..head against.
   let prHeadSha = task.pr_head_sha;
   if (!prHeadSha) {
     const cwd = taskWorkingDir(task);
@@ -189,8 +157,7 @@ router.post('/api/tasks/:taskId/review', async (req: Request, res: Response) => 
       const { stdout } = await execFile('git', ['-C', cwd!, 'rev-parse', 'HEAD']);
       prHeadSha = stdout.trim();
     } catch (err) {
-      res.status(500).json({ error: `failed to resolve HEAD: ${(err as Error).message}` });
-      return;
+      throw new ServiceError(`failed to resolve HEAD: ${(err as Error).message}`, 500);
     }
   }
 

--- a/server/routes/saved-files.ts
+++ b/server/routes/saved-files.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 import { listSavedFiles, getSavedFile, putSavedFile } from '../saved-files.js';
-import { sendDomainError } from './_shared.js';
+import { badRequest, toDomainServiceError } from '../services/errors.js';
 
 export const router = express.Router();
 
@@ -12,12 +12,8 @@ function decodeRepoPath(req: Request): string {
 // GET /api/repos/:repoPath/files — list saved files under .octomux/files/
 router.get('/api/repos/:repoPath/files', async (req: Request, res: Response) => {
   const repoPath = decodeRepoPath(req);
-  try {
-    const files = await listSavedFiles(repoPath);
-    res.json(files);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const files = await listSavedFiles(repoPath);
+  res.json(files);
 });
 
 // GET /api/repos/:repoPath/files/content?path=<rel> — read a saved file
@@ -25,14 +21,13 @@ router.get('/api/repos/:repoPath/files/content', async (req: Request, res: Respo
   const repoPath = decodeRepoPath(req);
   const relPath = req.query.path as string | undefined;
   if (!relPath) {
-    res.status(400).json({ error: 'path query parameter is required' });
-    return;
+    throw badRequest('path query parameter is required');
   }
   try {
     const file = await getSavedFile(repoPath, relPath);
     res.json(file);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
@@ -41,18 +36,16 @@ router.put('/api/repos/:repoPath/files/content', async (req: Request, res: Respo
   const repoPath = decodeRepoPath(req);
   const relPath = req.query.path as string | undefined;
   if (!relPath) {
-    res.status(400).json({ error: 'path query parameter is required' });
-    return;
+    throw badRequest('path query parameter is required');
   }
   const { content } = req.body as { content?: string };
   if (content === undefined || content === null) {
-    res.status(400).json({ error: 'content is required' });
-    return;
+    throw badRequest('content is required');
   }
   try {
     const file = await putSavedFile(repoPath, relPath, content);
     res.json(file);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -7,22 +7,32 @@ import {
   listRepoConfigs,
 } from '../repositories/repo-config.js';
 import { augmentDashboardSettings } from './_shared.js';
+import { badRequest, ServiceError } from '../services/errors.js';
+
+function throwSettingsError(err: unknown): never {
+  const message = (err as Error).message;
+  const clientInputError =
+    message.startsWith('Invalid editor') ||
+    message.startsWith('Invalid claudeFlags') ||
+    message.includes('Invalid claude-code') ||
+    message.includes('Invalid harnesses.claude-code');
+  if (clientInputError) {
+    throw badRequest(message);
+  }
+  throw new ServiceError(message, 500);
+}
 
 export const router = express.Router();
 
 router.get('/api/settings', async (_req: Request, res: Response) => {
-  try {
-    const settings = await getSettings();
-    const envClaudeFlags = process.env.OCTOMUX_CLAUDE_FLAGS?.trim();
-    res.json({
-      ...augmentDashboardSettings(settings),
-      envOverrides: {
-        claudeFlags: envClaudeFlags ? envClaudeFlags : null,
-      },
-    });
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const settings = await getSettings();
+  const envClaudeFlags = process.env.OCTOMUX_CLAUDE_FLAGS?.trim();
+  res.json({
+    ...augmentDashboardSettings(settings),
+    envOverrides: {
+      claudeFlags: envClaudeFlags ? envClaudeFlags : null,
+    },
+  });
 });
 
 router.patch('/api/settings', async (req: Request, res: Response) => {
@@ -30,55 +40,31 @@ router.patch('/api/settings', async (req: Request, res: Response) => {
     const settings = await updateSettings(req.body);
     res.json(augmentDashboardSettings(settings));
   } catch (err) {
-    const message = (err as Error).message;
-    const clientInputError =
-      message.startsWith('Invalid editor') ||
-      message.startsWith('Invalid claudeFlags') ||
-      message.includes('Invalid claude-code') ||
-      message.includes('Invalid harnesses.claude-code');
-    if (clientInputError) {
-      res.status(400).json({ error: message });
-    } else {
-      res.status(500).json({ error: message });
-    }
+    throwSettingsError(err);
   }
 });
 
 // ─── Repo Config ────────────────────────────────────────────────────────────
 
 router.get('/api/repo-configs', async (_req: Request, res: Response) => {
-  try {
-    const configs = listRepoConfigs();
-    res.json(configs);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const configs = listRepoConfigs();
+  res.json(configs);
 });
 
 router.get('/api/repo-config', async (req: Request, res: Response) => {
   const repoPath = req.query.repo_path as string;
   if (!repoPath) {
-    res.status(400).json({ error: 'repo_path query parameter is required' });
-    return;
+    throw badRequest('repo_path query parameter is required');
   }
-  try {
-    const config = await getOrCreateRepoConfig(repoPath);
-    res.json(config);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const config = await getOrCreateRepoConfig(repoPath);
+  res.json(config);
 });
 
 router.patch('/api/repo-config', async (req: Request, res: Response) => {
   const { repo_path, ...updates } = req.body as Record<string, unknown>;
   if (!repo_path || typeof repo_path !== 'string') {
-    res.status(400).json({ error: 'repo_path is required' });
-    return;
+    throw badRequest('repo_path is required');
   }
-  try {
-    const config = updateRepoConfig(repo_path, updates);
-    res.json(config);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const config = updateRepoConfig(repo_path, updates);
+  res.json(config);
 });

--- a/server/routes/setup.ts
+++ b/server/routes/setup.ts
@@ -1,23 +1,19 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 import { augmentDashboardSettings } from './_shared.js';
+import { badRequest, ServiceError } from '../services/errors.js';
 
 export const router = express.Router();
 
 router.get('/api/setup/status', async (_req: Request, res: Response) => {
-  try {
-    const { getSetupStatus } = await import('../setup-status.js');
-    res.json(await getSetupStatus());
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const { getSetupStatus } = await import('../setup-status.js');
+  res.json(await getSetupStatus());
 });
 
 router.post('/api/setup/install', async (req: Request, res: Response) => {
   const { id } = req.body as { id?: string };
   if (!id || typeof id !== 'string') {
-    res.status(400).json({ error: 'body must contain { id: string }' });
-    return;
+    throw badRequest('body must contain { id: string }');
   }
   try {
     const { runSetupInstall } = await import('../setup-status.js');
@@ -26,19 +22,14 @@ router.post('/api/setup/install', async (req: Request, res: Response) => {
   } catch (err) {
     const message = (err as Error).message;
     if (message.startsWith('Install not allowed')) {
-      res.status(400).json({ error: message });
-    } else {
-      res.status(500).json({ error: message });
+      throw badRequest(message);
     }
+    throw new ServiceError(message, 500);
   }
 });
 
 router.post('/api/setup/apply-recommended-defaults', async (_req: Request, res: Response) => {
-  try {
-    const { applyRecommendedDefaults } = await import('../setup-status.js');
-    const settings = await applyRecommendedDefaults();
-    res.json(augmentDashboardSettings(settings));
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const { applyRecommendedDefaults } = await import('../setup-status.js');
+  const settings = await applyRecommendedDefaults();
+  res.json(augmentDashboardSettings(settings));
 });

--- a/server/routes/skills.ts
+++ b/server/routes/skills.ts
@@ -8,7 +8,7 @@ import {
   deleteSkill,
   type SkillsOptions,
 } from '../skills.js';
-import { sendDomainError } from './_shared.js';
+import { badRequest, toDomainServiceError } from '../services/errors.js';
 
 export const router = express.Router();
 
@@ -18,12 +18,8 @@ function skillsOpts(req: Request): SkillsOptions | undefined {
 }
 
 router.get('/api/skills', async (req: Request, res: Response) => {
-  try {
-    const skills = await listSkills(skillsOpts(req));
-    res.json(skills);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const skills = await listSkills(skillsOpts(req));
+  res.json(skills);
 });
 
 router.get('/api/skills/:name', async (req: Request, res: Response) => {
@@ -31,35 +27,33 @@ router.get('/api/skills/:name', async (req: Request, res: Response) => {
     const skill = await getSkill(req.params.name as string, skillsOpts(req));
     res.json(skill);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
 router.post('/api/skills', async (req: Request, res: Response) => {
   const { name, content } = req.body as { name?: string; content?: string };
   if (!name) {
-    res.status(400).json({ error: 'name is required' });
-    return;
+    throw badRequest('name is required');
   }
   try {
     const skill = await createSkill(name, content || '', skillsOpts(req));
     res.status(201).json(skill);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
 router.put('/api/skills/:name', async (req: Request, res: Response) => {
   const { content } = req.body as { content?: string };
   if (content === undefined || content === null) {
-    res.status(400).json({ error: 'content is required' });
-    return;
+    throw badRequest('content is required');
   }
   try {
     const skill = await updateSkill(req.params.name as string, content, skillsOpts(req));
     res.json(skill);
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });
 
@@ -68,6 +62,6 @@ router.delete('/api/skills/:name', async (req: Request, res: Response) => {
     await deleteSkill(req.params.name as string, skillsOpts(req));
     res.status(204).send();
   } catch (err) {
-    sendDomainError(res, err);
+    throw toDomainServiceError(err);
   }
 });

--- a/server/routes/task-agents.ts
+++ b/server/routes/task-agents.ts
@@ -13,17 +13,15 @@ import { broadcast } from '../events.js';
 import { getAgentByIdAndTask, getUserTerminalByIdAndTask } from '../repositories/index.js';
 import type { AddAgentRequest } from '../types.js';
 import { loadTaskOrFail } from './_shared.js';
+import { badRequest, notFound } from '../services/errors.js';
 
 export const router = express.Router();
 
-// Add agent to task
 router.post('/api/tasks/:id/agents', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {
-    res.status(400).json({ error: 'Can only add agents to running tasks' });
-    return;
+    throw badRequest('Can only add agents to running tasks');
   }
 
   const body = req.body as AddAgentRequest;
@@ -32,8 +30,7 @@ router.post('/api/tasks/:id/agents', async (req: Request, res: Response) => {
     try {
       validateAgentName(body.agent);
     } catch (err) {
-      res.status(400).json({ error: (err as Error).message });
-      return;
+      throw badRequest((err as Error).message);
     }
   }
 
@@ -49,15 +46,12 @@ router.post('/api/tasks/:id/agents', async (req: Request, res: Response) => {
   res.status(201).json(agent);
 });
 
-// Stop agent
 router.delete('/api/tasks/:id/agents/:agentId', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const agent = getAgentByIdAndTask(req.params.agentId as string, req.params.id as string);
 
   if (!agent) {
-    res.status(404).json({ error: 'Task or agent not found' });
-    return;
+    throw notFound('Task or agent not found');
   }
 
   await stopAgent(task, agent);
@@ -65,27 +59,22 @@ router.delete('/api/tasks/:id/agents/:agentId', async (req: Request, res: Respon
   res.json({ success: true });
 });
 
-// Send message to agent via tmux send-keys
 router.post('/api/tasks/:id/agents/:agentId/message', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {
-    res.status(400).json({ error: 'Task is not running' });
-    return;
+    throw badRequest('Task is not running');
   }
 
   const agent = getAgentByIdAndTask(req.params.agentId as string, req.params.id as string);
 
   if (!agent) {
-    res.status(404).json({ error: 'Agent not found' });
-    return;
+    throw notFound('Agent not found');
   }
 
   const { message } = req.body as { message?: string };
   if (!message) {
-    res.status(400).json({ error: 'message is required' });
-    return;
+    throw badRequest('message is required');
   }
 
   await sendMessageToAgent(task.tmux_session!, agent.window_index, message);
@@ -93,57 +82,39 @@ router.post('/api/tasks/:id/agents/:agentId/message', async (req: Request, res: 
   res.json({ success: true });
 });
 
-// Create user terminal (lazily creates tmux window with nvim)
 router.post('/api/tasks/:id/user-terminal', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {
-    res.status(400).json({ error: 'Can only create user terminal for running tasks' });
-    return;
+    throw badRequest('Can only create user terminal for running tasks');
   }
 
   if (!task.tmux_session) {
-    res.status(400).json({ error: 'Task has no tmux session' });
-    return;
+    throw badRequest('Task has no tmux session');
   }
 
-  try {
-    const result = await createUserTerminal(task);
-    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
-    res.json(result);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const result = await createUserTerminal(task);
+  broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+  res.json(result);
 });
 
-// Create shell terminal
 router.post('/api/tasks/:id/terminals', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {
-    res.status(400).json({ error: 'Can only create terminals for running tasks' });
-    return;
+    throw badRequest('Can only create terminals for running tasks');
   }
   if (!task.tmux_session) {
-    res.status(400).json({ error: 'Task has no tmux session' });
-    return;
+    throw badRequest('Task has no tmux session');
   }
 
-  try {
-    const terminal = await createShellTerminal(task);
-    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
-    res.status(201).json(terminal);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const terminal = await createShellTerminal(task);
+  broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+  res.status(201).json(terminal);
 });
 
-// Close shell terminal
 router.delete('/api/tasks/:id/terminals/:terminalId', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   const terminal = getUserTerminalByIdAndTask(
     req.params.terminalId as string,
@@ -151,15 +122,10 @@ router.delete('/api/tasks/:id/terminals/:terminalId', async (req: Request, res: 
   );
 
   if (!terminal) {
-    res.status(404).json({ error: 'Terminal not found' });
-    return;
+    throw notFound('Terminal not found');
   }
 
-  try {
-    await closeShellTerminal(task, terminal);
-    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
-    res.status(204).send();
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  await closeShellTerminal(task, terminal);
+  broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+  res.status(204).send();
 });

--- a/server/routes/task-workflow.ts
+++ b/server/routes/task-workflow.ts
@@ -17,29 +17,25 @@ import {
   deleteTaskExternalRef,
 } from '../repositories/index.js';
 import { loadTaskOrFail, fetchTaskBundle } from './_shared.js';
+import { badRequest, notFound } from '../services/errors.js';
 
 export const router = express.Router();
 
 // Move task to a new workflow_status
 router.post('/api/tasks/:id/move', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const body = req.body as MoveTaskRequest;
 
   if (!body.workflow_status || !WORKFLOW_STATUSES.includes(body.workflow_status)) {
-    res.status(400).json({ error: `invalid workflow_status: ${body.workflow_status}` });
-    return;
+    throw badRequest(`invalid workflow_status: ${body.workflow_status}`);
   }
   if (
     (body.workflow_status === 'human_review' || body.workflow_status === 'planned') &&
     !body.note?.trim()
   ) {
-    res.status(400).json({ error: `note is required when moving to ${body.workflow_status}` });
-    return;
+    throw badRequest(`note is required when moving to ${body.workflow_status}`);
   }
 
-  // Auto-close runtime when moving to the terminal column (done) if
-  // the task is still actively running. Keeps the worktree/branch (close, not delete).
   if (
     body.workflow_status === 'done' &&
     (task.runtime_state === 'running' || task.runtime_state === 'setting_up')
@@ -58,9 +54,6 @@ router.post('/api/tasks/:id/move', async (req: Request, res: Response) => {
     body: body.note ?? null,
   });
 
-  // Auto-start: moving to in_progress should kick the task into setting_up
-  // if it isn't already running. Mirrors POST /api/tasks/:id/start and the
-  // resume branch of PATCH /api/tasks/:id, but triggered by a board move.
   let autoStart: 'start' | 'resume' | null = null;
   if (
     body.workflow_status === 'in_progress' &&
@@ -85,9 +78,6 @@ router.post('/api/tasks/:id/move', async (req: Request, res: Response) => {
   const updated = fetchTaskBundle(task.id);
   res.json(updated);
 
-  // Fire-and-forget after responding so the client gets the optimistic
-  // setting_up state immediately and a follow-up task:updated broadcast
-  // surfaces success or error.
   if (autoStart === 'start') {
     startTask(task)
       .then(() => broadcast({ type: 'task:updated', payload: { taskId: task.id } }))
@@ -99,15 +89,12 @@ router.post('/api/tasks/:id/move', async (req: Request, res: Response) => {
   }
 });
 
-// Post a summary for a task
 router.post('/api/tasks/:id/summary', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const body = req.body as SummaryRequest;
 
   if (!body.summary?.trim()) {
-    res.status(400).json({ error: 'summary is required' });
-    return;
+    throw badRequest('summary is required');
   }
 
   setCurrentSummary(task.id, body.summary);
@@ -124,15 +111,12 @@ router.post('/api/tasks/:id/summary', (req: Request, res: Response) => {
   res.json(updated);
 });
 
-// Add a note to a task
 router.post('/api/tasks/:id/note', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const body = req.body as NoteRequest;
 
   if (!body.body?.trim()) {
-    res.status(400).json({ error: 'body is required' });
-    return;
+    throw badRequest('body is required');
   }
 
   const updateId = addTaskUpdate({ task_id: task.id, kind: 'note', body: body.body });
@@ -146,27 +130,22 @@ router.post('/api/tasks/:id/note', (req: Request, res: Response) => {
   res.status(201).json({ id: updateId, task_id: task.id, kind: 'note', body: body.body });
 });
 
-// Add/replace an external ref
 router.post('/api/tasks/:id/refs', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const body = req.body as AddRefRequest & { metadata?: unknown };
 
   if (!body.integration?.trim()) {
-    res.status(400).json({ error: 'integration is required' });
-    return;
+    throw badRequest('integration is required');
   }
   if (!body.ref?.trim()) {
-    res.status(400).json({ error: 'ref is required' });
-    return;
+    throw badRequest('ref is required');
   }
   if (
     body.metadata !== undefined &&
     body.metadata !== null &&
     (typeof body.metadata !== 'object' || Array.isArray(body.metadata))
   ) {
-    res.status(400).json({ error: 'metadata must be a JSON object' });
-    return;
+    throw badRequest('metadata must be a JSON object');
   }
 
   const result = upsertTaskExternalRef({
@@ -192,16 +171,13 @@ router.post('/api/tasks/:id/refs', (req: Request, res: Response) => {
   res.status(201).json(result);
 });
 
-// Delete an external ref
 router.delete('/api/tasks/:id/refs/:integration', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const integration = (req.params as Record<string, string>).integration;
 
   const existing = getTaskExternalRef(task.id, integration);
   if (!existing) {
-    res.status(404).json({ error: 'Ref not found' });
-    return;
+    throw notFound('Ref not found');
   }
 
   deleteTaskExternalRef(task.id, integration);
@@ -215,10 +191,8 @@ router.delete('/api/tasks/:id/refs/:integration', (req: Request, res: Response) 
   res.status(204).send();
 });
 
-// Get task updates (timeline)
 router.get('/api/tasks/:id/updates', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const limitRaw = Number(req.query.limit ?? 100);
   const limit = Math.min(Math.max(Number.isFinite(limitRaw) ? limitRaw : 100, 1), 1000);
 
@@ -226,17 +200,13 @@ router.get('/api/tasks/:id/updates', (req: Request, res: Response) => {
   res.json(updates);
 });
 
-// Get task external refs
 router.get('/api/tasks/:id/refs', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   res.json(getTaskExternalRefs(task.id));
 });
 
-// ─── Hook executions for a task ──────────────────────────────────────────────
 router.get('/api/tasks/:id/hooks', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const limit = Math.min(parseInt((req.query.limit as string) || '50', 10), 200);
   const executions = getTaskHookExecutions(task.id, limit);
   res.json(executions);

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -42,7 +42,7 @@ import {
 } from '../repositories/index.js';
 
 import { createTask } from '../services/task-service.js';
-import { ServiceError } from '../services/errors.js';
+import { badRequest, conflict } from '../services/errors.js';
 import {
   loadTaskOrFail,
   lookupExistingReviewId,
@@ -51,6 +51,7 @@ import {
   validateCreateTaskBody,
   applyDraftUpdates,
   resolveTaskTitleAndDescription,
+  throwIfValidationError,
 } from './_shared.js';
 
 const apiLogger = childLogger('api');
@@ -150,8 +151,7 @@ router.post('/api/tasks/delete-done', async (req: Request, res: Response) => {
 
 // Mark a single task viewed
 router.patch('/api/tasks/:id/viewed', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   touchLastViewed(task.id);
   apiLogger.info({ task_id: task.id, operation: 'marked_viewed' }, 'marked task viewed');
   const updated = getTaskRepo(task.id) as Task;
@@ -160,8 +160,7 @@ router.patch('/api/tasks/:id/viewed', (req: Request, res: Response) => {
 
 // Get single task with agents
 router.get('/api/tasks/:id', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
   const rawAgents = listAllAgents(task.id);
   // Backfill hook_token for pre-step-1 agents that have an empty token.
   const agents = await Promise.all(
@@ -191,11 +190,7 @@ router.post('/api/tasks', async (req: Request, res: Response) => {
   const body = req.body as CreateTaskRequest;
   const runMode: RunMode = body.run_mode ?? 'new';
 
-  const validationError = validateCreateTaskBody(body, runMode);
-  if (validationError) {
-    res.status(validationError.status).json({ error: validationError.message });
-    return;
-  }
+  throwIfValidationError(validateCreateTaskBody(body, runMode));
 
   // Derive stored repo_path / worktree
   let storedRepoPath: string;
@@ -236,40 +231,31 @@ router.post('/api/tasks', async (req: Request, res: Response) => {
     initialWorkflowStatus = 'planned';
   }
 
-  try {
-    const created = await createTask({
-      resolved_title: resolvedTitle!,
-      resolved_description: resolvedDescription!,
-      initial_prompt: body.initial_prompt ?? null,
-      run_mode: runMode,
-      stored_repo_path: storedRepoPath,
-      staged_path: stagedPath,
-      branch: body.branch ?? null,
-      base_branch: body.base_branch ?? null,
-      worktree_status: 'available',
-      runtime_state: isDraft ? 'idle' : 'setting_up',
-      workflow_status: initialWorkflowStatus,
-      agent: body.agent ?? null,
-      harness_id: body.harness_id ?? 'claude-code',
-      model: body.model ?? null,
-      notify_task_id: body.notify_task_id ?? null,
-      is_draft: isDraft,
-    });
-    res.status(201).json(created);
-  } catch (err) {
-    if (err instanceof ServiceError) {
-      res.status(err.status).json({ error: err.message });
-    } else {
-      throw err;
-    }
-  }
+  const created = await createTask({
+    resolved_title: resolvedTitle!,
+    resolved_description: resolvedDescription!,
+    initial_prompt: body.initial_prompt ?? null,
+    run_mode: runMode,
+    stored_repo_path: storedRepoPath,
+    staged_path: stagedPath,
+    branch: body.branch ?? null,
+    base_branch: body.base_branch ?? null,
+    worktree_status: 'available',
+    runtime_state: isDraft ? 'idle' : 'setting_up',
+    workflow_status: initialWorkflowStatus,
+    agent: body.agent ?? null,
+    harness_id: body.harness_id ?? 'claude-code',
+    model: body.model ?? null,
+    notify_task_id: body.notify_task_id ?? null,
+    is_draft: isDraft,
+  });
+  res.status(201).json(created);
 });
 
 // Update task status
 router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
   const body = req.body as UpdateTaskRequest;
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   // Draft field updates
   const hasDraftFields = [
@@ -284,26 +270,19 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
   ].some((k) => (body as Record<string, unknown>)[k] !== undefined);
 
   if (hasDraftFields) {
-    const draftError = applyDraftUpdates(task, body);
-    if (draftError) {
-      res.status(draftError.status).json({ error: draftError.message });
-      return;
-    }
+    throwIfValidationError(applyDraftUpdates(task, body));
   } else if (body.status === 'running' || body.runtime_state === 'running') {
     // Resume task
     if (task.runtime_state !== 'idle' && task.runtime_state !== 'error') {
-      res.status(400).json({ error: 'Can only resume tasks in closed or error state' });
-      return;
+      throw badRequest('Can only resume tasks in closed or error state');
     }
     if (task.run_mode === 'new' || task.run_mode === 'existing' || task.run_mode === 'scratch') {
       if (!task.worktree || !fs.existsSync(task.worktree)) {
-        res.status(400).json({ error: 'Worktree no longer exists on disk' });
-        return;
+        throw badRequest('Worktree no longer exists on disk');
       }
     } else if (task.run_mode === 'none') {
       if (!fs.existsSync(task.repo_path)) {
-        res.status(400).json({ error: 'repo_path no longer exists on disk' });
-        return;
+        throw badRequest('repo_path no longer exists on disk');
       }
     }
     await resumeTask(task);
@@ -312,8 +291,7 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
   } else if (body.workflow_status) {
     // Direct workflow_status flip (simpler version without note/transition tracking)
     if (!WORKFLOW_STATUSES.includes(body.workflow_status)) {
-      res.status(400).json({ error: `invalid workflow_status: ${body.workflow_status}` });
-      return;
+      throw badRequest(`invalid workflow_status: ${body.workflow_status}`);
     }
     setWorkflowStatus(task.id, body.workflow_status);
   }
@@ -325,12 +303,10 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
 
 // Start a draft task
 router.post('/api/tasks/:id/start', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'idle') {
-    res.status(400).json({ error: 'Only draft tasks can be started' });
-    return;
+    throw badRequest('Only draft tasks can be started');
   }
 
   // Set status immediately so client sees setting_up
@@ -352,13 +328,11 @@ router.post('/api/tasks/:id/start', async (req: Request, res: Response) => {
 
 // Delete task (soft by default; ?purge=true hard-deletes a previously soft-deleted task)
 router.delete('/api/tasks/:id', async (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (req.query.purge === 'true') {
     if (task.deleted_at == null) {
-      res.status(409).json({ error: 'task must be soft-deleted before purge' });
-      return;
+      throw conflict('task must be soft-deleted before purge');
     }
     const taskId = task.id;
     await deleteTask(task);
@@ -375,12 +349,10 @@ router.delete('/api/tasks/:id', async (req: Request, res: Response) => {
 
 // Restore a soft-deleted task
 router.post('/api/tasks/:id/restore', (req: Request, res: Response) => {
-  const task = loadTaskOrFail(req, res);
-  if (!task) return;
+  const task = loadTaskOrFail(req);
 
   if (task.deleted_at == null) {
-    res.status(409).json({ error: 'task is not in trash' });
-    return;
+    throw conflict('task is not in trash');
   }
 
   restoreTaskRepo(task.id);

--- a/server/routes/teams.ts
+++ b/server/routes/teams.ts
@@ -1,24 +1,23 @@
 import express from 'express';
 import type { Request, Response } from 'express';
+import { badRequest } from '../services/errors.js';
 
 export const router = express.Router();
 
 router.post('/api/teams/run', async (req: Request, res: Response) => {
   const { name, repo_path } = req.body as { name?: string; repo_path?: string };
   if (!name) {
-    res.status(400).json({ error: 'name is required' });
-    return;
+    throw badRequest('name is required');
   }
   if (!repo_path) {
-    res.status(400).json({ error: 'repo_path is required' });
-    return;
+    throw badRequest('repo_path is required');
   }
   try {
     const { runTeam } = await import('../teams.js');
     const taskId = await runTeam({ name, repoPath: repo_path });
     res.status(201).json({ task_id: taskId });
   } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
+    throw badRequest((err as Error).message);
   }
 });
 
@@ -29,32 +28,25 @@ router.post('/api/teams/schedule', async (req: Request, res: Response) => {
     cron?: string;
   };
   if (!name) {
-    res.status(400).json({ error: 'name is required' });
-    return;
+    throw badRequest('name is required');
   }
   if (!repo_path) {
-    res.status(400).json({ error: 'repo_path is required' });
-    return;
+    throw badRequest('repo_path is required');
   }
   if (!cron) {
-    res.status(400).json({ error: 'cron is required' });
-    return;
+    throw badRequest('cron is required');
   }
   try {
     const { upsertTeamSchedule } = await import('../teams.js');
     upsertTeamSchedule({ name, repoPath: repo_path, cron });
     res.status(200).json({ ok: true });
   } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
+    throw badRequest((err as Error).message);
   }
 });
 
 router.get('/api/teams', async (_req: Request, res: Response) => {
-  try {
-    const { listTeamSchedules } = await import('../teams.js');
-    const schedules = listTeamSchedules();
-    res.json(schedules);
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-  }
+  const { listTeamSchedules } = await import('../teams.js');
+  const schedules = listTeamSchedules();
+  res.json(schedules);
 });

--- a/server/routes/worktrees.ts
+++ b/server/routes/worktrees.ts
@@ -12,6 +12,7 @@ import {
   deleteWorktree as deleteWorktreeRepo,
   unlinkWorktreeFromAllTasks,
 } from '../repositories/index.js';
+import { conflict, notFound } from '../services/errors.js';
 
 const execFile = promisify(execFileCb);
 const apiLogger = childLogger('api');
@@ -35,8 +36,7 @@ router.get('/api/worktrees', (_req: Request, res: Response) => {
 router.get('/api/worktrees/:id', (req: Request, res: Response) => {
   const worktree = getWorktree(req.params.id as string);
   if (!worktree) {
-    res.status(404).json({ error: 'Worktree not found' });
-    return;
+    throw notFound('Worktree not found');
   }
   const tasks = listTasksByWorktree(worktree.id);
   const active = tasks.find((t) => {
@@ -53,20 +53,17 @@ router.get('/api/worktrees/:id', (req: Request, res: Response) => {
 router.delete('/api/worktrees/:id', async (req: Request, res: Response) => {
   const worktree = getWorktree(req.params.id as string);
   if (!worktree) {
-    res.status(404).json({ error: 'Worktree not found' });
-    return;
+    throw notFound('Worktree not found');
   }
   if (worktree.status !== 'available') {
-    res.status(409).json({ error: 'Worktree is in use' });
-    return;
+    throw conflict('Worktree is in use');
   }
   const referencingTasks = listTasksForWorktree(worktree.id);
   const activeRef = referencingTasks.find((t) =>
     (['setting_up', 'running'] as const).includes(t.runtime_state as 'running'),
   );
   if (activeRef) {
-    res.status(409).json({ error: 'Worktree has an active task' });
-    return;
+    throw conflict('Worktree has an active task');
   }
 
   // Only delete filesystem for worktree-owned modes (new/scratch).

--- a/server/services/errors.ts
+++ b/server/services/errors.ts
@@ -1,16 +1,52 @@
 /**
- * Shared typed errors for the service layer.
+ * Shared typed errors for the service layer and route handlers.
  *
- * ServiceError carries an HTTP status code so route handlers can map it to the
- * correct HTTP response without knowing business logic.
+ * ServiceError carries an HTTP status code so the error middleware can map it to
+ * the correct HTTP response without route handlers knowing response wiring.
  */
 
 export class ServiceError extends Error {
+  /** When set, sent as the JSON body verbatim (preserves non-standard shapes). */
+  readonly body?: Record<string, unknown>;
+
   constructor(
     message: string,
     public readonly status: number,
+    body?: Record<string, unknown>,
   ) {
     super(message);
     this.name = 'ServiceError';
+    this.body = body;
   }
+}
+
+export function badRequest(message: string): ServiceError {
+  return new ServiceError(message, 400);
+}
+
+export function notFound(message: string): ServiceError {
+  return new ServiceError(message, 404);
+}
+
+export function conflict(message: string): ServiceError {
+  return new ServiceError(message, 409);
+}
+
+/**
+ * Map a thrown domain/errno error to ServiceError (replaces sendDomainError).
+ * Used in catch blocks where filesystem / domain errors are expected.
+ */
+export function toDomainServiceError(err: unknown): ServiceError {
+  const e = err as NodeJS.ErrnoException;
+  const msg = e.message || 'Unknown error';
+  if (e.code === 'ENOENT' || msg.includes('not found') || msg.includes('does not exist')) {
+    return new ServiceError(msg, 404);
+  }
+  if (msg.includes('already exists')) {
+    return new ServiceError(msg, 409);
+  }
+  if (msg.startsWith('Invalid') || msg.includes('required')) {
+    return new ServiceError(msg, 400);
+  }
+  return new ServiceError(msg, 500);
 }


### PR DESCRIPTION
## Summary
- Add `errorMiddleware` registered last in `createApp()` to map `ServiceError`, diff-engine base errors, and unknown errors to HTTP status + JSON in one place
- Extend `ServiceError` with helpers (`badRequest`, `notFound`, `conflict`, `toDomainServiceError`) and optional custom `body` for non-standard shapes (integration validation, test endpoint)
- Migrate all 20 route modules to `throw` typed errors; remove `sendDomainError` and inline `res.status(...).json({ error })` handlers

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint` (0 errors)
- [x] `bun run test` — 3351 passed (pre-push hook)
- [x] `bun run build`
- [x] Added `server/error-middleware.test.ts` covering ServiceError mapping and `loadTaskOrFail` 404 via createApp


Made with [Cursor](https://cursor.com)