### PR TITLE
refactor(harnesses): extract shared settings and command helpers

### DIFF
--- a/server/harnesses/claude-code.ts
+++ b/server/harnesses/claude-code.ts
@@ -1,17 +1,18 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import type { Harness, HarnessLaunchOpts, HarnessResumeOpts } from './types.js';
+import type { Harness } from './types.js';
 import { validateAgentName, validateFlagString } from './types.js';
+import {
+  buildClaudeContinueCommand,
+  buildClaudeLaunchCommand,
+  buildClaudeResumeCommand,
+  formatHarnessFlags,
+  validateSettingsObject,
+  writeJsonConfig,
+} from './shared.js';
 import { registerHarness } from './registry.js';
 import type { OctomuxSettings } from '../settings.js';
-
-/** Strip any existing --model <value> from a flags string, then append --model <model>. */
-function applyModel(flags: string, model: string | null | undefined): string {
-  if (!model) return flags;
-  const stripped = flags.replace(/\s*--model\s+\S+/g, '');
-  return `${stripped} --model ${model}`;
-}
 
 function buildHookEvents(baseUrl: string, token: string) {
   const url = (event: string) => `${baseUrl}/api/hooks/${event}?token=${encodeURIComponent(token)}`;
@@ -32,21 +33,9 @@ export const claudeCodeHarness: Harness = {
     return crypto.randomUUID();
   },
 
-  buildLaunchCommand({ sessionId, agent, flags = '', model }: HarnessLaunchOpts): string {
-    const agentPart = agent ? ` --agent ${validateAgentName(agent)}` : '';
-    const resolvedFlags = applyModel(flags, model);
-    return `claude${agentPart} --session-id ${sessionId}${resolvedFlags}`;
-  },
-
-  buildResumeCommand({ sessionId, flags = '', model }: HarnessResumeOpts): string {
-    const resolvedFlags = applyModel(flags, model);
-    return `claude --resume ${sessionId}${resolvedFlags}`;
-  },
-
-  buildContinueCommand({ sessionId, flags = '', model }: HarnessResumeOpts): string {
-    const resolvedFlags = applyModel(flags, model);
-    return `claude --continue --session-id ${sessionId}${resolvedFlags}`;
-  },
+  buildLaunchCommand: buildClaudeLaunchCommand,
+  buildResumeCommand: buildClaudeResumeCommand,
+  buildContinueCommand: buildClaudeContinueCommand,
 
   async installHooks(worktreePath: string, baseUrl: string, hookToken: string) {
     const { ALLOWED_TOOLS, DENIED_TOOLS } = await import('../hook-settings.js');
@@ -88,7 +77,7 @@ export const claudeCodeHarness: Harness = {
     const mergedPermissions = { ...existingPerms, allow: mergedAllow, deny: mergedDeny };
 
     const merged = { ...existing, permissions: mergedPermissions, hooks: mergedHooks };
-    fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+    writeJsonConfig(settingsPath, merged);
   },
 
   async syncAgents(worktreePath: string) {
@@ -120,25 +109,19 @@ export const claudeCodeHarness: Harness = {
     if (sub.flags) {
       parts.push(validateFlagString(sub.flags, 'harnesses.claude-code.flags'));
     }
-    return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+    return formatHarnessFlags(parts);
   },
 
   validateSettings(blob: unknown): Record<string, unknown> {
-    if (typeof blob !== 'object' || blob === null || Array.isArray(blob)) {
-      throw new Error('Invalid claude-code settings: expected object');
-    }
-    const obj = blob as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    if (obj.flags !== undefined) {
-      out.flags = validateFlagString(obj.flags as string, 'harnesses.claude-code.flags');
-    }
-    if (obj.dangerouslySkipPermissions !== undefined) {
-      if (typeof obj.dangerouslySkipPermissions !== 'boolean') {
-        throw new Error('Invalid claude-code.dangerouslySkipPermissions: expected boolean');
-      }
-      out.dangerouslySkipPermissions = obj.dangerouslySkipPermissions;
-    }
-    return out;
+    return validateSettingsObject(blob, 'claude-code', {
+      flags: (value) => validateFlagString(value as string, 'harnesses.claude-code.flags'),
+      dangerouslySkipPermissions: (value) => {
+        if (typeof value !== 'boolean') {
+          throw new Error('Invalid claude-code.dangerouslySkipPermissions: expected boolean');
+        }
+        return value;
+      },
+    });
   },
 
   validateAgentName(name: string): string {

--- a/server/harnesses/cursor.ts
+++ b/server/harnesses/cursor.ts
@@ -4,6 +4,12 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import type { Harness, HarnessLaunchOpts, HarnessResumeOpts } from './types.js';
 import { validateAgentName, validateFlagString } from './types.js';
+import {
+  formatHarnessFlags,
+  formatJsonConfig,
+  validateSettingsObject,
+  writeJsonConfig,
+} from './shared.js';
 import { registerHarness } from './registry.js';
 import type { OctomuxSettings } from '../settings.js';
 import { childLogger } from '../logger.js';
@@ -101,9 +107,9 @@ function pruneOctomuxCursorRules(rulesDir: string): void {
   }
 }
 
-function expectedHooksPayload(bridgeDest: string): string {
+function hooksJsonObject(bridgeDest: string) {
   const hookEntry = { command: bridgeDest, type: 'command', timeout: 5 };
-  const hooksJson = {
+  return {
     version: 1,
     hooks: {
       sessionStart: [hookEntry],
@@ -113,7 +119,6 @@ function expectedHooksPayload(bridgeDest: string): string {
       afterFileEdit: [hookEntry],
     },
   };
-  return JSON.stringify(hooksJson, null, 2) + '\n';
 }
 
 /**
@@ -175,18 +180,19 @@ export const cursorHarness: Harness = {
     fs.copyFileSync(bridgeSrc, bridgeDest);
     fs.chmodSync(bridgeDest, 0o500);
 
-    const expectedConfig = JSON.stringify({ baseUrl, token: hookToken }, null, 2) + '\n';
+    const expectedConfig = formatJsonConfig({ baseUrl, token: hookToken });
     const configPath = path.join(hooksDir, 'config.json');
     try {
       if (!fs.existsSync(configPath) || fs.readFileSync(configPath, 'utf-8') !== expectedConfig) {
-        fs.writeFileSync(configPath, expectedConfig, { mode: 0o600 });
+        writeJsonConfig(configPath, { baseUrl, token: hookToken }, { mode: 0o600 });
       }
     } catch {
-      fs.writeFileSync(configPath, expectedConfig, { mode: 0o600 });
+      writeJsonConfig(configPath, { baseUrl, token: hookToken }, { mode: 0o600 });
     }
     fs.chmodSync(configPath, 0o600);
 
-    const hooksJsonExpected = expectedHooksPayload(bridgeDest);
+    const hooksJsonObj = hooksJsonObject(bridgeDest);
+    const hooksJsonExpected = formatJsonConfig(hooksJsonObj);
     const cursorDir = path.join(worktreePath, '.cursor');
     fs.mkdirSync(cursorDir, { recursive: true });
     const hooksJsonPath = path.join(cursorDir, 'hooks.json');
@@ -195,10 +201,10 @@ export const cursorHarness: Harness = {
         !fs.existsSync(hooksJsonPath) ||
         fs.readFileSync(hooksJsonPath, 'utf-8') !== hooksJsonExpected
       ) {
-        fs.writeFileSync(hooksJsonPath, hooksJsonExpected);
+        writeJsonConfig(hooksJsonPath, hooksJsonObj);
       }
     } catch {
-      fs.writeFileSync(hooksJsonPath, hooksJsonExpected);
+      writeJsonConfig(hooksJsonPath, hooksJsonObj);
     }
   },
 
@@ -298,38 +304,32 @@ export const cursorHarness: Harness = {
           : CURSOR_DEFAULT_MODEL;
       parts.push(`--model ${modelId}`);
     }
-    return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+    return formatHarnessFlags(parts);
   },
 
   validateSettings(blob: unknown): Record<string, unknown> {
-    if (typeof blob !== 'object' || blob === null || Array.isArray(blob)) {
-      throw new Error('Invalid cursor settings: expected object');
-    }
-    const obj = blob as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    const allowed = new Set(['flags', 'force', 'model']);
-    for (const key of Object.keys(obj)) {
-      if (!allowed.has(key)) {
-        throw new Error(`Invalid cursor settings: unknown key "${key}"`);
-      }
-    }
-    if (obj.flags !== undefined) {
-      out.flags = validateFlagString(obj.flags as string, 'harnesses.cursor.flags');
-    }
-    if (obj.force !== undefined) {
-      if (typeof obj.force !== 'boolean') {
-        throw new Error('Invalid cursor.force: expected boolean');
-      }
-      out.force = obj.force;
-    }
-    if (obj.model !== undefined) {
-      if (typeof obj.model !== 'string') {
-        throw new Error('Invalid cursor.model: expected string');
-      }
-      const trimmed = obj.model.trim();
-      if (trimmed) out.model = validateCursorModel(trimmed);
-    }
-    return out;
+    return validateSettingsObject(
+      blob,
+      'cursor',
+      {
+        flags: (value) => validateFlagString(value as string, 'harnesses.cursor.flags'),
+        force: (value) => {
+          if (typeof value !== 'boolean') {
+            throw new Error('Invalid cursor.force: expected boolean');
+          }
+          return value;
+        },
+        model: (value) => {
+          if (typeof value !== 'string') {
+            throw new Error('Invalid cursor.model: expected string');
+          }
+          const trimmed = value.trim();
+          if (trimmed) return validateCursorModel(trimmed);
+          return undefined;
+        },
+      },
+      { rejectUnknownKeys: true },
+    );
   },
 
   validateAgentName(name: string): string {

--- a/server/harnesses/index.ts
+++ b/server/harnesses/index.ts
@@ -3,6 +3,16 @@ import './claude-code.js';
 import './cursor.js';
 
 export * from './types.js';
+export {
+  applyModel,
+  buildClaudeContinueCommand,
+  buildClaudeLaunchCommand,
+  buildClaudeResumeCommand,
+  formatHarnessFlags,
+  formatJsonConfig,
+  validateSettingsObject,
+  writeJsonConfig,
+} from './shared.js';
 export { registerHarness, getHarness, listHarnesses, DEFAULT_HARNESS_ID } from './registry.js';
 export { claudeCodeHarness } from './claude-code.js';
 export { cursorHarness } from './cursor.js';

--- a/server/harnesses/shared.test.ts
+++ b/server/harnesses/shared.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  applyModel,
+  formatHarnessFlags,
+  formatJsonConfig,
+  validateSettingsObject,
+  writeJsonConfig,
+} from './shared.js';
+
+describe('formatJsonConfig / writeJsonConfig', () => {
+  it('serializes with 2-space indent and trailing newline', () => {
+    expect(formatJsonConfig({ a: 1 })).toBe('{\n  "a": 1\n}\n');
+  });
+
+  it('writeJsonConfig writes byte-identical output', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-shared-'));
+    const filePath = path.join(tmp, 'cfg.json');
+    writeJsonConfig(filePath, { x: true });
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(formatJsonConfig({ x: true }));
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('formatHarnessFlags', () => {
+  it.each([
+    [[], ''],
+    [['--verbose'], ' --verbose'],
+    [['--force', '--model x'], ' --force --model x'],
+  ])('%j -> %s', (parts, expected) => {
+    expect(formatHarnessFlags(parts)).toBe(expected);
+  });
+});
+
+describe('applyModel', () => {
+  it('appends model when absent from flags', () => {
+    expect(applyModel('', 'sonnet')).toBe(' --model sonnet');
+  });
+
+  it('replaces existing --model token', () => {
+    expect(applyModel(' --model opus', 'sonnet')).toBe(' --model sonnet');
+  });
+
+  it('returns flags unchanged when model is unset', () => {
+    expect(applyModel(' --verbose', null)).toBe(' --verbose');
+  });
+});
+
+describe('validateSettingsObject', () => {
+  const fields = {
+    flags: (v: unknown) => (typeof v === 'string' ? v.trim() : v),
+    force: (v: unknown) => {
+      if (typeof v !== 'boolean') throw new Error('expected boolean');
+      return v;
+    },
+  };
+
+  it('throws on non-object input', () => {
+    expect(() => validateSettingsObject(null, 'test', fields)).toThrow(
+      'Invalid test settings: expected object',
+    );
+  });
+
+  it('validates only present keys', () => {
+    expect(validateSettingsObject({ flags: ' --x ' }, 'test', fields)).toEqual({ flags: '--x' });
+  });
+
+  it('rejects unknown keys when configured', () => {
+    expect(() =>
+      validateSettingsObject({ extra: 1 }, 'test', fields, { rejectUnknownKeys: true }),
+    ).toThrow('unknown key "extra"');
+  });
+
+  it('omits validator results that are undefined', () => {
+    const withOptional = {
+      ...fields,
+      model: (v: unknown) => {
+        if (typeof v !== 'string') throw new Error('expected string');
+        const trimmed = v.trim();
+        return trimmed || undefined;
+      },
+    };
+    expect(validateSettingsObject({ model: '  ' }, 'test', withOptional)).toEqual({});
+  });
+});

--- a/server/harnesses/shared.ts
+++ b/server/harnesses/shared.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import type { HarnessLaunchOpts, HarnessResumeOpts } from './types.js';
+import { validateAgentName } from './types.js';
+
+/** Canonical JSON settings/config serialization (trailing newline). */
+export function formatJsonConfig(obj: unknown): string {
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/** Write a JSON config file using the canonical harness serialization format. */
+export function writeJsonConfig(
+  filePath: string,
+  obj: unknown,
+  options?: fs.WriteFileOptions,
+): void {
+  fs.writeFileSync(filePath, formatJsonConfig(obj), options);
+}
+
+/** Join validated flag tokens with a leading space, or return '' when empty. */
+export function formatHarnessFlags(parts: string[]): string {
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+/** Strip any existing --model <value> from a flags string, then append --model <model>. */
+export function applyModel(flags: string, model: string | null | undefined): string {
+  if (!model) return flags;
+  const stripped = flags.replace(/\s*--model\s+\S+/g, '');
+  return `${stripped} --model ${model}`;
+}
+
+export type SettingsFieldValidator = (value: unknown) => unknown;
+
+export interface ValidateSettingsObjectOptions {
+  /** When true, reject keys not listed in `fields`. */
+  rejectUnknownKeys?: boolean;
+}
+
+/**
+ * Validate a harness settings sub-object. Only keys present on the input blob
+ * are validated and copied to the output; absent keys are omitted.
+ */
+export function validateSettingsObject(
+  blob: unknown,
+  harnessLabel: string,
+  fields: Record<string, SettingsFieldValidator>,
+  options?: ValidateSettingsObjectOptions,
+): Record<string, unknown> {
+  if (typeof blob !== 'object' || blob === null || Array.isArray(blob)) {
+    throw new Error(`Invalid ${harnessLabel} settings: expected object`);
+  }
+  const obj = blob as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  if (options?.rejectUnknownKeys) {
+    const allowed = new Set(Object.keys(fields));
+    for (const key of Object.keys(obj)) {
+      if (!allowed.has(key)) {
+        throw new Error(`Invalid ${harnessLabel} settings: unknown key "${key}"`);
+      }
+    }
+  }
+
+  for (const [key, validator] of Object.entries(fields)) {
+    if (obj[key] !== undefined) {
+      const validated = validator(obj[key]);
+      if (validated !== undefined) {
+        out[key] = validated;
+      }
+    }
+  }
+  return out;
+}
+
+export function buildClaudeLaunchCommand({
+  sessionId,
+  agent,
+  flags = '',
+  model,
+}: HarnessLaunchOpts): string {
+  const agentPart = agent ? ` --agent ${validateAgentName(agent)}` : '';
+  const resolvedFlags = applyModel(flags, model);
+  return `claude${agentPart} --session-id ${sessionId}${resolvedFlags}`;
+}
+
+export function buildClaudeResumeCommand({
+  sessionId,
+  flags = '',
+  model,
+}: HarnessResumeOpts): string {
+  const resolvedFlags = applyModel(flags, model);
+  return `claude --resume ${sessionId}${resolvedFlags}`;
+}
+
+export function buildClaudeContinueCommand({
+  sessionId,
+  flags = '',
+  model,
+}: HarnessResumeOpts): string {
+  const resolvedFlags = applyModel(flags, model);
+  return `claude --continue --session-id ${sessionId}${resolvedFlags}`;
+}

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -36,6 +36,7 @@ import { hookBaseUrl } from '../hook-base-url.js';
 import { octomuxRoot } from '../octomux-root.js';
 import { childLogger } from '../logger.js';
 import { DEFAULT_HARNESS_ID, getHarness } from '../harnesses/index.js';
+import { writeJsonConfig } from '../harnesses/shared.js';
 import { buildOrchestratorConductorFlags } from './conductor-flags.js';
 import {
   getConversation,
@@ -154,7 +155,7 @@ function writeOrchestratorsettings(convId: string): string {
     },
   };
 
-  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  writeJsonConfig(settingsPath, settings);
   return settingsPath;
 }
 
@@ -245,7 +246,7 @@ function writeOrchestratorMcpConfig(convId: string, hookToken: string): string |
       },
     },
   };
-  fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
+  writeJsonConfig(cfgPath, cfg);
   return cfgPath;
 }
 


### PR DESCRIPTION
## Summary
- Add `server/harnesses/shared.ts` with `validateSettingsObject`, `writeJsonConfig`/`formatJsonConfig`, `applyModel`, `formatHarnessFlags`, and Claude command builders
- Refactor `claude-code.ts`, `cursor.ts`, and `orchestrator/runner.ts` to reuse the shared helpers instead of duplicating validation, JSON writes, and command construction

## Why
A second harness (Cursor) already exists and more are planned. The harness modules duplicated `validateSettings`, settings-file writes, and `applyModel`/command-building logic — adding a harness meant copying boilerplate across several files.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`


Made with [Cursor](https://cursor.com)