### PR TITLE
refactor(integrations): extract HttpIntegrationClient and shared column types

### DIFF
--- a/server/integrations/http-client.test.ts
+++ b/server/integrations/http-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpIntegrationClient, HttpIntegrationError } from './http-client.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('HttpIntegrationClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends Basic auth header', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ id: '1' }),
+      text: vi.fn().mockResolvedValue(''),
+    });
+
+    const client = HttpIntegrationClient.basicAuth(
+      'https://acme.atlassian.net',
+      'dev@acme.com',
+      'token123',
+    );
+    await client.json('/rest/api/3/myself');
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const expected = Buffer.from('dev@acme.com:token123').toString('base64');
+    expect((opts.headers as Record<string, string>).Authorization).toBe(`Basic ${expected}`);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://acme.atlassian.net/rest/api/3/myself');
+  });
+
+  it('json() throws HttpIntegrationError on non-ok response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: vi.fn().mockResolvedValue('bad creds'),
+    });
+
+    const client = HttpIntegrationClient.basicAuth('https://x.io', 'a', 'b');
+    await expect(client.json('/nope')).rejects.toBeInstanceOf(HttpIntegrationError);
+  });
+
+  it('request() returns body without throwing on failure', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: vi.fn().mockResolvedValue('invalid transition'),
+    });
+
+    const client = HttpIntegrationClient.basicAuth('https://x.io', 'a', 'b');
+    const result = await client.request('/transitions', { method: 'POST' });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.body).toBe('invalid transition');
+  });
+
+  it('wraps network errors as HttpIntegrationError', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    const client = HttpIntegrationClient.basicAuth('https://x.io', 'a', 'b');
+    await expect(client.fetch('/x')).rejects.toMatchObject({ message: 'ECONNREFUSED' });
+  });
+});

--- a/server/integrations/http-client.ts
+++ b/server/integrations/http-client.ts
@@ -1,0 +1,123 @@
+/** Shared fetch wrapper for REST-based integration providers (Jira, future Slack/GitHub). */
+
+export class HttpIntegrationError extends Error {
+  readonly status?: number;
+  readonly body?: string;
+
+  constructor(message: string, opts?: { status?: number; body?: string }) {
+    super(message);
+    this.name = 'HttpIntegrationError';
+    this.status = opts?.status;
+    this.body = opts?.body;
+  }
+
+  static fromNetwork(err: unknown): HttpIntegrationError {
+    const message = err instanceof Error ? err.message : String(err);
+    return new HttpIntegrationError(message);
+  }
+
+  static async fromResponse(res: Response): Promise<HttpIntegrationError> {
+    const body = await res.text().catch(() => '');
+    const message = body ? `${res.status}: ${res.statusText} — ${body}` : `${res.status}: ${res.statusText}`;
+    return new HttpIntegrationError(message, { status: res.status, body });
+  }
+}
+
+export type HttpIntegrationAuth =
+  | { type: 'basic'; username: string; password: string }
+  | { type: 'bearer'; token: string }
+  | { type: 'headers'; headers: Record<string, string> };
+
+export interface HttpIntegrationClientOptions {
+  baseUrl: string;
+  auth: HttpIntegrationAuth;
+  defaultHeaders?: Record<string, string>;
+  fetchFn?: typeof fetch;
+}
+
+export interface HttpIntegrationResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: string;
+}
+
+function buildAuthHeaders(auth: HttpIntegrationAuth): Record<string, string> {
+  switch (auth.type) {
+    case 'basic': {
+      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      return { Authorization: `Basic ${credentials}` };
+    }
+    case 'bearer':
+      return { Authorization: `Bearer ${auth.token}` };
+    case 'headers':
+      return auth.headers;
+  }
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const base = baseUrl.replace(/\/$/, '');
+  if (path.startsWith('http://') || path.startsWith('https://')) return path;
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+export class HttpIntegrationClient {
+  private readonly baseUrl: string;
+  private readonly authHeaders: Record<string, string>;
+  private readonly defaultHeaders: Record<string, string>;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: HttpIntegrationClientOptions) {
+    this.baseUrl = options.baseUrl;
+    this.authHeaders = buildAuthHeaders(options.auth);
+    this.defaultHeaders = options.defaultHeaders ?? { Accept: 'application/json' };
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  static basicAuth(
+    baseUrl: string,
+    username: string,
+    password: string,
+    fetchFn?: typeof fetch,
+  ): HttpIntegrationClient {
+    return new HttpIntegrationClient({
+      baseUrl,
+      auth: { type: 'basic', username, password },
+      fetchFn,
+    });
+  }
+
+  async fetch(path: string, init?: RequestInit): Promise<Response> {
+    try {
+      return await this.fetchFn(joinUrl(this.baseUrl, path), {
+        ...init,
+        headers: {
+          ...this.defaultHeaders,
+          ...this.authHeaders,
+          ...(init?.headers as Record<string, string> | undefined),
+        },
+      });
+    } catch (err) {
+      throw HttpIntegrationError.fromNetwork(err);
+    }
+  }
+
+  async request(path: string, init?: RequestInit): Promise<HttpIntegrationResponse> {
+    const res = await this.fetch(path, init);
+    const body = await res.text().catch(() => '');
+    return {
+      ok: res.ok,
+      status: res.status,
+      statusText: res.statusText,
+      body,
+    };
+  }
+
+  async json<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.fetch(path, init);
+    if (!res.ok) {
+      throw await HttpIntegrationError.fromResponse(res);
+    }
+    return (await res.json()) as T;
+  }
+}

--- a/server/integrations/jira/index.ts
+++ b/server/integrations/jira/index.ts
@@ -1,7 +1,9 @@
 import { childLogger } from '../../logger.js';
-import type { IntegrationProvider, ValidationResult, JsonSchema } from '../types.js';
+import type { IntegrationProvider, ValidationResult, JsonSchema, OctomuxColumn } from '../types.js';
 import type { HookEnvelope } from '../../hook-types.js';
 import { registerProvider } from '../registry.js';
+import { HttpIntegrationClient, HttpIntegrationError } from '../http-client.js';
+import { validateStatusMapObject } from '../types.js';
 
 const logger = childLogger('integrations:jira');
 
@@ -10,7 +12,7 @@ export interface JiraConfig {
   email: string;
   api_token: string;
   default_project?: string;
-  status_map: Record<string, string>;
+  status_map: Partial<Record<OctomuxColumn, string>>;
 }
 
 const CONFIG_SCHEMA: JsonSchema = {
@@ -56,6 +58,10 @@ function isValidEmail(s: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
 }
 
+function createClient(cfg: JiraConfig): HttpIntegrationClient {
+  return HttpIntegrationClient.basicAuth(cfg.base_url, cfg.email, cfg.api_token);
+}
+
 function validate(config: unknown): ValidationResult {
   if (typeof config !== 'object' || config === null) {
     return { ok: false, errors: ['config must be an object'] };
@@ -79,9 +85,7 @@ function validate(config: unknown): ValidationResult {
     errors.push('api_token is required');
   }
 
-  if (!cfg.status_map || typeof cfg.status_map !== 'object' || Array.isArray(cfg.status_map)) {
-    errors.push('status_map is required and must be an object');
-  }
+  validateStatusMapObject(cfg.status_map, 'status_map', errors);
 
   return errors.length === 0 ? { ok: true } : { ok: false, errors };
 }
@@ -89,23 +93,20 @@ function validate(config: unknown): ValidationResult {
 async function testConnection(config: unknown): Promise<{ ok: boolean; message: string }> {
   const cfg = config as JiraConfig;
   try {
-    const credentials = Buffer.from(`${cfg.email}:${cfg.api_token}`).toString('base64');
-    const res = await fetch(`${cfg.base_url}/rest/api/3/myself`, {
-      headers: {
-        Authorization: `Basic ${credentials}`,
-        Accept: 'application/json',
-      },
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { displayName?: string; emailAddress?: string };
-      return {
-        ok: true,
-        message: `Connected as ${data.displayName ?? data.emailAddress ?? 'unknown user'}`,
-      };
-    }
-    return { ok: false, message: `Jira returned ${res.status}: ${res.statusText}` };
+    const data = await createClient(cfg).json<{ displayName?: string; emailAddress?: string }>(
+      '/rest/api/3/myself',
+    );
+    return {
+      ok: true,
+      message: `Connected as ${data.displayName ?? data.emailAddress ?? 'unknown user'}`,
+    };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg =
+      err instanceof HttpIntegrationError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
     return { ok: false, message: `Connection failed: ${msg}` };
   }
 }
@@ -114,7 +115,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
   const cfg = config as JiraConfig;
   const task = envelope.task;
 
-  // Find a matching external ref for Jira
   const refs = (task.external_refs ?? []) as Array<{ integration: string; ref: string }>;
   const jiraRef = refs.find((r) => r.integration === 'jira' || r.integration.startsWith('jira:'));
 
@@ -139,7 +139,7 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
   }
 
   const statusMap = cfg.status_map ?? {};
-  const transitionId = statusMap[toStatus];
+  const transitionId = statusMap[toStatus as OctomuxColumn];
   if (!transitionId) {
     logger.debug(
       { task_id: task.id, event: envelope.event, to_status: toStatus },
@@ -148,15 +148,10 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
     return;
   }
 
-  const credentials = Buffer.from(`${cfg.email}:${cfg.api_token}`).toString('base64');
   try {
-    const res = await fetch(`${cfg.base_url}/rest/api/3/issue/${issueKey}/transitions`, {
+    const res = await createClient(cfg).request(`/rest/api/3/issue/${issueKey}/transitions`, {
       method: 'POST',
-      headers: {
-        Authorization: `Basic ${credentials}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ transition: { id: transitionId } }),
     });
     if (res.ok || res.status === 204) {
@@ -165,7 +160,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
         'jira handler: transitioned issue',
       );
     } else {
-      const body = await res.text().catch(() => '');
       logger.warn(
         {
           task_id: task.id,
@@ -173,7 +167,7 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
           to_status: toStatus,
           transition_id: transitionId,
           status: res.status,
-          body,
+          body: res.body,
         },
         'jira handler: transition request failed',
       );
@@ -201,5 +195,4 @@ export const jiraProvider: IntegrationProvider = {
   handler,
 };
 
-// Register the provider
 registerProvider(jiraProvider);

--- a/server/integrations/linear/index.ts
+++ b/server/integrations/linear/index.ts
@@ -1,20 +1,11 @@
 import { childLogger } from '../../logger.js';
-import type { IntegrationProvider, ValidationResult, JsonSchema } from '../types.js';
+import type { IntegrationProvider, ValidationResult, JsonSchema, OctomuxColumn } from '../types.js';
+import { isOctomuxColumn, validateStatusMapByTeam } from '../types.js';
 import type { HookEnvelope } from '../../hook-types.js';
 import { registerProvider } from '../registry.js';
 import { invokeLinear, LinearApiError } from './graphql.js';
 
 const logger = childLogger('integrations:linear');
-
-const OCTOMUX_COLUMNS = [
-  'backlog',
-  'planned',
-  'in_progress',
-  'human_review',
-  'pr',
-  'done',
-] as const;
-type OctomuxColumn = (typeof OCTOMUX_COLUMNS)[number];
 
 export interface LinearConfig {
   api_key: string;
@@ -38,8 +29,6 @@ const CONFIG_SCHEMA: JsonSchema = {
   },
 };
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 function validate(config: unknown): ValidationResult {
   if (typeof config !== 'object' || config === null) {
     return { ok: false, errors: ['config must be an object'] };
@@ -51,29 +40,7 @@ function validate(config: unknown): ValidationResult {
     errors.push('api_key is required');
   }
 
-  if (
-    !cfg.status_map_by_team ||
-    typeof cfg.status_map_by_team !== 'object' ||
-    Array.isArray(cfg.status_map_by_team)
-  ) {
-    errors.push('status_map_by_team must be an object');
-  } else {
-    for (const [teamKey, teamMap] of Object.entries(cfg.status_map_by_team)) {
-      if (typeof teamMap !== 'object' || teamMap === null || Array.isArray(teamMap)) {
-        errors.push(`status_map_by_team.${teamKey} must be an object`);
-        continue;
-      }
-      for (const [col, uuid] of Object.entries(teamMap as Record<string, unknown>)) {
-        if (!OCTOMUX_COLUMNS.includes(col as OctomuxColumn)) {
-          errors.push(`status_map_by_team.${teamKey}: invalid column "${col}"`);
-          continue;
-        }
-        if (typeof uuid !== 'string' || !UUID_RE.test(uuid)) {
-          errors.push(`status_map_by_team.${teamKey}.${col}: not a valid uuid`);
-        }
-      }
-    }
-  }
+  validateStatusMapByTeam(cfg.status_map_by_team, 'status_map_by_team', errors);
 
   return errors.length === 0 ? { ok: true } : { ok: false, errors };
 }
@@ -113,7 +80,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
     return;
   }
 
-  // Resolve team_key from metadata or by parsing the ref string.
   const metadata = (linearRef.metadata ?? {}) as Record<string, unknown>;
   let teamKey = typeof metadata.team_key === 'string' ? metadata.team_key : '';
   let issueId = typeof metadata.issue_id === 'string' ? metadata.issue_id : '';
@@ -132,9 +98,7 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
   }
 
   const teamMap = cfg.status_map_by_team[teamKey];
-  const stateId = OCTOMUX_COLUMNS.includes(toStatus as OctomuxColumn)
-    ? teamMap?.[toStatus as OctomuxColumn]
-    : undefined;
+  const stateId = isOctomuxColumn(toStatus) ? teamMap?.[toStatus] : undefined;
   if (!stateId) {
     logger.debug(
       { task_id: task.id, team_key: teamKey, to_status: toStatus },
@@ -143,7 +107,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
     return;
   }
 
-  // Resolve issue UUID if we don't have it cached.
   if (!issueId) {
     try {
       const issue = await invokeLinear(cfg.api_key, (client) => client.issue(linearRef.ref));
@@ -161,7 +124,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
     }
   }
 
-  // State change.
   try {
     await invokeLinear(cfg.api_key, (client) => client.updateIssue(issueId, { stateId }));
     logger.info(
@@ -182,7 +144,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
     return;
   }
 
-  // Comment-back, unless we're resetting to backlog.
   if (toStatus === 'backlog') return;
 
   const prUrl = typeof data?.pr_url === 'string' ? data.pr_url : '';
@@ -191,7 +152,6 @@ async function handler(envelope: HookEnvelope, config: unknown): Promise<void> {
   try {
     await invokeLinear(cfg.api_key, (client) => client.createComment({ issueId, body }));
   } catch (err) {
-    // Comment failure shouldn't block the integration; log and move on.
     logger.warn(
       { task_id: task.id, issue_id: issueId, err: (err as Error).message },
       'linear handler: commentCreate failed',

--- a/server/integrations/types.test.ts
+++ b/server/integrations/types.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  OCTOMUX_COLUMNS,
+  isOctomuxColumn,
+  validateFlatStatusMap,
+  validateStatusMapObject,
+  validateStatusMapByTeam,
+} from './types.js';
+
+describe('integration column helpers', () => {
+  it('OCTOMUX_COLUMNS matches workflow statuses', () => {
+    expect(OCTOMUX_COLUMNS).toEqual([
+      'backlog',
+      'planned',
+      'in_progress',
+      'human_review',
+      'pr',
+      'done',
+    ]);
+  });
+
+  it.each([
+    ['done', true],
+    ['bogus', false],
+  ] as const)('isOctomuxColumn(%s) → %s', (col, expected) => {
+    expect(isOctomuxColumn(col)).toBe(expected);
+  });
+
+  it('validateStatusMapObject rejects non-object', () => {
+    const errors: string[] = [];
+    validateStatusMapObject(null, 'status_map', errors);
+    expect(errors).toContain('status_map is required and must be an object');
+  });
+
+  it('validateFlatStatusMap rejects invalid column keys', () => {
+    const errors: string[] = [];
+    validateFlatStatusMap({ done: '41', bogus: '99' }, 'status_map', errors);
+    expect(errors.some((e) => e.includes('bogus'))).toBe(true);
+  });
+
+  it('validateStatusMapByTeam rejects invalid uuid', () => {
+    const errors: string[] = [];
+    validateStatusMapByTeam({ BAC: { done: 'not-a-uuid' } }, 'status_map_by_team', errors);
+    expect(errors.some((e) => e.includes('uuid'))).toBe(true);
+  });
+});

--- a/server/integrations/types.ts
+++ b/server/integrations/types.ts
@@ -1,5 +1,80 @@
 import type { HookEnvelope, HookEventName } from '../hook-types.js';
 
+/** Octomux workflow board columns — shared by Jira/Linear status maps. */
+export const OCTOMUX_COLUMNS = [
+  'backlog',
+  'planned',
+  'in_progress',
+  'human_review',
+  'pr',
+  'done',
+] as const;
+
+export type OctomuxColumn = (typeof OCTOMUX_COLUMNS)[number];
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isOctomuxColumn(value: string): value is OctomuxColumn {
+  return (OCTOMUX_COLUMNS as readonly string[]).includes(value);
+}
+
+/** Ensure status_map is a plain object (Jira — no column-key validation). */
+export function validateStatusMapObject(
+  statusMap: unknown,
+  pathPrefix: string,
+  errors: string[],
+): void {
+  if (!statusMap || typeof statusMap !== 'object' || Array.isArray(statusMap)) {
+    errors.push(`${pathPrefix} is required and must be an object`);
+  }
+}
+
+/** Validate flat status_map keys (optional strict mode for integrations). */
+export function validateFlatStatusMap(
+  statusMap: unknown,
+  pathPrefix: string,
+  errors: string[],
+): void {
+  validateStatusMapObject(statusMap, pathPrefix, errors);
+  if (!statusMap || typeof statusMap !== 'object' || Array.isArray(statusMap)) return;
+  for (const col of Object.keys(statusMap as Record<string, unknown>)) {
+    if (!isOctomuxColumn(col)) {
+      errors.push(`${pathPrefix}: invalid column "${col}"`);
+    }
+  }
+}
+
+/** Validate per-team status maps with UUID values (Linear). */
+export function validateStatusMapByTeam(
+  statusMapByTeam: unknown,
+  pathPrefix: string,
+  errors: string[],
+): void {
+  if (
+    !statusMapByTeam ||
+    typeof statusMapByTeam !== 'object' ||
+    Array.isArray(statusMapByTeam)
+  ) {
+    errors.push(`${pathPrefix} must be an object`);
+    return;
+  }
+  for (const [teamKey, teamMap] of Object.entries(statusMapByTeam)) {
+    if (typeof teamMap !== 'object' || teamMap === null || Array.isArray(teamMap)) {
+      errors.push(`${pathPrefix}.${teamKey} must be an object`);
+      continue;
+    }
+    for (const [col, uuid] of Object.entries(teamMap as Record<string, unknown>)) {
+      if (!isOctomuxColumn(col)) {
+        errors.push(`${pathPrefix}.${teamKey}: invalid column "${col}"`);
+        continue;
+      }
+      if (typeof uuid !== 'string' || !UUID_RE.test(uuid)) {
+        errors.push(`${pathPrefix}.${teamKey}.${col}: not a valid uuid`);
+      }
+    }
+  }
+}
+
 export type JsonSchema = Record<string, unknown>;
 export interface ValidationResult {
   ok: boolean;


### PR DESCRIPTION
## Summary
- Extract `HttpIntegrationClient` with Basic auth, fetch wrapping, and `HttpIntegrationError` coercion; Jira now uses it instead of inlined fetch/base64 handling.
- Move `OCTOMUX_COLUMNS`, `OctomuxColumn`, and status-map validators (`validateStatusMapObject`, `validateStatusMapByTeam`, `isOctomuxColumn`) into `server/integrations/types.ts` for shared use by Linear and Jira.
- Linear continues on `@linear/sdk` — only the column/status-map types are shared; no hand-rolled GraphQL client reintroduced.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (254 files, 3395 tests passed)
- [x] `bun run build`

Resolves SHR-212

Made with [Cursor](https://cursor.com)