### PR TITLE
refactor(orchestrator): derive policy tiers from command registry

### DIFF
--- a/server/orchestrator/command-registry.test.ts
+++ b/server/orchestrator/command-registry.test.ts
@@ -13,10 +13,12 @@
  *    hand-written registerWriteTools (ensuring the refactor is a pure rename).
  */
 
-import { describe, it, expect } from 'vitest';
-import { COMMANDS, getCommandByAction } from './command-registry.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { COMMANDS, getCommandByAction, buildPolicySets } from './command-registry.js';
 import type { OrchestratorAction } from './command-registry.js';
 import { ORCHESTRATOR_ACTIONS } from './actions.js';
+import { classify } from './policy.js';
 
 // ─── All OrchestratorActions have a CommandDef ────────────────────────────────
 
@@ -153,5 +155,82 @@ describe('getCommandByAction', () => {
     // Cast to bypass type system — simulates an unexpected runtime value.
     const cmd = getCommandByAction('bogus-action' as OrchestratorAction);
     expect(cmd).toBeUndefined();
+  });
+});
+
+// ─── Policy tier derivation (SHR-213) ─────────────────────────────────────────
+
+describe('buildPolicySets', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('matches the pre-registry hand-maintained tier sets', () => {
+    const { AUTO_TOOLS, READ_SUBCOMMANDS, ASK_SUBCOMMANDS, ALWAYS_ASK_SUBCOMMANDS } =
+      buildPolicySets();
+
+    expect([...AUTO_TOOLS].sort()).toEqual(
+      [
+        'get_task',
+        'get_task_output',
+        'list_tasks',
+        'monitor_status',
+        'pull_linear_issue',
+      ].sort(),
+    );
+
+    expect([...READ_SUBCOMMANDS].sort()).toEqual(
+      [
+        'default-branch',
+        'get-skill',
+        'get-task',
+        'hooks-list',
+        'list-integrations',
+        'list-skills',
+        'list-tasks',
+        'recent-repos',
+        'task-summary',
+        'task-updates',
+      ].sort(),
+    );
+
+    expect([...ASK_SUBCOMMANDS].sort()).toEqual(
+      [
+        'add-agent',
+        'create-task',
+        'request-review',
+        'resume-task',
+        'send-message',
+        'set-status',
+      ].sort(),
+    );
+
+    expect([...ALWAYS_ASK_SUBCOMMANDS].sort()).toEqual(['close-task', 'delete-task'].sort());
+  });
+
+  it('every known command classifies to the same tier as before the registry refactor', () => {
+    const cases = [
+      ['list_tasks', [], 'auto'],
+      ['get_task', ['task-abc'], 'auto'],
+      ['monitor_status', [], 'auto'],
+      ['get_task_output', ['task-abc'], 'auto'],
+      ['pull_linear_issue', ['LIN-123'], 'auto'],
+      ['octomux', ['recent-repos'], 'auto'],
+      ['octomux', ['default-branch', '--repo-path', '/tmp/repo'], 'auto'],
+      ['octomux', ['list-tasks'], 'auto'],
+      ['octomux', ['get-task', 'task-abc'], 'auto'],
+      ['octomux', ['create-task', '--title', 'Foo'], 'ask'],
+      ['octomux', ['add-agent', '--task', 'task-abc'], 'ask'],
+      ['octomux', ['send-message', '--task', 'task-abc', '--text', 'hi'], 'ask'],
+      ['octomux', ['set-status', '--task', 'task-abc', '--status', 'in_progress'], 'ask'],
+      ['octomux', ['request-review', '--task', 'task-abc'], 'ask'],
+      ['octomux', ['resume-task', '--task', 'task-abc'], 'ask'],
+      ['octomux', ['delete-task', '--task', 'task-abc'], 'always-ask'],
+      ['octomux', ['close-task', '--task', 'task-abc'], 'always-ask'],
+    ] as const;
+
+    for (const [command, args, expected] of cases) {
+      expect(classify(command, [...args]), `${command} ${JSON.stringify(args)}`).toBe(expected);
+    }
   });
 });

--- a/server/orchestrator/command-registry.ts
+++ b/server/orchestrator/command-registry.ts
@@ -58,6 +58,11 @@ const resumeTaskInputSchema = z.object({
   task_id: z.string().describe('The octomux task id'),
 });
 
+// ─── Policy tier ──────────────────────────────────────────────────────────────
+
+/** Gate classification tier (spec §5). Declared once per command in the registry. */
+export type PolicyTier = 'auto' | 'ask' | 'always-ask';
+
 // ─── CommandDef type ──────────────────────────────────────────────────────────
 
 export interface CommandContext {
@@ -87,12 +92,43 @@ export interface CommandDef<S extends z.ZodTypeAny = z.ZodTypeAny> {
   input: S;
   /** Whether to register this command as an MCP write tool. */
   mcp: boolean;
+  /** PreToolUse gate tier for this command (octomux CLI subcommand + MCP write tool). */
+  tier: PolicyTier;
   /**
    * Execute the action. Receives the parsed input and the server-injected context.
    * Returns the result and optionally the activity receipt text.
    */
   handler: (parsedInput: z.infer<S>, ctx: CommandContext) => Promise<CommandResult>;
 }
+
+/**
+ * Read-only CLI / MCP commands that are not orchestrator write actions but still
+ * need a policy tier. Keeps AUTO_TOOLS and READ_SUBCOMMANDS in sync with COMMANDS.
+ */
+export interface PolicyOnlyCommand {
+  /** MCP tool name when invoked as a direct tool (snake_case). */
+  mcpName?: string;
+  /** octomux CLI subcommand when invoked via Bash (kebab-case). */
+  cliSubcommand?: string;
+  tier: PolicyTier;
+}
+
+export const POLICY_ONLY_COMMANDS: PolicyOnlyCommand[] = [
+  { mcpName: 'list_tasks', cliSubcommand: 'list-tasks', tier: 'auto' },
+  { mcpName: 'get_task', cliSubcommand: 'get-task', tier: 'auto' },
+  { mcpName: 'monitor_status', tier: 'auto' },
+  { mcpName: 'get_task_output', tier: 'auto' },
+  { mcpName: 'pull_linear_issue', tier: 'auto' },
+  { cliSubcommand: 'recent-repos', tier: 'auto' },
+  { cliSubcommand: 'default-branch', tier: 'auto' },
+  { cliSubcommand: 'list-skills', tier: 'auto' },
+  { cliSubcommand: 'get-skill', tier: 'auto' },
+  { cliSubcommand: 'task-summary', tier: 'auto' },
+  { cliSubcommand: 'task-updates', tier: 'auto' },
+  { cliSubcommand: 'hooks-list', tier: 'auto' },
+  { cliSubcommand: 'list-integrations', tier: 'auto' },
+  { cliSubcommand: 'request-review', tier: 'ask' },
+];
 
 // ─── Registry ─────────────────────────────────────────────────────────────────
 
@@ -115,6 +151,7 @@ export const COMMANDS: CommandDef[] = [
       'Returns the task id (a pointer).',
     input: createTaskInputSchema,
     mcp: true,
+    tier: 'ask',
     async handler(parsed, ctx) {
       const result = await runCreateTask({
         ...parsed,
@@ -131,6 +168,7 @@ export const COMMANDS: CommandDef[] = [
     summary: 'Send a message/instruction to a running task agent (e.g. nudge or redirect).',
     input: sendMessageInputSchema,
     mcp: true,
+    tier: 'ask',
     async handler(parsed, _ctx) {
       await runSendMessage(parsed.task_id, parsed.message);
       const result = { task_id: parsed.task_id };
@@ -146,6 +184,7 @@ export const COMMANDS: CommandDef[] = [
       'Set a task workflow status (backlog | planned | in_progress | human_review | pr | done).',
     input: setStatusInputSchema,
     mcp: true,
+    tier: 'ask',
     async handler(parsed, _ctx) {
       await runSetStatus(parsed.task_id, parsed.status as WorkflowStatus);
       const result = { task_id: parsed.task_id, status: parsed.status };
@@ -160,6 +199,7 @@ export const COMMANDS: CommandDef[] = [
     summary: 'Attach another agent (new tmux window) to a running task, sharing its worktree.',
     input: addAgentInputSchema,
     mcp: true,
+    tier: 'ask',
     async handler(parsed, _ctx) {
       const { task_id, ...opts } = parsed;
       const result = await runAddAgent(task_id, opts);
@@ -176,6 +216,7 @@ export const COMMANDS: CommandDef[] = [
       'so it can be resumed. Runs immediately (no approval).',
     input: closeTaskInputSchema,
     mcp: true,
+    tier: 'always-ask',
     async handler(parsed, _ctx) {
       await runCloseTask(parsed.task_id);
       const result = { task_id: parsed.task_id };
@@ -193,6 +234,7 @@ export const COMMANDS: CommandDef[] = [
     summary: '',
     input: resumeTaskInputSchema,
     mcp: false,
+    tier: 'ask',
     async handler(parsed, _ctx) {
       await runResumeTask(parsed.task_id);
       const result = { task_id: parsed.task_id };
@@ -209,6 +251,7 @@ export const COMMANDS: CommandDef[] = [
       'and irreversible. Runs immediately (no approval) -- only call when the user clearly intends it.',
     input: deleteTaskInputSchema,
     mcp: true,
+    tier: 'always-ask',
     async handler(parsed, _ctx) {
       await runDeleteTask(parsed.task_id);
       const result = { task_id: parsed.task_id };
@@ -217,6 +260,58 @@ export const COMMANDS: CommandDef[] = [
     },
   },
 ];
+
+// ─── Policy set derivation ────────────────────────────────────────────────────
+
+export interface PolicySets {
+  AUTO_TOOLS: Set<string>;
+  READ_SUBCOMMANDS: Set<string>;
+  ASK_SUBCOMMANDS: Set<string>;
+  ALWAYS_ASK_SUBCOMMANDS: Set<string>;
+}
+
+/** Build gate policy sets from the command registry at module load. */
+export function buildPolicySets(
+  commands: CommandDef[] = COMMANDS,
+  policyOnly: PolicyOnlyCommand[] = POLICY_ONLY_COMMANDS,
+): PolicySets {
+  const AUTO_TOOLS = new Set<string>();
+  const READ_SUBCOMMANDS = new Set<string>();
+  const ASK_SUBCOMMANDS = new Set<string>();
+  const ALWAYS_ASK_SUBCOMMANDS = new Set<string>();
+
+  for (const cmd of commands) {
+    switch (cmd.tier) {
+      case 'auto':
+        if (cmd.mcp) AUTO_TOOLS.add(cmd.name);
+        READ_SUBCOMMANDS.add(cmd.action);
+        break;
+      case 'ask':
+        ASK_SUBCOMMANDS.add(cmd.action);
+        break;
+      case 'always-ask':
+        ALWAYS_ASK_SUBCOMMANDS.add(cmd.action);
+        break;
+    }
+  }
+
+  for (const cmd of policyOnly) {
+    switch (cmd.tier) {
+      case 'auto':
+        if (cmd.mcpName) AUTO_TOOLS.add(cmd.mcpName);
+        if (cmd.cliSubcommand) READ_SUBCOMMANDS.add(cmd.cliSubcommand);
+        break;
+      case 'ask':
+        if (cmd.cliSubcommand) ASK_SUBCOMMANDS.add(cmd.cliSubcommand);
+        break;
+      case 'always-ask':
+        if (cmd.cliSubcommand) ALWAYS_ASK_SUBCOMMANDS.add(cmd.cliSubcommand);
+        break;
+    }
+  }
+
+  return { AUTO_TOOLS, READ_SUBCOMMANDS, ASK_SUBCOMMANDS, ALWAYS_ASK_SUBCOMMANDS };
+}
 
 // ─── Lookup helpers ───────────────────────────────────────────────────────────
 

--- a/server/orchestrator/policy.ts
+++ b/server/orchestrator/policy.ts
@@ -21,57 +21,11 @@ import {
   insertPermissionRule,
   deletePermissionRule,
 } from './store.js';
+import { buildPolicySets } from './command-registry.js';
 
-// ─── Tier constants ───────────────────────────────────────────────────────────
+// ─── Tier sets (derived from command registry at startup) ───────────────────────
 
-/** Commands that run inline without a card (MCP read tools). */
-const AUTO_TOOLS = new Set([
-  'list_tasks',
-  'get_task',
-  'monitor_status',
-  'get_task_output',
-  'pull_linear_issue',
-]);
-
-/**
- * Read-only octomux subcommands. These never mutate state — they query the
- * running server (recent repos, default branch, task listings, …). They must
- * NOT be gated: the conductor uses them to gather context (e.g. find the repo
- * path before creating a task). Auto-allowed so they run without an approval
- * card. (Fixes: `octomux recent-repos` being denied then failing because it has
- * no server-side executor — it's a read, not a write.)
- */
-const READ_SUBCOMMANDS = new Set([
-  'list-tasks',
-  'get-task',
-  'recent-repos',
-  'default-branch',
-  'list-skills',
-  'get-skill',
-  'task-summary',
-  'task-updates',
-  'hooks-list',
-  'list-integrations',
-]);
-
-/**
- * octomux subcommands that are reversible writes.
- * A learnable allow-rule can promote these to 'auto'.
- */
-const ASK_SUBCOMMANDS = new Set([
-  'create-task',
-  'add-agent',
-  'send-message',
-  'set-status',
-  'request-review',
-  'resume-task',
-]);
-
-/**
- * octomux subcommands that are destructive.
- * These are ALWAYS gated — no rule can silence them.
- */
-const ALWAYS_ASK_SUBCOMMANDS = new Set(['delete-task', 'close-task']);
+const { AUTO_TOOLS, READ_SUBCOMMANDS, ALWAYS_ASK_SUBCOMMANDS } = buildPolicySets();
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -125,9 +79,8 @@ export function classify(command: string, args: string[]): PolicyDecision {
       return 'always-ask';
     }
 
-    // Reversible write — check if a rule promotes it to auto.
-    const baseDecision: PolicyDecision = ASK_SUBCOMMANDS.has(subcommand) ? 'ask' : 'ask';
-    return applyRules(command, subcommand, baseDecision);
+    // Reversible write (or unknown subcommand — fail-safe ask); rule may promote to auto.
+    return applyRules(command, subcommand, 'ask');
   }
 
   // ── Any other command (bash, etc.) defaults to ask ────────────────────────


### PR DESCRIPTION
## Summary
- Add `tier: PolicyTier` to each `CommandDef` in the command registry and derive gate policy sets (`AUTO_TOOLS`, `READ_SUBCOMMANDS`, `ASK_SUBCOMMANDS`, `ALWAYS_ASK_SUBCOMMANDS`) via `buildPolicySets()` at startup.
- Remove hand-maintained tier sets and the dead `ASK_SUBCOMMANDS.has(...) ? 'ask' : 'ask'` ternary from `policy.ts`.
- Add regression tests asserting derived sets and `classify()` output match pre-refactor behavior.

Resolves SHR-213

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (3387 passed)
- [x] `bun run build`

Made with [Cursor](https://cursor.com)