### PR TITLE
refactor(routes): centralize task response shaping and git helpers

### DIFF
--- a/server/integrations/http-client.ts
+++ b/server/integrations/http-client.ts
@@ -18,7 +18,9 @@ export class HttpIntegrationError extends Error {
 
   static async fromResponse(res: Response): Promise<HttpIntegrationError> {
     const body = await res.text().catch(() => '');
-    const message = body ? `${res.status}: ${res.statusText} — ${body}` : `${res.status}: ${res.statusText}`;
+    const message = body
+      ? `${res.status}: ${res.statusText} — ${body}`
+      : `${res.status}: ${res.statusText}`;
     return new HttpIntegrationError(message, { status: res.status, body });
   }
 }

--- a/server/integrations/types.ts
+++ b/server/integrations/types.ts
@@ -50,11 +50,7 @@ export function validateStatusMapByTeam(
   pathPrefix: string,
   errors: string[],
 ): void {
-  if (
-    !statusMapByTeam ||
-    typeof statusMapByTeam !== 'object' ||
-    Array.isArray(statusMapByTeam)
-  ) {
+  if (!statusMapByTeam || typeof statusMapByTeam !== 'object' || Array.isArray(statusMapByTeam)) {
     errors.push(`${pathPrefix} must be an object`);
     return;
   }

--- a/server/orchestrator/command-registry.test.ts
+++ b/server/orchestrator/command-registry.test.ts
@@ -170,13 +170,7 @@ describe('buildPolicySets', () => {
       buildPolicySets();
 
     expect([...AUTO_TOOLS].sort()).toEqual(
-      [
-        'get_task',
-        'get_task_output',
-        'list_tasks',
-        'monitor_status',
-        'pull_linear_issue',
-      ].sort(),
+      ['get_task', 'get_task_output', 'list_tasks', 'monitor_status', 'pull_linear_issue'].sort(),
     );
 
     expect([...READ_SUBCOMMANDS].sort()).toEqual(

--- a/server/poller/github-repo.ts
+++ b/server/poller/github-repo.ts
@@ -1,7 +1,4 @@
-import { execFile as execFileCb } from 'child_process';
-import { promisify } from 'util';
-
-const execFile = promisify(execFileCb);
+import { getRemoteOriginUrl } from '../task-engine/git.js';
 
 /** Parse a git remote URL into `owner/repo` (nameWithOwner) form. Returns null if non-GitHub. */
 export function parseNameWithOwner(remoteUrl: string): string | null {
@@ -20,12 +17,9 @@ const repoNwoCache = new Map<string, string>();
 export async function repoNameWithOwner(repoPath: string): Promise<string | null> {
   const cached = repoNwoCache.get(repoPath);
   if (cached) return cached;
-  try {
-    const { stdout } = await execFile('git', ['-C', repoPath, 'remote', 'get-url', 'origin']);
-    const nwo = parseNameWithOwner(stdout.trim());
-    if (nwo) repoNwoCache.set(repoPath, nwo);
-    return nwo;
-  } catch {
-    return null;
-  }
+  const remoteUrl = await getRemoteOriginUrl(repoPath);
+  if (!remoteUrl) return null;
+  const nwo = parseNameWithOwner(remoteUrl);
+  if (nwo) repoNwoCache.set(repoPath, nwo);
+  return nwo;
 }

--- a/server/poller/reviewer-requests.ts
+++ b/server/poller/reviewer-requests.ts
@@ -16,6 +16,7 @@ import {
 } from '../repositories/tasks.js';
 import { deleteWorktree } from '../repositories/worktrees.js';
 import { findFirstActiveAgent } from '../repositories/agent-runtime.js';
+import { checkoutRef, fetchOriginQuiet, isAncestor } from '../task-engine/git.js';
 import { repoNameWithOwner } from './github-repo.js';
 
 const logger = childLogger('poller');
@@ -203,8 +204,8 @@ async function upsertReviewTask(
       let previousHeadReachable = true;
       if (existing.worktree_path) {
         try {
-          await execFile('git', ['-C', existing.worktree_path, 'fetch', 'origin', '--quiet']);
-          await execFile('git', ['-C', existing.worktree_path, 'checkout', pr.headRefOid]);
+          await fetchOriginQuiet(existing.worktree_path);
+          await checkoutRef(existing.worktree_path, pr.headRefOid);
         } catch (err) {
           logger.warn(
             { task_id: existing.id, err: (err as Error).message },
@@ -212,18 +213,11 @@ async function upsertReviewTask(
           );
         }
         if (existing.pr_head_sha) {
-          try {
-            await execFile('git', [
-              '-C',
-              existing.worktree_path,
-              'merge-base',
-              '--is-ancestor',
-              existing.pr_head_sha,
-              pr.headRefOid,
-            ]);
-          } catch {
-            previousHeadReachable = false;
-          }
+          previousHeadReachable = await isAncestor(
+            existing.worktree_path,
+            existing.pr_head_sha,
+            pr.headRefOid,
+          );
         }
       }
 

--- a/server/routes/_shared.ts
+++ b/server/routes/_shared.ts
@@ -4,12 +4,21 @@
  */
 import type { Request } from 'express';
 import { notFound, ServiceError } from '../services/errors.js';
-import { getTask as getTaskRepo, listAllAgents, listUserTerminals } from '../repositories/index.js';
+import {
+  getTask as getTaskRepo,
+  listAllAgents,
+  listUserTerminals,
+  listPendingPromptsByTask,
+} from '../repositories/index.js';
+import type { PermissionPromptRow } from '../repositories/permission-prompts.js';
 import { findReviewTaskByPrNumber, findReviewTaskBySource } from '../repositories/index.js';
 import { nanoid } from 'nanoid';
 import fs from 'fs';
 import type {
   Task,
+  Agent,
+  UserTerminal,
+  Worktree,
   DerivedTaskStatus,
   CreateTaskRequest,
   UpdateTaskRequest,
@@ -87,11 +96,54 @@ export function deepMerge(
   return result;
 }
 
-/** Reload a task with its related agents and user_terminals. */
-export function fetchTaskBundle(taskId: string): Task {
+export interface TaskRelations {
+  agents: Agent[];
+  user_terminals: UserTerminal[];
+  pending_prompts: PermissionPromptRow[];
+}
+
+export interface TaskResponseExtras {
+  worktree_row?: Worktree | null;
+  existing_review_id?: string | null;
+}
+
+/** Load a task plus agents, terminals, and pending permission prompts. */
+export function fetchTaskWithRelations(taskId: string): { task: Task; relations: TaskRelations } {
   const task = getTaskRepo(taskId) as Task;
-  task.agents = listAllAgents(taskId);
-  task.user_terminals = listUserTerminals(taskId);
+  return {
+    task,
+    relations: {
+      agents: listAllAgents(taskId),
+      user_terminals: listUserTerminals(taskId),
+      pending_prompts: listPendingPromptsByTask(taskId),
+    },
+  };
+}
+
+/** Shape a task + relations into the standard API envelope. */
+export function formatTaskResponse(
+  task: Task,
+  relations: TaskRelations,
+  extras?: TaskResponseExtras,
+) {
+  return {
+    ...task,
+    agents: relations.agents,
+    pending_prompts: relations.pending_prompts,
+    derived_status: derivedStatus({ runtime_state: task.runtime_state, agents: relations.agents }),
+    user_terminals: relations.user_terminals,
+    ...(extras?.worktree_row !== undefined ? { worktree_row: extras.worktree_row } : {}),
+    ...(extras?.existing_review_id !== undefined
+      ? { existing_review_id: extras.existing_review_id }
+      : {}),
+  };
+}
+
+/** Reload a task with its related agents and user_terminals (mutation-style, no prompts). */
+export function fetchTaskBundle(taskId: string): Task {
+  const { task, relations } = fetchTaskWithRelations(taskId);
+  task.agents = relations.agents;
+  task.user_terminals = relations.user_terminals;
   return task;
 }
 

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -1,9 +1,8 @@
 import express from 'express';
 import type { Request, Response } from 'express';
-import { execFile as execFileCb } from 'child_process';
-import { promisify } from 'util';
 import fs from 'fs';
 import { childLogger } from '../logger.js';
+import { hashObject, revParseHead } from '../task-engine/git.js';
 import { safeResolvePath } from '@octomux/diff-engine';
 import { taskWorkingDir } from '../task-paths.js';
 import { setReviewed, clearReviewed } from '../repositories/file-review-state.js';
@@ -22,7 +21,6 @@ import { createInlineComment } from '../services/comment-service.js';
 import { loadTaskOrFail } from './_shared.js';
 import { badRequest, conflict, notFound } from '../services/errors.js';
 
-const execFile = promisify(execFileCb);
 const logger = childLogger('api:comments');
 
 function resolveRelPath(req: Request): string {
@@ -50,15 +48,8 @@ router.post('/api/tasks/:id/files/*path/reviewed', async (req: Request, res: Res
   const relPath = resolveRelPath(req);
   assertValidPath(cwd, relPath);
 
-  const { stdout } = await execFile('git', ['-C', cwd, 'rev-parse', 'HEAD']);
-  const headSha = stdout.trim();
-  let blobSha: string | null = null;
-  try {
-    const { stdout: bs } = await execFile('git', ['-C', cwd, 'hash-object', '--', relPath]);
-    blobSha = bs.trim() || null;
-  } catch {
-    blobSha = null;
-  }
+  const headSha = await revParseHead(cwd);
+  const blobSha = await hashObject(cwd, relPath);
   setReviewed(task.id, relPath, headSha, blobSha);
   res.status(204).send();
 });

--- a/server/routes/reviews.ts
+++ b/server/routes/reviews.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { childLogger } from '../logger.js';
+import { getRemoteOriginUrl, revParseHead } from '../task-engine/git.js';
 import { listReviewsInbox, getReviewDetail } from '../reviews-inbox.js';
 import { taskWorkingDir } from '../task-paths.js';
 import {
@@ -51,14 +52,8 @@ router.post('/api/reviews', async (req: Request, res: Response) => {
     for (const row of rows) {
       const candidatePath = row.repo_path;
       try {
-        const { stdout } = await execFile('git', [
-          '-C',
-          candidatePath,
-          'remote',
-          'get-url',
-          'origin',
-        ]);
-        const remoteUrl = stdout.trim();
+        const remoteUrl = await getRemoteOriginUrl(candidatePath);
+        if (!remoteUrl) continue;
         const sshMatch = remoteUrl.match(/git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
         const httpsMatch = remoteUrl.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/);
         const remoteOwnerRepo = (sshMatch?.[1] ?? httpsMatch?.[1] ?? '').toLowerCase();
@@ -154,8 +149,7 @@ router.post('/api/tasks/:taskId/review', async (req: Request, res: Response) => 
   if (!prHeadSha) {
     const cwd = taskWorkingDir(task);
     try {
-      const { stdout } = await execFile('git', ['-C', cwd!, 'rev-parse', 'HEAD']);
-      prHeadSha = stdout.trim();
+      prHeadSha = await revParseHead(cwd!);
     } catch (err) {
       throw new ServiceError(`failed to resolve HEAD: ${(err as Error).message}`, 500);
     }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -33,13 +33,11 @@ import {
   touchLastViewed,
   touchAllLastViewed,
   getWorktree,
-  listAllAgents,
   listAgentsByTasks,
-  listPendingPromptsByTask,
   listPendingPromptsByTasks,
-  listUserTerminals,
   listUserTerminalsByTasks,
 } from '../repositories/index.js';
+import type { PermissionPromptRow } from '../repositories/permission-prompts.js';
 
 import { createTask } from '../services/task-service.js';
 import { badRequest, conflict } from '../services/errors.js';
@@ -47,7 +45,8 @@ import {
   loadTaskOrFail,
   lookupExistingReviewId,
   fetchTaskBundle,
-  derivedStatus,
+  fetchTaskWithRelations,
+  formatTaskResponse,
   validateCreateTaskBody,
   applyDraftUpdates,
   resolveTaskTitleAndDescription,
@@ -86,11 +85,11 @@ router.get('/api/tasks', (req: Request, res: Response) => {
     agentsByTask.set(agent.task_id, list);
   }
 
-  const promptsByTask = new Map<string, Array<Record<string, unknown>>>();
+  const promptsByTask = new Map<string, PermissionPromptRow[]>();
   for (const pp of allPrompts) {
     const taskId = pp.task_id as string;
     const list = promptsByTask.get(taskId) || [];
-    list.push({ ...pp });
+    list.push(pp);
     promptsByTask.set(taskId, list);
   }
 
@@ -101,16 +100,13 @@ router.get('/api/tasks', (req: Request, res: Response) => {
     terminalsByTask.set(ut.task_id, list);
   }
 
-  const result = tasks.map((task) => {
-    const agents = agentsByTask.get(task.id) || [];
-    return {
-      ...task,
-      agents,
+  const result = tasks.map((task) =>
+    formatTaskResponse(task, {
+      agents: agentsByTask.get(task.id) || [],
       pending_prompts: promptsByTask.get(task.id) || [],
-      derived_status: derivedStatus({ runtime_state: task.runtime_state, agents }),
       user_terminals: terminalsByTask.get(task.id) || [],
-    };
-  });
+    }),
+  );
 
   res.json(result);
 });
@@ -161,28 +157,26 @@ router.patch('/api/tasks/:id/viewed', (req: Request, res: Response) => {
 // Get single task with agents
 router.get('/api/tasks/:id', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
-  const rawAgents = listAllAgents(task.id);
+  const { relations } = fetchTaskWithRelations(task.id);
   // Backfill hook_token for pre-step-1 agents that have an empty token.
   const agents = await Promise.all(
-    rawAgents.map(async (agent) => {
+    relations.agents.map(async (agent) => {
       if (agent.hook_token !== '') return agent;
       const token = await ensureHookToken(agent, task.worktree ?? null);
       return { ...agent, hook_token: token };
     }),
   );
-  const pendingPrompts = listPendingPromptsByTask(task.id);
-  const parsedPrompts = pendingPrompts;
-  const userTerminals = listUserTerminals(task.id);
   const worktreeRow = task.worktree_id ? (getWorktree(task.worktree_id) ?? null) : null;
-  res.json({
-    ...task,
-    agents,
-    pending_prompts: parsedPrompts,
-    derived_status: derivedStatus({ runtime_state: task.runtime_state, agents }),
-    user_terminals: userTerminals,
-    worktree_row: worktreeRow,
-    existing_review_id: lookupExistingReviewId(task),
-  });
+  res.json(
+    formatTaskResponse(
+      task,
+      { ...relations, agents },
+      {
+        worktree_row: worktreeRow,
+        existing_review_id: lookupExistingReviewId(task),
+      },
+    ),
+  );
 });
 
 // Create task

--- a/server/task-engine/git.ts
+++ b/server/task-engine/git.ts
@@ -19,6 +19,48 @@ export async function revParseHead(cwd: string, ref = 'HEAD'): Promise<string> {
   return stdout.trim();
 }
 
+export async function getRemoteOriginUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile('git', ['-C', repoPath, 'remote', 'get-url', 'origin']);
+    const url = stdout.trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function hashObject(cwd: string, relPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile('git', ['-C', cwd, 'hash-object', '--', relPath]);
+    const sha = stdout.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchOriginQuiet(cwd: string): Promise<void> {
+  await execFile('git', ['-C', cwd, 'fetch', 'origin', '--quiet']);
+}
+
+export async function checkoutRef(cwd: string, ref: string): Promise<void> {
+  await execFile('git', ['-C', cwd, 'checkout', ref]);
+}
+
+/** True when `ancestor` is an ancestor of `descendant` in `cwd`. */
+export async function isAncestor(
+  cwd: string,
+  ancestor: string,
+  descendant: string,
+): Promise<boolean> {
+  try {
+    await execFile('git', ['-C', cwd, 'merge-base', '--is-ancestor', ancestor, descendant]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function checkDirty(repoPath: string): Promise<string[]> {
   const { stdout } = await execFile('git', ['-C', repoPath, 'status', '--porcelain=v1']);
   return stdout

--- a/server/task-engine/index.ts
+++ b/server/task-engine/index.ts
@@ -19,6 +19,11 @@ export {
 export {
   validateRepo,
   revParseHead,
+  getRemoteOriginUrl,
+  hashObject,
+  fetchOriginQuiet,
+  checkoutRef,
+  isAncestor,
   checkDirty,
   gitBranchExists,
   addWorktreeWithBranch,

--- a/server/task-engine/lifecycle/add-agent.ts
+++ b/server/task-engine/lifecycle/add-agent.ts
@@ -12,11 +12,7 @@ import {
   getTaskHookToken,
   insertAgentWithNotify,
 } from '../../repositories/index.js';
-import {
-  buildAgentStartupCommand,
-  launchAgentWindow,
-  computeFreshSessionIds,
-} from '../launch.js';
+import { buildAgentStartupCommand, launchAgentWindow, computeFreshSessionIds } from '../launch.js';
 import type { Agent, Task } from '../../types.js';
 import type { AddAgentOpts } from './types.js';
 

--- a/server/task-engine/lifecycle/resume-task.ts
+++ b/server/task-engine/lifecycle/resume-task.ts
@@ -15,11 +15,7 @@ import {
   setAgentWindowRunning,
   stopRunningAgents,
 } from '../../repositories/index.js';
-import {
-  buildAgentStartupCommand,
-  launchAgentWindow,
-  prepareResumeLaunch,
-} from '../launch.js';
+import { buildAgentStartupCommand, launchAgentWindow, prepareResumeLaunch } from '../launch.js';
 import { cleanupLinkedSessions } from '../sessions.js';
 import { checkDirty } from '../git.js';
 
@@ -65,7 +61,11 @@ export async function prepareResumeSession(task: Task, session: string): Promise
 }
 
 /** Install hooks once before relaunching stopped agents (or create an empty session). */
-export async function bootstrapResumeHooks(task: Task, cwd: string, session: string): Promise<void> {
+export async function bootstrapResumeHooks(
+  task: Task,
+  cwd: string,
+  session: string,
+): Promise<void> {
   const agents = listStoppedAgents(task.id);
 
   if (agents.length > 0) {


### PR DESCRIPTION
## Summary
- Add `fetchTaskWithRelations()` and `formatTaskResponse()` in `server/routes/_shared.ts`; use them for `GET /api/tasks` and `GET /api/tasks/:id` instead of hand-assembling the relations envelope.
- Extend `server/task-engine/git.ts` with `getRemoteOriginUrl`, `hashObject`, `fetchOriginQuiet`, `checkoutRef`, and `isAncestor`; route stray `execFile('git', ...)` calls in comments/reviews routes and poller modules through these helpers.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (256 files, 3402 tests passed)
- [x] `bun run build`


Made with [Cursor](https://cursor.com)