### PR TITLE
refactor(frontend): decompose TaskDetail and OrchestratorPage [SHR-216]

### DIFF
--- a/src/components/orchestrator/ChatInput.test.tsx
+++ b/src/components/orchestrator/ChatInput.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChatInput } from './ChatInput';
+
+describe('ChatInput', () => {
+  it('submits trimmed text on Enter and clears the field', () => {
+    const onSubmit = vi.fn();
+    render(<ChatInput onSubmit={onSubmit} />);
+
+    const input = screen.getByLabelText('Message input');
+    fireEvent.change(input, { target: { value: '  hello  ' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+
+    expect(onSubmit).toHaveBeenCalledWith('hello');
+    expect(input).toHaveValue('');
+  });
+
+  it('does not submit when disabled', () => {
+    const onSubmit = vi.fn();
+    render(<ChatInput onSubmit={onSubmit} disabled />);
+
+    const input = screen.getByLabelText('Message input');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/orchestrator/ChatInput.tsx
+++ b/src/components/orchestrator/ChatInput.tsx
@@ -1,0 +1,83 @@
+import { useState, useRef, useCallback, type FormEvent, type KeyboardEvent } from 'react';
+import { cn } from '@/lib/utils';
+import { ORCHESTRATOR_FOCUS_RING } from './types';
+
+export interface ChatInputProps {
+  onSubmit: (text: string) => void;
+  disabled?: boolean;
+}
+
+export function ChatInput({ onSubmit, disabled = false }: ChatInputProps) {
+  const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const submit = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSubmit(trimmed);
+    setValue('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, [value, disabled, onSubmit]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const handleInput = () => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+  };
+
+  return (
+    <form
+      onSubmit={(e: FormEvent) => {
+        e.preventDefault();
+        submit();
+      }}
+      className="flex items-end gap-2 border-t border-[rgba(255,255,255,0.08)] px-4 py-3"
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        disabled={disabled}
+        placeholder="Message orchestrator (Enter to send, Shift+Enter for newline)"
+        rows={1}
+        aria-label="Message input"
+        className={cn(
+          'flex-1 resize-none overflow-hidden rounded-xl border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.04)] px-4 py-2.5 text-sm text-foreground placeholder:text-[rgba(255,255,255,0.3)] focus:outline-none focus:ring-1 focus:ring-[#3B82F6]',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+        style={{ minHeight: 44, maxHeight: 160 }}
+      />
+      <button
+        type="submit"
+        disabled={disabled || !value.trim()}
+        aria-label="Send message"
+        className={cn(
+          'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#3B82F6] text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40',
+          ORCHESTRATOR_FOCUS_RING,
+        )}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M2 8h12M10 4l4 4-4 4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+    </form>
+  );
+}

--- a/src/components/orchestrator/ConnectionPill.tsx
+++ b/src/components/orchestrator/ConnectionPill.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils';
+import type { WsConnectionState } from '@/lib/orchestrator-api';
+
+/**
+ * WebSocket connection-status pill (SHR-162). Surfaces connecting / live /
+ * reconnecting so a dropped socket is visible instead of silently dead.
+ */
+export function ConnectionPill({ state }: { state: WsConnectionState }) {
+  const config: Record<
+    WsConnectionState,
+    { label: string; dot: string; pulse: boolean; aria: string }
+  > = {
+    connecting: { label: 'connecting', dot: 'bg-[#FB923C]', pulse: true, aria: 'Connecting' },
+    open: { label: 'live', dot: 'bg-[#22C55E]', pulse: false, aria: 'Connected' },
+    reconnecting: { label: 'reconnecting', dot: 'bg-[#FB923C]', pulse: true, aria: 'Reconnecting' },
+    closed: { label: 'offline', dot: 'bg-[rgba(255,255,255,0.3)]', pulse: false, aria: 'Offline' },
+  };
+  const { label, dot, pulse, aria } = config[state];
+
+  return (
+    <span
+      role="status"
+      aria-label={aria}
+      title={`WebSocket ${label}`}
+      className="ml-2 flex shrink-0 items-center gap-1.5 text-[11px] text-[rgba(255,255,255,0.45)]"
+    >
+      <span className={cn('h-2 w-2 rounded-full', dot, pulse && 'animate-pulse')} />
+      {label}
+    </span>
+  );
+}

--- a/src/components/orchestrator/LeanessIndicator.tsx
+++ b/src/components/orchestrator/LeanessIndicator.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@/lib/utils';
+import type { ConversationUsage } from '@/lib/orchestrator-api';
+
+/**
+ * Conductor-leanness indicator (§6.7).
+ *
+ * Surfaces orchestrator-vs-worker activity so the user can tell if the
+ * conductor is accumulating context that should be delegated. Shows:
+ *  - tasks spawned
+ *  - tool calls made
+ *
+ * Turns orange/warning when tasks_spawned >= 12 or tool_calls >= 40
+ * (spec §10: soft threshold = "12 tasks spawned or M minutes").
+ * These are configurable thresholds; off-by-default in the UI
+ * (only shown when a conversation is open).
+ */
+export interface LeanessIndicatorProps {
+  usage: ConversationUsage;
+}
+
+export function LeanessIndicator({ usage }: LeanessIndicatorProps) {
+  const TASKS_WARN = 12;
+  const CALLS_WARN = 40;
+  const isWarning = usage.tasks_spawned >= TASKS_WARN || usage.tool_calls >= CALLS_WARN;
+
+  return (
+    <div
+      aria-label="Conductor leanness stats"
+      title={`Conductor activity: ${usage.tasks_spawned} tasks spawned, ${usage.tool_calls} tool calls`}
+      className={cn(
+        'ml-auto flex items-center gap-2 rounded-md px-2 py-1 text-xs tabular-nums',
+        isWarning
+          ? 'bg-[rgba(251,146,60,0.12)] text-[#FB923C]'
+          : 'bg-[rgba(255,255,255,0.04)] text-[rgba(255,255,255,0.45)]',
+      )}
+    >
+      {isWarning && (
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+          <path d="M6 1L1 11h10L6 1zm0 2l3.5 7h-7L6 3zm-.5 3v2h1V6h-1zm0 3v1h1V9h-1z" />
+        </svg>
+      )}
+      <span>{usage.tasks_spawned} tasks</span>
+      <span aria-hidden="true">·</span>
+      <span>{usage.tool_calls} calls</span>
+    </div>
+  );
+}

--- a/src/components/orchestrator/MixedThread.test.tsx
+++ b/src/components/orchestrator/MixedThread.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MixedThread } from './MixedThread';
+import type { ThreadItem } from './types';
+
+vi.mock('./MessageThread', () => ({
+  MessageThread: ({ messages }: { messages: { text: string }[] }) => (
+    <div data-testid="message-thread">{messages.map((m) => m.text).join(',')}</div>
+  ),
+}));
+
+vi.mock('./ToolCallCard', () => ({
+  ToolCallCard: ({ toolName }: { toolName: string }) => (
+    <div data-testid="tool-call">{toolName}</div>
+  ),
+}));
+
+describe('MixedThread', () => {
+  const noop = vi.fn();
+
+  it('shows empty state when no items and not working', () => {
+    render(
+      <MixedThread
+        items={[]}
+        onCardDecision={noop}
+        onSpecCardDismiss={noop}
+        working={false}
+      />,
+    );
+    expect(screen.getByText('No messages yet. Start a conversation below.')).toBeInTheDocument();
+  });
+
+  it('renders message batches via MessageThread', () => {
+    const items: ThreadItem[] = [
+      { id: '1', role: 'user', text: 'hi' },
+      { id: '2', role: 'assistant', text: 'hello' },
+    ];
+    render(<MixedThread items={items} onCardDecision={noop} onSpecCardDismiss={noop} />);
+    expect(screen.getByTestId('message-thread')).toHaveTextContent('hi,hello');
+  });
+
+  it('shows working indicator when working', () => {
+    render(
+      <MixedThread items={[]} onCardDecision={noop} onSpecCardDismiss={noop} working />,
+    );
+    expect(screen.getByLabelText('Orchestrator is working')).toBeInTheDocument();
+  });
+});

--- a/src/components/orchestrator/MixedThread.test.tsx
+++ b/src/components/orchestrator/MixedThread.test.tsx
@@ -20,12 +20,7 @@ describe('MixedThread', () => {
 
   it('shows empty state when no items and not working', () => {
     render(
-      <MixedThread
-        items={[]}
-        onCardDecision={noop}
-        onSpecCardDismiss={noop}
-        working={false}
-      />,
+      <MixedThread items={[]} onCardDecision={noop} onSpecCardDismiss={noop} working={false} />,
     );
     expect(screen.getByText('No messages yet. Start a conversation below.')).toBeInTheDocument();
   });
@@ -40,9 +35,7 @@ describe('MixedThread', () => {
   });
 
   it('shows working indicator when working', () => {
-    render(
-      <MixedThread items={[]} onCardDecision={noop} onSpecCardDismiss={noop} working />,
-    );
+    render(<MixedThread items={[]} onCardDecision={noop} onSpecCardDismiss={noop} working />);
     expect(screen.getByLabelText('Orchestrator is working')).toBeInTheDocument();
   });
 });

--- a/src/components/orchestrator/MixedThread.tsx
+++ b/src/components/orchestrator/MixedThread.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { MessageThread, type ThreadMessage } from './MessageThread';
+import { ToolCallCard } from './ToolCallCard';
+import { PlanCard } from './PlanCard';
+import { SpecCard } from './SpecCard';
+import { ActionCard } from './ActionCard';
+import { WorkingIndicator } from './WorkingIndicator';
+import type { ActionCardDecision, ThreadItem } from './types';
+
+export interface MixedThreadProps {
+  items: ThreadItem[];
+  onCardDecision: (d: ActionCardDecision) => void;
+  onSpecCardDismiss: (cardId: string) => void;
+  /** True while the orchestrator is processing a turn (shows a working indicator). */
+  working?: boolean;
+}
+
+/**
+ * Renders the thread: a mix of chat messages and inline cards.
+ * ThreadMessages are delegated to MessageThread; cards are rendered inline.
+ */
+export function MixedThread({
+  items,
+  onCardDecision,
+  onSpecCardDismiss,
+  working = false,
+}: MixedThreadProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [items.length, working]);
+
+  if (items.length === 0 && !working) {
+    return (
+      <div
+        className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+        aria-live="polite"
+        aria-label="Message thread"
+      >
+        No messages yet. Start a conversation below.
+      </div>
+    );
+  }
+
+  const rendered: ReactNode[] = [];
+  let msgBatch: ThreadMessage[] = [];
+
+  function flushBatch() {
+    if (msgBatch.length === 0) return;
+    const key = msgBatch[0].id;
+    rendered.push(<MessageThread key={`msg-batch-${key}`} messages={msgBatch} />);
+    msgBatch = [];
+  }
+
+  for (const item of items) {
+    if ('role' in item) {
+      msgBatch.push(item as ThreadMessage);
+    } else if (item.kind === 'tool-call') {
+      flushBatch();
+      rendered.push(
+        <div key={item.id} className="px-4 py-1">
+          <ToolCallCard toolName={item.toolName} input={item.input} />
+        </div>,
+      );
+    } else if (item.kind === 'spec-card' && !item.resolved) {
+      flushBatch();
+      rendered.push(
+        <div key={item.id} className="px-4 py-2">
+          <SpecCard
+            cardId={item.id}
+            taskId={item.taskId}
+            specPath={item.specPath}
+            artifactUrl={item.artifactUrl}
+            onDismiss={() => onSpecCardDismiss(item.id)}
+          />
+        </div>,
+      );
+    } else if (item.kind === 'plan-card' && !item.resolved) {
+      flushBatch();
+      rendered.push(
+        <div key={item.id} className="px-4 py-2">
+          <PlanCard
+            cardId={item.id}
+            taskId={item.taskId}
+            planPath={item.planPath}
+            artifactUrl={item.artifactUrl}
+            onDecision={({ decision, card_id }) =>
+              onCardDecision({ card_id, decision: decision as 'approve' | 'reject' })
+            }
+          />
+        </div>,
+      );
+    } else if (item.kind === 'action-card' && !item.resolved) {
+      flushBatch();
+      rendered.push(
+        <div key={item.id} className="px-4 py-2">
+          <ActionCard
+            cardId={item.id}
+            command={item.command}
+            args={item.args}
+            alwaysAsk={item.alwaysAsk}
+            onDecision={onCardDecision}
+          />
+        </div>,
+      );
+    }
+  }
+  flushBatch();
+
+  return (
+    <div
+      className="flex flex-1 flex-col overflow-y-auto"
+      role="log"
+      aria-label="Message thread"
+      aria-live="polite"
+    >
+      {rendered}
+      {working && <WorkingIndicator />}
+      <div ref={bottomRef} aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/components/orchestrator/OrchestratorEmptyState.tsx
+++ b/src/components/orchestrator/OrchestratorEmptyState.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib/utils';
+import { ORCHESTRATOR_FOCUS_RING } from './types';
+
+export function OrchestratorEmptyState({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[rgba(59,130,246,0.12)]">
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#3B82F6"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      </div>
+      <div>
+        <p className="text-sm font-medium text-foreground">No conversation selected</p>
+        <p className="mt-1 text-xs text-[rgba(255,255,255,0.45)]">
+          Select a conversation from the list or start a new one.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onNew}
+        className={cn(
+          'rounded-lg bg-[#3B82F6] px-4 py-2 text-sm font-medium text-white hover:opacity-90',
+          ORCHESTRATOR_FOCUS_RING,
+        )}
+      >
+        New conversation
+      </button>
+    </div>
+  );
+}

--- a/src/components/orchestrator/WorkingIndicator.tsx
+++ b/src/components/orchestrator/WorkingIndicator.tsx
@@ -1,0 +1,17 @@
+/** Animated "orchestrator is working" indicator shown while a turn is in flight. */
+export function WorkingIndicator() {
+  return (
+    <div
+      className="flex items-center gap-2 px-4 py-3"
+      aria-live="polite"
+      aria-label="Orchestrator is working"
+    >
+      <span className="flex gap-1">
+        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.3s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.15s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
+      </span>
+      <span className="text-xs text-muted-foreground">orchestrator is working…</span>
+    </div>
+  );
+}

--- a/src/components/orchestrator/types.ts
+++ b/src/components/orchestrator/types.ts
@@ -1,0 +1,68 @@
+import type { ThreadMessage } from './MessageThread';
+import type { ActionCardDecision } from './ActionCard';
+
+/** A plan-approval card that appears inline in the message thread. */
+export interface PlanCardItem {
+  kind: 'plan-card';
+  id: string;
+  taskId: string;
+  planPath: string;
+  artifactUrl: string;
+  /** resolved once the user decides; removes the card from the thread */
+  resolved: boolean;
+}
+
+/**
+ * A read-only spec card for the workflow kind (SHR-143).
+ * Rendered by SpecCard; no ws decision event — local dismiss only.
+ */
+export interface SpecCardItem {
+  kind: 'spec-card';
+  id: string;
+  taskId: string;
+  specPath: string;
+  artifactUrl: string;
+  /** true when the user has locally dismissed the card */
+  resolved: boolean;
+}
+
+/**
+ * An action card for a gated write-command (Task 3.3 / SHR-132).
+ * Rendered by ActionCard; user can Approve/Edit/Reject/Respond.
+ */
+export interface ActionCardItem {
+  kind: 'action-card';
+  id: string;
+  command: string;
+  args: Record<string, unknown>;
+  /** true when the command is in the always-ask (destructive) tier */
+  alwaysAsk?: boolean;
+  /** resolved once the user decides; removes the card from the thread */
+  resolved: boolean;
+}
+
+/**
+ * A conductor tool-call, rendered as a collapsible card distinct from prose
+ * (SHR-161). Live/ephemeral — pushed from the transcript tail, not persisted.
+ */
+export interface ToolCallItem {
+  kind: 'tool-call';
+  id: string;
+  toolName: string;
+  input: unknown;
+}
+
+/** A union of everything that can appear in the thread. */
+export type ThreadItem =
+  | ThreadMessage
+  | PlanCardItem
+  | SpecCardItem
+  | ActionCardItem
+  | ToolCallItem;
+
+export const ORCHESTRATOR_FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]';
+
+export const ORCHESTRATOR_SIDEBAR_WIDTH = 240;
+
+export type { ActionCardDecision };

--- a/src/components/task-detail/DiffKeybindCheatSheet.tsx
+++ b/src/components/task-detail/DiffKeybindCheatSheet.tsx
@@ -1,0 +1,34 @@
+import { DIFF_KEYBINDS } from '@/hooks/useDiffKeyboardNav';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+/** Floating "?" chip that surfaces the diff keybind cheat sheet in a popover. */
+export function DiffKeybindCheatSheet() {
+  return (
+    <div className="pointer-events-none absolute bottom-3 right-3">
+      <Popover>
+        <PopoverTrigger
+          aria-label="Show diff keyboard shortcuts"
+          data-testid="diff-keybind-help"
+          className="pointer-events-auto inline-flex h-7 w-7 items-center justify-center rounded-full border border-glass-edge bg-glass-l1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          ?
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-72">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Diff shortcuts
+          </div>
+          <ul className="mt-2 space-y-1">
+            {DIFF_KEYBINDS.map((b) => (
+              <li key={b.keys} className="flex items-center justify-between gap-3 text-xs">
+                <kbd className="rounded border border-glass-edge bg-glass-l1 px-1.5 py-0.5 font-mono text-[10px]">
+                  {b.keys}
+                </kbd>
+                <span className="text-muted-foreground">{b.description}</span>
+              </li>
+            ))}
+          </ul>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/task-detail/TaskDetailAgentView.tsx
+++ b/src/components/task-detail/TaskDetailAgentView.tsx
@@ -1,0 +1,155 @@
+import { TerminalView } from '@/components/TerminalView';
+import { AgentTabs } from '@/components/AgentTabs';
+import { AgentGridCell } from '@/components/AgentGridCell';
+import { gridColumns } from '@/pages/GridMonitor';
+import { MoveAgentDialog } from '@/components/MoveAgentDialog';
+import { Button } from '@/components/ui/button';
+import { taskApi } from '@/lib/api/taskApi';
+import type { Task } from '@octomux/types';
+
+export interface TaskDetailAgentViewProps {
+  task: Task;
+  mode: 'agents' | 'editor' | 'diff' | 'info';
+  activeWindow: number | null;
+  terminalLRU: number[];
+  gridView: boolean;
+  isRunning: boolean;
+  movingAgentId: string | null;
+  onSelectWindow: (index: number) => void;
+  onGridViewToggle: () => void;
+  onAddAgent: (prompt?: string) => Promise<void>;
+  onStopAgent: (agentId: string) => Promise<void>;
+  onAddTerminal: () => Promise<void>;
+  onCloseTerminal: (terminalId: string) => Promise<void>;
+  onMoveAgent: (agentId: string) => void;
+  onDetachAgent: (agentId: string) => Promise<void>;
+  onMoveDialogClose: () => void;
+  onMoved: () => void;
+}
+
+export function TaskDetailAgentView({
+  task,
+  mode,
+  activeWindow,
+  terminalLRU,
+  gridView,
+  isRunning,
+  movingAgentId,
+  onSelectWindow,
+  onGridViewToggle,
+  onAddAgent,
+  onStopAgent,
+  onAddTerminal,
+  onCloseTerminal,
+  onMoveAgent,
+  onDetachAgent,
+  onMoveDialogClose,
+  onMoved,
+}: TaskDetailAgentViewProps) {
+  const agents = task.agents || [];
+
+  return (
+    <div className={mode === 'agents' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}>
+      <div className="flex shrink-0 items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <AgentTabs
+            agents={agents}
+            activeIndex={activeWindow ?? 0}
+            onSelect={onSelectWindow}
+            onAddAgent={onAddAgent}
+            onStopAgent={onStopAgent}
+            canAddAgent={isRunning}
+            userTerminals={isRunning ? task.user_terminals || [] : []}
+            onAddTerminal={isRunning ? onAddTerminal : undefined}
+            onCloseTerminal={isRunning ? onCloseTerminal : undefined}
+            onMoveAgent={isRunning ? onMoveAgent : undefined}
+            onDetachAgent={isRunning ? onDetachAgent : undefined}
+          />
+        </div>
+        {agents.filter((a) => a.status !== 'stopped').length > 1 && (
+          <Button
+            type="button"
+            size="xs"
+            variant={gridView ? 'default' : 'outline'}
+            data-testid="task-grid-toggle"
+            aria-pressed={gridView}
+            onClick={onGridViewToggle}
+            className="mr-2"
+          >
+            {gridView ? 'Single' : 'Grid view'}
+          </Button>
+        )}
+      </div>
+      {movingAgentId && (
+        <MoveAgentDialog
+          open={!!movingAgentId}
+          onOpenChange={(open) => !open && onMoveDialogClose()}
+          agentId={movingAgentId}
+          currentTaskId={task.id}
+          agentLabel={task.agents?.find((a) => a.id === movingAgentId)?.label}
+          onMoved={onMoved}
+        />
+      )}
+      {gridView ? (
+        <div data-testid="task-agent-grid" className="min-h-0 flex-1 overflow-auto p-2">
+          {(() => {
+            const running = agents.filter((a) => a.status !== 'stopped');
+            const cols = gridColumns(running.length);
+            return (
+              <div
+                className="grid gap-3"
+                style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+              >
+                {running.map((a) => (
+                  <AgentGridCell
+                    key={a.id}
+                    taskId={task.id}
+                    windowIndex={a.window_index}
+                    taskTitle={task.title || '(untitled task)'}
+                    agentName={a.label}
+                    activity={a.hook_activity}
+                  />
+                ))}
+              </div>
+            );
+          })()}
+        </div>
+      ) : (
+        <div className="relative min-h-0 flex-1 overflow-hidden p-1">
+          {terminalLRU.map((wi) => {
+            const isActive = wi === activeWindow;
+            return (
+              <div
+                key={wi}
+                data-window-index={wi}
+                data-terminal-active={isActive ? 'true' : 'false'}
+                aria-hidden={!isActive}
+                inert={!isActive}
+                className={
+                  isActive
+                    ? 'absolute inset-0'
+                    : 'pointer-events-none absolute inset-0 opacity-0'
+                }
+              >
+                <TerminalView
+                  taskId={task.id}
+                  windowIndex={wi}
+                  visible={isActive && mode === 'agents'}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export async function detachAgent(agentId: string, navigate: (path: string) => void): Promise<void> {
+  try {
+    await taskApi.moveAgentToTask(agentId, null);
+    navigate(`/chats/${agentId}`);
+  } catch (err) {
+    console.error('Failed to detach agent:', err);
+  }
+}

--- a/src/components/task-detail/TaskDetailAgentView.tsx
+++ b/src/components/task-detail/TaskDetailAgentView.tsx
@@ -126,9 +126,7 @@ export function TaskDetailAgentView({
                 aria-hidden={!isActive}
                 inert={!isActive}
                 className={
-                  isActive
-                    ? 'absolute inset-0'
-                    : 'pointer-events-none absolute inset-0 opacity-0'
+                  isActive ? 'absolute inset-0' : 'pointer-events-none absolute inset-0 opacity-0'
                 }
               >
                 <TerminalView
@@ -145,7 +143,10 @@ export function TaskDetailAgentView({
   );
 }
 
-export async function detachAgent(agentId: string, navigate: (path: string) => void): Promise<void> {
+export async function detachAgent(
+  agentId: string,
+  navigate: (path: string) => void,
+): Promise<void> {
   try {
     await taskApi.moveAgentToTask(agentId, null);
     navigate(`/chats/${agentId}`);

--- a/src/components/task-detail/TaskDetailDiffView.tsx
+++ b/src/components/task-detail/TaskDetailDiffView.tsx
@@ -32,12 +32,7 @@ export interface TaskDetailDiffViewProps {
   onSummaryLoaded: (summary: DiffSummaryResponse) => void;
   onToggleReviewed: (filePath: string, currentlyReviewed: boolean) => Promise<void>;
   onFilesChange: (files: string[]) => void;
-  onJumpToComment: (
-    filePath: string,
-    line: number,
-    side: 'old' | 'new',
-    commentId: string,
-  ) => void;
+  onJumpToComment: (filePath: string, line: number, side: 'old' | 'new', commentId: string) => void;
   onQueueRemove: (id: string) => void;
   onQueueJumpTo: (path: string) => void;
   onSendBatch: () => Promise<void>;

--- a/src/components/task-detail/TaskDetailDiffView.tsx
+++ b/src/components/task-detail/TaskDetailDiffView.tsx
@@ -1,0 +1,148 @@
+import { Button } from '@/components/ui/button';
+import { DiffViewer } from '@/components/DiffViewer';
+import { ReviewBaseRefBanner } from '@/components/ReviewBaseRefBanner';
+import { DiffRangePicker } from '@/components/DiffRangePicker';
+import { CommentQueueDrawer } from '@/components/CommentQueueDrawer';
+import { CommentsSidePanel } from '@/components/CommentsSidePanel';
+import { DiffKeybindCheatSheet } from '@/components/task-detail/DiffKeybindCheatSheet';
+import { CommentsContext } from '@/hooks/useTaskComments';
+import type { DiffRange, DiffSummaryResponse } from '@/lib/api/taskApi';
+import type { Agent, Task } from '@octomux/types';
+import type { DiffFileListHandle } from '@/components/DiffFileList';
+import type { QueuedComment } from '@/hooks/useReviewQueue';
+
+export interface TaskDetailDiffViewProps {
+  task: Task;
+  range: DiffRange;
+  diffSummary: DiffSummaryResponse | null;
+  currentRangeLabel: string;
+  showCommentsPanel: boolean;
+  filesInDiffSet: Set<string>;
+  diffListRef: React.RefObject<DiffFileListHandle | null>;
+  reviewQueueComments: QueuedComment[];
+  commentCount: number;
+  taskComments: React.ComponentProps<typeof CommentsContext.Provider>['value'];
+  onRangeChange: (range: DiffRange) => void;
+  onBaseChange: (baseBranch: string) => Promise<void>;
+  onRefetchDiff: () => Promise<void>;
+  onJumpToNextUnreviewed: () => void;
+  onToggleCommentsPanel: () => void;
+  onCloseCommentsPanel: () => void;
+  onSelectionChange: (path: string | null) => void;
+  onSummaryLoaded: (summary: DiffSummaryResponse) => void;
+  onToggleReviewed: (filePath: string, currentlyReviewed: boolean) => Promise<void>;
+  onFilesChange: (files: string[]) => void;
+  onJumpToComment: (
+    filePath: string,
+    line: number,
+    side: 'old' | 'new',
+    commentId: string,
+  ) => void;
+  onQueueRemove: (id: string) => void;
+  onQueueJumpTo: (path: string) => void;
+  onSendBatch: () => Promise<void>;
+}
+
+export function TaskDetailDiffView({
+  task,
+  range,
+  diffSummary,
+  currentRangeLabel,
+  showCommentsPanel,
+  filesInDiffSet,
+  diffListRef,
+  reviewQueueComments,
+  commentCount,
+  taskComments,
+  onRangeChange,
+  onBaseChange,
+  onRefetchDiff,
+  onJumpToNextUnreviewed,
+  onToggleCommentsPanel,
+  onCloseCommentsPanel,
+  onSelectionChange,
+  onSummaryLoaded,
+  onToggleReviewed,
+  onFilesChange,
+  onJumpToComment,
+  onQueueRemove,
+  onQueueJumpTo,
+  onSendBatch,
+}: TaskDetailDiffViewProps) {
+  const agents: Agent[] = task.agents ?? [];
+
+  return (
+    <CommentsContext.Provider value={taskComments}>
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        {diffSummary && diffSummary.base_ref ? (
+          <ReviewBaseRefBanner
+            baseRef={diffSummary.base_ref}
+            baseIsStale={!!diffSummary.base_is_stale}
+            totalCount={diffSummary.total_count ?? 0}
+            reviewedCount={diffSummary.reviewed_count ?? 0}
+            onRefresh={onRefetchDiff}
+            onJumpToNextUnreviewed={onJumpToNextUnreviewed}
+            currentRangeLabel={currentRangeLabel}
+            rangePicker={
+              <DiffRangePicker
+                taskId={task.id}
+                currentBaseBranch={task.base_branch}
+                range={range}
+                onRangeChange={onRangeChange}
+                onBaseChange={onBaseChange}
+              />
+            }
+            rightSlot={
+              <Button
+                variant="outline"
+                size="xs"
+                data-testid="comments-toggle"
+                data-active={showCommentsPanel ? 'true' : undefined}
+                className={
+                  showCommentsPanel ? 'border-primary/40 bg-primary/15 text-primary' : undefined
+                }
+                onClick={onToggleCommentsPanel}
+              >
+                Comments ({commentCount})
+              </Button>
+            }
+          />
+        ) : null}
+        <div className="flex min-h-0 min-w-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            <DiffViewer
+              taskId={task.id}
+              isRunning={task.runtime_state === 'running'}
+              onSelectionChange={onSelectionChange}
+              onSummaryLoaded={onSummaryLoaded}
+              onToggleReviewed={onToggleReviewed}
+              range={range}
+              listRef={diffListRef}
+              enableComments={true}
+              agents={agents}
+              onFilesChange={onFilesChange}
+            />
+          </div>
+          {showCommentsPanel ? (
+            <CommentsSidePanel
+              agents={agents}
+              filesInDiff={filesInDiffSet}
+              rangeIsBase={range.kind === 'base'}
+              onJumpTo={onJumpToComment}
+              onClose={onCloseCommentsPanel}
+            />
+          ) : null}
+          {reviewQueueComments.length > 0 ? (
+            <CommentQueueDrawer
+              comments={reviewQueueComments}
+              onRemove={onQueueRemove}
+              onJumpTo={onQueueJumpTo}
+              onSend={onSendBatch}
+            />
+          ) : null}
+        </div>
+        <DiffKeybindCheatSheet />
+      </div>
+    </CommentsContext.Provider>
+  );
+}

--- a/src/hooks/perTaskUiState.ts
+++ b/src/hooks/perTaskUiState.ts
@@ -1,0 +1,22 @@
+export type TaskMode = 'agents' | 'editor' | 'diff' | 'info';
+
+/** Per-task UI state preserved across task switches (session-only, not persisted to disk). */
+export interface PerTaskUiState {
+  activeWindow: number | null;
+  mode: TaskMode;
+}
+
+const perTaskUiState = new Map<string, PerTaskUiState>();
+
+export function getPerTaskUiState(taskId: string): PerTaskUiState | undefined {
+  return perTaskUiState.get(taskId);
+}
+
+export function setPerTaskUiState(taskId: string, state: PerTaskUiState): void {
+  perTaskUiState.set(taskId, state);
+}
+
+/** Reset per-task UI state — exposed for tests only. */
+export function _resetPerTaskUiState(): void {
+  perTaskUiState.clear();
+}

--- a/src/hooks/useDiffState.ts
+++ b/src/hooks/useDiffState.ts
@@ -3,7 +3,12 @@ import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import type { DiffFileListHandle } from '@/components/DiffFileList';
 import { useDiffKeyboardNav } from '@/hooks/useDiffKeyboardNav';
-import { diffRangeToParam, taskApi, type DiffRange, type DiffSummaryResponse } from '@/lib/api/taskApi';
+import {
+  diffRangeToParam,
+  taskApi,
+  type DiffRange,
+  type DiffSummaryResponse,
+} from '@/lib/api/taskApi';
 
 export interface UseDiffStateOptions {
   taskId: string;

--- a/src/hooks/useDiffState.ts
+++ b/src/hooks/useDiffState.ts
@@ -1,0 +1,268 @@
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import type { DiffFileListHandle } from '@/components/DiffFileList';
+import { useDiffKeyboardNav } from '@/hooks/useDiffKeyboardNav';
+import { diffRangeToParam, taskApi, type DiffRange, type DiffSummaryResponse } from '@/lib/api/taskApi';
+
+export interface UseDiffStateOptions {
+  taskId: string;
+  isDiffMode: boolean;
+  activeAgentId: string | null;
+  reviewQueue: {
+    comments: { id: string; filePath: string; line: number; body: string }[];
+    format: () => string;
+    remove: (id: string) => void;
+  };
+  taskComments: {
+    post: (input: {
+      file_path: string;
+      line: number;
+      side: 'new';
+      body: string;
+    }) => Promise<unknown>;
+    setFocusedId: (id: string | null) => void;
+  };
+  refresh: () => void;
+}
+
+export interface UseDiffStateResult {
+  range: DiffRange;
+  setRange: (next: DiffRange) => void;
+  diffSummary: DiffSummaryResponse | null;
+  setDiffSummary: React.Dispatch<React.SetStateAction<DiffSummaryResponse | null>>;
+  activeFilePath: string | null;
+  setActiveFilePath: React.Dispatch<React.SetStateAction<string | null>>;
+  filesInDiff: string[];
+  setFilesInDiff: React.Dispatch<React.SetStateAction<string[]>>;
+  filesInDiffSet: Set<string>;
+  visibleFiles: NonNullable<DiffSummaryResponse['files']>;
+  currentRangeLabel: string;
+  diffListRef: React.RefObject<DiffFileListHandle | null>;
+  refetchDiff: () => Promise<void>;
+  handleBaseChange: (newBaseBranch: string) => Promise<void>;
+  handleToggleReviewed: (filePath: string, currentlyReviewed: boolean) => Promise<void>;
+  handleJumpToComment: (
+    filePath: string,
+    line: number,
+    side: 'old' | 'new',
+    commentId: string,
+  ) => void;
+  jumpToNextUnreviewed: () => void;
+  handleSendBatch: () => Promise<void>;
+}
+
+export function useDiffState({
+  taskId,
+  isDiffMode,
+  activeAgentId,
+  reviewQueue,
+  taskComments,
+  refresh,
+}: UseDiffStateOptions): UseDiffStateResult {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [diffSummary, setDiffSummary] = useState<DiffSummaryResponse | null>(null);
+  const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
+  const [filesInDiff, setFilesInDiff] = useState<string[]>([]);
+  const diffListRef = useRef<DiffFileListHandle | null>(null);
+  const focusClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const range = useMemo<DiffRange>(() => {
+    const raw = searchParams.get('range');
+    if (!raw || raw === 'base') return { kind: 'base' };
+    if (raw === 'working') return { kind: 'working' };
+    if (raw.startsWith('commit:')) {
+      const sha = raw.slice('commit:'.length);
+      if (/^[0-9a-f]{4,40}$/i.test(sha)) return { kind: 'commit', sha };
+    }
+    if (raw.startsWith('range:')) {
+      const rest = raw.slice('range:'.length);
+      const idx = rest.indexOf('..');
+      if (idx > 0) {
+        const from = rest.slice(0, idx);
+        const to = rest.slice(idx + 2);
+        if (from && to) return { kind: 'range', from, to };
+      }
+    }
+    return { kind: 'base' };
+  }, [searchParams]);
+
+  const setRange = useCallback(
+    (next: DiffRange) => {
+      setSearchParams(
+        (prev) => {
+          const sp = new URLSearchParams(prev);
+          const param = diffRangeToParam(next);
+          if (param) sp.set('range', param);
+          else sp.delete('range');
+          return sp;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  useEffect(
+    () => () => {
+      if (focusClearTimer.current) clearTimeout(focusClearTimer.current);
+    },
+    [],
+  );
+
+  const filesInDiffSet = useMemo(() => new Set(filesInDiff), [filesInDiff]);
+
+  const handleJumpToComment = useCallback(
+    (filePath: string, line: number, side: 'old' | 'new', commentId: string) => {
+      diffListRef.current?.revealLineInFile(filePath, line, side);
+      taskComments.setFocusedId(commentId);
+      if (focusClearTimer.current) clearTimeout(focusClearTimer.current);
+      focusClearTimer.current = setTimeout(() => {
+        taskComments.setFocusedId(null);
+      }, 1200);
+    },
+    [taskComments],
+  );
+
+  const visibleFiles = useMemo(
+    () => (diffSummary?.files ?? []).filter((f) => !f.ignored),
+    [diffSummary],
+  );
+
+  const refetchDiff = useCallback(async () => {
+    if (!taskId) return;
+    try {
+      const s = await taskApi.getTaskDiffSummary(taskId, range);
+      setDiffSummary(s);
+    } catch {
+      // swallow — banner is best-effort, DiffViewer surfaces its own errors
+    }
+  }, [taskId, range]);
+
+  const handleBaseChange = useCallback(
+    async (newBaseBranch: string) => {
+      if (!taskId) return;
+      await taskApi.updateTaskBase(taskId, newBaseBranch);
+      setRange({ kind: 'base' });
+      await refetchDiff();
+      refresh();
+    },
+    [taskId, refetchDiff, refresh, setRange],
+  );
+
+  const currentRangeLabel = useMemo(() => {
+    switch (range.kind) {
+      case 'base':
+        return 'full diff';
+      case 'working':
+        return 'working tree';
+      case 'commit':
+        return `commit ${range.sha.slice(0, 7)}`;
+      case 'range':
+        return `${range.from.slice(0, 7)}..${range.to.slice(0, 7)}`;
+    }
+  }, [range]);
+
+  const handleToggleReviewed = useCallback(
+    async (filePath: string, currentlyReviewed: boolean) => {
+      if (!taskId) return;
+      try {
+        if (currentlyReviewed) await taskApi.unmarkReviewed(taskId, filePath);
+        else await taskApi.markReviewed(taskId, filePath);
+        await refetchDiff();
+      } catch (err) {
+        console.error('Failed to toggle reviewed:', err);
+      }
+    },
+    [taskId, refetchDiff],
+  );
+
+  const handleSendBatch = useCallback(async () => {
+    if (!taskId || !activeAgentId || reviewQueue.comments.length === 0) return;
+    const body = reviewQueue.format();
+    const drafts = reviewQueue.comments;
+
+    const failed: string[] = [];
+    await Promise.all(
+      drafts.map(async (d) => {
+        const row = await taskComments.post({
+          file_path: d.filePath,
+          line: d.line,
+          side: 'new',
+          body: d.body,
+        });
+        if (row) reviewQueue.remove(d.id);
+        else failed.push(d.id);
+      }),
+    );
+    if (failed.length > 0) {
+      toast.error(`Failed to save ${failed.length} of ${drafts.length} comments`);
+      return;
+    }
+
+    try {
+      await taskApi.sendAgentMessage(taskId, activeAgentId, body);
+    } catch (err) {
+      console.error('Failed to send review batch:', err);
+      toast.error((err as Error).message);
+    }
+  }, [taskId, activeAgentId, reviewQueue, taskComments]);
+
+  const moveActiveFile = useCallback(
+    (delta: 1 | -1) => {
+      if (visibleFiles.length === 0) return;
+      const idx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
+      const next = (idx + delta + visibleFiles.length) % visibleFiles.length;
+      setActiveFilePath(visibleFiles[next].path);
+    },
+    [visibleFiles, activeFilePath],
+  );
+
+  const jumpToNextUnreviewed = useCallback(() => {
+    if (visibleFiles.length === 0) return;
+    const startIdx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
+    for (let i = 1; i <= visibleFiles.length; i++) {
+      const candidate = visibleFiles[(startIdx + i) % visibleFiles.length];
+      if (!candidate.reviewed) {
+        setActiveFilePath(candidate.path);
+        return;
+      }
+    }
+  }, [visibleFiles, activeFilePath]);
+
+  useDiffKeyboardNav({
+    onNextFile: isDiffMode ? () => moveActiveFile(1) : undefined,
+    onPrevFile: isDiffMode ? () => moveActiveFile(-1) : undefined,
+    onToggleReviewed: isDiffMode
+      ? () => {
+          if (!activeFilePath) return;
+          const file = visibleFiles.find((f) => f.path === activeFilePath);
+          if (!file) return;
+          handleToggleReviewed(activeFilePath, !!file.reviewed);
+        }
+      : undefined,
+    onJumpToNextUnreviewed: isDiffMode ? jumpToNextUnreviewed : undefined,
+    onSendBatch: isDiffMode ? handleSendBatch : undefined,
+  });
+
+  return {
+    range,
+    setRange,
+    diffSummary,
+    setDiffSummary,
+    activeFilePath,
+    setActiveFilePath,
+    filesInDiff,
+    setFilesInDiff,
+    filesInDiffSet,
+    visibleFiles,
+    currentRangeLabel,
+    diffListRef,
+    refetchDiff,
+    handleBaseChange,
+    handleToggleReviewed,
+    handleJumpToComment,
+    jumpToNextUnreviewed,
+    handleSendBatch,
+  };
+}

--- a/src/hooks/useTaskDetailComments.ts
+++ b/src/hooks/useTaskDetailComments.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useReviewQueue } from '@/hooks/useReviewQueue';
+import { useTaskComments } from '@/hooks/useTaskComments';
+
+export interface UseTaskDetailCommentsOptions {
+  taskId: string;
+}
+
+export function useTaskDetailComments({ taskId }: UseTaskDetailCommentsOptions) {
+  const reviewQueue = useReviewQueue(taskId);
+
+  const handleQueueDraft = useCallback(
+    (draft: {
+      filePath: string;
+      line: number;
+      side: 'old' | 'new';
+      body: string;
+      lineText: string;
+    }) => {
+      reviewQueue.add({
+        filePath: draft.filePath,
+        line: draft.line,
+        lineText: draft.lineText,
+        body: draft.body,
+      });
+    },
+    [reviewQueue],
+  );
+
+  const taskComments = useTaskComments(taskId, {
+    onError: (msg) => toast.error(msg),
+    onQueueDraft: handleQueueDraft,
+  });
+
+  return { reviewQueue, taskComments };
+}

--- a/src/hooks/useTaskViewMode.ts
+++ b/src/hooks/useTaskViewMode.ts
@@ -2,11 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import type { Task } from '@octomux/types';
 import { taskApi } from '@/lib/api/taskApi';
-import {
-  type TaskMode,
-  getPerTaskUiState,
-  setPerTaskUiState,
-} from '@/hooks/perTaskUiState';
+import { type TaskMode, getPerTaskUiState, setPerTaskUiState } from '@/hooks/perTaskUiState';
 
 export interface UseTaskViewModeOptions {
   taskId: string;

--- a/src/hooks/useTaskViewMode.ts
+++ b/src/hooks/useTaskViewMode.ts
@@ -1,0 +1,130 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { Task } from '@octomux/types';
+import { taskApi } from '@/lib/api/taskApi';
+import {
+  type TaskMode,
+  getPerTaskUiState,
+  setPerTaskUiState,
+} from '@/hooks/perTaskUiState';
+
+export interface UseTaskViewModeOptions {
+  taskId: string;
+  task: Task | null;
+  refresh: () => void;
+}
+
+export interface UseTaskViewModeResult {
+  mode: TaskMode;
+  setMode: React.Dispatch<React.SetStateAction<TaskMode>>;
+  activeWindow: number | null;
+  setActiveWindow: React.Dispatch<React.SetStateAction<number | null>>;
+  gridView: boolean;
+  setGridView: React.Dispatch<React.SetStateAction<boolean>>;
+  localUserWindowIndex: number | null;
+  setLocalUserWindowIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  userWindowIndex: number | null | undefined;
+  creatingEditor: boolean;
+  handleToggleEditor: () => Promise<void>;
+}
+
+export function useTaskViewMode({
+  taskId,
+  task,
+  refresh,
+}: UseTaskViewModeOptions): UseTaskViewModeResult {
+  const [activeWindow, setActiveWindow] = useState<number | null>(null);
+  const [mode, setMode] = useState<TaskMode>('agents');
+  const [gridView, setGridView] = useState(false);
+  const [creatingEditor, setCreatingEditor] = useState(false);
+  const [searchParams] = useSearchParams();
+  const agentParam = searchParams.get('agent');
+
+  const [localUserWindowIndex, setLocalUserWindowIndex] = useState<number | null>(null);
+  const userWindowIndex = task?.user_window_index ?? localUserWindowIndex;
+
+  const prevTaskIdRef = useRef<string>(taskId);
+  const activeWindowRef = useRef(activeWindow);
+  const modeRef = useRef(mode);
+  activeWindowRef.current = activeWindow;
+  modeRef.current = mode;
+
+  useEffect(() => {
+    const prevId = prevTaskIdRef.current;
+    if (prevId !== taskId) {
+      setPerTaskUiState(prevId, {
+        activeWindow: activeWindowRef.current,
+        mode: modeRef.current,
+      });
+      const saved = getPerTaskUiState(taskId);
+      setActiveWindow(saved?.activeWindow ?? null);
+      setMode(saved?.mode ?? 'agents');
+      setLocalUserWindowIndex(null);
+      prevTaskIdRef.current = taskId;
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    if (taskId) {
+      setPerTaskUiState(taskId, { activeWindow, mode });
+    }
+  }, [taskId, activeWindow, mode]);
+
+  const firstAgentWindow = task?.agents?.[0]?.window_index ?? null;
+  useEffect(() => {
+    if (agentParam && task?.agents) {
+      const agent = task.agents.find((a) => a.id === agentParam);
+      if (agent) {
+        setActiveWindow(agent.window_index);
+        return;
+      }
+    }
+    if (activeWindow === null && firstAgentWindow !== null) {
+      setActiveWindow(firstAgentWindow);
+    }
+  }, [firstAgentWindow, activeWindow, agentParam, task?.agents]);
+
+  useEffect(() => {
+    if (task && task.runtime_state !== 'running') {
+      setMode((m) => (m === 'editor' ? 'agents' : m));
+      setLocalUserWindowIndex(null);
+    }
+  }, [task?.runtime_state]);
+
+  const handleToggleEditor = useCallback(async () => {
+    if (mode === 'editor') {
+      setMode('agents');
+      return;
+    }
+    if (creatingEditor) return;
+    setCreatingEditor(true);
+    try {
+      const result = await taskApi.createUserTerminal(taskId);
+      if (result.editor === 'vscode' || result.editor === 'cursor') {
+        setLocalUserWindowIndex(null);
+      } else {
+        setLocalUserWindowIndex(result.windowIndex);
+        setMode('editor');
+      }
+      refresh();
+    } catch (err) {
+      console.error('Failed to create user terminal:', err);
+    } finally {
+      setCreatingEditor(false);
+    }
+  }, [mode, taskId, creatingEditor, refresh]);
+
+  return {
+    mode,
+    setMode,
+    activeWindow,
+    setActiveWindow,
+    gridView,
+    setGridView,
+    localUserWindowIndex,
+    setLocalUserWindowIndex,
+    userWindowIndex,
+    creatingEditor,
+    handleToggleEditor,
+  };
+}

--- a/src/hooks/useTerminalCache.test.tsx
+++ b/src/hooks/useTerminalCache.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { _resetPerTaskUiState, setPerTaskUiState } from './perTaskUiState';
+import { useTerminalCache } from './useTerminalCache';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe('useTerminalCache', () => {
+  beforeEach(() => {
+    _resetPerTaskUiState();
+  });
+
+  it('seeds LRU from perTaskUiState on task switch', () => {
+    setPerTaskUiState('task-A', { activeWindow: 2, mode: 'agents' });
+
+    const { result, rerender } = renderHook(
+      ({ taskId, activeWindow }) =>
+        useTerminalCache({
+          taskId,
+          activeWindow,
+          validWindowIndexes: new Set([0, 1, 2]),
+        }),
+      {
+        wrapper,
+        initialProps: { taskId: 'task-B', activeWindow: null as number | null },
+      },
+    );
+
+    expect(result.current.terminalLRU).toEqual([]);
+
+    rerender({ taskId: 'task-A', activeWindow: 2 });
+
+    expect(result.current.terminalLRU).toEqual([2]);
+  });
+
+  it('promotes active window to front of LRU', () => {
+    const { result, rerender } = renderHook(
+      ({ activeWindow }) =>
+        useTerminalCache({
+          taskId: 'task-1',
+          activeWindow,
+          validWindowIndexes: new Set([0, 1, 2]),
+        }),
+      {
+        wrapper,
+        initialProps: { activeWindow: 0 as number | null },
+      },
+    );
+
+    expect(result.current.terminalLRU).toEqual([0]);
+
+    rerender({ activeWindow: 1 });
+    expect(result.current.terminalLRU).toEqual([1, 0]);
+
+    rerender({ activeWindow: 2 });
+    expect(result.current.terminalLRU).toEqual([2, 1, 0]);
+  });
+
+  it('evicts invalid window indexes from LRU', () => {
+    const { result, rerender } = renderHook(
+      ({ activeWindow, validWindowIndexes }) =>
+        useTerminalCache({ taskId: 'task-1', activeWindow, validWindowIndexes }),
+      {
+        wrapper,
+        initialProps: {
+          activeWindow: 2 as number | null,
+          validWindowIndexes: new Set([0, 1, 2]),
+        },
+      },
+    );
+
+    expect(result.current.terminalLRU).toEqual([2]);
+
+    rerender({ activeWindow: 1, validWindowIndexes: new Set([0, 1, 2]) });
+    expect(result.current.terminalLRU).toEqual([1, 2]);
+
+    rerender({ activeWindow: 1, validWindowIndexes: new Set([0, 1]) });
+    expect(result.current.terminalLRU).toEqual([1]);
+  });
+});

--- a/src/hooks/useTerminalCache.ts
+++ b/src/hooks/useTerminalCache.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef } from 'react';
+import { useTerminalCacheSize } from '@/lib/terminal-cache-settings';
+import { getPerTaskUiState } from '@/hooks/perTaskUiState';
+
+export interface UseTerminalCacheOptions {
+  taskId: string;
+  activeWindow: number | null;
+  validWindowIndexes: Set<number>;
+}
+
+export interface UseTerminalCacheResult {
+  terminalLRU: number[];
+}
+
+export function useTerminalCache({
+  taskId,
+  activeWindow,
+  validWindowIndexes,
+}: UseTerminalCacheOptions): UseTerminalCacheResult {
+  const terminalCacheSize = useTerminalCacheSize();
+  const [terminalLRU, setTerminalLRU] = useState<number[]>([]);
+  const prevTaskIdRef = useRef<string>(taskId);
+
+  useEffect(() => {
+    const prevId = prevTaskIdRef.current;
+    if (prevId !== taskId) {
+      const saved = getPerTaskUiState(taskId);
+      const nextActive = saved?.activeWindow ?? null;
+      setTerminalLRU(nextActive !== null ? [nextActive] : []);
+      prevTaskIdRef.current = taskId;
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    if (activeWindow === null) return;
+    setTerminalLRU((prev) => {
+      const without = prev.filter((k) => k !== activeWindow);
+      const next = [activeWindow, ...without].slice(0, terminalCacheSize);
+      if (next.length === prev.length && next.every((k, i) => k === prev[i])) return prev;
+      return next;
+    });
+  }, [activeWindow, terminalCacheSize]);
+
+  useEffect(() => {
+    setTerminalLRU((prev) =>
+      prev.length <= terminalCacheSize ? prev : prev.slice(0, terminalCacheSize),
+    );
+  }, [terminalCacheSize]);
+
+  useEffect(() => {
+    setTerminalLRU((prev) => {
+      const filtered = prev.filter((k) => validWindowIndexes.has(k));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [validWindowIndexes]);
+
+  return { terminalLRU };
+}

--- a/src/pages/OrchestratorPage.tsx
+++ b/src/pages/OrchestratorPage.tsx
@@ -25,21 +25,23 @@
  *   fetch the plan body browser-side; the orchestrator LLM never sees the body.
  */
 
-import {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  type FormEvent,
-  type KeyboardEvent,
-  type ReactNode,
-} from 'react';
-import { MessageThread, type ThreadMessage } from '../components/orchestrator/MessageThread';
-import { ToolCallCard } from '../components/orchestrator/ToolCallCard';
-import { PlanCard } from '../components/orchestrator/PlanCard';
-import { SpecCard } from '../components/orchestrator/SpecCard';
-import { ActionCard, type ActionCardDecision } from '../components/orchestrator/ActionCard';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ThreadMessage } from '../components/orchestrator/MessageThread';
 import { ConversationList } from '../components/orchestrator/ConversationList';
+import { ChatInput } from '../components/orchestrator/ChatInput';
+import { MixedThread } from '../components/orchestrator/MixedThread';
+import { ConnectionPill } from '../components/orchestrator/ConnectionPill';
+import { LeanessIndicator } from '../components/orchestrator/LeanessIndicator';
+import { OrchestratorEmptyState } from '../components/orchestrator/OrchestratorEmptyState';
+import {
+  ORCHESTRATOR_SIDEBAR_WIDTH,
+  type ActionCardDecision,
+  type ActionCardItem,
+  type PlanCardItem,
+  type SpecCardItem,
+  type ThreadItem,
+  type ToolCallItem,
+} from '../components/orchestrator/types';
 import { toast } from 'sonner';
 import {
   orchestratorApi,
@@ -51,309 +53,18 @@ import {
   type WsOutgoingEvent,
   type WsConnectionState,
 } from '../lib/orchestrator-api';
-import { cn } from '@/lib/utils';
-
-// ─── Thread item types ────────────────────────────────────────────────────────
-
-/** A plan-approval card that appears inline in the message thread. */
-interface PlanCardItem {
-  kind: 'plan-card';
-  id: string;
-  taskId: string;
-  planPath: string;
-  artifactUrl: string;
-  /** resolved once the user decides; removes the card from the thread */
-  resolved: boolean;
-}
-
-/**
- * A read-only spec card for the workflow kind (SHR-143).
- * Rendered by SpecCard; no ws decision event — local dismiss only.
- */
-interface SpecCardItem {
-  kind: 'spec-card';
-  id: string;
-  taskId: string;
-  specPath: string;
-  artifactUrl: string;
-  /** true when the user has locally dismissed the card */
-  resolved: boolean;
-}
-
-/**
- * An action card for a gated write-command (Task 3.3 / SHR-132).
- * Rendered by ActionCard; user can Approve/Edit/Reject/Respond.
- */
-interface ActionCardItem {
-  kind: 'action-card';
-  id: string;
-  command: string;
-  args: Record<string, unknown>;
-  /** true when the command is in the always-ask (destructive) tier */
-  alwaysAsk?: boolean;
-  /** resolved once the user decides; removes the card from the thread */
-  resolved: boolean;
-}
-
-/**
- * A conductor tool-call, rendered as a collapsible card distinct from prose
- * (SHR-161). Live/ephemeral — pushed from the transcript tail, not persisted.
- */
-interface ToolCallItem {
-  kind: 'tool-call';
-  id: string;
-  toolName: string;
-  input: unknown;
-}
-
-/** A union of everything that can appear in the thread. */
-type ThreadItem = ThreadMessage | PlanCardItem | SpecCardItem | ActionCardItem | ToolCallItem;
-
-const SIDEBAR_WIDTH = 240;
-const FOCUS_RING = 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]';
-
-// ─── ChatInput ────────────────────────────────────────────────────────────────
-
-interface ChatInputProps {
-  onSubmit: (text: string) => void;
-  disabled?: boolean;
-}
-
-function ChatInput({ onSubmit, disabled = false }: ChatInputProps) {
-  const [value, setValue] = useState('');
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const submit = useCallback(() => {
-    const trimmed = value.trim();
-    if (!trimmed || disabled) return;
-    onSubmit(trimmed);
-    setValue('');
-    // Reset textarea height
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-    }
-  }, [value, disabled, onSubmit]);
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      submit();
-    }
-  };
-
-  const handleInput = () => {
-    const ta = textareaRef.current;
-    if (!ta) return;
-    ta.style.height = 'auto';
-    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
-  };
-
-  return (
-    <form
-      onSubmit={(e: FormEvent) => {
-        e.preventDefault();
-        submit();
-      }}
-      className="flex items-end gap-2 border-t border-[rgba(255,255,255,0.08)] px-4 py-3"
-    >
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        onInput={handleInput}
-        disabled={disabled}
-        placeholder="Message orchestrator (Enter to send, Shift+Enter for newline)"
-        rows={1}
-        aria-label="Message input"
-        className={cn(
-          'flex-1 resize-none overflow-hidden rounded-xl border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.04)] px-4 py-2.5 text-sm text-foreground placeholder:text-[rgba(255,255,255,0.3)] focus:outline-none focus:ring-1 focus:ring-[#3B82F6]',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
-        style={{ minHeight: 44, maxHeight: 160 }}
-      />
-      <button
-        type="submit"
-        disabled={disabled || !value.trim()}
-        aria-label="Send message"
-        className={cn(
-          'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#3B82F6] text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40',
-          FOCUS_RING,
-        )}
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <path
-            d="M2 8h12M10 4l4 4-4 4"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
-    </form>
-  );
-}
-
-// ─── MixedThread ─────────────────────────────────────────────────────────────
-
-/**
- * Renders the thread: a mix of chat messages and inline cards.
- * ThreadMessages are delegated to MessageThread; cards are rendered inline.
- */
-interface MixedThreadProps {
-  items: ThreadItem[];
-  onCardDecision: (d: ActionCardDecision) => void;
-  onSpecCardDismiss: (cardId: string) => void;
-  /** True while the orchestrator is processing a turn (shows a working indicator). */
-  working?: boolean;
-}
-
-function MixedThread({
-  items,
-  onCardDecision,
-  onSpecCardDismiss,
-  working = false,
-}: MixedThreadProps) {
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [items.length, working]);
-
-  if (items.length === 0 && !working) {
-    return (
-      <div
-        className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
-        aria-live="polite"
-        aria-label="Message thread"
-      >
-        No messages yet. Start a conversation below.
-      </div>
-    );
-  }
-
-  // Collect contiguous message runs to pass to MessageThread in batches;
-  // cards break the run and are rendered inline.
-  const rendered: ReactNode[] = [];
-  let msgBatch: ThreadMessage[] = [];
-
-  function flushBatch() {
-    if (msgBatch.length === 0) return;
-    const key = msgBatch[0].id;
-    rendered.push(<MessageThread key={`msg-batch-${key}`} messages={msgBatch} />);
-    msgBatch = [];
-  }
-
-  for (const item of items) {
-    if ('role' in item) {
-      // It's a ThreadMessage
-      msgBatch.push(item as ThreadMessage);
-    } else if (item.kind === 'tool-call') {
-      flushBatch();
-      rendered.push(
-        <div key={item.id} className="px-4 py-1">
-          <ToolCallCard toolName={item.toolName} input={item.input} />
-        </div>,
-      );
-    } else if (item.kind === 'spec-card' && !item.resolved) {
-      flushBatch();
-      rendered.push(
-        <div key={item.id} className="px-4 py-2">
-          <SpecCard
-            cardId={item.id}
-            taskId={item.taskId}
-            specPath={item.specPath}
-            artifactUrl={item.artifactUrl}
-            onDismiss={() => onSpecCardDismiss(item.id)}
-          />
-        </div>,
-      );
-    } else if (item.kind === 'plan-card' && !item.resolved) {
-      flushBatch();
-      rendered.push(
-        <div key={item.id} className="px-4 py-2">
-          <PlanCard
-            cardId={item.id}
-            taskId={item.taskId}
-            planPath={item.planPath}
-            artifactUrl={item.artifactUrl}
-            onDecision={({ decision, card_id }) =>
-              onCardDecision({ card_id, decision: decision as 'approve' | 'reject' })
-            }
-          />
-        </div>,
-      );
-    } else if (item.kind === 'action-card' && !item.resolved) {
-      flushBatch();
-      rendered.push(
-        <div key={item.id} className="px-4 py-2">
-          <ActionCard
-            cardId={item.id}
-            command={item.command}
-            args={item.args}
-            alwaysAsk={item.alwaysAsk}
-            onDecision={onCardDecision}
-          />
-        </div>,
-      );
-    }
-  }
-  flushBatch();
-
-  return (
-    <div
-      className="flex flex-1 flex-col overflow-y-auto"
-      role="log"
-      aria-label="Message thread"
-      aria-live="polite"
-    >
-      {rendered}
-      {working && <WorkingIndicator />}
-      <div ref={bottomRef} aria-hidden="true" />
-    </div>
-  );
-}
-
-/** Animated "orchestrator is working" indicator shown while a turn is in flight. */
-function WorkingIndicator() {
-  return (
-    <div
-      className="flex items-center gap-2 px-4 py-3"
-      aria-live="polite"
-      aria-label="Orchestrator is working"
-    >
-      <span className="flex gap-1">
-        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.3s]" />
-        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground [animation-delay:-0.15s]" />
-        <span className="h-2 w-2 animate-bounce rounded-full bg-muted-foreground" />
-      </span>
-      <span className="text-xs text-muted-foreground">orchestrator is working…</span>
-    </div>
-  );
-}
-
-// ─── OrchestratorPage ─────────────────────────────────────────────────────────
 
 export default function OrchestratorPage() {
   const [conversations, setConversations] = useState<OrchestratorConversation[]>([]);
   const [loadingConvs, setLoadingConvs] = useState(true);
   const [activeConvId, setActiveConvId] = useState<string | null>(null);
-  /** Mixed thread of messages + inline cards. */
   const [items, setItems] = useState<ThreadItem[]>([]);
-  /** WebSocket connection lifecycle state (drives the status pill, SHR-162). */
   const [wsState, setWsState] = useState<WsConnectionState>('closed');
-  // True from when the user sends a turn until the orchestrator's next output
-  // (a message or a card) arrives — drives the "working" indicator.
   const [working, setWorking] = useState(false);
   const [creatingConv, setCreatingConv] = useState(false);
-  /** Conductor-leanness usage stats for the active conversation (§6.7). */
   const [usage, setUsage] = useState<ConversationUsage | null>(null);
 
-  /** Ref to the ws send/close handle so we can send user turns. */
   const wsRef = useRef<{ send: (e: WsOutgoingEvent) => void; close: () => void } | null>(null);
-
-  // ─── Load conversation list ──────────────────────────────────────────────
 
   const loadConversations = useCallback(async () => {
     try {
@@ -370,10 +81,7 @@ export default function OrchestratorPage() {
     void loadConversations();
   }, [loadConversations]);
 
-  // ─── Open a conversation ─────────────────────────────────────────────────
-
   const openConversation = useCallback(async (convId: string) => {
-    // Close any existing ws connection
     if (wsRef.current) {
       wsRef.current.close();
       wsRef.current = null;
@@ -385,7 +93,6 @@ export default function OrchestratorPage() {
     setWorking(false);
     setUsage(null);
 
-    // Load message history and usage stats in parallel
     const [historyResult, usageResult] = await Promise.allSettled([
       orchestratorApi.listMessages(convId),
       orchestratorApi.getUsage(convId),
@@ -400,8 +107,6 @@ export default function OrchestratorPage() {
       setUsage(usageResult.value);
     }
 
-    // Re-fetch history and merge any messages missed while the socket was down.
-    // Dedupes by id so already-rendered messages aren't duplicated.
     const replayHistory = async () => {
       try {
         const history = await orchestratorApi.listMessages(convId);
@@ -416,7 +121,6 @@ export default function OrchestratorPage() {
       }
     };
 
-    // Open ws
     const handle = openOrchestratorWs(convId, {
       onStatusChange: (state) => setWsState(state),
       onReconnect: () => {
@@ -424,7 +128,6 @@ export default function OrchestratorPage() {
         void replayHistory();
       },
       onMessage: (event: WsIncomingEvent) => {
-        // Any orchestrator output (message or card) ends the "working" state.
         setWorking(false);
         if (event.type === 'message') {
           const msg: ThreadMessage = {
@@ -433,12 +136,7 @@ export default function OrchestratorPage() {
             text: event.text,
           };
           setItems((prev) => {
-            // Avoid duplicate message ids (history + ws replay)
             if (msg.id && prev.some((m) => 'id' in m && m.id === msg.id)) return prev;
-            // Dedup the optimistic user echo: handleSend adds a `local-…` user
-            // message immediately; the transcript tail then streams the SAME turn
-            // back with the real id. Match the pending local echo by text and
-            // adopt the real id instead of appending a second bubble.
             if (msg.role === 'user') {
               const echoIdx = prev.findIndex(
                 (m) =>
@@ -457,7 +155,6 @@ export default function OrchestratorPage() {
             return [...prev, msg];
           });
         } else if (event.type === 'tool') {
-          // Conductor tool call → collapsible tool card (SHR-161)
           const card: ToolCallItem = {
             kind: 'tool-call',
             id: event.id,
@@ -469,7 +166,6 @@ export default function OrchestratorPage() {
             return [...prev, card];
           });
         } else if (event.type === 'card') {
-          // Dispatch the right card variant based on command
           if (event.command === 'view-spec') {
             const args = event.args as {
               task_id?: string;
@@ -507,13 +203,11 @@ export default function OrchestratorPage() {
               return [...prev, card];
             });
           } else {
-            // Gated write-command card (Task 3.3) — render as ActionCard
             const alwaysAsk = (event.args as { always_ask?: boolean }).always_ask === true;
             const card: ActionCardItem = {
               kind: 'action-card',
               id: event.id,
               command: event.command,
-              // Strip the always_ask meta-field from the displayed args
               args: Object.fromEntries(
                 Object.entries(event.args).filter(([k]) => k !== 'always_ask'),
               ),
@@ -526,8 +220,6 @@ export default function OrchestratorPage() {
             });
           }
         } else if (event.type === 'error') {
-          // Surface delivery/runtime errors instead of silently dropping them —
-          // otherwise a failed turn just sits in the thread looking unsent.
           const msg: ThreadMessage = {
             id: `error-${Date.now()}-${Math.random()}`,
             role: 'assistant',
@@ -535,21 +227,17 @@ export default function OrchestratorPage() {
           };
           setItems((prev) => [...prev, msg]);
         }
-        // status events are handled in Phase 3+
       },
     });
 
     wsRef.current = handle;
   }, []);
 
-  // Cleanup ws on unmount
   useEffect(() => {
     return () => {
       wsRef.current?.close();
     };
   }, []);
-
-  // ─── Create a new conversation ───────────────────────────────────────────
 
   const handleNewConversation = useCallback(async () => {
     if (creatingConv) return;
@@ -565,20 +253,14 @@ export default function OrchestratorPage() {
     }
   }, [creatingConv, openConversation]);
 
-  // ─── Toggle global-monitor mode ──────────────────────────────────────────
-
   const handleToggleMonitor = useCallback(async (convId: string) => {
     try {
       const result = await orchestratorApi.toggleGlobalMonitor(convId);
-      // Update conversations list to reflect the new global-monitor state.
-      // At most one conversation can be global-monitor at a time, so we must
-      // clear the flag on all others when enabling.
       setConversations((prev) =>
         prev.map((c) => {
           if (c.id === convId) {
             return { ...c, is_global_monitor: result.is_global_monitor ? 1 : 0 };
           }
-          // Clear global-monitor on other conversations when enabling one
           if (result.is_global_monitor) {
             return { ...c, is_global_monitor: 0 };
           }
@@ -590,19 +272,15 @@ export default function OrchestratorPage() {
     }
   }, []);
 
-  // ─── Send user turn ──────────────────────────────────────────────────────
-
   const handleSend = useCallback((text: string) => {
     const sent = wsRef.current?.send({ type: 'user_turn' as const, text }) ?? false;
     if (!sent) {
-      // Not silently dropped — surface it and offer a one-click retry (SHR-162).
       toast.error('Not connected — message not sent', {
         description: 'The orchestrator socket is offline. Retry once it reconnects.',
         action: { label: 'Retry', onClick: () => handleSend(text) },
       });
       return;
     }
-    // Optimistically add the user message to the thread
     const msg: ThreadMessage = {
       id: `local-${Date.now()}`,
       role: 'user',
@@ -612,14 +290,11 @@ export default function OrchestratorPage() {
     setWorking(true);
   }, []);
 
-  // ─── Card decision ───────────────────────────────────────────────────────
-
   const handleCardDecision = useCallback((d: ActionCardDecision) => {
     if (!wsRef.current) return;
     const { card_id, decision, args, text, always_allow } = d;
 
     if (decision === 'respond' && text) {
-      // Respond injects a free-text follow-up as a user turn
       wsRef.current.send({ type: 'user_turn', text });
       const msg: ThreadMessage = {
         id: `local-${Date.now()}`,
@@ -631,7 +306,6 @@ export default function OrchestratorPage() {
       return;
     }
 
-    // approve / edit / reject → card_decision event
     const outgoing: WsOutgoingEvent = {
       type: 'card_decision',
       card_id,
@@ -641,7 +315,6 @@ export default function OrchestratorPage() {
     };
     wsRef.current.send(outgoing);
 
-    // Mark the card as resolved so it disappears from the thread
     setItems((prev) =>
       prev.map((item) => {
         if (!('kind' in item)) return item;
@@ -656,8 +329,6 @@ export default function OrchestratorPage() {
     );
   }, []);
 
-  // ─── Spec card dismiss (local only — no ws event) ────────────────────────
-
   const handleSpecCardDismiss = useCallback((cardId: string) => {
     setItems((prev) =>
       prev.map((item) => {
@@ -670,26 +341,14 @@ export default function OrchestratorPage() {
     );
   }, []);
 
-  // ─── Expose messages for tests (backward compat) ─────────────────────────
-
-  // The existing OrchestratorPage tests reference `messages` via the
-  // MessageThread render; we use MixedThread but keep the legacy path for
-  // pure message rendering via MessageThread when there are no cards.
-  // This is transparent to the test suite since MixedThread still renders
-  // MessageThread internally for message runs.
-
-  // ─── Render ──────────────────────────────────────────────────────────────
-
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Page heading (visually hidden but accessible) */}
       <h1 className="sr-only">Orchestrator</h1>
 
       <div className="flex min-h-0 flex-1">
-        {/* Conversation list */}
         <div
           className="border-r border-[rgba(255,255,255,0.08)]"
-          style={{ width: SIDEBAR_WIDTH, minWidth: SIDEBAR_WIDTH }}
+          style={{ width: ORCHESTRATOR_SIDEBAR_WIDTH, minWidth: ORCHESTRATOR_SIDEBAR_WIDTH }}
         >
           <ConversationList
             conversations={conversations}
@@ -701,22 +360,17 @@ export default function OrchestratorPage() {
           />
         </div>
 
-        {/* Chat area */}
         <div className="flex min-h-0 flex-1 flex-col">
           {activeConvId ? (
             <>
-              {/* Thread header */}
               <div className="flex items-center border-b border-[rgba(255,255,255,0.08)] px-4 py-3">
                 <h2 className="truncate text-sm font-semibold text-foreground">
                   {conversations.find((c) => c.id === activeConvId)?.title ?? 'Conversation'}
                 </h2>
                 <ConnectionPill state={wsState} />
-                {/* Conductor-leanness indicator (§6.7): surfaces orchestrator activity
-                    so the user can see if the conductor is accumulating too much context. */}
                 {usage !== null && <LeanessIndicator usage={usage} />}
               </div>
 
-              {/* Mixed thread (messages + plan cards + spec cards) */}
               <MixedThread
                 items={items}
                 onCardDecision={handleCardDecision}
@@ -724,132 +378,13 @@ export default function OrchestratorPage() {
                 working={working}
               />
 
-              {/* Input */}
               <ChatInput onSubmit={handleSend} />
             </>
           ) : (
-            <EmptyState onNew={handleNewConversation} />
+            <OrchestratorEmptyState onNew={handleNewConversation} />
           )}
         </div>
       </div>
-    </div>
-  );
-}
-
-// ─── ConnectionPill ─────────────────────────────────────────────────────────
-
-/**
- * WebSocket connection-status pill (SHR-162). Surfaces connecting / live /
- * reconnecting so a dropped socket is visible instead of silently dead.
- */
-function ConnectionPill({ state }: { state: WsConnectionState }) {
-  const config: Record<
-    WsConnectionState,
-    { label: string; dot: string; pulse: boolean; aria: string }
-  > = {
-    connecting: { label: 'connecting', dot: 'bg-[#FB923C]', pulse: true, aria: 'Connecting' },
-    open: { label: 'live', dot: 'bg-[#22C55E]', pulse: false, aria: 'Connected' },
-    reconnecting: { label: 'reconnecting', dot: 'bg-[#FB923C]', pulse: true, aria: 'Reconnecting' },
-    closed: { label: 'offline', dot: 'bg-[rgba(255,255,255,0.3)]', pulse: false, aria: 'Offline' },
-  };
-  const { label, dot, pulse, aria } = config[state];
-
-  return (
-    <span
-      role="status"
-      aria-label={aria}
-      title={`WebSocket ${label}`}
-      className="ml-2 flex shrink-0 items-center gap-1.5 text-[11px] text-[rgba(255,255,255,0.45)]"
-    >
-      <span className={cn('h-2 w-2 rounded-full', dot, pulse && 'animate-pulse')} />
-      {label}
-    </span>
-  );
-}
-
-// ─── LeanessIndicator ─────────────────────────────────────────────────────────
-
-/**
- * Conductor-leanness indicator (§6.7).
- *
- * Surfaces orchestrator-vs-worker activity so the user can tell if the
- * conductor is accumulating context that should be delegated. Shows:
- *  - tasks spawned
- *  - tool calls made
- *
- * Turns orange/warning when tasks_spawned >= 12 or tool_calls >= 40
- * (spec §10: soft threshold = "12 tasks spawned or M minutes").
- * These are configurable thresholds; off-by-default in the UI
- * (only shown when a conversation is open).
- */
-interface LeanessIndicatorProps {
-  usage: ConversationUsage;
-}
-
-function LeanessIndicator({ usage }: LeanessIndicatorProps) {
-  const TASKS_WARN = 12;
-  const CALLS_WARN = 40;
-  const isWarning = usage.tasks_spawned >= TASKS_WARN || usage.tool_calls >= CALLS_WARN;
-
-  return (
-    <div
-      aria-label="Conductor leanness stats"
-      title={`Conductor activity: ${usage.tasks_spawned} tasks spawned, ${usage.tool_calls} tool calls`}
-      className={cn(
-        'ml-auto flex items-center gap-2 rounded-md px-2 py-1 text-xs tabular-nums',
-        isWarning
-          ? 'bg-[rgba(251,146,60,0.12)] text-[#FB923C]'
-          : 'bg-[rgba(255,255,255,0.04)] text-[rgba(255,255,255,0.45)]',
-      )}
-    >
-      {isWarning && (
-        <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
-          <path d="M6 1L1 11h10L6 1zm0 2l3.5 7h-7L6 3zm-.5 3v2h1V6h-1zm0 3v1h1V9h-1z" />
-        </svg>
-      )}
-      <span>{usage.tasks_spawned} tasks</span>
-      <span aria-hidden="true">·</span>
-      <span>{usage.tool_calls} calls</span>
-    </div>
-  );
-}
-
-// ─── EmptyState ───────────────────────────────────────────────────────────────
-
-function EmptyState({ onNew }: { onNew: () => void }) {
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
-      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[rgba(59,130,246,0.12)]">
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="#3B82F6"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-        </svg>
-      </div>
-      <div>
-        <p className="text-sm font-medium text-foreground">No conversation selected</p>
-        <p className="mt-1 text-xs text-[rgba(255,255,255,0.45)]">
-          Select a conversation from the list or start a new one.
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={onNew}
-        className={cn(
-          'rounded-lg bg-[#3B82F6] px-4 py-2 text-sm font-medium text-white hover:opacity-90',
-          FOCUS_RING,
-        )}
-      >
-        New conversation
-      </button>
     </div>
   );
 }

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -1,36 +1,15 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { TerminalView } from '@/components/TerminalView';
-import { AgentTabs } from '@/components/AgentTabs';
-import { AgentGridCell } from '@/components/AgentGridCell';
-import { gridColumns } from '@/pages/GridMonitor';
-import { DiffViewer } from '@/components/DiffViewer';
-import { clearDiffTreeExpandedState } from '@/lib/diff-tree-storage';
 import { DraftEditForm } from '@/components/DraftEditForm';
 import { EmptyState } from '@/components/EmptyState';
-import { MoveAgentDialog } from '@/components/MoveAgentDialog';
 import { TaskSettingUpView } from '@/components/TaskSettingUpView';
 import { TaskErrorView } from '@/components/TaskErrorView';
-import { ReviewBaseRefBanner } from '@/components/ReviewBaseRefBanner';
-import { DiffRangePicker } from '@/components/DiffRangePicker';
-import { CommentQueueDrawer } from '@/components/CommentQueueDrawer';
-import { CommentsSidePanel } from '@/components/CommentsSidePanel';
-import type { DiffFileListHandle } from '@/components/DiffFileList';
-import { useReviewQueue } from '@/hooks/useReviewQueue';
-import { useTaskComments, CommentsContext } from '@/hooks/useTaskComments';
-import { DIFF_KEYBINDS, useDiffKeyboardNav } from '@/hooks/useDiffKeyboardNav';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-
+import { clearDiffTreeExpandedState } from '@/lib/diff-tree-storage';
 import { useTask } from '@/lib/hooks';
-import { useTerminalCacheSize } from '@/lib/terminal-cache-settings';
-import {
-  diffRangeToParam,
-  taskApi,
-  type DiffRange,
-  type DiffSummaryResponse,
-} from '@/lib/api/taskApi';
+import { taskApi } from '@/lib/api/taskApi';
 import { reviewApi } from '@/lib/api/reviewApi';
 import { TaskDetailHeader } from '@/components/layout/task-detail-header';
 import { TaskDetailMeta } from '@/components/layout/task-detail-meta';
@@ -40,327 +19,37 @@ import { TaskActivityPanel } from '@/components/TaskActivityPanel';
 import { TaskRefsPanel } from '@/components/TaskRefsPanel';
 import { TaskHooksPanel } from '@/components/TaskHooksPanel';
 import { JiraLinkHelper } from '@/components/integrations/JiraLinkHelper';
+import { TaskDetailAgentView, detachAgent } from '@/components/task-detail/TaskDetailAgentView';
+import { TaskDetailDiffView } from '@/components/task-detail/TaskDetailDiffView';
+import { useTaskViewMode } from '@/hooks/useTaskViewMode';
+import { useTerminalCache } from '@/hooks/useTerminalCache';
+import { useDiffState } from '@/hooks/useDiffState';
+import { useTaskDetailComments } from '@/hooks/useTaskDetailComments';
+import { _resetPerTaskUiState } from '@/hooks/perTaskUiState';
 import type { RunMode } from '@octomux/types';
 
 export const SHIP_EVENT = 'octomux:open-pr-sheet';
 
-type TaskMode = 'agents' | 'editor' | 'diff' | 'info';
-
-// Per-task UI state preserved across task switches (session-only, not persisted to disk).
-interface PerTaskUiState {
-  activeWindow: number | null;
-  mode: TaskMode;
-}
-const perTaskUiState = new Map<string, PerTaskUiState>();
-
-/** Reset per-task UI state — exposed for tests only. */
-export function _resetPerTaskUiState() {
-  perTaskUiState.clear();
-}
-
-/** Floating "?" chip that surfaces the diff keybind cheat sheet in a popover. */
-function DiffKeybindCheatSheet() {
-  return (
-    <div className="pointer-events-none absolute bottom-3 right-3">
-      <Popover>
-        <PopoverTrigger
-          aria-label="Show diff keyboard shortcuts"
-          data-testid="diff-keybind-help"
-          className="pointer-events-auto inline-flex h-7 w-7 items-center justify-center rounded-full border border-glass-edge bg-glass-l1 text-xs text-muted-foreground hover:text-foreground"
-        >
-          ?
-        </PopoverTrigger>
-        <PopoverContent align="end" className="w-72">
-          <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Diff shortcuts
-          </div>
-          <ul className="mt-2 space-y-1">
-            {DIFF_KEYBINDS.map((b) => (
-              <li key={b.keys} className="flex items-center justify-between gap-3 text-xs">
-                <kbd className="rounded border border-glass-edge bg-glass-l1 px-1.5 py-0.5 font-mono text-[10px]">
-                  {b.keys}
-                </kbd>
-                <span className="text-muted-foreground">{b.description}</span>
-              </li>
-            ))}
-          </ul>
-        </PopoverContent>
-      </Popover>
-    </div>
-  );
-}
+/** Re-export for tests that import from TaskDetail. */
+export { _resetPerTaskUiState };
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const taskId = id ?? '';
   const { task, loading, error, refresh } = useTask(taskId);
-  const [activeWindow, setActiveWindow] = useState<number | null>(null);
-  const terminalCacheSize = useTerminalCacheSize();
-  // LRU of mounted agent terminals by window_index. Most-recently-active first.
-  // Lets the user flip between recent tabs without xterm/WS teardown.
-  const [terminalLRU, setTerminalLRU] = useState<number[]>([]);
 
-  const [resuming, setResuming] = useState(false);
-  const [mode, setMode] = useState<TaskMode>('agents');
-  const [gridView, setGridView] = useState(false);
-  const [creatingEditor, setCreatingEditor] = useState(false);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const agentParam = searchParams.get('agent');
+  const {
+    mode,
+    setMode,
+    activeWindow,
+    setActiveWindow,
+    gridView,
+    setGridView,
+    userWindowIndex,
+    handleToggleEditor,
+  } = useTaskViewMode({ taskId, task, refresh });
 
-  // ─── Diff range URL state ──────────────────────────────────────────────────
-  const range = useMemo<DiffRange>(() => {
-    const raw = searchParams.get('range');
-    if (!raw || raw === 'base') return { kind: 'base' };
-    if (raw === 'working') return { kind: 'working' };
-    if (raw.startsWith('commit:')) {
-      const sha = raw.slice('commit:'.length);
-      if (/^[0-9a-f]{4,40}$/i.test(sha)) return { kind: 'commit', sha };
-    }
-    if (raw.startsWith('range:')) {
-      const rest = raw.slice('range:'.length);
-      const idx = rest.indexOf('..');
-      if (idx > 0) {
-        const from = rest.slice(0, idx);
-        const to = rest.slice(idx + 2);
-        if (from && to) return { kind: 'range', from, to };
-      }
-    }
-    return { kind: 'base' };
-  }, [searchParams]);
-
-  const setRange = useCallback(
-    (next: DiffRange) => {
-      setSearchParams(
-        (prev) => {
-          const sp = new URLSearchParams(prev);
-          const param = diffRangeToParam(next);
-          if (param) sp.set('range', param);
-          else sp.delete('range');
-          return sp;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  // Local override for user_window_index so we can set it immediately from
-  // the createUserTerminal API response instead of waiting for the next poll.
-  const [localUserWindowIndex, setLocalUserWindowIndex] = useState<number | null>(null);
-  // Derive userWindowIndex — prefer server-persisted data, fall back to local override.
-  const userWindowIndex = task?.user_window_index ?? localUserWindowIndex;
-
-  // --- Per-task state save/restore on task switch ---
-  // Refs let the switch effect read current values without depending on them,
-  // so it only fires when taskId actually changes.
-  const prevTaskIdRef = useRef<string>(taskId);
-  const activeWindowRef = useRef(activeWindow);
-  const modeRef = useRef(mode);
-  activeWindowRef.current = activeWindow;
-  modeRef.current = mode;
-
-  useEffect(() => {
-    const prevId = prevTaskIdRef.current;
-    if (prevId !== taskId) {
-      // Save outgoing task state
-      perTaskUiState.set(prevId, {
-        activeWindow: activeWindowRef.current,
-        mode: modeRef.current,
-      });
-      // Restore incoming task state (or reset to defaults)
-      const saved = perTaskUiState.get(taskId);
-      const nextActive = saved?.activeWindow ?? null;
-      setActiveWindow(nextActive);
-      setMode(saved?.mode ?? 'agents');
-      setLocalUserWindowIndex(null);
-      // Window indexes are task-scoped; seed the LRU directly from the restored
-      // active window instead of clearing it and waiting for the promote effect
-      // to refill — that effect won't fire if `nextActive` equals the outgoing
-      // task's activeWindow, leaving the LRU empty and the terminal pane blank
-      // on cache-hit task switches (e.g. B→A where both had activeWindow=0).
-      setTerminalLRU(nextActive !== null ? [nextActive] : []);
-      prevTaskIdRef.current = taskId;
-    }
-  }, [taskId]);
-
-  // Promote active window to front of LRU; evict beyond cache size.
-  useEffect(() => {
-    if (activeWindow === null) return;
-    setTerminalLRU((prev) => {
-      const without = prev.filter((k) => k !== activeWindow);
-      const next = [activeWindow, ...without].slice(0, terminalCacheSize);
-      if (next.length === prev.length && next.every((k, i) => k === prev[i])) return prev;
-      return next;
-    });
-  }, [activeWindow, terminalCacheSize]);
-
-  // When the user shrinks the cache size, trim the LRU immediately.
-  useEffect(() => {
-    setTerminalLRU((prev) =>
-      prev.length <= terminalCacheSize ? prev : prev.slice(0, terminalCacheSize),
-    );
-  }, [terminalCacheSize]);
-
-  // Keep the map in sync as user interacts
-  useEffect(() => {
-    if (taskId) {
-      perTaskUiState.set(taskId, { activeWindow, mode });
-    }
-  }, [taskId, activeWindow, mode]);
-
-  // Initialize activeWindow from URL ?agent= param or first agent's window_index
-  const firstAgentWindow = task?.agents?.[0]?.window_index ?? null;
-  useEffect(() => {
-    if (agentParam && task?.agents) {
-      const agent = task.agents.find((a) => a.id === agentParam);
-      if (agent) {
-        setActiveWindow(agent.window_index);
-        return;
-      }
-    }
-    if (activeWindow === null && firstAgentWindow !== null) {
-      setActiveWindow(firstAgentWindow);
-    }
-  }, [firstAgentWindow, activeWindow, agentParam, task?.agents]);
-
-  // Mark the task as viewed once when the page opens for this task id.
-  // Fire-and-forget — no loading state, no error toast.
-  useEffect(() => {
-    if (!taskId) return;
-    taskApi.markTaskViewed(taskId).catch((err) => {
-      console.warn('Failed to mark task viewed:', err);
-    });
-  }, [taskId]);
-
-  // auto_review tasks live on /reviews/:id — redirect any stale /tasks/:id link.
-  useEffect(() => {
-    if (task?.source === 'auto_review') {
-      navigate(`/reviews/${task.id}`, { replace: true });
-    }
-  }, [task, navigate]);
-
-  // Auto-switch back to agents when task enters non-running state.
-  // Diff mode is allowed to persist so users can keep reviewing a closed task's diff.
-  useEffect(() => {
-    if (task && task.runtime_state !== 'running') {
-      setMode((m) => (m === 'editor' ? 'agents' : m));
-      setLocalUserWindowIndex(null);
-    }
-  }, [task?.runtime_state]);
-
-  const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
-  const [closeConfirm, setCloseConfirm] = useState(false);
-
-  // ─── Review cockpit state ────────────────────────────────────────────────
-  const reviewQueue = useReviewQueue(taskId);
-  const [diffSummary, setDiffSummary] = useState<DiffSummaryResponse | null>(null);
-  const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
-  const [filesInDiff, setFilesInDiff] = useState<string[]>([]);
-  const [showCommentsPanel, setShowCommentsPanel] = useState(false);
-  const diffListRef = useRef<DiffFileListHandle | null>(null);
-  const focusClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleQueueDraft = useCallback(
-    (draft: {
-      filePath: string;
-      line: number;
-      side: 'old' | 'new';
-      body: string;
-      lineText: string;
-    }) => {
-      reviewQueue.add({
-        filePath: draft.filePath,
-        line: draft.line,
-        lineText: draft.lineText,
-        body: draft.body,
-      });
-    },
-    [reviewQueue],
-  );
-
-  const taskComments = useTaskComments(taskId, {
-    onError: (msg) => toast.error(msg),
-    onQueueDraft: handleQueueDraft,
-  });
-
-  useEffect(
-    () => () => {
-      if (focusClearTimer.current) clearTimeout(focusClearTimer.current);
-    },
-    [],
-  );
-
-  const filesInDiffSet = useMemo(() => new Set(filesInDiff), [filesInDiff]);
-
-  const handleJumpToComment = useCallback(
-    (filePath: string, line: number, side: 'old' | 'new', commentId: string) => {
-      diffListRef.current?.revealLineInFile(filePath, line, side);
-      taskComments.setFocusedId(commentId);
-      if (focusClearTimer.current) clearTimeout(focusClearTimer.current);
-      focusClearTimer.current = setTimeout(() => {
-        taskComments.setFocusedId(null);
-      }, 1200);
-    },
-    [taskComments],
-  );
-
-  const visibleFiles = useMemo(
-    () => (diffSummary?.files ?? []).filter((f) => !f.ignored),
-    [diffSummary],
-  );
-
-  const refetchDiff = useCallback(async () => {
-    if (!taskId) return;
-    try {
-      const s = await taskApi.getTaskDiffSummary(taskId, range);
-      setDiffSummary(s);
-    } catch {
-      // swallow — banner is best-effort, DiffViewer surfaces its own errors
-    }
-  }, [taskId, range]);
-
-  const handleBaseChange = useCallback(
-    async (newBaseBranch: string) => {
-      if (!taskId) return;
-      await taskApi.updateTaskBase(taskId, newBaseBranch);
-      // Reset range to full diff and refetch summary under the new base.
-      setRange({ kind: 'base' });
-      await refetchDiff();
-      refresh();
-    },
-    [taskId, refetchDiff, refresh, setRange],
-  );
-
-  const currentRangeLabel = useMemo(() => {
-    switch (range.kind) {
-      case 'base':
-        return 'full diff';
-      case 'working':
-        return 'working tree';
-      case 'commit':
-        return `commit ${range.sha.slice(0, 7)}`;
-      case 'range':
-        return `${range.from.slice(0, 7)}..${range.to.slice(0, 7)}`;
-    }
-  }, [range]);
-
-  const handleToggleReviewed = useCallback(
-    async (filePath: string, currentlyReviewed: boolean) => {
-      if (!taskId) return;
-      try {
-        if (currentlyReviewed) await taskApi.unmarkReviewed(taskId, filePath);
-        else await taskApi.markReviewed(taskId, filePath);
-        await refetchDiff();
-      } catch (err) {
-        console.error('Failed to toggle reviewed:', err);
-      }
-    },
-    [taskId, refetchDiff],
-  );
-
-  // Set of window indexes currently present on this task (agents + user terminals).
-  // Used to evict LRU entries whose underlying agent/terminal is gone.
   const validWindowIndexes = useMemo(() => {
     const s = new Set<number>();
     for (const a of task?.agents || []) s.add(a.window_index);
@@ -368,12 +57,14 @@ export default function TaskDetail() {
     return s;
   }, [task?.agents, task?.user_terminals]);
 
-  useEffect(() => {
-    setTerminalLRU((prev) => {
-      const filtered = prev.filter((k) => validWindowIndexes.has(k));
-      return filtered.length === prev.length ? prev : filtered;
-    });
-  }, [validWindowIndexes]);
+  const { terminalLRU } = useTerminalCache({ taskId, activeWindow, validWindowIndexes });
+
+  const [resuming, setResuming] = useState(false);
+  const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
+  const [closeConfirm, setCloseConfirm] = useState(false);
+  const [showCommentsPanel, setShowCommentsPanel] = useState(false);
+
+  const { reviewQueue, taskComments } = useTaskDetailComments({ taskId });
 
   const activeAgentId = useMemo(() => {
     const ags = task?.agents ?? [];
@@ -384,85 +75,37 @@ export default function TaskDetail() {
     return ags.find((x) => x.status !== 'stopped')?.id ?? null;
   }, [task?.agents, activeWindow]);
 
-  const handleSendBatch = useCallback(async () => {
-    if (!taskId || !activeAgentId || reviewQueue.comments.length === 0) return;
-    const body = reviewQueue.format();
-    const drafts = reviewQueue.comments;
-
-    // Persist each queued draft. Failures stay in the queue with a toast so the
-    // human can retry; successes are removed.
-    const failed: string[] = [];
-    await Promise.all(
-      drafts.map(async (d) => {
-        const row = await taskComments.post({
-          file_path: d.filePath,
-          line: d.line,
-          side: 'new',
-          body: d.body,
-        });
-        if (row) reviewQueue.remove(d.id);
-        else failed.push(d.id);
-      }),
-    );
-    if (failed.length > 0) {
-      toast.error(`Failed to save ${failed.length} of ${drafts.length} comments`);
-      return;
-    }
-
-    try {
-      await taskApi.sendAgentMessage(taskId, activeAgentId, body);
-    } catch (err) {
-      console.error('Failed to send review batch:', err);
-      toast.error((err as Error).message);
-    }
-  }, [taskId, activeAgentId, reviewQueue, taskComments]);
-
-  const moveActiveFile = useCallback(
-    (delta: 1 | -1) => {
-      if (visibleFiles.length === 0) return;
-      const idx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
-      const next = (idx + delta + visibleFiles.length) % visibleFiles.length;
-      setActiveFilePath(visibleFiles[next].path);
-    },
-    [visibleFiles, activeFilePath],
-  );
-
-  const jumpToNextUnreviewed = useCallback(() => {
-    if (visibleFiles.length === 0) return;
-    const startIdx = activeFilePath ? visibleFiles.findIndex((f) => f.path === activeFilePath) : -1;
-    for (let i = 1; i <= visibleFiles.length; i++) {
-      const candidate = visibleFiles[(startIdx + i) % visibleFiles.length];
-      if (!candidate.reviewed) {
-        setActiveFilePath(candidate.path);
-        return;
-      }
-    }
-  }, [visibleFiles, activeFilePath]);
-
   const isDiffMode = mode === 'diff';
-  useDiffKeyboardNav({
-    onNextFile: isDiffMode ? () => moveActiveFile(1) : undefined,
-    onPrevFile: isDiffMode ? () => moveActiveFile(-1) : undefined,
-    onToggleReviewed: isDiffMode
-      ? () => {
-          if (!activeFilePath) return;
-          const file = visibleFiles.find((f) => f.path === activeFilePath);
-          if (!file) return;
-          handleToggleReviewed(activeFilePath, !!file.reviewed);
-        }
-      : undefined,
-    onJumpToNextUnreviewed: isDiffMode ? jumpToNextUnreviewed : undefined,
-    onSendBatch: isDiffMode ? handleSendBatch : undefined,
+  const diffState = useDiffState({
+    taskId,
+    isDiffMode,
+    activeAgentId,
+    reviewQueue,
+    taskComments,
+    refresh,
   });
 
-  const handleShip = useCallback(() => {
+  useEffect(() => {
     if (!taskId) return;
-    // T7 will mount the PR sheet listener. Route stub deferred — event-only for now.
-    window.dispatchEvent(new CustomEvent(SHIP_EVENT, { detail: { taskId } }));
+    taskApi.markTaskViewed(taskId).catch((err) => {
+      console.warn('Failed to mark task viewed:', err);
+    });
   }, [taskId]);
+
+  useEffect(() => {
+    if (task?.source === 'auto_review') {
+      navigate(`/reviews/${task.id}`, { replace: true });
+    }
+  }, [task, navigate]);
 
   const [reviewBusy, setReviewBusy] = useState(false);
   const existingReviewId = task?.existing_review_id ?? null;
+
+  const handleShip = useCallback(() => {
+    if (!taskId) return;
+    window.dispatchEvent(new CustomEvent(SHIP_EVENT, { detail: { taskId } }));
+  }, [taskId]);
+
   const handleReview = useCallback(async () => {
     if (!taskId) return;
     if (existingReviewId) {
@@ -492,7 +135,7 @@ export default function TaskDetail() {
         console.error('Failed to add agent:', err);
       }
     },
-    [taskId, refresh],
+    [taskId, refresh, setActiveWindow],
   );
 
   const handleStopAgent = useCallback(
@@ -502,7 +145,6 @@ export default function TaskDetail() {
         const taskAgents = task?.agents || [];
         const stoppedAgent = taskAgents.find((a) => a.id === agentId);
         await taskApi.stopAgent(taskId, agentId);
-        // If we stopped the active tab, switch to the first remaining running agent
         if (stoppedAgent && stoppedAgent.window_index === activeWindow) {
           const nextAgent = taskAgents.find((a) => a.id !== agentId && a.status !== 'stopped');
           if (nextAgent) setActiveWindow(nextAgent.window_index);
@@ -512,7 +154,7 @@ export default function TaskDetail() {
         console.error('Failed to stop agent:', err);
       }
     },
-    [taskId, refresh, task, activeWindow],
+    [taskId, refresh, task, activeWindow, setActiveWindow],
   );
 
   const handleClose = useCallback(async () => {
@@ -569,7 +211,7 @@ export default function TaskDetail() {
     } catch (err) {
       console.error('Failed to create terminal:', err);
     }
-  }, [taskId, refresh]);
+  }, [taskId, refresh, setActiveWindow]);
 
   const handleCloseTerminal = useCallback(
     async (terminalId: string) => {
@@ -578,7 +220,6 @@ export default function TaskDetail() {
         const terminals = task?.user_terminals || [];
         const closedTerminal = terminals.find((t) => t.id === terminalId);
         await taskApi.closeTerminal(taskId, terminalId);
-        // If we closed the active tab, switch to first agent or next terminal
         if (closedTerminal && closedTerminal.window_index === activeWindow) {
           const agents = task?.agents || [];
           const runningAgent = agents.find((a) => a.status !== 'stopped');
@@ -590,32 +231,8 @@ export default function TaskDetail() {
         console.error('Failed to close terminal:', err);
       }
     },
-    [taskId, refresh, task, activeWindow],
+    [taskId, refresh, task, activeWindow, setActiveWindow],
   );
-
-  const handleToggleEditor = useCallback(async () => {
-    if (mode === 'editor') {
-      setMode('agents');
-      return;
-    }
-    if (creatingEditor) return;
-    setCreatingEditor(true);
-    try {
-      const result = await taskApi.createUserTerminal(taskId);
-      if (result.editor === 'vscode' || result.editor === 'cursor') {
-        // External editor opened — stay on agents view
-        setLocalUserWindowIndex(null);
-      } else {
-        setLocalUserWindowIndex(result.windowIndex);
-        setMode('editor');
-      }
-      refresh();
-    } catch (err) {
-      console.error('Failed to create user terminal:', err);
-    } finally {
-      setCreatingEditor(false);
-    }
-  }, [mode, taskId, creatingEditor, refresh]);
 
   if (loading) {
     return (
@@ -682,7 +299,6 @@ export default function TaskDetail() {
         onReview={handleReview}
       />
 
-      {/* Error display — only when status !== 'error' (dedicated error view shows error) */}
       {task.error && task.runtime_state !== 'error' && (
         <div className="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive">
           {task.error}
@@ -696,130 +312,38 @@ export default function TaskDetail() {
         />
       )}
 
-      {/* Dedicated lifecycle state: setting_up */}
       {task.runtime_state === 'setting_up' && !hasTerminal && mode === 'agents' && (
         <TaskSettingUpView task={task} />
       )}
 
-      {/* Dedicated lifecycle state: error */}
       {task.runtime_state === 'error' && mode === 'agents' && (
         <TaskErrorView task={task} onRetry={handleResume} onDelete={handleDelete} />
       )}
 
-      {/* Agent view — shown in agents mode. Skip entirely when a dedicated
-          lifecycle state (setting_up / error) is rendering above. */}
       {task.runtime_state === 'error' ||
       (task.runtime_state === 'setting_up' && !hasTerminal) ? null : hasTerminal ? (
-        <div className={mode === 'agents' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}>
-          <div className="flex shrink-0 items-center gap-1">
-            <div className="min-w-0 flex-1">
-              <AgentTabs
-                agents={agents}
-                activeIndex={activeWindow}
-                onSelect={setActiveWindow}
-                onAddAgent={handleAddAgent}
-                onStopAgent={handleStopAgent}
-                canAddAgent={isRunning}
-                userTerminals={isRunning ? task.user_terminals || [] : []}
-                onAddTerminal={isRunning ? handleAddTerminal : undefined}
-                onCloseTerminal={isRunning ? handleCloseTerminal : undefined}
-                onMoveAgent={isRunning ? (id) => setMovingAgentId(id) : undefined}
-                onDetachAgent={
-                  isRunning
-                    ? async (id) => {
-                        try {
-                          await taskApi.moveAgentToTask(id, null);
-                          navigate(`/chats/${id}`);
-                        } catch (err) {
-                          console.error('Failed to detach agent:', err);
-                        }
-                      }
-                    : undefined
-                }
-              />
-            </div>
-            {agents.filter((a) => a.status !== 'stopped').length > 1 && (
-              <Button
-                type="button"
-                size="xs"
-                variant={gridView ? 'default' : 'outline'}
-                data-testid="task-grid-toggle"
-                aria-pressed={gridView}
-                onClick={() => setGridView((v) => !v)}
-                className="mr-2"
-              >
-                {gridView ? 'Single' : 'Grid view'}
-              </Button>
-            )}
-          </div>
-          {movingAgentId && (
-            <MoveAgentDialog
-              open={!!movingAgentId}
-              onOpenChange={(open) => !open && setMovingAgentId(null)}
-              agentId={movingAgentId}
-              currentTaskId={task.id}
-              agentLabel={task.agents?.find((a) => a.id === movingAgentId)?.label}
-              onMoved={() => {
-                setMovingAgentId(null);
-                refresh();
-              }}
-            />
-          )}
-          {gridView ? (
-            <div data-testid="task-agent-grid" className="min-h-0 flex-1 overflow-auto p-2">
-              {(() => {
-                const running = agents.filter((a) => a.status !== 'stopped');
-                const cols = gridColumns(running.length);
-                return (
-                  <div
-                    className="grid gap-3"
-                    style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
-                  >
-                    {running.map((a) => (
-                      <AgentGridCell
-                        key={a.id}
-                        taskId={task.id}
-                        windowIndex={a.window_index}
-                        taskTitle={task.title || '(untitled task)'}
-                        agentName={a.label}
-                        activity={a.hook_activity}
-                      />
-                    ))}
-                  </div>
-                );
-              })()}
-            </div>
-          ) : (
-            <div className="relative min-h-0 flex-1 overflow-hidden p-1">
-              {terminalLRU.map((wi) => {
-                const isActive = wi === activeWindow;
-                return (
-                  <div
-                    key={wi}
-                    data-window-index={wi}
-                    data-terminal-active={isActive ? 'true' : 'false'}
-                    aria-hidden={!isActive}
-                    // `inert` blocks focus + input on the cached-but-hidden
-                    // terminals so xterm's textarea can't capture keystrokes
-                    // intended for the active tab.
-                    inert={!isActive}
-                    className={
-                      isActive
-                        ? 'absolute inset-0'
-                        : 'pointer-events-none absolute inset-0 opacity-0'
-                    }
-                  >
-                    <TerminalView
-                      taskId={task.id}
-                      windowIndex={wi}
-                      visible={isActive && mode === 'agents'}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+        <TaskDetailAgentView
+          task={task}
+          mode={mode}
+          activeWindow={activeWindow}
+          terminalLRU={terminalLRU}
+          gridView={gridView}
+          isRunning={isRunning}
+          movingAgentId={movingAgentId}
+          onSelectWindow={setActiveWindow}
+          onGridViewToggle={() => setGridView((v) => !v)}
+          onAddAgent={handleAddAgent}
+          onStopAgent={handleStopAgent}
+          onAddTerminal={handleAddTerminal}
+          onCloseTerminal={handleCloseTerminal}
+          onMoveAgent={setMovingAgentId}
+          onDetachAgent={(agentId) => detachAgent(agentId, navigate)}
+          onMoveDialogClose={() => setMovingAgentId(null)}
+          onMoved={() => {
+            setMovingAgentId(null);
+            refresh();
+          }}
+        />
       ) : isDraft ? (
         <div className={mode === 'agents' ? 'min-h-0 flex-1 overflow-y-auto' : 'hidden'}>
           <DraftEditForm task={task} onSaved={refresh} onStart={handleStart} />
@@ -873,83 +397,35 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Diff view — review cockpit */}
       {mode === 'diff' && canShowDiff && (
-        <CommentsContext.Provider value={taskComments}>
-          <div className="relative flex min-h-0 flex-1 flex-col">
-            {diffSummary && diffSummary.base_ref ? (
-              <ReviewBaseRefBanner
-                baseRef={diffSummary.base_ref}
-                baseIsStale={!!diffSummary.base_is_stale}
-                totalCount={diffSummary.total_count ?? 0}
-                reviewedCount={diffSummary.reviewed_count ?? 0}
-                onRefresh={refetchDiff}
-                onJumpToNextUnreviewed={jumpToNextUnreviewed}
-                currentRangeLabel={currentRangeLabel}
-                rangePicker={
-                  <DiffRangePicker
-                    taskId={task.id}
-                    currentBaseBranch={task.base_branch}
-                    range={range}
-                    onRangeChange={setRange}
-                    onBaseChange={handleBaseChange}
-                  />
-                }
-                rightSlot={
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    data-testid="comments-toggle"
-                    data-active={showCommentsPanel ? 'true' : undefined}
-                    className={
-                      showCommentsPanel ? 'border-primary/40 bg-primary/15 text-primary' : undefined
-                    }
-                    onClick={() => setShowCommentsPanel((v) => !v)}
-                  >
-                    Comments ({taskComments.byId.size})
-                  </Button>
-                }
-              />
-            ) : null}
-            <div className="flex min-h-0 min-w-0 flex-1">
-              <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-                <DiffViewer
-                  taskId={task.id}
-                  isRunning={task.runtime_state === 'running'}
-                  onSelectionChange={setActiveFilePath}
-                  onSummaryLoaded={setDiffSummary}
-                  onToggleReviewed={handleToggleReviewed}
-                  range={range}
-                  listRef={diffListRef}
-                  enableComments={true}
-                  agents={task.agents ?? []}
-                  onFilesChange={setFilesInDiff}
-                />
-              </div>
-              {showCommentsPanel ? (
-                <CommentsSidePanel
-                  agents={task.agents ?? []}
-                  filesInDiff={filesInDiffSet}
-                  rangeIsBase={range.kind === 'base'}
-                  onJumpTo={handleJumpToComment}
-                  onClose={() => setShowCommentsPanel(false)}
-                />
-              ) : null}
-              {reviewQueue.comments.length > 0 ? (
-                <CommentQueueDrawer
-                  comments={reviewQueue.comments}
-                  onRemove={reviewQueue.remove}
-                  onJumpTo={(p) => setActiveFilePath(p)}
-                  onSend={handleSendBatch}
-                />
-              ) : null}
-            </div>
-            <DiffKeybindCheatSheet />
-          </div>
-        </CommentsContext.Provider>
+        <TaskDetailDiffView
+          task={task}
+          range={diffState.range}
+          diffSummary={diffState.diffSummary}
+          currentRangeLabel={diffState.currentRangeLabel}
+          showCommentsPanel={showCommentsPanel}
+          filesInDiffSet={diffState.filesInDiffSet}
+          diffListRef={diffState.diffListRef}
+          reviewQueueComments={reviewQueue.comments}
+          commentCount={taskComments.byId.size}
+          taskComments={taskComments}
+          onRangeChange={diffState.setRange}
+          onBaseChange={diffState.handleBaseChange}
+          onRefetchDiff={diffState.refetchDiff}
+          onJumpToNextUnreviewed={diffState.jumpToNextUnreviewed}
+          onToggleCommentsPanel={() => setShowCommentsPanel((v) => !v)}
+          onCloseCommentsPanel={() => setShowCommentsPanel(false)}
+          onSelectionChange={diffState.setActiveFilePath}
+          onSummaryLoaded={diffState.setDiffSummary}
+          onToggleReviewed={diffState.handleToggleReviewed}
+          onFilesChange={diffState.setFilesInDiff}
+          onJumpToComment={diffState.handleJumpToComment}
+          onQueueRemove={reviewQueue.remove}
+          onQueueJumpTo={diffState.setActiveFilePath}
+          onSendBatch={diffState.handleSendBatch}
+        />
       )}
 
-      {/* Editor view — only shown for nvim (external editors stay on agents view) */}
       {userWindowIndex !== null && mode === 'editor' && (
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="min-h-0 flex-1 overflow-hidden p-1">
@@ -958,7 +434,6 @@ export default function TaskDetail() {
         </div>
       )}
 
-      {/* Info view — Activity / Refs / Hooks panels, opened via the INFO toolbar button */}
       {mode === 'info' && !isDraft && (
         <div data-testid="task-detail-panels" className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- Extract TaskDetail domain logic into focused hooks: `useDiffState`, `useTerminalCache`, `useTaskViewMode`, `useTaskDetailComments`, plus shared `perTaskUiState` module
- Pull TaskDetail agent/diff views into `src/components/task-detail/` presentational components
- Extract OrchestratorPage inline `ChatInput`, `MixedThread`, `ConnectionPill`, `LeanessIndicator`, and `OrchestratorEmptyState` into `src/components/orchestrator/`
- Preserve terminal LRU cache and `perTaskUiState` behavior byte-for-byte; re-export `_resetPerTaskUiState` from TaskDetail for existing tests

## Why
Interdependent state in the two largest frontend pages made diff/terminal/mode/comments logic hard to test and risky to change. Splitting into hooks and components isolates each concern.

Resolves SHR-216

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (3410 passed)
- [x] `bun run build`
- [x] Existing `TaskDetail.test.tsx`, `TaskDetail.terminal-cache.test.tsx`, and `OrchestratorPage.test.tsx` pass unchanged
- [x] Added `useTerminalCache.test.tsx`, `ChatInput.test.tsx`, `MixedThread.test.tsx`


Made with [Cursor](https://cursor.com)