### PR TITLE
refactor(types): finish TaskStatus → runtime_state migration

### DIFF
--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -7,6 +7,7 @@ import type {
   Task,
   TaskExternalRef,
   TaskUpdate,
+  UpdateTaskRequest,
   WorkflowStatus,
 } from '@octomux/types';
 
@@ -54,7 +55,7 @@ export interface OctomuxClient {
   createTask(data: CreateTaskRequest & { title: string; description: string }): Promise<Task>;
   listTasks(params?: { repo_path?: string }): Promise<Task[]>;
   getTask(id: string): Promise<Task>;
-  updateTask(id: string, data: { status: string }): Promise<Task>;
+  updateTask(id: string, data: UpdateTaskRequest): Promise<Task>;
   deleteTask(id: string): Promise<void>;
   addAgent(
     taskId: string,

--- a/cli/src/commands/close-task.ts
+++ b/cli/src/commands/close-task.ts
@@ -9,7 +9,7 @@ export function registerCloseTask(program: Command): void {
     .action(async (id: string, _opts, cmd) => {
       const { client, json } = getContext(cmd);
 
-      const task = await client.updateTask(id, { status: 'closed' });
+      const task = await client.updateTask(id, { runtime_state: 'idle' });
 
       if (json) {
         outputJson(task);

--- a/cli/src/commands/resume-task.ts
+++ b/cli/src/commands/resume-task.ts
@@ -9,7 +9,7 @@ export function registerResumeTask(program: Command): void {
     .action(async (id: string, _opts, cmd) => {
       const { client, json } = getContext(cmd);
 
-      const task = await client.updateTask(id, { status: 'running' });
+      const task = await client.updateTask(id, { runtime_state: 'running' });
 
       if (json) {
         outputJson(task);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import { type Page, expect } from '@playwright/test';
+import type { RuntimeState } from '@octomux/types';
 
 const SERVER_URL = (process.env.OCTOMUX_URL || 'http://localhost:7777').replace(/\/$/, '');
 const API = `${SERVER_URL}/api`;
@@ -17,31 +18,33 @@ export async function createTaskViaAPI(
   });
   expect(res.ok()).toBeTruthy();
   const task = await res.json();
-  return task as { id: string; status: string };
+  return task as { id: string; runtime_state: RuntimeState };
 }
 
-/** Wait for a task to reach a given status via polling. */
+/** Wait for a task to reach a given runtime_state via polling. */
 export async function waitForStatus(
   page: Page,
   taskId: string,
-  status: string,
+  runtimeState: RuntimeState,
   timeoutMs = 15_000,
 ) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const res = await page.request.get(`${API}/tasks/${taskId}`);
     const task = await res.json();
-    if (task.status === status) return task;
+    if (task.runtime_state === runtimeState) return task;
     await page.waitForTimeout(500);
   }
-  throw new Error(`Task ${taskId} did not reach status "${status}" within ${timeoutMs}ms`);
+  throw new Error(
+    `Task ${taskId} did not reach runtime_state "${runtimeState}" within ${timeoutMs}ms`,
+  );
 }
 
 /** Close + delete a task and clean up its resources. */
 export async function cleanupTask(page: Page, taskId: string) {
   // Close first (stops tmux, removes worktree)
   await page.request.patch(`${API}/tasks/${taskId}`, {
-    data: { status: 'closed' },
+    data: { runtime_state: 'idle' },
   });
   // Then delete the DB record
   await page.request.delete(`${API}/tasks/${taskId}`);
@@ -89,9 +92,9 @@ export async function cleanupTasks(page: Page, taskIds: readonly string[]) {
     try {
       const res = await page.request.get(`${API}/tasks/${id}`);
       if (!res.ok()) continue;
-      const task = (await res.json()) as { status: string };
-      if (task.status === 'running' || task.status === 'setting_up') {
-        await page.request.patch(`${API}/tasks/${id}`, { data: { status: 'closed' } });
+      const task = (await res.json()) as { runtime_state: RuntimeState };
+      if (task.runtime_state === 'running' || task.runtime_state === 'setting_up') {
+        await page.request.patch(`${API}/tasks/${id}`, { data: { runtime_state: 'idle' } });
       }
       await page.request.delete(`${API}/tasks/${id}`);
     } catch {
@@ -106,11 +109,11 @@ export async function cleanupTasks(page: Page, taskIds: readonly string[]) {
  */
 export async function deleteAllTasks(page: Page) {
   const res = await page.request.get(`${API}/tasks`);
-  const tasks = (await res.json()) as { id: string; status: string }[];
+  const tasks = (await res.json()) as { id: string; runtime_state: RuntimeState }[];
   for (const task of tasks) {
-    if (task.status === 'running' || task.status === 'setting_up') {
+    if (task.runtime_state === 'running' || task.runtime_state === 'setting_up') {
       await page.request.patch(`${API}/tasks/${task.id}`, {
-        data: { status: 'closed' },
+        data: { runtime_state: 'idle' },
       });
     }
     await page.request.delete(`${API}/tasks/${task.id}`);

--- a/e2e/ui-screenshots.spec.ts
+++ b/e2e/ui-screenshots.spec.ts
@@ -43,7 +43,7 @@ async function createDraftTask(
     },
   });
   expect(res.ok()).toBeTruthy();
-  return (await res.json()) as { id: string; status: string };
+  return (await res.json()) as { id: string; runtime_state: string };
 }
 
 // Track test tasks so we can clean them up
@@ -156,8 +156,8 @@ test.describe.serial('UI Screenshots', () => {
     await page.setViewportSize(DESKTOP);
     // Find a running task
     const res = await page.request.get(`${API}/tasks`);
-    const tasks = (await res.json()) as { id: string; status: string }[];
-    const runningTask = tasks.find((t) => t.status === 'running');
+    const tasks = (await res.json()) as { id: string; runtime_state: string }[];
+    const runningTask = tasks.find((t) => t.runtime_state === 'running');
     if (!runningTask) {
       test.skip();
       return;
@@ -300,8 +300,8 @@ test.describe.serial('UI Screenshots', () => {
 
   test('16 responsive - task detail tablet', async ({ page }) => {
     const res = await page.request.get(`${API}/tasks`);
-    const tasks = (await res.json()) as { id: string; status: string }[];
-    const task = tasks.find((t) => t.status === 'running') ?? tasks[0];
+    const tasks = (await res.json()) as { id: string; runtime_state: string }[];
+    const task = tasks.find((t) => t.runtime_state === 'running') ?? tasks[0];
     if (!task) {
       test.skip();
       return;
@@ -315,8 +315,8 @@ test.describe.serial('UI Screenshots', () => {
 
   test('17 responsive - task detail mobile', async ({ page }) => {
     const res = await page.request.get(`${API}/tasks`);
-    const tasks = (await res.json()) as { id: string; status: string }[];
-    const task = tasks.find((t) => t.status === 'running') ?? tasks[0];
+    const tasks = (await res.json()) as { id: string; runtime_state: string }[];
+    const task = tasks.find((t) => t.runtime_state === 'running') ?? tasks[0];
     if (!task) {
       test.skip();
       return;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,3 @@
-export type TaskStatus = 'draft' | 'setting_up' | 'running' | 'closed' | 'error';
-/** New runtime state — replaces TaskStatus for the runtime column. */
 export type RuntimeState = 'idle' | 'setting_up' | 'running' | 'error';
 /** Workflow status — human-facing board column. */
 export type WorkflowStatus = 'backlog' | 'planned' | 'in_progress' | 'human_review' | 'pr' | 'done';
@@ -207,7 +205,6 @@ export interface AddAgentRequest {
 }
 
 export interface UpdateTaskRequest {
-  status?: 'closed' | 'running';
   runtime_state?: RuntimeState;
   workflow_status?: WorkflowStatus;
   title?: string;

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -259,7 +259,7 @@ const notFoundCases = [
     name: 'PATCH /api/tasks/:id',
     method: 'patch' as const,
     url: '/api/tasks/nonexistent',
-    body: { status: 'closed' },
+    body: { runtime_state: 'idle' },
   },
   { name: 'DELETE /api/tasks/:id', method: 'delete' as const, url: '/api/tasks/nonexistent' },
   {
@@ -679,13 +679,13 @@ describe('POST /api/tasks/:id/start', () => {
 // ─── PATCH /api/tasks/:id ────────────────────────────────────────────────────
 
 describe('PATCH /api/tasks/:id', () => {
-  it('updates status and returns updated task with agents', async () => {
+  it('updates runtime_state and returns updated task with agents', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db);
 
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'closed' });
+      .send({ runtime_state: 'idle' });
 
     expect(res.status).toBe(200);
     expect(res.body.runtime_state).toBe('idle');
@@ -697,16 +697,16 @@ describe('PATCH /api/tasks/:id', () => {
 
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'closed' });
+      .send({ runtime_state: 'idle' });
 
     expect(res.body.updated_at).not.toBe('2020-01-01 00:00:00');
   });
 
   // ─── closeTask trigger ─────────────────────────────────────────────────
 
-  it('calls closeTask when status=closed', async () => {
+  it('calls closeTask when runtime_state=idle', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
-    await request(app).patch(`/api/tasks/${DEFAULTS.task.id}`).send({ status: 'closed' });
+    await request(app).patch(`/api/tasks/${DEFAULTS.task.id}`).send({ runtime_state: 'idle' });
     expect(closeTask).toHaveBeenCalledOnce();
   });
 
@@ -714,7 +714,7 @@ describe('PATCH /api/tasks/:id', () => {
     insertTask(db);
     await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'running' } as any);
+      .send({ runtime_state: 'running' } as any);
     expect(closeTask).not.toHaveBeenCalled();
   });
 
@@ -726,13 +726,13 @@ describe('PATCH /api/tasks/:id', () => {
     expect(closeTask).not.toHaveBeenCalled();
   });
 
-  // ─── Resume flow (status=running) ─────────────────────────────────────
+  // ─── Resume flow (runtime_state=running) ─────────────────────────────────
 
   it('returns 400 when resuming a non-closed/non-error task', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'running' });
+      .send({ runtime_state: 'running' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('resume');
   });
@@ -744,7 +744,7 @@ describe('PATCH /api/tasks/:id', () => {
     insertTask(db, { ...DEFAULTS.runningTask, runtime_state: state });
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'running' });
+      .send({ runtime_state: 'running' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Worktree');
   });
@@ -754,7 +754,7 @@ describe('PATCH /api/tasks/:id', () => {
     insertTask(db, { ...DEFAULTS.runningTask, runtime_state: state });
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'running' });
+      .send({ runtime_state: 'running' });
     expect(res.status).toBe(200);
     expect(resumeTask).toHaveBeenCalledOnce();
   });
@@ -769,7 +769,7 @@ describe('PATCH /api/tasks/:id', () => {
     });
     const res = await request(app)
       .patch(`/api/tasks/${DEFAULTS.task.id}`)
-      .send({ status: 'running' });
+      .send({ runtime_state: 'running' });
     expect(res.status).toBe(200);
     expect(resumeTask).toHaveBeenCalledOnce();
   });
@@ -786,7 +786,7 @@ describe('PATCH /api/tasks/:id', () => {
       });
       const res = await request(app)
         .patch(`/api/tasks/${DEFAULTS.task.id}`)
-        .send({ status: 'running' });
+        .send({ runtime_state: 'running' });
       expect(res.status).toBe(400);
     },
   );
@@ -2084,7 +2084,7 @@ describe('Chats API (standalone agents)', () => {
     const created = await request(app).post('/api/chats').send({ label: 'Bad patch' });
     const res = await request(app)
       .patch(`/api/chats/${created.body.id}`)
-      .send({ status: 'running' });
+      .send({ runtime_state: 'running' });
     expect(res.status).toBe(400);
   });
 

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -265,7 +265,7 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
 
   if (hasDraftFields) {
     throwIfValidationError(applyDraftUpdates(task, body));
-  } else if (body.status === 'running' || body.runtime_state === 'running') {
+  } else if (body.runtime_state === 'running') {
     // Resume task
     if (task.runtime_state !== 'idle' && task.runtime_state !== 'error') {
       throw badRequest('Can only resume tasks in closed or error state');
@@ -280,7 +280,7 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
       }
     }
     await resumeTask(task);
-  } else if (body.status === 'closed' || body.runtime_state === 'idle') {
+  } else if (body.runtime_state === 'idle') {
     await closeTask(task);
   } else if (body.workflow_status) {
     // Direct workflow_status flip (simpler version without note/transition tracking)

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -319,7 +319,7 @@ describe('Composer / submit', () => {
   it('conflict dialog opens when another task is on a different branch', async () => {
     apiMock.preflightNoneMode.mockResolvedValueOnce({
       ok: false,
-      conflicts: [{ task_id: 't1', title: 'other', status: 'running', branch: 'main' }],
+      conflicts: [{ task_id: 't1', title: 'other', runtime_state: 'running', branch: 'main' }],
       warnings: [],
       dirty: null,
       currentBranch: 'main',
@@ -336,7 +336,7 @@ describe('Composer / submit', () => {
     apiMock.preflightNoneMode.mockResolvedValueOnce({
       ok: true,
       conflicts: [],
-      warnings: [{ task_id: 't1', title: 'other', status: 'running', branch: 'feature-x' }],
+      warnings: [{ task_id: 't1', title: 'other', runtime_state: 'running', branch: 'feature-x' }],
       dirty: null,
       currentBranch: 'feature-x',
       targetBranch: 'feature-x',

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -357,7 +357,7 @@ export function Composer({ onSubmitted }: Props = {}) {
           targetBranch={preflightBlock.result.targetBranch}
           onClose={() => setPreflightBlock(null)}
           onCloseTask={async (taskId) => {
-            await taskApi.updateTask(taskId, { status: 'closed' });
+            await taskApi.updateTask(taskId, { runtime_state: 'idle' });
             const repoForPreflight = preflightBlock.payload.repo_path!;
             const branchForPreflight = preflightBlock.payload.base_branch!;
             const next = await taskApi.preflightNoneMode(repoForPreflight, branchForPreflight);

--- a/src/components/NoneModeConflictDialog.test.tsx
+++ b/src/components/NoneModeConflictDialog.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { NoneModeConflictDialog } from './NoneModeConflictDialog';
 
 const conflicts = [
-  { task_id: 't1', title: 'first', status: 'running' as const, branch: 'feature-x' },
-  { task_id: 't2', title: 'second', status: 'setting_up' as const, branch: 'feature-x' },
+  { task_id: 't1', title: 'first', runtime_state: 'running' as const, branch: 'feature-x' },
+  { task_id: 't2', title: 'second', runtime_state: 'setting_up' as const, branch: 'feature-x' },
 ];
 
 describe('NoneModeConflictDialog', () => {

--- a/src/components/NoneModeConflictDialog.tsx
+++ b/src/components/NoneModeConflictDialog.tsx
@@ -52,7 +52,7 @@ export function NoneModeConflictDialog({
           {conflicts.map((c) => (
             <li key={c.task_id} className="flex items-center justify-between gap-2">
               <span className="truncate">
-                {c.title} <span className="text-xs text-muted-foreground">({c.status})</span>
+                {c.title} <span className="text-xs text-muted-foreground">({c.runtime_state})</span>
               </span>
               <Button
                 size="sm"

--- a/src/components/NoneModeSharedBranchDialog.tsx
+++ b/src/components/NoneModeSharedBranchDialog.tsx
@@ -46,7 +46,7 @@ export function NoneModeSharedBranchDialog({
         <ul className="mt-4 space-y-1">
           {warnings.map((w) => (
             <li key={w.task_id} className="truncate text-sm">
-              {w.title} <span className="text-xs text-muted-foreground">({w.status})</span>
+              {w.title} <span className="text-xs text-muted-foreground">({w.runtime_state})</span>
             </li>
           ))}
         </ul>

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -23,7 +23,7 @@ describe('StatusBadge', () => {
     },
   );
 
-  it('covers every TaskStatus value', () => {
+  it('covers every RuntimeState value', () => {
     const testedStatuses = statusLabels.map(([s]) => s);
     expect(testedStatuses).toEqual(TASK_STATUSES);
   });

--- a/src/lib/api.test.tsx
+++ b/src/lib/api.test.tsx
@@ -48,11 +48,11 @@ const apiCases = [
   },
   {
     name: 'updateTask',
-    call: () => taskApi.updateTask('t1', { status: 'closed' }),
+    call: () => taskApi.updateTask('t1', { runtime_state: 'idle' }),
     expectedUrl: '/api/tasks/t1',
     expectedMethod: 'PATCH',
-    expectedBody: JSON.stringify({ status: 'closed' }),
-    response: { id: 't1', status: 'closed' },
+    expectedBody: JSON.stringify({ runtime_state: 'idle' }),
+    response: { id: 't1', runtime_state: 'idle' },
   },
   {
     name: 'startTask',

--- a/src/lib/api/taskApi.ts
+++ b/src/lib/api/taskApi.ts
@@ -47,7 +47,7 @@ export interface RecentRepo {
 export interface PreflightConflict {
   task_id: string;
   title: string;
-  status: RuntimeState;
+  runtime_state: RuntimeState;
   branch: string | null;
 }
 

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -193,7 +193,7 @@ export default function TaskDetail() {
     if (!taskId) return;
     setResuming(true);
     try {
-      await taskApi.updateTask(taskId, { status: 'running' });
+      await taskApi.updateTask(taskId, { runtime_state: 'running' });
       refresh();
     } catch (err) {
       console.error('Failed to resume task:', err);


### PR DESCRIPTION
## Summary
- Remove `TaskStatus` and the legacy `PATCH /api/tasks/:id` `{ status: 'closed' | 'running' }` shim; `runtime_state` is now the sole runtime field on `Task`.
- Update API route, CLI (`close-task` / `resume-task`), dashboard, preflight conflict types, and E2E helpers to read/write `runtime_state` (`idle` replaces `closed`, `running` unchanged).
- Wave 4 DB migration (drop `tasks.status`) was already in place on `next`; this completes the code-side collapse.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (3410 passed)
- [x] `bun run build`
- [x] `bun run format:check`


Made with [Cursor](https://cursor.com)