### PR TITLE
refactor(frontend): extract CRUD/list/form primitives for settings pages

### DIFF
--- a/src/components/crud-dialog.test.tsx
+++ b/src/components/crud-dialog.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CreateNameDialog, DeleteConfirmDialog } from './crud-dialog';
+
+describe('CreateNameDialog', () => {
+  it('submits via button and Enter key', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateNameDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Create Agent"
+        placeholder="Agent name"
+        value="my-agent"
+        onChange={vi.fn()}
+        onSubmit={onSubmit}
+        submitting={false}
+        canSubmit
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});
+
+describe('DeleteConfirmDialog', () => {
+  it('renders description and confirm action', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DeleteConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Delete Skill"
+        description="Are you sure?"
+        onConfirm={onConfirm}
+        submitting={false}
+      />,
+    );
+
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/crud-dialog.tsx
+++ b/src/components/crud-dialog.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { GlassButton } from '@/components/ui/glass-button';
+import { GlassInput } from '@/components/ui/glass-input';
+
+export interface CreateNameDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  submitting: boolean;
+  canSubmit: boolean;
+  submitLabel?: string;
+  submittingLabel?: string;
+}
+
+export function CreateNameDialog({
+  open,
+  onOpenChange,
+  title,
+  placeholder,
+  value,
+  onChange,
+  onSubmit,
+  submitting,
+  canSubmit,
+  submitLabel = 'Create',
+  submittingLabel = 'Creating…',
+}: CreateNameDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-sm font-bold">{title}</DialogTitle>
+        </DialogHeader>
+        <GlassInput
+          type="text"
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && onSubmit()}
+          autoFocus
+        />
+        <div className="flex justify-end gap-2">
+          <GlassButton variant="cancel" onClick={() => onOpenChange(false)}>
+            Cancel
+          </GlassButton>
+          <GlassButton onClick={onSubmit} disabled={submitting || !canSubmit}>
+            {submitting ? submittingLabel : submitLabel}
+          </GlassButton>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export interface DeleteConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: ReactNode;
+  onConfirm: () => void;
+  submitting: boolean;
+  confirmLabel?: string;
+  submittingLabel?: string;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  submitting,
+  confirmLabel = 'Delete',
+  submittingLabel = 'Deleting…',
+}: DeleteConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm font-bold">{title}</DialogTitle>
+          <DialogDescription className="text-xs text-[#b5b5bd]">{description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <GlassButton variant="cancel" onClick={() => onOpenChange(false)}>
+            Cancel
+          </GlassButton>
+          <GlassButton variant="destructive" onClick={onConfirm} disabled={submitting}>
+            {submitting ? submittingLabel : confirmLabel}
+          </GlassButton>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function FormDialogActions({
+  onCancel,
+  onSubmit,
+  submitLabel,
+  submittingLabel,
+  canSubmit = true,
+  submitting = false,
+  submitVariant = 'primary',
+  className,
+}: {
+  onCancel: () => void;
+  onSubmit: () => void;
+  submitLabel: string;
+  submittingLabel?: string;
+  canSubmit?: boolean;
+  submitting?: boolean;
+  submitVariant?: 'primary' | 'destructive';
+  className?: string;
+}) {
+  return (
+    <div className={className ?? 'flex justify-end gap-2'}>
+      <GlassButton variant="cancel" size="inline" onClick={onCancel}>
+        Cancel
+      </GlassButton>
+      <GlassButton
+        variant={submitVariant}
+        size="inline"
+        onClick={onSubmit}
+        disabled={!canSubmit || submitting}
+      >
+        {submitting ? (submittingLabel ?? `${submitLabel}…`) : submitLabel}
+      </GlassButton>
+    </div>
+  );
+}

--- a/src/components/data-section.test.tsx
+++ b/src/components/data-section.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DataSection } from './data-section';
+
+describe('DataSection', () => {
+  it('renders skeleton rows while loading', () => {
+    const { container } = render(
+      <DataSection loading error={null} isEmpty={false} skeletonRows={2}>
+        <div>List</div>
+      </DataSection>,
+    );
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(2);
+    expect(screen.queryByText('List')).not.toBeInTheDocument();
+  });
+
+  it('renders error with retry', async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DataSection loading={false} error="boom" onRetry={onRetry} isEmpty={false}>
+        <div>List</div>
+      </DataSection>,
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('renders empty state when not loading and no error', () => {
+    render(
+      <DataSection loading={false} error={null} isEmpty empty={<div>Nothing here</div>}>
+        <div>List</div>
+      </DataSection>,
+    );
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.queryByText('List')).not.toBeInTheDocument();
+  });
+
+  it('renders children when data is present', () => {
+    render(
+      <DataSection loading={false} error={null} isEmpty={false}>
+        <div>List content</div>
+      </DataSection>,
+    );
+    expect(screen.getByText('List content')).toBeInTheDocument();
+  });
+});

--- a/src/components/data-section.tsx
+++ b/src/components/data-section.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { GlassButton } from '@/components/ui/glass-button';
+
+export interface DataSectionProps {
+  loading: boolean;
+  error: string | null;
+  onRetry?: () => void;
+  isEmpty: boolean;
+  empty?: ReactNode;
+  skeletonRows?: number;
+  children: ReactNode;
+}
+
+export function DataSection({
+  loading,
+  error,
+  onRetry,
+  isEmpty,
+  empty,
+  skeletonRows = 3,
+  children,
+}: DataSectionProps) {
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: skeletonRows }, (_, i) => (
+          <div key={i} className="h-12 animate-pulse border border-glass-edge bg-glass-l1" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
+        <span className="text-sm text-red-400">{error}</span>
+        {onRetry && (
+          <GlassButton variant="link" size="inline" onClick={onRetry}>
+            Retry
+          </GlassButton>
+        )}
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return <>{empty}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/ui/form-select.test.tsx
+++ b/src/components/ui/form-select.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FormSelect } from './form-select';
+
+describe('FormSelect', () => {
+  it('renders sm size classes by default', () => {
+    render(
+      <FormSelect data-testid="select">
+        <option value="a">A</option>
+      </FormSelect>,
+    );
+    const select = screen.getByTestId('select');
+    expect(select.className).toContain('px-3');
+    expect(select.className).toContain('py-1');
+    expect(select.className).toContain('text-xs');
+    expect(select.className).toContain('focus-ring');
+  });
+
+  it('renders md size classes', () => {
+    render(
+      <FormSelect data-testid="select" fieldSize="md">
+        <option value="a">A</option>
+      </FormSelect>,
+    );
+    expect(screen.getByTestId('select').className).toContain('py-2');
+    expect(screen.getByTestId('select').className).toContain('text-sm');
+  });
+});

--- a/src/components/ui/form-select.tsx
+++ b/src/components/ui/form-select.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const formSelectVariants = cva(
+  'focus-ring border border-glass-edge bg-[#0B0C0F] text-white outline-none focus:border-[#3B82F6]',
+  {
+    variants: {
+      fieldSize: {
+        sm: 'px-3 py-1 text-xs',
+        md: 'px-3 py-2 text-sm',
+      },
+    },
+    defaultVariants: {
+      fieldSize: 'sm',
+    },
+  },
+);
+
+function FormSelect({
+  className,
+  fieldSize,
+  ...props
+}: Omit<React.ComponentProps<'select'>, 'size'> & VariantProps<typeof formSelectVariants>) {
+  return <select className={cn(formSelectVariants({ fieldSize }), className)} {...props} />;
+}
+
+export { FormSelect, formSelectVariants };

--- a/src/components/ui/glass-button.test.tsx
+++ b/src/components/ui/glass-button.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GlassButton } from './glass-button';
+
+describe('GlassButton', () => {
+  it('renders primary dialog variant by default', () => {
+    render(<GlassButton>Save</GlassButton>);
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn.className).toContain('bg-[#3B82F6]');
+    expect(btn.className).toContain('py-1.5');
+  });
+
+  it('renders cancel and destructive variants', () => {
+    render(
+      <>
+        <GlassButton variant="cancel">Cancel</GlassButton>
+        <GlassButton variant="destructive">Delete</GlassButton>
+      </>,
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' }).className).toContain('text-[#b5b5bd]');
+    expect(screen.getByRole('button', { name: 'Delete' }).className).toContain('bg-red-600');
+  });
+
+  it('calls onClick when enabled', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<GlassButton onClick={onClick}>Go</GlassButton>);
+    await user.click(screen.getByRole('button', { name: 'Go' }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ui/glass-button.tsx
+++ b/src/components/ui/glass-button.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const glassButtonVariants = cva('focus-ring text-xs disabled:opacity-40', {
+  variants: {
+    variant: {
+      primary: 'bg-[#3B82F6] text-white hover:bg-[#2563eb] active:bg-[#1d4ed8]',
+      cancel: 'text-[#b5b5bd] hover:text-white',
+      destructive: 'bg-red-600 text-white hover:bg-red-700 active:bg-red-800',
+      link: 'text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]',
+    },
+    size: {
+      dialog: 'px-3 py-1.5',
+      inline: 'px-3 py-1',
+    },
+  },
+  defaultVariants: {
+    variant: 'primary',
+    size: 'dialog',
+  },
+});
+
+function GlassButton({
+  className,
+  variant,
+  size,
+  type = 'button',
+  ...props
+}: React.ComponentProps<'button'> & VariantProps<typeof glassButtonVariants>) {
+  return (
+    <button
+      type={type}
+      className={cn(glassButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { GlassButton, glassButtonVariants };

--- a/src/components/ui/glass-input.test.tsx
+++ b/src/components/ui/glass-input.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GlassInput } from './glass-input';
+
+describe('GlassInput', () => {
+  it('renders md size classes by default', () => {
+    render(<GlassInput data-testid="input" />);
+    const input = screen.getByTestId('input');
+    expect(input.className).toContain('w-full');
+    expect(input.className).toContain('px-3');
+    expect(input.className).toContain('py-2');
+    expect(input.className).toContain('text-sm');
+    expect(input.className).toContain('bg-[#0B0C0F]');
+    expect(input.className).toContain('border-glass-edge');
+  });
+
+  it('renders sm size classes', () => {
+    render(<GlassInput data-testid="input" fieldSize="sm" />);
+    const input = screen.getByTestId('input');
+    expect(input.className).toContain('px-2');
+    expect(input.className).toContain('py-1');
+    expect(input.className).toContain('text-xs');
+  });
+
+  it('merges caller className', () => {
+    render(<GlassInput data-testid="input" className="flex-1 custom" />);
+    expect(screen.getByTestId('input').className).toContain('flex-1');
+    expect(screen.getByTestId('input').className).toContain('custom');
+  });
+});

--- a/src/components/ui/glass-input.tsx
+++ b/src/components/ui/glass-input.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const glassInputVariants = cva(
+  'border border-glass-edge bg-[#0B0C0F] font-mono text-white outline-none focus:border-[#3B82F6]',
+  {
+    variants: {
+      fieldSize: {
+        md: 'w-full px-3 py-2 text-sm',
+        sm: 'px-2 py-1 text-xs',
+        narrow: 'w-20 px-2 py-1 text-right text-xs',
+      },
+    },
+    defaultVariants: {
+      fieldSize: 'md',
+    },
+  },
+);
+
+function GlassInput({
+  className,
+  fieldSize,
+  ...props
+}: Omit<React.ComponentProps<'input'>, 'size'> & VariantProps<typeof glassInputVariants>) {
+  return <input className={cn(glassInputVariants({ fieldSize }), className)} {...props} />;
+}
+
+export { GlassInput, glassInputVariants };

--- a/src/hooks/useCrudSection.test.tsx
+++ b/src/hooks/useCrudSection.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCrudSection } from './useCrudSection';
+
+describe('useCrudSection', () => {
+  it('opens and closes create dialog', () => {
+    const { result } = renderHook(() => useCrudSection());
+    act(() => result.current.create.openDialog());
+    expect(result.current.create.open).toBe(true);
+    act(() => result.current.create.onOpenChange(false));
+    expect(result.current.create.open).toBe(false);
+  });
+
+  it('submits create and closes on success', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCrudSection({ onCreate }));
+
+    act(() => {
+      result.current.create.openDialog();
+      result.current.create.onChange('agent-one');
+    });
+
+    await act(async () => {
+      await result.current.create.submit();
+    });
+
+    expect(onCreate).toHaveBeenCalledWith('agent-one');
+    expect(result.current.create.open).toBe(false);
+    expect(result.current.create.value).toBe('');
+  });
+
+  it('does not submit create when value is blank', async () => {
+    const onCreate = vi.fn();
+    const { result } = renderHook(() => useCrudSection({ onCreate }));
+
+    act(() => result.current.create.openDialog());
+    await act(async () => {
+      await result.current.create.submit();
+    });
+
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('submits delete and clears target on success', async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCrudSection({ onDelete }));
+
+    act(() => result.current.delete.setTarget('skill-a'));
+    expect(result.current.delete.open).toBe(true);
+
+    await act(async () => {
+      await result.current.delete.submit();
+    });
+
+    expect(onDelete).toHaveBeenCalledWith('skill-a');
+    expect(result.current.delete.open).toBe(false);
+  });
+
+  it('tracks creating and deleting flags', async () => {
+    let resolveCreate!: () => void;
+    const onCreate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useCrudSection({ onCreate }));
+
+    act(() => {
+      result.current.create.onChange('x');
+    });
+
+    act(() => {
+      void result.current.create.submit();
+    });
+    await waitFor(() => expect(result.current.create.creating).toBe(true));
+
+    await act(async () => {
+      resolveCreate();
+    });
+    await waitFor(() => expect(result.current.create.creating).toBe(false));
+  });
+});

--- a/src/hooks/useCrudSection.ts
+++ b/src/hooks/useCrudSection.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from 'react';
+
+export interface UseCrudSectionOptions<TTarget extends string = string> {
+  onCreate?: (value: string) => Promise<void>;
+  onDelete?: (target: TTarget) => Promise<void>;
+  validateCreate?: (value: string) => boolean;
+  initialCreateValue?: string;
+}
+
+export function useCrudSection<TTarget extends string = string>({
+  onCreate,
+  onDelete,
+  validateCreate,
+  initialCreateValue = '',
+}: UseCrudSectionOptions<TTarget> = {}) {
+  const [showCreate, setShowCreate] = useState(false);
+  const [createValue, setCreateValue] = useState(initialCreateValue);
+  const [creating, setCreating] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<TTarget | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const closeCreate = useCallback(() => {
+    setShowCreate(false);
+    setCreateValue(initialCreateValue);
+  }, [initialCreateValue]);
+
+  const openCreate = useCallback(() => {
+    setShowCreate(true);
+  }, []);
+
+  const handleCreateOpenChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        setShowCreate(true);
+        return;
+      }
+      closeCreate();
+    },
+    [closeCreate],
+  );
+
+  const trimmedCreateValue = createValue.trim();
+  const canCreate =
+    Boolean(trimmedCreateValue) && (!validateCreate || validateCreate(trimmedCreateValue));
+
+  const submitCreate = useCallback(async () => {
+    if (!canCreate || creating || !onCreate) return;
+    setCreating(true);
+    try {
+      await onCreate(trimmedCreateValue);
+      closeCreate();
+    } finally {
+      setCreating(false);
+    }
+  }, [canCreate, creating, onCreate, trimmedCreateValue, closeCreate]);
+
+  const handleDeleteOpenChange = useCallback((next: boolean) => {
+    if (!next) setDeleteTarget(null);
+  }, []);
+
+  const submitDelete = useCallback(async () => {
+    if (!deleteTarget || deleting || !onDelete) return;
+    setDeleting(true);
+    try {
+      await onDelete(deleteTarget);
+      setDeleteTarget(null);
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteTarget, deleting, onDelete]);
+
+  return {
+    create: {
+      open: showCreate,
+      onOpenChange: handleCreateOpenChange,
+      value: createValue,
+      onChange: setCreateValue,
+      creating,
+      canSubmit: canCreate,
+      openDialog: openCreate,
+      closeDialog: closeCreate,
+      submit: submitCreate,
+    },
+    delete: {
+      target: deleteTarget,
+      setTarget: setDeleteTarget,
+      open: deleteTarget !== null,
+      onOpenChange: handleDeleteOpenChange,
+      deleting,
+      submit: submitDelete,
+    },
+  };
+}

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -4,6 +4,7 @@ import { SectionCard } from '@/components/layout/section-card';
 import { SettingsLayout } from '@/components/layout/settings-layout';
 import { Switch } from '@/components/ui/switch';
 import { InfoTooltip } from '@/components/ui/tooltip';
+import { FormSelect } from '@/components/ui/form-select';
 import { showToast } from '@/components/CustomToast';
 import { ROW_DIVIDER } from '@/lib/design-tokens';
 import { configApi } from '@/lib/api/configApi';
@@ -12,6 +13,7 @@ import { JiraConfigForm, toJiraConfig } from '@/components/integrations/JiraConf
 import type { JiraConfig } from '@/components/integrations/JiraConfigForm';
 import { LinearConfigForm, toLinearConfig } from '@/components/integrations/LinearConfigForm';
 import type { LinearConfig } from '@/components/integrations/LinearConfigForm';
+import { useCrudSection } from '@/hooks/useCrudSection';
 
 function providerIcon(kind: string): string {
   if (kind === 'jira') return 'J';
@@ -152,7 +154,12 @@ export default function IntegrationsPage() {
     | { kind: 'edit-linear'; integration: IntegrationRow }
     | null
   >(null);
-  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const deleteCrud = useCrudSection({
+    onDelete: async (id) => {
+      await configApi.deleteIntegration(id);
+      void refresh();
+    },
+  });
   const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>(
     {},
   );
@@ -241,10 +248,8 @@ export default function IntegrationsPage() {
     void refresh();
   }
 
-  async function handleDelete(id: string) {
-    await configApi.deleteIntegration(id);
-    setDeleteConfirmId(null);
-    void refresh();
+  async function handleDelete() {
+    await deleteCrud.delete.submit();
   }
 
   async function handleToggle(id: string, enabled: boolean) {
@@ -328,7 +333,7 @@ export default function IntegrationsPage() {
                   if (i.kind === 'jira') setModal({ kind: 'edit-jira', integration: i });
                   else if (i.kind === 'linear') setModal({ kind: 'edit-linear', integration: i });
                 }}
-                onDelete={() => setDeleteConfirmId(i.id)}
+                onDelete={() => deleteCrud.delete.setTarget(i.id)}
                 onToggle={(enabled) => void handleToggle(i.id, enabled)}
                 onTest={() => void handleTest(i.id)}
                 testResult={testResults[i.id] ?? null}
@@ -350,18 +355,18 @@ export default function IntegrationsPage() {
                 Used by the create-task flow when more than one tracker is configured.
               </p>
             </div>
-            <select
+            <FormSelect
               value={tracker}
               disabled={savingTracker}
+              fieldSize="md"
               onChange={(e) => void handleTrackerChange(e.target.value as 'jira' | 'linear' | '')}
-              className="border border-glass-edge bg-[#0B0C0F] px-3 py-2 text-sm text-white outline-none focus:border-[#3B82F6]"
               data-testid="primary-tracker-select"
               aria-label="Primary tracker"
             >
               <option value="">— none —</option>
               <option value="linear">Linear</option>
               <option value="jira">Jira</option>
-            </select>
+            </FormSelect>
           </div>
         </SectionCard>
 
@@ -448,21 +453,26 @@ export default function IntegrationsPage() {
         </Modal>
       )}
 
-      {deleteConfirmId && (
-        <Modal title="Delete integration" onClose={() => setDeleteConfirmId(null)}>
+      {deleteCrud.delete.open && (
+        <Modal title="Delete integration" onClose={() => deleteCrud.delete.onOpenChange(false)}>
           <p className="mb-4 text-sm text-muted-foreground">
             Are you sure you want to delete this integration? This action cannot be undone.
           </p>
           <div className="flex justify-end gap-2">
-            <Button variant="outline" size="sm" onClick={() => setDeleteConfirmId(null)}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => deleteCrud.delete.onOpenChange(false)}
+            >
               Cancel
             </Button>
             <Button
               variant="destructive"
               size="sm"
-              onClick={() => void handleDelete(deleteConfirmId)}
+              disabled={deleteCrud.delete.deleting}
+              onClick={() => void handleDelete()}
             >
-              Delete
+              {deleteCrud.delete.deleting ? 'Deleting…' : 'Delete'}
             </Button>
           </div>
         </Modal>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -17,40 +17,32 @@ import { AddChip } from '@/components/layout/add-chip';
 import { SectionCard } from '@/components/layout/section-card';
 import { SettingRow } from '@/components/layout/setting-row';
 import { SettingsLayout, type SettingsScrollSection } from '@/components/layout/settings-layout';
+import { DataSection } from '@/components/data-section';
+import { CreateNameDialog, DeleteConfirmDialog, FormDialogActions } from '@/components/crud-dialog';
 import { GlassPanel } from '@/components/ui/glass-panel';
+import { GlassButton } from '@/components/ui/glass-button';
+import { GlassInput } from '@/components/ui/glass-input';
+import { FormSelect } from '@/components/ui/form-select';
 import { Switch } from '@/components/ui/switch';
 import { ROW_DIVIDER } from '@/lib/design-tokens';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
+import { useCrudSection } from '@/hooks/useCrudSection';
 
 function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => void }) {
   const { agents, loading, error, refresh } = useAgents();
   const navigate = useNavigate();
-  const [showCreate, setShowCreate] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [creating, setCreating] = useState(false);
-
-  const handleCreate = useCallback(async () => {
-    if (!newName.trim()) return;
-    setCreating(true);
-    try {
-      const content = `---\nname: ${newName.trim()}\ndescription: \n---\n`;
-      await configApi.createAgent({ name: newName.trim(), content });
-      showToast('success', 'AGENT CREATED', `Agent "${newName.trim()}" created`);
-      setShowCreate(false);
-      setNewName('');
-      navigate(`/agents/${encodeURIComponent(newName.trim())}`);
-    } catch (err) {
-      showToast('error', 'ERROR', (err as Error).message);
-    } finally {
-      setCreating(false);
-    }
-  }, [newName, navigate]);
+  const crud = useCrudSection({
+    onCreate: async (name) => {
+      try {
+        const content = `---\nname: ${name}\ndescription: \n---\n`;
+        await configApi.createAgent({ name, content });
+        showToast('success', 'AGENT CREATED', `Agent "${name}" created`);
+        navigate(`/agents/${encodeURIComponent(name)}`);
+      } catch (err) {
+        showToast('error', 'ERROR', (err as Error).message);
+        throw err;
+      }
+    },
+  });
 
   return (
     <SectionCard
@@ -58,33 +50,15 @@ function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
       title="Agents"
       count={!loading && !error ? agents.length : undefined}
       scrollRef={scrollRef}
-      trailing={<AddChip label="+ New agent" onClick={() => setShowCreate(true)} />}
+      trailing={<AddChip label="+ New agent" onClick={crud.create.openDialog} />}
     >
-      {loading && (
-        <div className="space-y-2">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-12 animate-pulse bg-glass-l1 border border-glass-edge" />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
-          <span className="text-sm text-red-400">{error}</span>
-          <button
-            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
-            onClick={refresh}
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && agents.length === 0 && (
-        <div className="py-8 text-center text-sm text-[#8a8a8a]">No agents found.</div>
-      )}
-
-      {!loading && !error && agents.length > 0 && (
+      <DataSection
+        loading={loading}
+        error={error}
+        onRetry={refresh}
+        isEmpty={agents.length === 0}
+        empty={<div className="py-8 text-center text-sm text-[#8a8a8a]">No agents found.</div>}
+      >
         <div>
           {agents.map((agent, i) => (
             <div
@@ -103,39 +77,20 @@ function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
             </div>
           ))}
         </div>
-      )}
+      </DataSection>
 
-      <Dialog open={showCreate} onOpenChange={setShowCreate}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="text-sm font-bold">Create Agent</DialogTitle>
-          </DialogHeader>
-          <input
-            type="text"
-            placeholder="Agent name"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-            className="w-full border border-glass-edge bg-[#0B0C0F] px-3 py-2 font-mono text-sm text-white outline-none focus:border-[#3B82F6]"
-            autoFocus
-          />
-          <div className="flex justify-end gap-2">
-            <button
-              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
-              onClick={() => setShowCreate(false)}
-            >
-              Cancel
-            </button>
-            <button
-              className="focus-ring bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
-              onClick={handleCreate}
-              disabled={creating || !newName.trim()}
-            >
-              {creating ? 'Creating...' : 'Create'}
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <CreateNameDialog
+        open={crud.create.open}
+        onOpenChange={crud.create.onOpenChange}
+        title="Create Agent"
+        placeholder="Agent name"
+        value={crud.create.value}
+        onChange={crud.create.onChange}
+        onSubmit={crud.create.submit}
+        submitting={crud.create.creating}
+        canSubmit={crud.create.canSubmit}
+        submittingLabel="Creating..."
+      />
     </SectionCard>
   );
 }
@@ -143,43 +98,29 @@ function AgentsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
 function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => void }) {
   const { skills, loading, error, refresh } = useSkills();
   const navigate = useNavigate();
-  const [showCreate, setShowCreate] = useState(false);
-  const [newName, setNewName] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
-
-  const handleCreate = useCallback(async () => {
-    if (!newName.trim()) return;
-    setCreating(true);
-    try {
-      const content = `---\nname: ${newName.trim()}\ndescription: \n---\n`;
-      await configApi.createSkill({ name: newName.trim(), content });
-      showToast('success', 'SKILL CREATED', `Skill "${newName.trim()}" created`);
-      setShowCreate(false);
-      setNewName('');
-      navigate(`/skills/${encodeURIComponent(newName.trim())}`);
-    } catch (err) {
-      showToast('error', 'ERROR', (err as Error).message);
-    } finally {
-      setCreating(false);
-    }
-  }, [newName, navigate]);
-
-  const handleDelete = useCallback(async () => {
-    if (!deleteTarget) return;
-    setDeleting(true);
-    try {
-      await configApi.deleteSkill(deleteTarget);
-      showToast('success', 'SKILL DELETED', `Skill "${deleteTarget}" deleted`);
-      setDeleteTarget(null);
-      refresh();
-    } catch (err) {
-      showToast('error', 'ERROR', (err as Error).message);
-    } finally {
-      setDeleting(false);
-    }
-  }, [deleteTarget, refresh]);
+  const crud = useCrudSection({
+    onCreate: async (name) => {
+      try {
+        const content = `---\nname: ${name}\ndescription: \n---\n`;
+        await configApi.createSkill({ name, content });
+        showToast('success', 'SKILL CREATED', `Skill "${name}" created`);
+        navigate(`/skills/${encodeURIComponent(name)}`);
+      } catch (err) {
+        showToast('error', 'ERROR', (err as Error).message);
+        throw err;
+      }
+    },
+    onDelete: async (target) => {
+      try {
+        await configApi.deleteSkill(target);
+        showToast('success', 'SKILL DELETED', `Skill "${target}" deleted`);
+        refresh();
+      } catch (err) {
+        showToast('error', 'ERROR', (err as Error).message);
+        throw err;
+      }
+    },
+  });
 
   return (
     <SectionCard
@@ -187,41 +128,22 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
       title="Skills"
       count={!loading && !error ? skills.length : undefined}
       scrollRef={scrollRef}
-      trailing={<AddChip label="+ New skill" onClick={() => setShowCreate(true)} />}
+      trailing={<AddChip label="+ New skill" onClick={crud.create.openDialog} />}
     >
-      {loading && (
-        <div className="space-y-2">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-12 animate-pulse bg-glass-l1 border border-glass-edge" />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
-          <span className="text-sm text-red-400">{error}</span>
-          <button
-            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
-            onClick={refresh}
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && skills.length === 0 && (
-        <div className="py-8 text-center text-sm text-[#8a8a8a]">
-          No skills installed.{' '}
-          <button
-            className="focus-ring text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
-            onClick={() => setShowCreate(true)}
-          >
-            Create your first skill
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && skills.length > 0 && (
+      <DataSection
+        loading={loading}
+        error={error}
+        onRetry={refresh}
+        isEmpty={skills.length === 0}
+        empty={
+          <div className="py-8 text-center text-sm text-[#8a8a8a]">
+            No skills installed.{' '}
+            <GlassButton variant="link" size="inline" onClick={crud.create.openDialog}>
+              Create your first skill
+            </GlassButton>
+          </div>
+        }
+      >
         <div>
           {skills.map((skill, i) => (
             <div
@@ -238,7 +160,7 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
                 className="focus-ring text-xs text-[#8a8a8a] opacity-0 transition-opacity group-hover:opacity-100 hover:text-red-400 focus-visible:opacity-100"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setDeleteTarget(skill.name);
+                  crud.delete.setTarget(skill.name);
                 }}
               >
                 Delete
@@ -246,71 +168,34 @@ function SkillsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
             </div>
           ))}
         </div>
-      )}
+      </DataSection>
 
-      <Dialog open={showCreate} onOpenChange={setShowCreate}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="text-sm font-bold">Create Skill</DialogTitle>
-          </DialogHeader>
-          <input
-            type="text"
-            placeholder="Skill name"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-            className="w-full border border-glass-edge bg-[#0B0C0F] px-3 py-2 font-mono text-sm text-white outline-none focus:border-[#3B82F6]"
-            autoFocus
-          />
-          <div className="flex justify-end gap-2">
-            <button
-              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
-              onClick={() => setShowCreate(false)}
-            >
-              Cancel
-            </button>
-            <button
-              className="focus-ring bg-[#3B82F6] px-3 py-1.5 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
-              onClick={handleCreate}
-              disabled={creating || !newName.trim()}
-            >
-              {creating ? 'Creating…' : 'Create'}
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <CreateNameDialog
+        open={crud.create.open}
+        onOpenChange={crud.create.onOpenChange}
+        title="Create Skill"
+        placeholder="Skill name"
+        value={crud.create.value}
+        onChange={crud.create.onChange}
+        onSubmit={crud.create.submit}
+        submitting={crud.create.creating}
+        canSubmit={crud.create.canSubmit}
+      />
 
-      <Dialog
-        open={deleteTarget !== null}
-        onOpenChange={(next) => {
-          if (!next) setDeleteTarget(null);
-        }}
-      >
-        <DialogContent className="sm:max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="text-sm font-bold">Delete Skill</DialogTitle>
-            <DialogDescription className="text-xs text-[#b5b5bd]">
-              Are you sure you want to delete{' '}
-              <span className="font-mono text-white">{deleteTarget}</span>? This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <button
-              className="focus-ring px-3 py-1.5 text-xs text-[#b5b5bd] hover:text-white"
-              onClick={() => setDeleteTarget(null)}
-            >
-              Cancel
-            </button>
-            <button
-              className="focus-ring bg-red-600 px-3 py-1.5 text-xs text-white hover:bg-red-700 active:bg-red-800 disabled:opacity-40"
-              onClick={handleDelete}
-              disabled={deleting}
-            >
-              {deleting ? 'Deleting…' : 'Delete'}
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <DeleteConfirmDialog
+        open={crud.delete.open}
+        onOpenChange={crud.delete.onOpenChange}
+        title="Delete Skill"
+        description={
+          <>
+            Are you sure you want to delete{' '}
+            <span className="font-mono text-white">{crud.delete.target}</span>? This cannot be
+            undone.
+          </>
+        }
+        onConfirm={crud.delete.submit}
+        submitting={crud.delete.deleting}
+      />
     </SectionCard>
   );
 }
@@ -428,53 +313,40 @@ function RepoConfigsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
         />
       }
     >
-      {loading && (
-        <div className="space-y-2">
-          {[1, 2].map((i) => (
-            <div key={i} className="h-12 animate-pulse bg-glass-l1 border border-glass-edge" />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
-          <span className="text-sm text-red-400">{error}</span>
-          <button
-            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
-            onClick={refresh}
+      <DataSection
+        loading={loading}
+        error={error}
+        onRetry={refresh}
+        isEmpty={configs.length === 0}
+        skeletonRows={2}
+        empty={
+          <div
+            data-testid="repos-empty"
+            className="flex flex-col items-center gap-2 py-10 text-center"
           >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && configs.length === 0 && (
-        <div
-          data-testid="repos-empty"
-          className="flex flex-col items-center gap-2 py-10 text-center"
-        >
-          <button
-            type="button"
-            data-testid="repos-add-first"
-            onClick={() => {
-              navigate('/');
-              requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('focus-composer')));
-            }}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[#3B82F666] bg-[#3B82F61F] px-3 py-2 text-[12px] font-semibold text-[#60a5fa] hover:bg-[#3B82F633]"
-          >
-            + Add your first repo
-          </button>
-          <p className="text-[11px] text-[#8a8a8a]">
-            Repositories appear here automatically when you create tasks.
-          </p>
-        </div>
-      )}
-
-      {!loading &&
-        !error &&
-        configs.map((config) => (
+            <button
+              type="button"
+              data-testid="repos-add-first"
+              onClick={() => {
+                navigate('/');
+                requestAnimationFrame(() =>
+                  window.dispatchEvent(new CustomEvent('focus-composer')),
+                );
+              }}
+              className="inline-flex items-center gap-1.5 rounded-md border border-[#3B82F666] bg-[#3B82F61F] px-3 py-2 text-[12px] font-semibold text-[#60a5fa] hover:bg-[#3B82F633]"
+            >
+              + Add your first repo
+            </button>
+            <p className="text-[11px] text-[#8a8a8a]">
+              Repositories appear here automatically when you create tasks.
+            </p>
+          </div>
+        }
+      >
+        {configs.map((config) => (
           <RepoRow key={config.repo_path} config={config} onEditClick={() => startEdit(config)} />
         ))}
+      </DataSection>
 
       {editing && (
         <div className="mt-3 space-y-2 border border-glass-edge bg-glass-l1 p-3">
@@ -485,30 +357,24 @@ function RepoConfigsSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
             (field) => (
               <div key={field} className="flex items-center gap-2">
                 <label className="w-32 text-xs text-[#b5b5bd]">{field.replace(/_/g, ' ')}</label>
-                <input
+                <GlassInput
                   type="text"
+                  fieldSize="sm"
+                  className="flex-1"
                   value={editForm[field] ?? ''}
                   onChange={(e) => setEditForm((prev) => ({ ...prev, [field]: e.target.value }))}
-                  className="flex-1 border border-glass-edge bg-[#0B0C0F] px-2 py-1 font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
                 />
               </div>
             ),
           )}
-          <div className="flex justify-end gap-2 pt-1">
-            <button
-              onClick={() => setEditingPath(null)}
-              className="focus-ring px-3 py-1 text-xs text-[#b5b5bd] hover:text-white"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
-            >
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
+          <FormDialogActions
+            className="flex justify-end gap-2 pt-1"
+            onCancel={() => setEditingPath(null)}
+            onSubmit={handleSave}
+            submitLabel="Save"
+            submittingLabel="Saving..."
+            submitting={saving}
+          />
         </div>
       )}
     </SectionCard>
@@ -558,15 +424,11 @@ function EditorSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => v
         description="Editor to open when clicking the Editor button on tasks"
         lastRow
       >
-        <select
-          value={editor}
-          onChange={(e) => handleChange(e.target.value)}
-          className="focus-ring bg-[#0B0C0F] border border-glass-edge px-3 py-1 text-xs text-white outline-none focus:border-[#3B82F6]"
-        >
+        <FormSelect value={editor} onChange={(e) => handleChange(e.target.value)}>
           <option value="nvim">Neovim</option>
           <option value="vscode">VS Code</option>
           <option value="cursor">Cursor</option>
-        </select>
+        </FormSelect>
       </SettingRow>
     </SectionCard>
   );
@@ -671,21 +533,18 @@ function ClaudeLaunchFlagsSection({ scrollRef }: { scrollRef: (el: HTMLElement |
           </div>
           <div className="flex items-center gap-2">
             {isDirty && <span className="text-xs text-[#FFB800]">unsaved</span>}
-            <button
-              onClick={saveFlags}
-              disabled={!isDirty || saving}
-              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
-            >
+            <GlassButton size="inline" onClick={saveFlags} disabled={!isDirty || saving}>
               {saving ? 'Saving...' : 'Save'}
-            </button>
+            </GlassButton>
           </div>
         </div>
-        <input
+        <GlassInput
           type="text"
+          fieldSize="md"
+          className="text-xs"
           value={flagsBuffer}
           onChange={(e) => setFlagsBuffer(e.target.value)}
           placeholder="--model opus --verbose"
-          className="w-full border border-glass-edge bg-[#0B0C0F] px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
           spellCheck={false}
         />
       </div>
@@ -858,18 +717,17 @@ function CodingAgentSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
         label="Default coding agent"
         description="New tasks and chats use this coding agent unless overridden in the composer"
       >
-        <select
+        <FormSelect
           data-testid="default-harness-select"
           value={defaultHarnessId}
           onChange={(e) => handleDefaultChange(e.target.value)}
-          className="focus-ring bg-[#0B0C0F] border border-glass-edge px-3 py-1 text-xs text-white outline-none focus:border-[#3B82F6]"
         >
           {harnesses.map((h) => (
             <option key={h.id} value={h.id}>
               {h.displayName}
             </option>
           ))}
-        </select>
+        </FormSelect>
       </SettingRow>
 
       <div className="mt-4 mb-2 text-[10px] font-bold uppercase tracking-wider text-[#8a8a8a]">
@@ -887,26 +745,27 @@ function CodingAgentSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
           </div>
           <div className="flex items-center gap-2">
             {cursorModelDirty && <span className="text-xs text-[#FFB800]">unsaved</span>}
-            <button
+            <GlassButton
               type="button"
+              size="inline"
               onClick={handleCursorModelSave}
               disabled={!cursorModelDirty || savingModel}
-              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
             >
               {savingModel ? 'Saving...' : 'Save'}
-            </button>
+            </GlassButton>
           </div>
         </div>
-        <input
+        <GlassInput
           type="text"
           data-testid="cursor-model-input"
+          fieldSize="md"
+          className="text-xs"
           value={cursorModelBuffer}
           onChange={(e) => setCursorModelBuffer(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') void handleCursorModelSave();
           }}
           placeholder={CURSOR_DEFAULT_MODEL}
-          className="w-full border border-glass-edge bg-[#0B0C0F] px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
           spellCheck={false}
         />
       </div>
@@ -943,22 +802,23 @@ function CodingAgentSection({ scrollRef }: { scrollRef: (el: HTMLElement | null)
           </div>
           <div className="flex items-center gap-2">
             {cursorFlagsDirty && <span className="text-xs text-[#FFB800]">unsaved</span>}
-            <button
+            <GlassButton
+              size="inline"
               onClick={saveCursorFlags}
               disabled={!cursorFlagsDirty || savingFlags}
-              className="focus-ring bg-[#3B82F6] px-3 py-1 text-xs text-white hover:bg-[#2563eb] active:bg-[#1d4ed8] disabled:opacity-40"
             >
               {savingFlags ? 'Saving...' : 'Save'}
-            </button>
+            </GlassButton>
           </div>
         </div>
-        <input
+        <GlassInput
           type="text"
           data-testid="cursor-flags-input"
+          fieldSize="md"
+          className="text-xs"
           value={cursorFlagsBuffer}
           onChange={(e) => setCursorFlagsBuffer(e.target.value)}
           placeholder="--print"
-          className="w-full border border-glass-edge bg-[#0B0C0F] px-3 py-2 font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
           spellCheck={false}
         />
       </div>
@@ -1059,33 +919,11 @@ function HooksSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) => vo
       count={!loading && !error ? hooks.length : undefined}
       scrollRef={scrollRef}
     >
-      {loading && (
-        <div className="space-y-2">
-          {[1, 2].map((i) => (
-            <div key={i} className="h-12 animate-pulse bg-glass-l1 border border-glass-edge" />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="flex items-center gap-3 border border-red-400/30 bg-red-400/5 px-4 py-3">
-          <span className="text-sm text-red-400">{error}</span>
-          <button
-            className="focus-ring text-xs text-[#3B82F6] hover:text-[#60a5fa] active:text-[#93c5fd]"
-            onClick={load}
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && (
-        <>
-          <HookGroup title="Built-in" entries={builtins} emptyMsg="No built-in hooks." />
-          <HookGroup title="Global" entries={globals} emptyMsg="No global hooks installed." />
-          <HookGroup title="Repo" entries={repos} emptyMsg="No repo hooks from active tasks." />
-        </>
-      )}
+      <DataSection loading={loading} error={error} onRetry={load} isEmpty={false} skeletonRows={2}>
+        <HookGroup title="Built-in" entries={builtins} emptyMsg="No built-in hooks." />
+        <HookGroup title="Global" entries={globals} emptyMsg="No global hooks installed." />
+        <HookGroup title="Repo" entries={repos} emptyMsg="No repo hooks from active tasks." />
+      </DataSection>
     </SectionCard>
   );
 }
@@ -1145,8 +983,10 @@ function AdvancedSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) =>
         lastRow
       >
         <div className="flex items-center gap-2">
-          <input
+          <GlassInput
             type="number"
+            fieldSize="narrow"
+            className="focus-ring"
             min={TERMINAL_CACHE_MIN}
             max={TERMINAL_CACHE_MAX}
             value={buffer}
@@ -1158,7 +998,6 @@ function AdvancedSection({ scrollRef }: { scrollRef: (el: HTMLElement | null) =>
               }
             }}
             data-testid="terminal-cache-size-input"
-            className="focus-ring w-20 border border-glass-edge bg-[#0B0C0F] px-2 py-1 text-right font-mono text-xs text-white outline-none focus:border-[#3B82F6]"
           />
         </div>
       </SettingRow>


### PR DESCRIPTION
## Summary
- Add shared frontend primitives: `useCrudSection`, `DataSection`, `GlassInput` / `GlassButton` / `FormSelect`, plus `CreateNameDialog` / `DeleteConfirmDialog`.
- Refactor `SettingsPage` and `IntegrationsPage` onto the primitives, removing duplicated loading/error/empty/list blocks, CRUD dialog flows, and verbatim glass form class strings (~150 LOC net removed from SettingsPage alone).
- Preserve existing glass styling and behavior; add unit tests for all new primitives.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (3429 passed)
- [x] `bun run build`
- [x] `bun run format:check`
- [x] Existing `SettingsPage` / `IntegrationsPage` tests pass


Made with [Cursor](https://cursor.com)