### PR TITLE
refactor(frontend): migrate remaining pages onto useResource hooks

### DIFF
--- a/src/lib/hooks.test.tsx
+++ b/src/lib/hooks.test.tsx
@@ -1,15 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { useTasks, useTask } from './hooks';
+import {
+  useTasks,
+  useTask,
+  useGraceHours,
+  useProviders,
+  useIntegrations,
+  useHookTemplates,
+  useSettings,
+  useReviewDetail,
+} from './hooks';
 
 // ─── Mock API ────────────────────────────────────────────────────────────────
 
-const { taskApiProxy, configApiProxy, apiMock } = await vi.hoisted(async () =>
+const { taskApiProxy, configApiProxy, reviewApiProxy, apiMock } = await vi.hoisted(async () =>
   (await import('../test-helpers')).setupApiMock(),
 );
 
 vi.mock('./api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('./api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('./api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 
 // ─── Mock event-source ──────────────────────────────────────────────────────
 
@@ -172,5 +182,100 @@ describe('useTask', () => {
     await waitFor(() => {
       expect(apiMock.getTask).toHaveBeenCalledWith('my-task');
     });
+  });
+});
+
+// ─── useResource-based config/review hooks ───────────────────────────────────
+
+const resourceHookCases = [
+  {
+    name: 'useGraceHours',
+    renderFn: () => renderHook(() => useGraceHours()),
+    mockFn: () => apiMock.getSettings,
+    successValue: { deleteGraceHours: 12 },
+    resultKey: 'graceHours' as const,
+    expectedValue: 12,
+    fallbackValue: 6,
+  },
+  {
+    name: 'useProviders',
+    renderFn: () => renderHook(() => useProviders()),
+    mockFn: () => apiMock.listProviders,
+    successValue: [{ kind: 'jira', displayName: 'Jira', configSchema: {}, events: [] }],
+    resultKey: 'providers' as const,
+    expectedValue: [{ kind: 'jira', displayName: 'Jira', configSchema: {}, events: [] }],
+    fallbackValue: [],
+  },
+  {
+    name: 'useIntegrations',
+    renderFn: () => renderHook(() => useIntegrations()),
+    mockFn: () => apiMock.listIntegrations,
+    successValue: [{ id: 'i1', kind: 'jira', name: 'Jira', config: {}, enabled: true }],
+    resultKey: 'integrations' as const,
+    expectedValue: [{ id: 'i1', kind: 'jira', name: 'Jira', config: {}, enabled: true }],
+    fallbackValue: [],
+  },
+  {
+    name: 'useHookTemplates',
+    renderFn: () => renderHook(() => useHookTemplates()),
+    mockFn: () => apiMock.listHookTemplates,
+    successValue: [{ id: 'jira-status', installed: false }],
+    resultKey: 'hookTemplates' as const,
+    expectedValue: [{ id: 'jira-status', installed: false }],
+    fallbackValue: [],
+  },
+  {
+    name: 'useSettings',
+    renderFn: () => renderHook(() => useSettings()),
+    mockFn: () => apiMock.getSettings,
+    successValue: { defaultTracker: 'linear' },
+    resultKey: 'settings' as const,
+    expectedValue: { defaultTracker: 'linear' },
+    fallbackValue: null,
+  },
+];
+
+describe.each(resourceHookCases)(
+  '$name',
+  ({ renderFn, mockFn, successValue, resultKey, expectedValue, fallbackValue }) => {
+    it('returns data after fetch', async () => {
+      mockFn().mockResolvedValue(successValue);
+
+      const { result } = renderFn();
+
+      await waitFor(() => {
+        expect((result.current as any)[resultKey]).toEqual(expectedValue);
+      });
+    });
+
+    it('falls back safely on fetch failure when applicable', async () => {
+      mockFn().mockRejectedValue(new Error('fail'));
+
+      const { result } = renderFn();
+
+      await waitFor(() => {
+        expect((result.current as any)[resultKey]).toEqual(fallbackValue);
+      });
+    });
+  },
+);
+
+describe('useReviewDetail', () => {
+  it('fetches review detail for the given id', async () => {
+    const detail = { task: { id: 't1', title: 'Review me' }, comments: [], all_runs: [] };
+    apiMock.getReviewDetail.mockResolvedValue(detail);
+
+    const { result } = renderHook(() => useReviewDetail('t1'));
+
+    await waitFor(() => {
+      expect(result.current.detail).toEqual(detail);
+    });
+    expect(apiMock.getReviewDetail).toHaveBeenCalledWith('t1');
+  });
+
+  it('does not fetch when id is undefined', async () => {
+    renderHook(() => useReviewDetail(undefined));
+    await Promise.resolve();
+    expect(apiMock.getReviewDetail).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,10 +1,22 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Task } from '@octomux/types';
-import type { Skill, RepoConfig, AgentDefinition, HarnessSummary } from './api/configApi';
+import type {
+  Skill,
+  RepoConfig,
+  AgentDefinition,
+  HarnessSummary,
+  IntegrationProvider,
+  IntegrationRow,
+  HookTemplate,
+  OctomuxSettings,
+} from './api/configApi';
 import { taskApi } from './api/taskApi';
 import { configApi } from './api/configApi';
+import { reviewApi, type ReviewDetail } from './api/reviewApi';
 import { subscribe } from './event-source';
 import { useResource } from './use-resource';
+
+const DEFAULT_GRACE_HOURS = 6;
 
 export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -99,4 +111,71 @@ export function useHarnesses() {
     configApi.listHarnesses(),
   );
   return { harnesses: data ?? [], loading, error, refresh };
+}
+
+export function useGraceHours() {
+  const { data } = useResource('settings:grace-hours', async () => {
+    try {
+      const settings = await configApi.getSettings();
+      return settings.deleteGraceHours ?? DEFAULT_GRACE_HOURS;
+    } catch {
+      return DEFAULT_GRACE_HOURS;
+    }
+  });
+  return { graceHours: data ?? DEFAULT_GRACE_HOURS };
+}
+
+export function useProviders() {
+  const { data, loading, error, refresh } = useResource<IntegrationProvider[]>('providers', () =>
+    configApi.listProviders(),
+  );
+  return { providers: data ?? [], loading, error, refresh };
+}
+
+export function useIntegrations() {
+  const { data, loading, error, refresh } = useResource<IntegrationRow[]>('integrations', () =>
+    configApi.listIntegrations(),
+  );
+  return { integrations: data ?? [], loading, error, refresh };
+}
+
+export function useHookTemplates() {
+  const { data, loading, error, refresh } = useResource<HookTemplate[]>(
+    'hook-templates',
+    async () => {
+      try {
+        return await configApi.listHookTemplates();
+      } catch {
+        return [];
+      }
+    },
+  );
+  return { hookTemplates: data ?? [], loading, error, refresh };
+}
+
+export function useSettings() {
+  const { data, loading, error, refresh } = useResource<OctomuxSettings | null>(
+    'settings',
+    async () => {
+      try {
+        return await configApi.getSettings();
+      } catch {
+        return null;
+      }
+    },
+  );
+  return { settings: data, loading, error, refresh };
+}
+
+export function useReviewDetail(id: string | undefined) {
+  const { data, loading, error, refresh } = useResource<ReviewDetail>(
+    id ? `review:${id}` : null,
+    () => reviewApi.getReviewDetail(id!),
+    {
+      events: (e) =>
+        e.payload.taskId === id &&
+        (e.type === 'review:drafts-ready' || e.type === 'review:published'),
+    },
+  );
+  return { detail: data, loading, error, refresh };
 }

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -8,7 +8,8 @@ import { FormSelect } from '@/components/ui/form-select';
 import { showToast } from '@/components/CustomToast';
 import { ROW_DIVIDER } from '@/lib/design-tokens';
 import { configApi } from '@/lib/api/configApi';
-import type { IntegrationProvider, IntegrationRow, HookTemplate } from '@/lib/api/configApi';
+import type { IntegrationRow } from '@/lib/api/configApi';
+import { useProviders, useIntegrations, useHookTemplates, useSettings } from '@/lib/hooks';
 import { JiraConfigForm, toJiraConfig } from '@/components/integrations/JiraConfigForm';
 import type { JiraConfig } from '@/components/integrations/JiraConfigForm';
 import { LinearConfigForm, toLinearConfig } from '@/components/integrations/LinearConfigForm';
@@ -144,9 +145,20 @@ function Modal({
 }
 
 export default function IntegrationsPage() {
-  const [providers, setProviders] = useState<IntegrationProvider[]>([]);
-  const [integrations, setIntegrations] = useState<IntegrationRow[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { providers, loading: providersLoading, refresh: refreshProviders } = useProviders();
+  const {
+    integrations,
+    loading: integrationsLoading,
+    refresh: refreshIntegrations,
+  } = useIntegrations();
+  const {
+    hookTemplates,
+    loading: hookTemplatesLoading,
+    refresh: refreshHookTemplates,
+  } = useHookTemplates();
+  const { settings, loading: settingsLoading, refresh: refreshSettings } = useSettings();
+  const loading =
+    providersLoading || integrationsLoading || hookTemplatesLoading || settingsLoading;
   const [modal, setModal] = useState<
     | { kind: 'create-jira' }
     | { kind: 'edit-jira'; integration: IntegrationRow }
@@ -164,29 +176,21 @@ export default function IntegrationsPage() {
     {},
   );
   const [testing, setTesting] = useState<Record<string, boolean>>({});
-  const [hookTemplates, setHookTemplates] = useState<HookTemplate[]>([]);
   const [installingHook, setInstallingHook] = useState<string | null>(null);
-  const [tracker, setTracker] = useState<'jira' | 'linear' | ''>('');
+  const [trackerOverride, setTrackerOverride] = useState<'jira' | 'linear' | '' | null>(null);
   const [savingTracker, setSavingTracker] = useState(false);
+  const tracker = trackerOverride ?? settings?.defaultTracker ?? '';
 
-  const refresh = useCallback(async () => {
-    try {
-      const [p, i, hooks, settings] = await Promise.all([
-        configApi.listProviders(),
-        configApi.listIntegrations(),
-        configApi.listHookTemplates().catch(() => [] as HookTemplate[]),
-        configApi.getSettings().catch(() => null),
-      ]);
-      setProviders(p);
-      setIntegrations(i);
-      setHookTemplates(hooks);
-      if (settings) setTracker(settings.defaultTracker ?? '');
-    } catch {
-      // silently ignore
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const refresh = useCallback(() => {
+    void refreshProviders();
+    void refreshIntegrations();
+    void refreshHookTemplates();
+    void refreshSettings();
+  }, [refreshProviders, refreshIntegrations, refreshHookTemplates, refreshSettings]);
+
+  useEffect(() => {
+    setTrackerOverride(null);
+  }, [settings]);
 
   async function handleInstallHook(id: string) {
     setInstallingHook(id);
@@ -202,7 +206,7 @@ export default function IntegrationsPage() {
   }
 
   async function handleTrackerChange(next: 'jira' | 'linear' | '') {
-    setTracker(next);
+    setTrackerOverride(next);
     setSavingTracker(true);
     try {
       await configApi.updateSettings({ defaultTracker: next || undefined });
@@ -213,10 +217,6 @@ export default function IntegrationsPage() {
       setSavingTracker(false);
     }
   }
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
 
   async function handleCreateJira(config: JiraConfig, name: string) {
     await configApi.createIntegration('jira', name, config as unknown as Record<string, unknown>);

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { taskApi, type DiffSummaryResponse } from '../lib/api/taskApi';
-import { reviewApi, type ReviewDetail } from '../lib/api/reviewApi';
-import { useResource } from '../lib/use-resource';
+import { useReviewDetail } from '../lib/hooks';
 import { WalkthroughPanel } from '../components/review/WalkthroughPanel';
 import type { Walkthrough } from '../components/review/walkthrough-types';
 import { buildGroups, orderedPathsFromGroups } from '@/lib/review-file-groups';
@@ -32,15 +31,7 @@ function defaultCommentsPanelOpen(): boolean {
 export default function ReviewDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const {
-    data: detail,
-    error,
-    refresh,
-  } = useResource<ReviewDetail>(id ? `review:${id}` : null, () => reviewApi.getReviewDetail(id!), {
-    events: (e) =>
-      e.payload.taskId === id &&
-      (e.type === 'review:drafts-ready' || e.type === 'review:published'),
-  });
+  const { detail, error, refresh } = useReviewDetail(id);
   const [filesInDiff, setFilesInDiff] = useState<string[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [showCommentsPanel, setShowCommentsPanel] = useState(defaultCommentsPanelOpen);

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useState, useMemo, useEffect } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTasksContext } from '@/lib/tasks-context';
+import { useGraceHours } from '@/lib/hooks';
 import { TaskBoard } from '@/components/TaskBoard';
 import { EmptyState } from '@/components/EmptyState';
 import { PageHeader } from '@/components/layout/page-header';
@@ -14,7 +15,6 @@ import { repoName } from '@/lib/utils';
 import { ChevronDownIcon } from '@/components/icons';
 import { cn } from '@/lib/utils';
 import type { Task } from '@octomux/types';
-import { configApi } from '@/lib/api/configApi';
 import { BulkCreateDialog } from '@/components/BulkCreateDialog';
 
 function TaskCreateActions({
@@ -187,19 +187,7 @@ export default function TasksPage() {
   const navigate = useNavigate();
   const openCreate = useCallback(() => navigate('/'), [navigate]);
   const [bulkOpen, setBulkOpen] = useState(false);
-
-  // Fetch grace hours for the trash countdown
-  const [graceHours, setGraceHours] = useState(6);
-  useEffect(() => {
-    configApi
-      .getSettings()
-      .then((s) => {
-        if (s.deleteGraceHours != null) setGraceHours(s.deleteGraceHours);
-      })
-      .catch(() => {
-        // use default
-      });
-  }, []);
+  const { graceHours } = useGraceHours();
 
   // Board filters
   const [activeRepo, setActiveRepo] = useState(


### PR DESCRIPTION
## Summary
- Add `useGraceHours`, `useProviders`, `useIntegrations`, `useHookTemplates`, `useSettings`, and `useReviewDetail` resource hooks in `src/lib/hooks.ts`
- Migrate `TasksPage`, `IntegrationsPage`, and `ReviewDetailPage` off inline `.then/.catch` fetch + manual state
- Extend `hooks.test.tsx` with coverage for the new resource hooks

## Why
A good `useResource` abstraction already exists, but a few pages still hand-rolled fetching. Two mental models means new pages copy the worse pattern, and error-handling improvements only reach one code path.

Resolves SHR-218

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (3441 passed)
- [x] `bun run build`
- [x] `bun run format:check`
- [x] IntegrationsPage primary-tracker seeding preserved (derived from settings, not post-render effect)


Made with [Cursor](https://cursor.com)