### PR TITLE
fix(build): trust node-pty for linux CI native build (1.1.0 release fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
   },
   "trustedDependencies": [
     "better-sqlite3",
-    "husky"
+    "husky",
+    "node-pty"
   ],
   "dependencies": {
     "@base-ui/react": "^1.2.0",


### PR DESCRIPTION
Follow-up to #176 to unblock the v1.1.0 publish.

The v1.1.0 publish workflow failed at the test step: `substrate-pty.test.ts` couldn't load node-pty's native `pty.node` on the ubuntu runner.

**Cause:** node-pty ships prebuilds only for darwin/win32 — on linux it builds from source via node-gyp during install. bun gates install scripts behind `trustedDependencies`, and node-pty wasn't listed, so the binary was never built. (This also means bun/linux installs of octomux had no working PTY at runtime.)

**Fix:** add `node-pty` to `trustedDependencies`.

After merge, the `v1.1.0` tag is re-pointed to main's tip to re-trigger publish.