### PR TITLE
fix(terminal): enable mobile typing via tap-to-focus and Android IME bridge

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -6,6 +6,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useMediaQuery } from '@/lib/use-media-query';
 import { installTerminalMobileTouch, scrollTerminalByWheel } from '@/lib/terminal-mobile-touch';
 import { installTerminalVisualViewport } from '@/lib/terminal-visual-viewport';
+import { isAndroid, attachAndroidImeBridge } from '@/lib/terminal-android-ime';
 import { MobileTerminalScrollControls } from '@/components/MobileTerminalScrollControls';
 import { CloudOffIcon } from './icons';
 
@@ -43,6 +44,7 @@ export function TerminalView({
   const countdownTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const viewportCleanup = useRef<(() => void) | null>(null);
   const mobileTouchCleanup = useRef<(() => void) | null>(null);
+  const androidImeCleanup = useRef<(() => void) | null>(null);
   const isMobile = useMediaQuery('(max-width: 767px)');
   const [disconnected, setDisconnected] = useState(false);
   const [retrySecs, setRetrySecs] = useState<number>(0);
@@ -194,6 +196,8 @@ export function TerminalView({
     viewportCleanup.current = null;
     mobileTouchCleanup.current?.();
     mobileTouchCleanup.current = null;
+    androidImeCleanup.current?.();
+    androidImeCleanup.current = null;
 
     const resolvedFontSize = isMobile ? Math.max(fontSize, 14) : fontSize;
 
@@ -216,6 +220,20 @@ export function TerminalView({
     term.loadAddon(new WebLinksAddon());
     term.open(containerRef.current);
 
+    // De-decorate xterm's hidden capture textarea so mobile Safari / Chrome
+    // don't draw autofill / suggestion / accessory UI above the soft
+    // keyboard. Harmless on desktop (there's no textarea chrome to suppress
+    // there), so this runs unconditionally rather than gating on isMobile.
+    const helperTextarea =
+      containerRef.current.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea');
+    if (helperTextarea) {
+      helperTextarea.setAttribute('autocapitalize', 'off');
+      helperTextarea.setAttribute('autocorrect', 'off');
+      helperTextarea.setAttribute('autocomplete', 'off');
+      helperTextarea.spellcheck = false;
+      helperTextarea.setAttribute('enterkeyhint', 'send');
+    }
+
     // Force the xterm viewport to use a non-overlay scrollbar so FitAddon
     // correctly subtracts scrollbar width when calculating columns.
     // Without this, macOS overlay scrollbars report 0 width and the last
@@ -233,17 +251,65 @@ export function TerminalView({
     fitRef.current = fitAddon;
     reconnectDelay.current = INITIAL_RECONNECT_DELAY;
 
+    const androidIme = !readOnly && isAndroid();
+    if (androidIme) {
+      androidImeCleanup.current = attachAndroidImeBridge(term, (bytes) => {
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(bytes);
+        }
+      });
+      // Short-circuit xterm's broken composition path: returning false for
+      // keydown keyCode 229 (IME composition) stops CompositionHelper from
+      // scheduling its own naive textarea diff before the bridge above can
+      // translate the mutation itself. Every other key falls through to
+      // xterm's normal keymap untouched.
+      term.attachCustomKeyEventHandler((e) => e.keyCode !== 229);
+    }
+
     // Register input handler once per terminal lifetime — always forwards to
     // the latest WebSocket via wsRef, so reconnects don't accumulate listeners.
     // Skipped in readOnly mode so panes can't receive keystrokes.
     if (!readOnly) {
-      term.onData((data) => {
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(data);
+      // PHANTOM-ENTER GUARD. `term.onData` fires both for real user input
+      // (keystroke / paste / IME) AND for xterm-synthesized control-sequence
+      // responses (focus-report escapes, DSR/CPR cursor reports, etc.) that
+      // xterm emits on its own in response to programmatic calls like
+      // `term.focus()`. Forwarding the latter to the pty can land stray
+      // escape bytes at the shell prompt. xterm's internal
+      // `coreService.onUserInput` fires immediately before `onData` on the
+      // genuine user-input path (same synchronous tick), so gating on a flag
+      // set there forwards only real input. If a future xterm rev removes
+      // this internal, fall back to forwarding everything so the terminal
+      // never silently stops accepting input.
+      const coreService = (
+        term as unknown as {
+          _core?: { coreService?: { onUserInput?: (cb: () => void) => unknown } };
         }
-        scrollCursorIntoView();
-      });
+      )._core?.coreService;
+      if (coreService?.onUserInput) {
+        let wasUserInput = false;
+        coreService.onUserInput(() => {
+          wasUserInput = true;
+        });
+        term.onData((data) => {
+          if (!wasUserInput) return;
+          wasUserInput = false;
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(data);
+          }
+          scrollCursorIntoView();
+        });
+      } else {
+        term.onData((data) => {
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(data);
+          }
+          scrollCursorIntoView();
+        });
+      }
     }
 
     // Defer initial fit to next frame so the browser has completed flex layout.
@@ -291,6 +357,8 @@ export function TerminalView({
       viewportCleanup.current = null;
       mobileTouchCleanup.current?.();
       mobileTouchCleanup.current = null;
+      androidImeCleanup.current?.();
+      androidImeCleanup.current = null;
     };
   }, [connect]);
 
@@ -361,6 +429,18 @@ export function TerminalView({
         ref={containerRef}
         className="octomux-terminal-host h-full w-full min-h-0 overflow-hidden rounded-lg bg-[#09090b] transition-opacity"
         style={{ opacity: showOverlay ? 0.7 : 1 }}
+        onClick={() => {
+          // Focus inside a real user gesture (tap) so mobile browsers raise
+          // the soft keyboard. The terminal may already be disposed (e.g. a
+          // tap racing an unmount), so this is best-effort.
+          if (!readOnly) {
+            try {
+              termRef.current?.focus();
+            } catch {
+              /* terminal disposed mid-tap — nothing to focus */
+            }
+          }
+        }}
       />
       {connecting && (
         <div

--- a/src/lib/terminal-android-ime.test.ts
+++ b/src/lib/terminal-android-ime.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { imeDelta, deltaToBytes } from './terminal-android-ime';
+
+describe('terminal-android-ime', () => {
+  describe('imeDelta', () => {
+    it('plain append counts only the appended text', () => {
+      expect(imeDelta('he', 'hel')).toEqual({ erase: 0, insert: 'l' });
+    });
+
+    it('backspace counts a single erase with nothing to insert', () => {
+      expect(imeDelta('hel', 'he')).toEqual({ erase: 1, insert: '' });
+    });
+
+    it('suggestion replacement diffs to the common prefix/suffix only', () => {
+      // "teh " -> "the ": common prefix "t", common suffix " " (the trailing
+      // space). The differing middle "eh" -> "he" is what gets erased/inserted.
+      expect(imeDelta('teh ', 'the ')).toEqual({ erase: 2, insert: 'he' });
+    });
+
+    it('identical strings produce a no-op delta', () => {
+      expect(imeDelta('same', 'same')).toEqual({ erase: 0, insert: '' });
+    });
+
+    it('surrogate pair safety: appending an emoji counts as one code point', () => {
+      expect(imeDelta('a', 'a😀')).toEqual({ erase: 0, insert: '😀' });
+    });
+
+    it('surrogate pair safety: removing an emoji erases exactly one code point', () => {
+      expect(imeDelta('a😀', 'a')).toEqual({ erase: 1, insert: '' });
+    });
+
+    it('never splits a surrogate pair at the diff boundary when a common emoji follows', () => {
+      // Both strings share a trailing emoji; the prefix boundary must not land
+      // between the high and low surrogate halves of the differing "b"/"c" edit.
+      expect(imeDelta('ab😀', 'ac😀')).toEqual({ erase: 1, insert: 'c' });
+    });
+  });
+
+  describe('deltaToBytes', () => {
+    it('maps a newline in the insert to \\r, not \\n', () => {
+      expect(deltaToBytes({ erase: 0, insert: '\n' })).toBe('\r');
+    });
+
+    it('maps a CRLF insert to a single \\r', () => {
+      expect(deltaToBytes({ erase: 0, insert: '\r\n' })).toBe('\r');
+    });
+
+    it('erase N produces N DEL (\\x7f) bytes', () => {
+      expect(deltaToBytes({ erase: 3, insert: '' })).toBe('\x7f\x7f\x7f');
+    });
+
+    it('combines erase DELs and insert text in order', () => {
+      expect(deltaToBytes({ erase: 2, insert: 'he' })).toBe('\x7f\x7fhe');
+    });
+
+    it('empty delta produces an empty string', () => {
+      expect(deltaToBytes({ erase: 0, insert: '' })).toBe('');
+    });
+  });
+});

--- a/src/lib/terminal-android-ime.ts
+++ b/src/lib/terminal-android-ime.ts
@@ -1,0 +1,205 @@
+// Adapted from supermux (MIT, © Sander van Meggelen): web/src/lib/android-ime.ts
+//
+// Android (GBoard & friends) IME → pty translation layer.
+//
+// WHY. xterm.js does not support Android IMEs (upstream #3600 / #2403 / #1101):
+// soft keyboards deliver nearly everything through COMPOSITION events
+// (keydown keyCode 229), and xterm's CompositionHelper diffs the hidden
+// textarea naively — `newValue.replace(oldValue, '')` degenerates to
+// re-sending the WHOLE value on a word replacement, and a shrink of N chars
+// sends exactly ONE DEL. Tapping an autocomplete suggestion ("delete the
+// composing word, insert the replacement") therefore lands as duplicated
+// text at the shell prompt.
+//
+// THE FIX. On Android we take xterm out of the IME loop entirely and own the
+// textarea→pty translation ourselves:
+//
+//   1. A `term.attachCustomKeyEventHandler` that returns false for keydown
+//      keyCode 229 short-circuits xterm's `_keyDown` BEFORE
+//      `CompositionHelper.keydown` (which would otherwise schedule its naive
+//      `_handleAnyTextareaChanges` diff-sender on a 0ms timer).
+//   2. This module installs CAPTURE-phase listeners on `term.element` (an
+//      ANCESTOR of the hidden textarea — capture on an ancestor runs before
+//      the at-target listeners xterm registered) and stopPropagation()s
+//      `compositionstart/update/end` + `input` so xterm's own handlers
+//      (CompositionHelper + `_inputEvent`) never see IME traffic.
+//   3. We translate the textarea mutations to pty bytes with a REAL diff:
+//      snapshot the value on `beforeinput` (fires before the DOM mutation,
+//      so programmatic value clears between events can never corrupt the
+//      pairing), then on `input` compute the longest-common-prefix/suffix
+//      delta and send DEL × (erased code points) followed by the inserted
+//      text. A GBoard suggestion tap becomes exactly "N backspaces + the new
+//      word" — which any readline-style prompt applies correctly.
+//
+// WHAT STAYS WITH XTERM. Real key events keep flowing through xterm's keymap
+// untouched: hardware keys, Enter (keyCode 13), Backspace when there is no
+// composition (GBoard sends a real keyCode 8 then), arrows, Ctrl chords.
+// xterm preventDefault()s every keydown it handles, so those never mutate
+// the textarea → never produce an `input` event → no double-send with the
+// diff path. Paste stays on xterm's `paste` listener (also preventDefault'd).
+//
+// KNOWN LIMITS (accepted): if the IME edits text it remembers from BEFORE
+// the current line (e.g. cursor-control moves the caret into an earlier
+// word), the DELs land at the pty cursor — which sits at the line end — and
+// the edit desyncs. That niche gesture was equally broken before; the common
+// flows (type, suggestion tap, autocorrect-on-space, backspace-through-word,
+// dictation) all map correctly.
+
+import type { Terminal } from '@xterm/xterm';
+
+/** ASCII DEL — what a terminal Backspace sends (xterm's own default). */
+const DEL = '\x7f';
+
+/** Android detection. UA-based on purpose: the breakage is specific to
+ *  Android IME behaviour, not to coarse pointers in general (iOS keyboards
+ *  deliver discrete key events and work with xterm's composition handling). */
+export function isAndroid(): boolean {
+  return typeof navigator !== 'undefined' && /android/i.test(navigator.userAgent);
+}
+
+export interface ImeDelta {
+  /** Number of CODE POINTS to erase (→ that many DEL bytes). */
+  erase: number;
+  /** Replacement text to type after the erases. */
+  insert: string;
+}
+
+/** Longest-common-prefix/suffix delta between two textarea values, with
+ *  surrogate-pair-safe boundaries. Exported for direct testing. */
+export function imeDelta(before: string, after: string): ImeDelta {
+  if (before === after) return { erase: 0, insert: '' };
+  let p = 0;
+  const maxP = Math.min(before.length, after.length);
+  while (p < maxP && before.charCodeAt(p) === after.charCodeAt(p)) p++;
+  // Never split a surrogate pair at the prefix boundary: if the last common
+  // unit is a high surrogate, pull it back into the differing region.
+  if (p > 0 && isHighSurrogate(before.charCodeAt(p - 1))) p--;
+  let s = 0;
+  const maxS = Math.min(before.length, after.length) - p;
+  while (
+    s < maxS &&
+    before.charCodeAt(before.length - 1 - s) === after.charCodeAt(after.length - 1 - s)
+  )
+    s++;
+  // Mirror guard: don't let the suffix start on a low surrogate whose high
+  // half is inside the differing region.
+  if (s > 0 && isLowSurrogate(before.charCodeAt(before.length - s))) s--;
+  const removed = before.slice(p, before.length - s);
+  const inserted = after.slice(p, after.length - s);
+  return { erase: codePointCount(removed), insert: inserted };
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+function codePointCount(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    n++;
+    if (
+      isHighSurrogate(s.charCodeAt(i)) &&
+      i + 1 < s.length &&
+      isLowSurrogate(s.charCodeAt(i + 1))
+    ) {
+      i++;
+    }
+  }
+  return n;
+}
+
+/** Translate one textarea delta into pty bytes. Newlines map to `\r` — the
+ *  byte xterm itself sends for Enter (a bare `\n` would be Ctrl+J; the shell
+ *  treats `\r` as submit, which is the soft-keyboard Enter's meaning here). */
+export function deltaToBytes(delta: ImeDelta): string {
+  if (delta.erase === 0 && delta.insert.length === 0) return '';
+  return DEL.repeat(delta.erase) + delta.insert.replace(/\r?\n/g, '\r');
+}
+
+/**
+ * Install the Android IME bridge on an OPEN terminal (term.element and
+ * term.textarea must exist — call after `term.open()`).
+ *
+ * Returns a dispose function. The caller gates on `isAndroid()` + writability;
+ * this module does not re-check.
+ */
+export function attachAndroidImeBridge(term: Terminal, send: (data: string) => void): () => void {
+  const root = term.element;
+  const textarea = term.textarea;
+  if (!root || !textarea) return () => {};
+
+  // Value snapshot taken on `beforeinput` — the true pre-mutation value even
+  // if something (xterm clears it on real-Enter keydowns) reset it between
+  // events. `null` = no beforeinput seen for the upcoming input event; fall
+  // back to the running shadow value then.
+  let pending: string | null = null;
+  // Running shadow of the last value we reconciled — the fallback `before`
+  // for engines/IMEs that fire `input` without a preceding `beforeinput`.
+  let shadow = textarea.value;
+
+  const isOurs = (e: Event) => e.target === textarea;
+
+  // Composition events: blackhole them before xterm's at-target listeners.
+  // The `input` events carry every mutation; CompositionHelper would only
+  // double-send. (Capture on an ancestor fires before at-target listeners,
+  // and stopPropagation() halts delivery to the target.)
+  const onComposition = (e: Event) => {
+    if (!isOurs(e)) return;
+    e.stopPropagation();
+  };
+
+  const onBeforeInput = (e: Event) => {
+    if (!isOurs(e)) return;
+    // Snapshot only — never stopPropagation/preventDefault here:
+    // `insertCompositionText` beforeinput is not cancelable anyway, and xterm
+    // has no beforeinput listener to shield.
+    pending = textarea.value;
+  };
+
+  const onInput = (e: Event) => {
+    if (!isOurs(e)) return;
+    // Keep xterm's `_inputEvent` (and any ancestor delegates) out of the loop.
+    e.stopPropagation();
+    const before = pending ?? shadow;
+    pending = null;
+    const after = textarea.value;
+    const bytes = deltaToBytes(imeDelta(before, after));
+    if (bytes.length > 0) send(bytes);
+    // A committed newline ends the "line" the IME is editing — reset the
+    // textarea so the next suggestion context starts clean and the value
+    // can't grow without bound. Safe outside composition only (clearing a
+    // mid-composition value confuses IMEs).
+    const composing = (e as InputEvent).isComposing === true;
+    if (!composing && after.includes('\n')) {
+      textarea.value = '';
+      shadow = '';
+    } else {
+      shadow = textarea.value;
+    }
+  };
+
+  // On (re)focus, resync the shadow to whatever the textarea holds — xterm
+  // and the browser may have touched the value while we weren't looking.
+  const onFocus = () => {
+    pending = null;
+    shadow = textarea.value;
+  };
+
+  root.addEventListener('compositionstart', onComposition, { capture: true });
+  root.addEventListener('compositionupdate', onComposition, { capture: true });
+  root.addEventListener('compositionend', onComposition, { capture: true });
+  root.addEventListener('beforeinput', onBeforeInput, { capture: true });
+  root.addEventListener('input', onInput, { capture: true });
+  textarea.addEventListener('focus', onFocus);
+
+  return () => {
+    root.removeEventListener('compositionstart', onComposition, { capture: true });
+    root.removeEventListener('compositionupdate', onComposition, { capture: true });
+    root.removeEventListener('compositionend', onComposition, { capture: true });
+    root.removeEventListener('beforeinput', onBeforeInput, { capture: true });
+    root.removeEventListener('input', onInput, { capture: true });
+    textarea.removeEventListener('focus', onFocus);
+  };
+}


### PR DESCRIPTION
## Problem

The chat terminal — a raw full-screen `TerminalView` on `/ws/terminal/chat/:id`, i.e. live-typing straight into xterm.js — could not be typed into on phones. Users couldn't respond to agents from mobile.

The wire (`onData` → `ws.send` → `pty.write` → tmux) is fine; the whole problem is client-side xterm-on-mobile behavior.

## Fixes (all in `src/components/TerminalView.tsx`, gated so read-only grid previews are unaffected)

1. **Tap-to-focus** — `onClick` → `term.focus()` inside the user gesture raises the mobile soft keyboard. *This is the primary blocker: nothing previously focused xterm's hidden textarea on tap.*
2. **iOS textarea de-decoration** — `autocapitalize/autocorrect/autocomplete=off`, `spellcheck=false`, `enterkeyhint=send` on `.xterm-helper-textarea` (kills the autofill/suggestion accessory strip).
3. **Android IME bridge** — new `src/lib/terminal-android-ime.ts`, ported from [supermux](https://github.com/sanderbz/supermux) (MIT, © Sander van Meggelen). xterm.js can't handle Android soft-keyboard composition (upstream #3600); GBoard suggestion taps duplicated text at the prompt. We take xterm out of the IME loop and translate textarea mutations into a real prefix/suffix diff → `DEL × n + inserted` bytes.
4. **Phantom-Enter guard** — `onData` now forwards only user-initiated input via `coreService.onUserInput`, with a forward-everything fallback if that internal ever disappears. Prevents xterm's synthesized escape responses (from programmatic `focus()`) landing as stray bytes at the shell.

Already present and **not** touched: visual-viewport keyboard sizing, mobile touch-scroll.

## Tests

- `src/lib/terminal-android-ime.test.ts` — 12 unit tests for the diff logic incl. surrogate-pair safety and newline→CR mapping.
- `tsc -b` clean · 33/33 terminal tests pass · no new lint issues.

## ⚠️ Needs on-device smoke test

The Android-IME and soft-keyboard behaviors can't be exercised headlessly. The pure diff logic is unit-tested, but please smoke-test actual typing on a real iPhone **and** Android phone before merge.

---
Note: base is `main` because the `next` branch was merged (v1.1.0) and deleted on the remote at PR time; retarget if a `next` branch is recreated.