### PR TITLE
feat(loop): fresh-context respawn primitive + poller exemption for loop tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,23 @@ Three workflows octomux makes one-click:
 
 ## How it compares
 
-|                                        | **octomux**      | vibe-kanban       | Conductor     | Emdash          |
-| -------------------------------------- | ---------------- | ----------------- | ------------- | --------------- |
-| License                                | MIT, open source | MIT (community\*) | Closed        | Open source     |
-| Fully local, no cloud                  | Yes              | Now local\*       | Cloud account | Yes             |
-| One permission inbox                   | **Yes**          | No                | No            | No              |
-| Monitor grid (all agents at once)      | **Yes**          | No                | No            | No              |
-| Automated review + human-gated publish | **Yes**          | Partial           | Partial       | No              |
-| Recursive orchestration                | **Yes**          | No                | No            | No              |
-| Reach it from your phone               | **Yes** (tailnet)| No                | No            | Partial (SSH)   |
-| Claude Code + Cursor                   | Yes              | Yes (10+)         | Yes           | Yes (20+)       |
-| Platform                               | macOS + Linux    | macOS/Linux/Win   | macOS only    | macOS/Linux/Win |
+|                                        | **octomux**       | vibe-kanban       | Conductor     | Emdash          |
+| -------------------------------------- | ----------------- | ----------------- | ------------- | --------------- |
+| License                                | MIT, open source  | MIT (community\*) | Closed        | Open source     |
+| Fully local, no cloud                  | Yes               | Now local\*       | Cloud account | Yes             |
+| One permission inbox                   | **Yes**           | No                | No            | No              |
+| Monitor grid (all agents at once)      | **Yes**           | No                | No            | No              |
+| Automated review + human-gated publish | **Yes**           | Partial           | Partial       | No              |
+| Recursive orchestration                | **Yes**           | No                | No            | No              |
+| Reach it from your phone               | **Yes** (tailnet) | No                | No            | Partial (SSH)   |
+| Claude Code + Cursor                   | Yes               | Yes (10+)         | Yes           | Yes (20+)       |
+| Platform                               | macOS + Linux     | macOS/Linux/Win   | macOS only    | macOS/Linux/Win |
 
 <sub>\* Bloop, the company behind vibe-kanban, wound down in early 2026; it continues as a community project.</sub>
 
 ## Why octomux
 
-The editor was built around a human typing one file at a time. That's not the job anymore. The job is directing a fleet — and the hard part moved from *writing* code to *reviewing* it, *unblocking* it, and *knowing what's happening* across ten sessions.
+The editor was built around a human typing one file at a time. That's not the job anymore. The job is directing a fleet — and the hard part moved from _writing_ code to _reviewing_ it, _unblocking_ it, and _knowing what's happening_ across ten sessions.
 
 octomux is a bet on what that surface should look like: not a chat box bolted onto a file tree, but a control deck. It handles the ugly backend of running agents and puts the human's job — the inbox, the fleet grid, the review workstation, the orchestrator — front and center. It's early and opinionated, and the roadmap is shaped in the open.
 
@@ -92,17 +92,17 @@ octomux is a bet on what that surface should look like: not a chat box bolted on
 <details>
 <summary><b>Full CLI reference</b></summary>
 
-| Command                                  | Description                                                         |
-| ---------------------------------------- | ------------------------------------------------------------------ |
-| `octomux start`                          | Dashboard at `:7777` (add `--bind 0.0.0.0` for remote)             |
-| `octomux init`                           | Defaults wizard (Jira/Linear, base branch, harness prefs)          |
-| `octomux create-task`                    | New task (`--harness`, `--model`, `--mode`, `--fork-from`)         |
-| `octomux list-tasks` / `get-task`        | Inspect tasks                                                      |
-| `octomux close-task` / `delete-task`     | Stop or fully remove                                               |
-| `octomux resume-task`                    | Resume a closed task                                               |
-| `octomux add-agent`                      | Another agent window (`--model`, `--notify-agent`)                 |
-| `octomux send-message`                   | Message a running agent — course-correct without restart           |
-| `octomux team run` / `schedule` / `list` | Run or schedule an agent crew from `.octomux/team.yaml`            |
+| Command                                  | Description                                                |
+| ---------------------------------------- | ---------------------------------------------------------- |
+| `octomux start`                          | Dashboard at `:7777` (add `--bind 0.0.0.0` for remote)     |
+| `octomux init`                           | Defaults wizard (Jira/Linear, base branch, harness prefs)  |
+| `octomux create-task`                    | New task (`--harness`, `--model`, `--mode`, `--fork-from`) |
+| `octomux list-tasks` / `get-task`        | Inspect tasks                                              |
+| `octomux close-task` / `delete-task`     | Stop or fully remove                                       |
+| `octomux resume-task`                    | Resume a closed task                                       |
+| `octomux add-agent`                      | Another agent window (`--model`, `--notify-agent`)         |
+| `octomux send-message`                   | Message a running agent — course-correct without restart   |
+| `octomux team run` / `schedule` / `list` | Run or schedule an agent crew from `.octomux/team.yaml`    |
 
 Full setup, Jira/Linear, and orchestrator skills: **[ONBOARDING.md](./ONBOARDING.md)**.
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,4 @@
-export type RuntimeState = 'idle' | 'setting_up' | 'running' | 'error';
+export type RuntimeState = 'idle' | 'setting_up' | 'running' | 'error' | 'looping';
 /** Workflow status — human-facing board column. */
 export type WorkflowStatus = 'backlog' | 'planned' | 'in_progress' | 'human_review' | 'pr' | 'done';
 export const WORKFLOW_STATUSES: readonly WorkflowStatus[] = [

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -195,6 +195,64 @@ describe('pollStatuses', () => {
     expect(task.runtime_state).toBe('running');
   });
 
+  // ─── Loop-task poller exemption ────────────────────────────────────────────
+  // A 'looping' task's tmux session briefly appears dead during respawnAgentFresh's
+  // new-window-then-kill-old-window swap. The poller must never tear the loop
+  // down for that gap — only a normal 'running'/'setting_up' task is affected.
+
+  describe('when a "looping" task session dies', () => {
+    beforeEach(() => {
+      vi.mocked(execFile).mockImplementation(deadSessionMock as any);
+    });
+
+    it('does not flip runtime_state away from "looping"', async () => {
+      insertTask(db, { ...DEFAULTS.runningTask, runtime_state: 'looping' });
+      insertAgent(db);
+
+      await pollStatuses();
+
+      const task = getTask(db, DEFAULTS.task.id)!;
+      expect(task.runtime_state).toBe('looping');
+    });
+
+    it('does not mark its agents as stopped', async () => {
+      insertTask(db, { ...DEFAULTS.runningTask, runtime_state: 'looping' });
+      insertAgent(db);
+      insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
+
+      await pollStatuses();
+
+      const agents = getAgents(db, DEFAULTS.task.id);
+      expect(agents.every((a) => a.status !== 'stopped')).toBe(true);
+    });
+
+    it('still checks tmux has-session for it (poller keeps tracking the task)', async () => {
+      insertTask(db, { ...DEFAULTS.runningTask, runtime_state: 'looping' });
+
+      await pollStatuses();
+
+      expect(execFile).toHaveBeenCalledWith(
+        'tmux',
+        expect.arrayContaining(['has-session', '-t', DEFAULTS.runningTask.tmux_session]),
+        expect.anything(),
+        expect.any(Function),
+      );
+    });
+  });
+
+  it('still flips a normal "running" task to idle in the same poll (existing behavior preserved)', async () => {
+    vi.mocked(execFile).mockImplementation(deadSessionMock as any);
+    insertTask(db, { ...DEFAULTS.runningTask, runtime_state: 'running' });
+    insertAgent(db);
+
+    await pollStatuses();
+
+    const task = getTask(db, DEFAULTS.task.id)!;
+    expect(task.runtime_state).toBe('idle');
+    const agents = getAgents(db, DEFAULTS.task.id);
+    expect(agents.every((a) => a.status === 'stopped')).toBe(true);
+  });
+
   // ─── Status filtering (table-driven) ──────────────────────────────────────
 
   const ignoredStates = ['idle', 'error'] as const;

--- a/server/poller/status.ts
+++ b/server/poller/status.ts
@@ -89,6 +89,10 @@ export async function pollStatuses(): Promise<void> {
     if (status !== 'dead') continue;
 
     const rs = task.runtime_state;
+    // 'looping' tasks are exempt: respawnAgentFresh briefly swaps tmux windows
+    // (new window up, then old one killed), which can make has-session look
+    // dead for an instant. Tearing the task down on that gap would kill the loop.
+    if (rs === 'looping') continue;
     if (rs === 'running') {
       setRuntimeStateIdle(task.id);
     } else if (rs === 'setting_up') {

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -120,11 +120,16 @@ export function listRecoverableTasks(): Task[] {
     .all() as Task[];
 }
 
-/** List running/setting_up tasks that have a tmux session (for status polling). */
+/**
+ * List running/setting_up/looping tasks that have a tmux session (for status
+ * polling). 'looping' tasks are included so the poller keeps checking their
+ * session, but pollStatuses must never act on a dead result for them — a loop
+ * respawn briefly swaps tmux windows and must not be torn down for that gap.
+ */
 export function listRunningTasks(): Task[] {
   return getDb()
     .prepare(
-      `${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'setting_up') AND t.tmux_session IS NOT NULL`,
+      `${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'setting_up', 'looping') AND t.tmux_session IS NOT NULL`,
     )
     .all() as Task[];
 }

--- a/server/task-engine/index.ts
+++ b/server/task-engine/index.ts
@@ -39,7 +39,14 @@ export {
   prepareResumeLaunch,
 } from './launch.js';
 export type { AddAgentOpts } from './lifecycle.js';
-export { preflightWorktree, startTask, addAgent, resumeTask, hopAgent } from './lifecycle.js';
+export {
+  preflightWorktree,
+  startTask,
+  addAgent,
+  resumeTask,
+  hopAgent,
+  respawnAgentFresh,
+} from './lifecycle.js';
 export { closeTask, softDeleteTask, deleteTask, stopAgent } from './cleanup.js';
 export type { UserTerminalResult } from './terminals.js';
 export { createUserTerminal, createShellTerminal, closeShellTerminal } from './terminals.js';

--- a/server/task-engine/lifecycle.ts
+++ b/server/task-engine/lifecycle.ts
@@ -5,6 +5,7 @@ export {
   addAgent,
   resumeTask,
   hopAgent,
+  respawnAgentFresh,
   validateAndResolveAddAgentOpts,
   prepareAddAgentLaunch,
   launchAddAgentWindow,

--- a/server/task-engine/lifecycle/index.ts
+++ b/server/task-engine/lifecycle/index.ts
@@ -16,3 +16,4 @@ export {
   relaunchStoppedAgents,
 } from './resume-task.js';
 export { hopAgent } from './hop-agent.js';
+export { respawnAgentFresh } from './respawn-agent.js';

--- a/server/task-engine/lifecycle/respawn-agent.test.ts
+++ b/server/task-engine/lifecycle/respawn-agent.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTestDb, insertTask, insertAgent, DEFAULTS } from '../../test-helpers.js';
+import type { Task, Agent } from '../../types.js';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const mocked = {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  };
+  return { ...mocked, default: mocked };
+});
+
+let nextWindowIndex = 5;
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(
+    (_cmd: string, args: string[], optsOrCb: Function | object, maybeCb?: Function) => {
+      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb!;
+      if (args.includes('list-windows')) {
+        cb(null, { stdout: String(nextWindowIndex), stderr: '' });
+      } else if (args.includes('new-window')) {
+        nextWindowIndex++;
+        cb(null, { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: '', stderr: '' });
+      }
+    },
+  ),
+}));
+
+vi.mock('../../orchestrator/store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../orchestrator/store.js')>();
+  return { ...actual, isOrchestratorManaged: vi.fn(() => false) };
+});
+
+vi.mock('../../orchestrator/runner.js', () => ({
+  mcpServerInvocation: vi.fn(() => null),
+}));
+
+vi.mock('../../hook-base-url.js', () => ({
+  hookBaseUrl: vi.fn(() => 'http://127.0.0.1:7777'),
+}));
+
+vi.mock('../../settings.js', () => ({
+  getSettings: vi.fn(async () => ({})),
+}));
+
+vi.mock('../../skills.js', () => ({
+  syncSkills: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../events.js', () => ({
+  broadcast: vi.fn(),
+}));
+
+const newSessionId = vi.fn(() => 'fresh-session-id');
+const buildLaunchCommand = vi.fn(() => 'claude --session-id fresh-session-id');
+const buildResumeCommand = vi.fn(() => 'claude --resume old-session');
+
+vi.mock('../../harnesses/index.js', () => ({
+  getHarness: vi.fn(() => ({
+    id: 'claude-code',
+    sessionIdMode: 'orchestrator-assigned',
+    newSessionId,
+    buildLaunchCommand,
+    buildResumeCommand,
+    resolveFlags: vi.fn(() => ''),
+    syncAgents: vi.fn(async () => undefined),
+    installHooks: vi.fn(async () => undefined),
+    postLaunch: vi.fn(async () => undefined),
+  })),
+}));
+
+const { respawnAgentFresh } = await import('./respawn-agent.js');
+const { execFile } = await import('child_process');
+const { broadcast } = await import('../../events.js');
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createTestDb();
+  vi.clearAllMocks();
+  nextWindowIndex = 5;
+  insertTask(db, { ...DEFAULTS.runningTask });
+});
+
+function makeAgentRow(overrides: Partial<Agent> = {}): Agent {
+  return insertAgent(db, {
+    ...DEFAULTS.agent,
+    window_index: 1,
+    harness_session_id: 'old-session-id',
+    ...overrides,
+  });
+}
+
+// ─── respawnAgentFresh ────────────────────────────────────────────────────────
+
+describe('respawnAgentFresh', () => {
+  it('issues tmux new-window before any kill-window', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    await respawnAgentFresh(task, agent);
+
+    const calls = vi.mocked(execFile).mock.calls;
+    const newWindowIdx = calls.findIndex((c) => (c[1] as string[])?.includes('new-window'));
+    const killWindowIdx = calls.findIndex((c) => (c[1] as string[])?.includes('kill-window'));
+    expect(newWindowIdx).toBeGreaterThanOrEqual(0);
+    expect(killWindowIdx).toBeGreaterThan(newWindowIdx);
+  });
+
+  it('launches with a fresh session id and does not resume', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    await respawnAgentFresh(task, agent);
+
+    expect(newSessionId).toHaveBeenCalled();
+    expect(buildLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'fresh-session-id' }),
+    );
+    expect(buildResumeCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns an agent whose harness_session_id differs from the input', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    const result = await respawnAgentFresh(task, agent);
+
+    expect(result.harness_session_id).not.toBe(agent.harness_session_id);
+    expect(result.harness_session_id).toBe('fresh-session-id');
+  });
+
+  it('keeps the same task_id on the returned agent', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    const result = await respawnAgentFresh(task, agent);
+
+    expect(result.task_id).toBe(task.id);
+  });
+
+  it('broadcasts a task:updated event', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    await respawnAgentFresh(task, agent);
+
+    expect(broadcast).toHaveBeenCalledWith({
+      type: 'task:updated',
+      payload: { taskId: task.id },
+    });
+  });
+
+  it('creates the new window in the task tmux_session, not a new session', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    await respawnAgentFresh(task, agent);
+
+    const newSessionCall = vi
+      .mocked(execFile)
+      .mock.calls.find((c) => (c[1] as string[])?.includes('new-session'));
+    expect(newSessionCall).toBeUndefined();
+  });
+});

--- a/server/task-engine/lifecycle/respawn-agent.ts
+++ b/server/task-engine/lifecycle/respawn-agent.ts
@@ -1,0 +1,88 @@
+import { getSettings } from '../../settings.js';
+import { getHarness } from '../../harnesses/index.js';
+import { hookBaseUrl } from '../../hook-base-url.js';
+import { syncSkills } from '../../skills.js';
+import { childLogger } from '../../logger.js';
+import { broadcast } from '../../events.js';
+import { execTmux } from '../../tmux-bin.js';
+import {
+  getAgent,
+  setAgentWindowRunning,
+  setAgentHarnessSessionId,
+} from '../../repositories/index.js';
+import { buildAgentStartupCommand, launchAgentWindow, computeFreshSessionIds } from '../launch.js';
+import { isTmuxTargetMissing } from '../sessions.js';
+import type { Agent, Task } from '../../types.js';
+
+const logger = childLogger('task-engine/lifecycle');
+
+/**
+ * Respawn an agent with a FRESH context: new tmux window, new harness session
+ * (no --resume), in the task's EXISTING tmux session. The new window is
+ * created (and its index confirmed via tmux) before the old one is killed, so
+ * the session never drops to zero windows — which would otherwise destroy it.
+ */
+export async function respawnAgentFresh(task: Task, agent: Agent): Promise<Agent> {
+  logger.info(
+    { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh' },
+    'respawn_fresh: start',
+  );
+
+  const harness = getHarness(agent.harness_id);
+  const flags = harness.resolveFlags(await getSettings());
+  const { sessionIdForDb, sessionIdForLaunch } = computeFreshSessionIds(harness);
+
+  await harness.syncAgents(task.worktree!);
+  await syncSkills(task.worktree!);
+  await harness.installHooks(task.worktree!, hookBaseUrl(), agent.hook_token);
+
+  const baseCmd = harness.buildLaunchCommand({
+    sessionId: sessionIdForLaunch,
+    agent: agent.agent,
+    flags,
+    model: (task as { model?: string | null }).model ?? null,
+    workspacePath: task.worktree!,
+  });
+  const startupCmd = buildAgentStartupCommand({ baseCmd });
+
+  const oldWindowIndex = agent.window_index;
+  const newWindowIndex = await launchAgentWindow({
+    session: task.tmux_session!,
+    cwd: task.worktree!,
+    startupCmd,
+    fresh: false,
+  });
+
+  setAgentWindowRunning(agent.id, newWindowIndex);
+  if (harness.sessionIdMode === 'orchestrator-assigned' && sessionIdForDb) {
+    setAgentHarnessSessionId(agent.id, sessionIdForDb);
+  }
+
+  const target = `${task.tmux_session}:${newWindowIndex}`;
+  void harness.postLaunch?.(target);
+
+  await execTmux(['kill-window', '-t', `${task.tmux_session}:${oldWindowIndex}`]).catch((err) => {
+    if (!isTmuxTargetMissing(err)) {
+      logger.warn(
+        { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh', err },
+        'respawn_fresh: kill old window failed',
+      );
+    }
+  });
+
+  const updated = getAgent(agent.id) as Agent;
+  broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+
+  logger.info(
+    {
+      task_id: task.id,
+      agent_id: agent.id,
+      operation: 'respawn_fresh',
+      window_index: newWindowIndex,
+      harness_session_id: updated.harness_session_id,
+    },
+    'respawn_fresh: complete',
+  );
+
+  return updated;
+}


### PR DESCRIPTION
## Summary

P0 of the Loop Harness — the de-risking spike everything else depends on. Builds only the two lowest-level primitives; no loop engine, DB tables, emit endpoint, or UI.

1. **`respawnAgentFresh(task, agent)`** (`server/task-engine/lifecycle/respawn-agent.ts`, wired through `lifecycle.ts` / `task-engine/index.ts` alongside `addAgent`/`hopAgent`): creates a **new tmux window in the task's existing session**, launches the harness fresh (`computeFreshSessionIds` → `harness.newSessionId()`, no `--resume`), then kills the **old** window only after the new one exists and its index has been confirmed via tmux (`launchAgentWindow`'s `new-window` + `list-windows` round trip). Same agent row is updated in place (new `harness_session_id` + `window_index`), same `task_id` — no DB growth per loop iteration. Broadcasts `task:updated` and logs `operation: 'respawn_fresh'` with `task_id`/`agent_id` throughout.

   **New-window-before-kill ordering guarantee**: because the new window is created (and its index round-tripped through tmux) *before* the old window is killed, the session's window count never drops to zero — which is what would cause tmux to destroy the whole session. This is the core invariant the loop engine depends on for every iteration.

   Note: this codebase already runs the harness command as the tmux pane's own startup process (not typed in via `send-keys`), which structurally eliminates the shell-readiness race the original ask referenced — there's no separate "wait for shell ready" step because tmux only returns from `new-window` once the pane (and its initial process) exists.

2. **`'looping'` runtime state** (`packages/types/src/index.ts`) + **poller exemption** (`server/poller/status.ts`, `server/repositories/tasks.ts`): `tasks.runtime_state` is a plain `TEXT NOT NULL DEFAULT 'idle'` column with **no CHECK constraint**, so no migration was needed — just widening the TypeScript union. `listRunningTasks()` now includes `'looping'` tasks (so the poller keeps checking their tmux session), but `pollStatuses` skips reconciliation for them (`continue`) instead of flipping them to `idle` or calling `stopRunningAgentsForTask`. This is why the exemption exists: `respawnAgentFresh` briefly has two windows in flight (new up, old not yet killed) — if `has-session` ever raced against that gap, the old poller behavior would tear the whole task down.

3. Drive-by: `README.md` had a pre-existing prettier drift from the docs-restructure PR just merged to `next`, which was failing this branch's `format:check` gate after rebasing. Fixed as its own commit (`style(readme): ...`) since it blocks the gate for every branch built on `next` until someone reformats it.

## Test plan

- [x] `server/task-engine/lifecycle/respawn-agent.test.ts` (new) — asserts `new-window` is issued before any `kill-window`, no `new-session`, launches with a fresh session id (`buildResumeCommand` never called), returns an agent with a differing `harness_session_id` and the same `task_id`, broadcasts `task:updated`.
- [x] `server/poller.test.ts` (extended) — a `'looping'` task whose `has-session` fails stays `'looping'` and its agents are not marked `stopped`, while `has-session` is still checked for it; a normal `'running'` task in the same poll is still flipped to `idle` with its agents stopped (existing behavior unchanged).

### Gate (green)

```
$ bun run typecheck
tsc -b
(no output — clean)

$ bun run lint
✖ 60 problems (0 errors, 60 warnings)
(all 60 pre-existing warnings, none in touched files)

$ bun run test
 Test Files  266 passed (266)
      Tests  3461 passed (3461)
```

(One diff-engine/diff-review-state test that shells out to real `git` is flaky under full-suite parallel load in this sandbox — timed out on a couple of ad-hoc runs, always passed standalone and passed clean in the final pre-push run above. Unrelated to this diff; not one of the touched files.)