### PR TITLE
feat(loop): loop_runs/loop_iterations persistence + octomux emit completion callback

### DIFF
--- a/cli/src/commands/emit.test.ts
+++ b/cli/src/commands/emit.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerEmit } from './emit.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  registerEmit(program);
+  return program;
+}
+
+describe('emit command', () => {
+  const origBaseUrl = process.env.OCTOMUX_ACTION_BASE_URL;
+  const origToken = process.env.OCTOMUX_ACTION_TOKEN;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env.OCTOMUX_ACTION_BASE_URL = 'http://127.0.0.1:7777';
+    process.env.OCTOMUX_ACTION_TOKEN = 'tok-agent';
+  });
+
+  afterEach(() => {
+    if (origBaseUrl === undefined) delete process.env.OCTOMUX_ACTION_BASE_URL;
+    else process.env.OCTOMUX_ACTION_BASE_URL = origBaseUrl;
+    if (origToken === undefined) delete process.env.OCTOMUX_ACTION_TOKEN;
+    else process.env.OCTOMUX_ACTION_TOKEN = origToken;
+  });
+
+  it('POSTs the emit payload with a bearer token from env', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'run-1', status: 'done' }),
+      text: async () => '',
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(
+      ['emit', '--run', 'run-1', '--status', 'done', '--reason', 'all tests pass'],
+      { from: 'user' },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:7777/api/loops/run-1/emit',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer tok-agent',
+        }),
+        body: JSON.stringify({ status: 'done', reason: 'all tests pass' }),
+      }),
+    );
+  });
+
+  it('rejects a status not in the fixed enum', async () => {
+    const program = buildProgram();
+
+    await expect(
+      program.parseAsync(['emit', '--run', 'run-1', '--status', 'finished', '--reason', 'x'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('exits with an error when OCTOMUX_ACTION_TOKEN is missing', async () => {
+    delete process.env.OCTOMUX_ACTION_TOKEN;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const program = buildProgram();
+    await program.parseAsync(['emit', '--run', 'run-1', '--status', 'done', '--reason', 'x'], {
+      from: 'user',
+    });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});

--- a/cli/src/commands/emit.ts
+++ b/cli/src/commands/emit.ts
@@ -1,0 +1,53 @@
+import { Command, Option } from 'commander';
+import { errorMessage, success } from '../format.js';
+
+const EMIT_STATUSES = ['done', 'blocked', 'needs_human'] as const;
+type EmitStatus = (typeof EMIT_STATUSES)[number];
+
+/**
+ * octomux emit — the loop-harness completion callback. Reads the base URL and
+ * bearer token from the same OCTOMUX_ACTION_* env vars the orchestrator's
+ * other hook-calling code (server/orchestrator/mcp/write.ts) reads, since
+ * they're set into the loop agent's shell the same way.
+ */
+export function registerEmit(program: Command): void {
+  program
+    .command('emit')
+    .description('Report loop-run completion status back to octomux')
+    .requiredOption('-r, --run <run-id>', 'loop run ID')
+    .addOption(
+      new Option('-s, --status <status>', 'completion status')
+        .choices(EMIT_STATUSES)
+        .makeOptionMandatory(),
+    )
+    .requiredOption('--reason <text>', 'reason for the status')
+    .action(async (opts: { run: string; status: EmitStatus; reason: string }) => {
+      const baseUrl = process.env.OCTOMUX_ACTION_BASE_URL;
+      const token = process.env.OCTOMUX_ACTION_TOKEN;
+      if (!baseUrl || !token) {
+        errorMessage(
+          'octomux emit is not configured (missing OCTOMUX_ACTION_BASE_URL / OCTOMUX_ACTION_TOKEN)',
+        );
+        process.exit(1);
+        return;
+      }
+
+      const res = await fetch(`${baseUrl}/api/loops/${encodeURIComponent(opts.run)}/emit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: opts.status, reason: opts.reason }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        errorMessage(`emit failed (HTTP ${res.status}): ${text}`);
+        process.exit(1);
+        return;
+      }
+
+      success(`Emitted ${opts.status} for loop run ${opts.run}`);
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -31,6 +31,7 @@ import { registerListIntegrations } from './commands/list-integrations.js';
 import { registerInit } from './commands/init.js';
 import { registerTeam } from './commands/team.js';
 import { registerFiles } from './commands/files.js';
+import { registerEmit } from './commands/emit.js';
 
 const program = new Command();
 
@@ -73,6 +74,7 @@ registerListIntegrations(program);
 registerInit(program);
 registerTeam(program);
 registerFiles(program);
+registerEmit(program);
 
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();

--- a/server/api.loops.test.ts
+++ b/server/api.loops.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { createTestDb, insertTask, insertAgent } from './test-helpers.js';
+import { createLoopRun, appendIteration } from './repositories/loop-runs.js';
+
+describe('loop routes', () => {
+  let app: ReturnType<typeof createApp>;
+  let db: ReturnType<typeof createTestDb>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    insertTask(db, { id: 't1', runtime_state: 'looping' });
+    insertAgent(db, { id: 'a1', task_id: 't1', hook_token: 'tok-loop' } as any);
+  });
+
+  describe('POST /api/loops/:runId/emit', () => {
+    it('persists a valid emit and returns 200', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+      appendIteration(run.id, { sha_from: 'a1', sha_to: 'a2' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .set('Authorization', 'Bearer tok-loop')
+        .send({ status: 'done', reason: 'all good' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('done');
+      expect(res.body.termination_reason).toBe('all good');
+
+      const iteration = db
+        .prepare(`SELECT emit_status, emit_reason FROM loop_iterations WHERE loop_run_id = ?`)
+        .get(run.id) as { emit_status: string; emit_reason: string };
+      expect(iteration.emit_status).toBe('done');
+      expect(iteration.emit_reason).toBe('all good');
+    });
+
+    it('rejects an invalid status enum with 400', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .set('Authorization', 'Bearer tok-loop')
+        .send({ status: 'finished', reason: 'x' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a missing reason with 400', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .set('Authorization', 'Bearer tok-loop')
+        .send({ status: 'done' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a blank reason with 400', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .set('Authorization', 'Bearer tok-loop')
+        .send({ status: 'done', reason: '   ' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a missing token with 401', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .send({ status: 'done', reason: 'x' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects an unrecognized token with 401', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post(`/api/loops/${run.id}/emit`)
+        .set('Authorization', 'Bearer nope')
+        .send({ status: 'done', reason: 'x' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 404 for an unknown run id', async () => {
+      const res = await request(app)
+        .post(`/api/loops/does-not-exist/emit`)
+        .set('Authorization', 'Bearer tok-loop')
+        .send({ status: 'done', reason: 'x' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/loops', () => {
+    it('lists loop runs', async () => {
+      createLoopRun({ task_id: 't1', spec_json: '{}' });
+      createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app).get('/api/loops');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+  });
+
+  describe('GET /api/loops/:runId', () => {
+    it('returns the run with its iterations', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+      appendIteration(run.id, { sha_from: 'a1', sha_to: 'a2' });
+      appendIteration(run.id, { sha_from: 'a2', sha_to: 'a3' });
+
+      const res = await request(app).get(`/api/loops/${run.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(run.id);
+      expect(res.body.iterations).toHaveLength(2);
+      expect(res.body.iterations[0].n).toBe(1);
+      expect(res.body.iterations[1].n).toBe(2);
+    });
+
+    it('returns 404 for an unknown run id', async () => {
+      const res = await request(app).get('/api/loops/does-not-exist');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/server/api.ts
+++ b/server/api.ts
@@ -18,6 +18,7 @@ import { router as orchestratorRouter } from './routes/orchestrator.js';
 import { router as integrationsRouter } from './routes/integrations.js';
 import { router as reviewsRouter } from './routes/reviews.js';
 import { router as reviewRunsRouter } from './routes/review-runs.js';
+import { router as loopsRouter } from './routes/loops.js';
 import { router as commentsRouter } from './routes/comments.js';
 import { router as diffsRouter } from './routes/diffs.js';
 import { router as tasksRouter } from './routes/tasks.js';
@@ -46,6 +47,7 @@ export function setupRoutes(app: Express): void {
   app.use(integrationsRouter);
   app.use(reviewsRouter);
   app.use(reviewRunsRouter);
+  app.use(loopsRouter);
   app.use(commentsRouter);
   app.use(diffsRouter);
   app.use(tasksRouter);

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -834,4 +834,35 @@ export function runMigrations(instance: Database.Database): void {
   // Ensure at most one row has is_global_monitor=1 (partial unique index — SQLite
   // WHERE clause filters NULLs but since we use 0/1 we need a different approach;
   // enforce uniqueness in application logic via setGlobalMonitor clearing old value).
+
+  // ── Loop harness persistence (2026-07-12, P1a) ──────────────────────────────
+  instance.exec(`
+    CREATE TABLE IF NOT EXISTS loop_runs (
+      id                  TEXT PRIMARY KEY,
+      task_id             TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+      spec_json           TEXT NOT NULL,
+      status              TEXT NOT NULL DEFAULT 'running',
+      iteration           INTEGER NOT NULL DEFAULT 0,
+      max_iterations      INTEGER,
+      budget_json         TEXT,
+      termination_reason  TEXT,
+      created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_loop_runs_task ON loop_runs(task_id);
+
+    CREATE TABLE IF NOT EXISTS loop_iterations (
+      id             TEXT PRIMARY KEY,
+      loop_run_id    TEXT NOT NULL REFERENCES loop_runs(id) ON DELETE CASCADE,
+      n              INTEGER NOT NULL,
+      sha_from       TEXT,
+      sha_to         TEXT,
+      verify_passed  INTEGER,
+      tokens         INTEGER,
+      emit_status    TEXT,
+      emit_reason    TEXT,
+      created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_loop_iterations_run ON loop_iterations(loop_run_id, n);
+  `);
 }

--- a/server/events.ts
+++ b/server/events.ts
@@ -25,6 +25,10 @@ export type ServerEvent =
   | {
       type: 'task:stuck';
       payload: { taskId: string; reason?: string; [key: string]: unknown };
+    }
+  | {
+      type: 'loop:emit';
+      payload: { taskId: string; loopRunId: string; status: string; reason: string };
     };
 
 /** Event types that carry a taskId and should be persisted to the durable events log. */

--- a/server/repositories/index.ts
+++ b/server/repositories/index.ts
@@ -11,5 +11,6 @@ export * from './inline-comments.js';
 export * from './published-reviews.js';
 export * from './review-learnings.js';
 export * from './file-review-state.js';
+export * from './loop-runs.js';
 export * from '../orchestrator/store.js';
 export * from '../integrations/store.js';

--- a/server/repositories/loop-runs.test.ts
+++ b/server/repositories/loop-runs.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { createLoopRun, getLoopRun, appendIteration, recordEmit } from './loop-runs.js';
+
+const TASK_ID = 't_task1';
+
+function insertTask(db: ReturnType<typeof createTestDb>): void {
+  db.prepare(
+    `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, source)
+     VALUES (?, 'x', '', 'looping', 'backlog', 'loop')`,
+  ).run(TASK_ID);
+}
+
+describe('loop-runs', () => {
+  let db: ReturnType<typeof createTestDb>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    insertTask(db);
+  });
+
+  it('createLoopRun round-trips', () => {
+    const run = createLoopRun({
+      task_id: TASK_ID,
+      spec_json: '{"goal":"fix bug"}',
+      max_iterations: 5,
+      budget_json: '{"tokens":100000}',
+    });
+
+    expect(run.id).toMatch(/^[a-zA-Z0-9_-]{12}$/);
+    expect(run.task_id).toBe(TASK_ID);
+    expect(run.spec_json).toBe('{"goal":"fix bug"}');
+    expect(run.status).toBe('running');
+    expect(run.iteration).toBe(0);
+    expect(run.max_iterations).toBe(5);
+    expect(run.budget_json).toBe('{"tokens":100000}');
+    expect(run.termination_reason).toBeNull();
+
+    const fetched = getLoopRun(run.id);
+    expect(fetched).toEqual(run);
+  });
+
+  it('getLoopRun returns undefined for an unknown id', () => {
+    expect(getLoopRun('nope')).toBeUndefined();
+  });
+
+  it('appendIteration increments n starting at 1', () => {
+    const run = createLoopRun({ task_id: TASK_ID, spec_json: '{}' });
+
+    const first = appendIteration(run.id, { sha_from: 'a1', sha_to: 'a2' });
+    expect(first.n).toBe(1);
+    expect(first.loop_run_id).toBe(run.id);
+    expect(first.sha_from).toBe('a1');
+    expect(first.sha_to).toBe('a2');
+
+    const second = appendIteration(run.id, { sha_from: 'a2', sha_to: 'a3', tokens: 500 });
+    expect(second.n).toBe(2);
+    expect(second.tokens).toBe(500);
+
+    const updatedRun = getLoopRun(run.id);
+    expect(updatedRun?.iteration).toBe(2);
+  });
+
+  it('recordEmit updates run status + latest iteration emit fields', () => {
+    const run = createLoopRun({ task_id: TASK_ID, spec_json: '{}' });
+    appendIteration(run.id, { sha_from: 'a1', sha_to: 'a2' });
+    const latest = appendIteration(run.id, { sha_from: 'a2', sha_to: 'a3' });
+
+    recordEmit(run.id, { status: 'done', reason: 'all tests pass' });
+
+    const updatedRun = getLoopRun(run.id);
+    expect(updatedRun?.status).toBe('done');
+    expect(updatedRun?.termination_reason).toBe('all tests pass');
+
+    const iterations = db.prepare(`SELECT * FROM loop_iterations WHERE id = ?`).get(latest.id) as {
+      emit_status: string;
+      emit_reason: string;
+    };
+    expect(iterations.emit_status).toBe('done');
+    expect(iterations.emit_reason).toBe('all tests pass');
+  });
+});

--- a/server/repositories/loop-runs.ts
+++ b/server/repositories/loop-runs.ts
@@ -1,0 +1,110 @@
+import { nanoid } from 'nanoid';
+import { getDb } from '../db.js';
+import { childLogger } from '../logger.js';
+import type { LoopRun, LoopIteration, LoopEmitStatus } from '../types.js';
+
+const logger = childLogger('loop-runs');
+
+export interface CreateLoopRunInput {
+  task_id: string;
+  spec_json: string;
+  max_iterations?: number | null;
+  budget_json?: string | null;
+}
+
+export function createLoopRun(input: CreateLoopRunInput): LoopRun {
+  const id = nanoid(12);
+  getDb()
+    .prepare(
+      `INSERT INTO loop_runs (id, task_id, spec_json, max_iterations, budget_json)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.task_id,
+      input.spec_json,
+      input.max_iterations ?? null,
+      input.budget_json ?? null,
+    );
+  const row = getLoopRun(id);
+  if (!row) throw new Error('failed to read loop_run after insert');
+  logger.info({ task_id: input.task_id, loop_run_id: id }, 'loop_run created');
+  return row;
+}
+
+export function getLoopRun(id: string): LoopRun | undefined {
+  return getDb().prepare(`SELECT * FROM loop_runs WHERE id = ?`).get(id) as LoopRun | undefined;
+}
+
+export function listLoopRuns(): LoopRun[] {
+  return getDb().prepare(`SELECT * FROM loop_runs ORDER BY created_at DESC`).all() as LoopRun[];
+}
+
+export function listIterationsForRun(loopRunId: string): LoopIteration[] {
+  return getDb()
+    .prepare(`SELECT * FROM loop_iterations WHERE loop_run_id = ? ORDER BY n ASC`)
+    .all(loopRunId) as LoopIteration[];
+}
+
+export interface AppendIterationInput {
+  sha_from?: string | null;
+  sha_to?: string | null;
+  verify_passed?: number | null;
+  tokens?: number | null;
+}
+
+/** Insert the next iteration row for a loop run, auto-incrementing `n`. */
+export function appendIteration(loopRunId: string, row: AppendIterationInput): LoopIteration {
+  const db = getDb();
+  const id = nanoid(12);
+  const { n } = db
+    .prepare(`SELECT COALESCE(MAX(n), 0) + 1 AS n FROM loop_iterations WHERE loop_run_id = ?`)
+    .get(loopRunId) as { n: number };
+
+  db.prepare(
+    `INSERT INTO loop_iterations (id, loop_run_id, n, sha_from, sha_to, verify_passed, tokens)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    loopRunId,
+    n,
+    row.sha_from ?? null,
+    row.sha_to ?? null,
+    row.verify_passed ?? null,
+    row.tokens ?? null,
+  );
+
+  db.prepare(`UPDATE loop_runs SET iteration = ?, updated_at = datetime('now') WHERE id = ?`).run(
+    n,
+    loopRunId,
+  );
+
+  logger.info({ loop_run_id: loopRunId, n }, 'loop_iteration appended');
+  return db.prepare(`SELECT * FROM loop_iterations WHERE id = ?`).get(id) as LoopIteration;
+}
+
+export interface RecordEmitInput {
+  status: LoopEmitStatus;
+  reason: string;
+}
+
+/** Set loop_runs.status + the latest iteration's emit_status/emit_reason. */
+export function recordEmit(loopRunId: string, input: RecordEmitInput): void {
+  const db = getDb();
+  db.prepare(
+    `UPDATE loop_runs SET status = ?, termination_reason = ?, updated_at = datetime('now') WHERE id = ?`,
+  ).run(input.status, input.reason, loopRunId);
+
+  const latest = db
+    .prepare(`SELECT id FROM loop_iterations WHERE loop_run_id = ? ORDER BY n DESC LIMIT 1`)
+    .get(loopRunId) as { id: string } | undefined;
+  if (latest) {
+    db.prepare(`UPDATE loop_iterations SET emit_status = ?, emit_reason = ? WHERE id = ?`).run(
+      input.status,
+      input.reason,
+      latest.id,
+    );
+  }
+
+  logger.info({ loop_run_id: loopRunId, status: input.status }, 'loop_run emit recorded');
+}

--- a/server/routes/loops.ts
+++ b/server/routes/loops.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { broadcast } from '../events.js';
+import { childLogger } from '../logger.js';
+import { checkAgentTokenExists } from '../repositories/agent-runtime.js';
+import {
+  getLoopRun,
+  listLoopRuns,
+  listIterationsForRun,
+  recordEmit,
+} from '../repositories/loop-runs.js';
+import { badRequest, notFound } from '../services/errors.js';
+import type { LoopEmitStatus } from '../types.js';
+
+const logger = childLogger('routes/loops');
+
+export const router = express.Router();
+
+const EMIT_STATUSES: LoopEmitStatus[] = ['done', 'blocked', 'needs_human'];
+
+/**
+ * Authorize a loop emit by its `Authorization: Bearer <hook_token>` header —
+ * reuses the same agent hook_token verification as server/hooks.ts.
+ */
+function requireBearerHookToken(req: Request, res: Response, next: NextFunction): void {
+  const match = /^Bearer (.+)$/.exec(req.headers.authorization ?? '');
+  const token = match?.[1];
+  if (!token || !checkAgentTokenExists(token)) {
+    logger.warn({ path: req.path, ip: req.ip }, 'loop emit: missing or invalid bearer token');
+    res.status(401).send();
+    return;
+  }
+  next();
+}
+
+router.post('/api/loops/:runId/emit', requireBearerHookToken, (req: Request, res: Response) => {
+  const { runId } = req.params as Record<string, string>;
+  const run = getLoopRun(runId);
+  if (!run) throw notFound('Loop run not found');
+
+  const body = req.body as { status?: unknown; reason?: unknown };
+  const status = body.status;
+  if (typeof status !== 'string' || !EMIT_STATUSES.includes(status as LoopEmitStatus)) {
+    throw badRequest(`status must be one of: ${EMIT_STATUSES.join(', ')}`);
+  }
+  const reason = body.reason;
+  if (typeof reason !== 'string' || !reason.trim()) {
+    throw badRequest('reason is required');
+  }
+
+  recordEmit(runId, { status: status as LoopEmitStatus, reason });
+
+  logger.info({ task_id: run.task_id, loop_run_id: runId, status }, 'loop emit: recorded');
+
+  broadcast({
+    type: 'loop:emit',
+    payload: { taskId: run.task_id, loopRunId: runId, status, reason },
+  });
+
+  res.status(200).json(getLoopRun(runId));
+});
+
+router.get('/api/loops', (_req: Request, res: Response) => {
+  res.json(listLoopRuns());
+});
+
+router.get('/api/loops/:runId', (req: Request, res: Response) => {
+  const { runId } = req.params as Record<string, string>;
+  const run = getLoopRun(runId);
+  if (!run) throw notFound('Loop run not found');
+  res.json({ ...run, iterations: listIterationsForRun(runId) });
+});

--- a/server/types.ts
+++ b/server/types.ts
@@ -78,6 +78,37 @@ export interface ReviewLearning {
 
 export type CommentStatus = 'draft' | 'accepted' | 'rejected' | 'published' | 'stale';
 export type CommentKind = 'comment' | 'suggestion';
+
+// ── Loop harness types ────────────────────────────────────────────────────
+
+export type LoopEmitStatus = 'done' | 'blocked' | 'needs_human';
+export type LoopRunStatus = 'running' | LoopEmitStatus;
+
+export interface LoopRun {
+  id: string;
+  task_id: string;
+  spec_json: string;
+  status: LoopRunStatus;
+  iteration: number;
+  max_iterations: number | null;
+  budget_json: string | null;
+  termination_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LoopIteration {
+  id: string;
+  loop_run_id: string;
+  n: number;
+  sha_from: string | null;
+  sha_to: string | null;
+  verify_passed: number | null;
+  tokens: number | null;
+  emit_status: string | null;
+  emit_reason: string | null;
+  created_at: string;
+}
 export type CommentBucket = 'actionable' | 'informational';
 export type CommentSeverity = 'nit' | 'suggestion' | 'issue' | 'critical';
 export type LastCheckStatus = 'resolved' | 'still_applies' | 'partial' | 'unclear';


### PR DESCRIPTION
## Summary
- P1a of the octomux Loop Harness: persistence for loop runs + the `octomux emit` completion callback (POST → validated → persisted). No loop engine, verifier, or respawn logic here — those are later phases.
- New tables `loop_runs` / `loop_iterations` (forward-only migration, mirrors the `review_runs` vertical).
- `server/repositories/loop-runs.ts`: `createLoopRun`, `getLoopRun`, `listLoopRuns`, `appendIteration` (auto-increments `n`), `recordEmit` (updates run status + latest iteration's emit fields).
- `server/routes/loops.ts`: `POST /api/loops/:runId/emit` (bearer-token auth via the agent's `hook_token`, hand-validated `{status, reason}` body — no ajv), `GET /api/loops`, `GET /api/loops/:runId`. Broadcasts a `loop:emit` event.
- `cli/src/commands/emit.ts`: `octomux emit --run <id> --status <s> --reason <text>` — reads `OCTOMUX_ACTION_BASE_URL` / `OCTOMUX_ACTION_TOKEN` from env (same env vars `server/orchestrator/mcp/write.ts` already reads for hook-calling code) and POSTs the emit payload.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (0 errors; pre-existing warnings only)
- [x] `bun run test` — full suite green (3478 passed, confirmed again by the pre-push hook)
- [x] New tests: `server/repositories/loop-runs.test.ts`, `server/api.loops.test.ts`, `cli/src/commands/emit.test.ts` (17 tests covering round-trip persistence, iteration increment, emit recording, 200/400/401/404 route behavior, and CLI POST construction)

```
$ bun run typecheck && bun run lint && bun run test
$ tsc -b
✖ 60 problems (0 errors, 60 warnings)   # pre-existing, unrelated to this change
 Test Files  269 passed (269)
      Tests  3478 passed (3478)
```