### PR TITLE
feat(loop): /loops feed, iteration ledger, control strip, new-loop form

### DIFF
--- a/server/api.loops.test.ts
+++ b/server/api.loops.test.ts
@@ -203,6 +203,38 @@ describe('loop routes', () => {
     });
   });
 
+  describe('POST /api/loops/:runId/stop', () => {
+    it('terminates a running loop and idles the task', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+      db.prepare(`UPDATE tasks SET runtime_state = 'looping' WHERE id = 't1'`).run();
+
+      const res = await request(app).post(`/api/loops/${run.id}/stop`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('needs_human');
+      expect(res.body.termination_reason).toBe('stopped');
+
+      const task = db.prepare('SELECT runtime_state FROM tasks WHERE id = ?').get('t1') as {
+        runtime_state: string;
+      };
+      expect(task.runtime_state).toBe('idle');
+    });
+
+    it('is a no-op for an already-terminated loop', async () => {
+      const run = createLoopRun({ task_id: 't1', spec_json: '{}' });
+      await request(app).post(`/api/loops/${run.id}/stop`);
+
+      const res = await request(app).post(`/api/loops/${run.id}/stop`);
+      expect(res.status).toBe(200);
+      expect(res.body.termination_reason).toBe('stopped');
+    });
+
+    it('returns 404 for an unknown run id', async () => {
+      const res = await request(app).post('/api/loops/does-not-exist/stop');
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe('GET /api/loops', () => {
     it('lists loop runs', async () => {
       createLoopRun({ task_id: 't1', spec_json: '{}' });

--- a/server/routes/loops.ts
+++ b/server/routes/loops.ts
@@ -8,8 +8,9 @@ import {
   listLoopRuns,
   listIterationsForRun,
   recordEmit,
+  terminateLoopRun,
 } from '../repositories/loop-runs.js';
-import { getTask } from '../repositories/tasks.js';
+import { getTask, setRuntimeState } from '../repositories/tasks.js';
 import { badRequest, notFound } from '../services/errors.js';
 import { startLoop } from '../task-engine/loop/engine.js';
 import type { LoopEmitStatus, LoopSpec } from '../types.js';
@@ -91,6 +92,21 @@ router.post('/api/loops/:runId/emit', requireBearerHookToken, (req: Request, res
   });
 
   res.status(200).json(getLoopRun(runId));
+});
+
+router.post('/api/loops/:runId/stop', (req: Request, res: Response) => {
+  const { runId } = req.params as Record<string, string>;
+  const run = getLoopRun(runId);
+  if (!run) throw notFound('Loop run not found');
+
+  if (run.status === 'running') {
+    terminateLoopRun(runId, 'needs_human', 'stopped');
+    setRuntimeState(run.task_id, 'idle');
+    logger.info({ task_id: run.task_id, loop_run_id: runId }, 'loop: stopped by user');
+    broadcast({ type: 'task:updated', payload: { taskId: run.task_id } });
+  }
+
+  res.json(getLoopRun(runId));
 });
 
 router.get('/api/loops', (_req: Request, res: Response) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ const IntegrationsPage = lazy(() => import('./pages/IntegrationsPage'));
 const SetupPage = lazy(() => import('./pages/SetupPage'));
 const ReviewDetailPage = lazy(() => import('./pages/ReviewDetailPage'));
 const OrchestratorPage = lazy(() => import('./pages/OrchestratorPage'));
+const LoopsPage = lazy(() => import('./pages/LoopsPage'));
+const LoopDetailPage = lazy(() => import('./pages/LoopDetailPage'));
 
 /** Runs at app root so notifications fire on every page. */
 function GlobalNotifications() {
@@ -129,6 +131,8 @@ export function AppShell() {
                 <Route path="/integrations" element={<IntegrationsPage />} />
                 <Route path="/setup" element={<SetupPage />} />
                 <Route path="/orchestrator" element={<OrchestratorPage />} />
+                <Route path="/loops" element={<LoopsPage />} />
+                <Route path="/loops/:id" element={<LoopDetailPage />} />
               </Routes>
             </Suspense>
           </div>

--- a/src/components/loop/IterationLedger.test.tsx
+++ b/src/components/loop/IterationLedger.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import { IterationLedger } from './IterationLedger';
+import type { LoopIteration } from '@/lib/api/loopApi';
+
+const { taskApiProxy, taskApiMock } = await vi.hoisted(async () =>
+  (await import('../../test-helpers')).setupApiMock(),
+);
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+
+function makeIteration(overrides: Partial<LoopIteration> = {}): LoopIteration {
+  return {
+    id: `it-${overrides.n ?? 1}`,
+    loop_run_id: 'loop-1',
+    n: 1,
+    sha_from: 'sha-a',
+    sha_to: 'sha-b',
+    verify_passed: 1,
+    tokens: 100,
+    emit_status: null,
+    emit_reason: null,
+    created_at: '2026-01-01 00:00:00',
+    ...overrides,
+  };
+}
+
+describe('IterationLedger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskApiMock.getTaskDiffSummary.mockResolvedValue({ files: [] });
+  });
+
+  it('renders one row per iteration with verify badges', () => {
+    const iterations = [
+      makeIteration({ id: 'it-1', n: 1, verify_passed: 1 }),
+      makeIteration({ id: 'it-2', n: 2, verify_passed: 0 }),
+      makeIteration({ id: 'it-3', n: 3, verify_passed: null }),
+    ];
+    render(<IterationLedger taskId="task-1" iterations={iterations} />);
+
+    expect(screen.getByTestId('iteration-row-1')).toBeTruthy();
+    expect(screen.getByTestId('iteration-row-2')).toBeTruthy();
+    expect(screen.getByTestId('iteration-row-3')).toBeTruthy();
+    expect(screen.getByText('verify pass')).toBeTruthy();
+    expect(screen.getByText('verify fail')).toBeTruthy();
+    expect(screen.getByText('pending')).toBeTruthy();
+  });
+
+  it('shows an empty state with no iterations', () => {
+    render(<IterationLedger taskId="task-1" iterations={[]} />);
+    expect(screen.getByText(/no iterations yet/i)).toBeTruthy();
+  });
+
+  it('requests the diff for the clicked iteration range', async () => {
+    const user = userEvent.setup();
+    const iterations = [
+      makeIteration({ id: 'it-1', n: 1, sha_from: 'aaa111', sha_to: 'bbb222' }),
+      makeIteration({ id: 'it-2', n: 2, sha_from: 'bbb222', sha_to: 'ccc333' }),
+    ];
+    render(<IterationLedger taskId="task-1" iterations={iterations} />);
+
+    expect(screen.queryByTestId('iteration-diff-pane')).toBeNull();
+
+    await user.click(screen.getByTestId('iteration-row-2'));
+
+    await waitFor(() =>
+      expect(taskApiMock.getTaskDiffSummary).toHaveBeenCalledWith('task-1', {
+        kind: 'range',
+        from: 'bbb222',
+        to: 'ccc333',
+      }),
+    );
+    expect(screen.getByTestId('iteration-diff-pane')).toBeTruthy();
+  });
+});

--- a/src/components/loop/IterationLedger.tsx
+++ b/src/components/loop/IterationLedger.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { DiffViewer } from '@/components/DiffViewer';
+import type { LoopIteration } from '@/lib/api/loopApi';
+
+interface IterationLedgerProps {
+  taskId: string;
+  iterations: LoopIteration[];
+}
+
+function verifyBadge(iteration: LoopIteration) {
+  if (iteration.verify_passed === null) {
+    return <Badge variant="secondary">pending</Badge>;
+  }
+  return iteration.verify_passed ? (
+    <Badge variant="outline">verify pass</Badge>
+  ) : (
+    <Badge variant="destructive">verify fail</Badge>
+  );
+}
+
+export function IterationLedger({ taskId, iterations }: IterationLedgerProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = iterations.find((it) => it.id === selectedId) ?? null;
+
+  if (iterations.length === 0) {
+    return <p className="text-sm text-muted-foreground">No iterations yet.</p>;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <ul className="flex shrink-0 flex-col gap-1.5" data-testid="iteration-ledger">
+        {iterations.map((it) => {
+          const rowSelected = it.id === selectedId;
+          return (
+            <li key={it.id}>
+              <button
+                type="button"
+                data-testid={`iteration-row-${it.n}`}
+                onClick={() => setSelectedId(it.id)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-lg border border-glass-edge bg-glass-l1 px-3 py-2 text-left transition-colors hover:bg-glass-l2/60',
+                  rowSelected && 'border-primary bg-glass-l2/80',
+                )}
+              >
+                <span className="w-8 shrink-0 font-mono text-xs text-muted-foreground">
+                  #{it.n}
+                </span>
+                {verifyBadge(it)}
+                <span className="text-xs text-muted-foreground">
+                  {it.tokens != null ? `${it.tokens} tokens` : '—'}
+                </span>
+                {it.emit_status && (
+                  <span className="ml-auto shrink-0 text-[11px] text-muted-soft">
+                    {it.emit_status}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {selected && (
+        <div
+          className="min-h-0 flex-1 overflow-hidden rounded-lg border border-glass-edge"
+          data-testid="iteration-diff-pane"
+        >
+          <DiffViewer
+            taskId={taskId}
+            range={{ kind: 'range', from: selected.sha_from ?? '', to: selected.sha_to ?? '' }}
+            hideFileTree
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/loop/NewLoopDialog.tsx
+++ b/src/components/loop/NewLoopDialog.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { TaskPickerField } from '@/components/fields/TaskPickerField';
+import { loopApi, type LoopRun } from '@/lib/api/loopApi';
+
+interface NewLoopDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (run: LoopRun) => void;
+}
+
+export function NewLoopDialog({ open, onOpenChange, onCreated }: NewLoopDialogProps) {
+  const [taskId, setTaskId] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [verify, setVerify] = useState('');
+  const [maxIterations, setMaxIterations] = useState('10');
+  const [budgetTokens, setBudgetTokens] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setTaskId('');
+    setPrompt('');
+    setVerify('');
+    setMaxIterations('10');
+    setBudgetTokens('');
+    setError(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (submitting) return;
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [submitting, reset, onOpenChange],
+  );
+
+  const maxIterationsN = Number.parseInt(maxIterations, 10);
+  const canSubmit =
+    !submitting &&
+    taskId.length > 0 &&
+    prompt.trim().length > 0 &&
+    verify.trim().length > 0 &&
+    Number.isInteger(maxIterationsN) &&
+    maxIterationsN >= 1;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const budgetTokensN = Number.parseInt(budgetTokens, 10);
+      const run = await loopApi.createLoop(taskId, {
+        prompt: prompt.trim(),
+        verify: verify.trim(),
+        maxIterations: maxIterationsN,
+        ...(Number.isInteger(budgetTokensN) && budgetTokensN > 0
+          ? { budget: { tokens: budgetTokensN } }
+          : {}),
+      });
+      reset();
+      onOpenChange(false);
+      onCreated(run);
+    } catch (err) {
+      setError((err as Error).message || 'Failed to create loop');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    canSubmit,
+    taskId,
+    prompt,
+    verify,
+    maxIterationsN,
+    budgetTokens,
+    reset,
+    onOpenChange,
+    onCreated,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="new-loop-dialog" className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New loop</DialogTitle>
+          <DialogDescription>
+            Run a task's agent repeatedly, verifying and auto-committing each iteration until it
+            reports done, gets blocked, or hits a limit.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label>Task</Label>
+            <TaskPickerField value={taskId} onChange={setTaskId} />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="loop-prompt">Prompt</Label>
+            <Textarea
+              id="loop-prompt"
+              data-testid="loop-prompt"
+              rows={4}
+              placeholder="What should the agent do each iteration?"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="loop-verify">Verify command</Label>
+            <Input
+              id="loop-verify"
+              data-testid="loop-verify"
+              className="font-mono text-sm"
+              placeholder="bun run test"
+              value={verify}
+              onChange={(e) => setVerify(e.target.value)}
+            />
+          </div>
+
+          <div className="flex items-end gap-3">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="loop-max-iterations">Max iterations</Label>
+              <Input
+                id="loop-max-iterations"
+                data-testid="loop-max-iterations"
+                type="number"
+                min={1}
+                value={maxIterations}
+                onChange={(e) => setMaxIterations(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="loop-budget-tokens">Budget tokens (optional)</Label>
+              <Input
+                id="loop-budget-tokens"
+                data-testid="loop-budget-tokens"
+                type="number"
+                min={0}
+                placeholder="none"
+                value={budgetTokens}
+                onChange={(e) => setBudgetTokens(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button data-testid="new-loop-submit" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? 'Starting…' : 'Start loop'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/sidebar/glyphs.tsx
+++ b/src/components/sidebar/glyphs.tsx
@@ -268,6 +268,25 @@ export function OrchestratorIcon({ color }: { color: string }) {
   );
 }
 
+export function LoopsIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <path d="M17 2.1 21 6l-4 3.9M3 12v-2a4 4 0 0 1 4-4h14M7 21.9 3 18l4-3.9M21 12v2a4 4 0 0 1-4 4H3" />
+    </svg>
+  );
+}
+
 export function SettingsIcon({ color }: { color: string }) {
   return (
     <svg

--- a/src/components/sidebar/nav-items.ts
+++ b/src/components/sidebar/nav-items.ts
@@ -6,6 +6,7 @@ import {
   MonitorIcon,
   WorkspacesIcon,
   OrchestratorIcon,
+  LoopsIcon,
   SettingsIcon,
   type NavIcon,
 } from './glyphs';
@@ -30,6 +31,7 @@ export const MORE_ITEMS = [
   { key: 'monitor', label: 'Monitor', to: '/monitor', Icon: MonitorIcon },
   { key: 'workspaces', label: 'Workspaces', to: '/workspaces', Icon: WorkspacesIcon },
   { key: 'orchestrator', label: 'Orchestrator', to: '/orchestrator', Icon: OrchestratorIcon },
+  { key: 'loops', label: 'Loops', to: '/loops', Icon: LoopsIcon },
 ] as const;
 
 // ─── Fork refusal helper ────────────────────────────────────────────────────

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -14,6 +14,7 @@ export type { ReviewLearning } from '../../../server/types';
 export * from './taskApi';
 export * from './reviewApi';
 export * from './configApi';
+export * from './loopApi';
 
 // Re-export the orchestrator REST + WebSocket client. It stays a separate,
 // incompatibly-shaped surface (its `/ws/orchestrator/:id` socket is not folded

--- a/src/lib/api/loopApi.ts
+++ b/src/lib/api/loopApi.ts
@@ -1,0 +1,23 @@
+/**
+ * src/lib/api/loopApi.ts
+ *
+ * Loop harness API surface: loop run feed, detail (with iterations), create,
+ * and stop. Mirrors `server/routes/loops.ts`.
+ */
+
+import type { LoopRun, LoopIteration, LoopSpec } from '../../../server/types';
+import { request } from './client';
+
+export type { LoopRun, LoopIteration, LoopSpec };
+
+export interface LoopRunDetail extends LoopRun {
+  iterations: LoopIteration[];
+}
+
+export const loopApi = {
+  listLoops: () => request<LoopRun[]>('/loops'),
+  getLoop: (runId: string) => request<LoopRunDetail>(`/loops/${runId}`),
+  createLoop: (taskId: string, spec: LoopSpec) =>
+    request<LoopRun>('/loops', { method: 'POST', body: JSON.stringify({ taskId, spec }) }),
+  stopLoop: (runId: string) => request<LoopRun>(`/loops/${runId}/stop`, { method: 'POST' }),
+};

--- a/src/lib/event-source.ts
+++ b/src/lib/event-source.ts
@@ -23,7 +23,8 @@ export type ServerEventType =
   | 'review:drafts-ready'
   | 'review:run-failed'
   | 'review:published'
-  | 'review:head-advanced';
+  | 'review:head-advanced'
+  | 'loop:emit';
 
 /**
  * A real-time event delivered over `/ws/events`. The payload is intentionally a
@@ -41,6 +42,8 @@ export interface ServerEvent {
     github_review_url?: string | null;
     phase?: string;
     reason?: string;
+    loopRunId?: string;
+    status?: string;
     [key: string]: unknown;
   };
 }

--- a/src/pages/LoopDetailPage.test.tsx
+++ b/src/pages/LoopDetailPage.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoopDetailPage from './LoopDetailPage';
+import { renderWithRouter, makeTask } from '../test-helpers';
+import type { LoopRunDetail } from '@/lib/api/loopApi';
+
+const { taskApiProxy, reviewApiProxy, configApiProxy, loopApiProxy, apiMock } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
+vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('@/lib/api/loopApi', () => ({ loopApi: loopApiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useParams: () => ({ id: 'loop-1' }) };
+});
+vi.mock('../components/loop/IterationLedger', () => ({
+  IterationLedger: ({ iterations }: { iterations: unknown[] }) => (
+    <div data-testid="iteration-ledger-stub">{iterations.length} iterations</div>
+  ),
+}));
+vi.mock('../components/TerminalView', () => ({
+  TerminalView: ({ windowIndex }: { windowIndex: number }) => (
+    <div data-testid="terminal-view-stub">window {windowIndex}</div>
+  ),
+}));
+
+function makeRun(overrides: Partial<LoopRunDetail> = {}): LoopRunDetail {
+  return {
+    id: 'loop-1',
+    task_id: 'task-1',
+    spec_json: '{}',
+    status: 'running',
+    iteration: 2,
+    max_iterations: 10,
+    budget_json: null,
+    termination_reason: null,
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    iterations: [],
+    ...overrides,
+  };
+}
+
+describe('LoopDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getTask.mockResolvedValue(makeTask({ id: 'task-1' }));
+  });
+
+  it('renders the control strip with iteration/max and the ledger', async () => {
+    apiMock.getLoop.mockResolvedValue(
+      makeRun({ iteration: 2, max_iterations: 10, iterations: [{}, {}] as never }),
+    );
+    renderWithRouter(<LoopDetailPage />);
+
+    expect(await screen.findByTestId('loop-control-strip')).toBeTruthy();
+    expect(screen.getByText('Iteration 2 / 10')).toBeTruthy();
+    expect(screen.getByTestId('iteration-ledger-stub')).toBeTruthy();
+  });
+
+  it('shows the termination reason when present', async () => {
+    apiMock.getLoop.mockResolvedValue(
+      makeRun({ status: 'needs_human', termination_reason: 'max_iterations' }),
+    );
+    renderWithRouter(<LoopDetailPage />);
+    expect(await screen.findByTestId('termination-reason')).toHaveTextContent('max_iterations');
+  });
+
+  it('shows Stop for a running loop and calls stopLoop on click', async () => {
+    const user = userEvent.setup();
+    apiMock.getLoop.mockResolvedValue(makeRun({ status: 'running' }));
+    apiMock.stopLoop.mockResolvedValue({ id: 'loop-1', status: 'needs_human' });
+    renderWithRouter(<LoopDetailPage />);
+
+    const stopButton = await screen.findByTestId('loop-stop-button');
+    await user.click(stopButton);
+
+    await waitFor(() => expect(apiMock.stopLoop).toHaveBeenCalledWith('loop-1'));
+  });
+
+  it('hides Stop once the loop has terminated', async () => {
+    apiMock.getLoop.mockResolvedValue(makeRun({ status: 'done' }));
+    renderWithRouter(<LoopDetailPage />);
+    await screen.findByTestId('loop-control-strip');
+    expect(screen.queryByTestId('loop-stop-button')).toBeNull();
+  });
+});

--- a/src/pages/LoopDetailPage.tsx
+++ b/src/pages/LoopDetailPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { loopApi, type LoopRunDetail } from '../lib/api/loopApi';
+import { taskApi } from '../lib/api/taskApi';
+import { useResource } from '../lib/use-resource';
+import { IterationLedger } from '../components/loop/IterationLedger';
+import { TerminalView } from '../components/TerminalView';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { PageHeader } from '@/components/layout/page-header';
+
+type Tab = 'ledger' | 'agent';
+
+export default function LoopDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const {
+    data: run,
+    loading,
+    refresh,
+  } = useResource<LoopRunDetail>(id ? `loop:${id}` : null, () => loopApi.getLoop(id!), {
+    events: (event) =>
+      (event.type === 'loop:emit' && event.payload.loopRunId === id) ||
+      event.type === 'task:updated',
+  });
+  const [tab, setTab] = useState<Tab>('ledger');
+  const [stopping, setStopping] = useState(false);
+
+  const { data: task } = useResource(run ? `task:${run.task_id}` : null, () =>
+    taskApi.getTask(run!.task_id),
+  );
+
+  if (loading) return <div className="p-6 text-sm text-muted-foreground">Loading…</div>;
+  if (!run) return <div className="p-6 text-sm text-destructive">Loop run not found.</div>;
+
+  const spec = (() => {
+    try {
+      return JSON.parse(run.spec_json) as { budget?: { tokens?: number } };
+    } catch {
+      return {};
+    }
+  })();
+  const tokensUsed = run.iterations.reduce((sum, it) => sum + (it.tokens ?? 0), 0);
+
+  const handleStop = async () => {
+    setStopping(true);
+    try {
+      await loopApi.stopLoop(run.id);
+      await refresh();
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  const activeAgent = task?.agents?.find((a) => a.status !== 'stopped') ?? null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col p-6">
+      <PageHeader title={`Loop ${run.id}`} />
+
+      <div
+        data-testid="loop-control-strip"
+        className="mt-4 flex flex-wrap items-center gap-3 rounded-2xl border border-glass-edge bg-glass-l1 px-4 py-3"
+      >
+        <Badge data-testid="loop-status-badge">{run.status}</Badge>
+        <span className="font-mono text-sm">
+          Iteration {run.iteration} / {run.max_iterations ?? '∞'}
+        </span>
+        {spec.budget?.tokens != null && (
+          <span className="text-xs text-muted-foreground">
+            {tokensUsed} / {spec.budget.tokens} tokens
+          </span>
+        )}
+        {run.termination_reason && (
+          <span data-testid="termination-reason" className="text-xs text-muted-foreground">
+            {run.termination_reason}
+          </span>
+        )}
+        {run.status === 'running' && (
+          <Button
+            size="sm"
+            variant="destructive"
+            className="ml-auto"
+            data-testid="loop-stop-button"
+            onClick={handleStop}
+            disabled={stopping}
+          >
+            {stopping ? 'Stopping…' : 'Stop'}
+          </Button>
+        )}
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <Button
+          variant={tab === 'ledger' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setTab('ledger')}
+        >
+          Iterations
+        </Button>
+        <Button
+          variant={tab === 'agent' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setTab('agent')}
+        >
+          Live agent
+        </Button>
+      </div>
+
+      <div className="mt-4 min-h-0 flex-1">
+        {tab === 'ledger' ? (
+          <IterationLedger taskId={run.task_id} iterations={run.iterations} />
+        ) : activeAgent ? (
+          <TerminalView taskId={run.task_id} windowIndex={activeAgent.window_index} />
+        ) : (
+          <p className="text-sm text-muted-foreground">No active agent session.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/LoopsPage.test.tsx
+++ b/src/pages/LoopsPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoopsPage from './LoopsPage';
+import { renderWithRouter } from '../test-helpers';
+import type { LoopRun } from '@/lib/api/loopApi';
+
+const { taskApiProxy, reviewApiProxy, configApiProxy, loopApiProxy, apiMock } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
+vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('@/lib/api/loopApi', () => ({ loopApi: loopApiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+
+const { routerMockFactory, mockNavigate } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function makeRun(overrides: Partial<LoopRun> = {}): LoopRun {
+  return {
+    id: 'loop-1',
+    task_id: 'task-1',
+    spec_json: '{}',
+    status: 'running',
+    iteration: 2,
+    max_iterations: 10,
+    budget_json: null,
+    termination_reason: null,
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    ...overrides,
+  };
+}
+
+describe('LoopsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows empty state when no loops', async () => {
+    apiMock.listLoops.mockResolvedValue([]);
+    renderWithRouter(<LoopsPage />);
+    expect(await screen.findByText(/no loop runs yet/i)).toBeTruthy();
+  });
+
+  it('renders loop rows with status + iteration/max', async () => {
+    apiMock.listLoops.mockResolvedValue([
+      makeRun({ id: 'loop-1', status: 'running', iteration: 2, max_iterations: 10 }),
+      makeRun({ id: 'loop-2', status: 'done', iteration: 5, max_iterations: 5 }),
+    ]);
+    renderWithRouter(<LoopsPage />);
+
+    expect(await screen.findByTestId('loop-row-loop-1')).toBeTruthy();
+    expect(screen.getByTestId('loop-row-loop-2')).toBeTruthy();
+    expect(screen.getByText('running')).toBeTruthy();
+    expect(screen.getByText('done')).toBeTruthy();
+    expect(screen.getByText('2 / 10')).toBeTruthy();
+    expect(screen.getByText('5 / 5')).toBeTruthy();
+  });
+
+  it('shows the termination reason when present', async () => {
+    apiMock.listLoops.mockResolvedValue([
+      makeRun({ id: 'loop-1', status: 'needs_human', termination_reason: 'max_iterations' }),
+    ]);
+    renderWithRouter(<LoopsPage />);
+    expect(await screen.findByText('max_iterations')).toBeTruthy();
+  });
+
+  it('navigates to /loops/:id on row click', async () => {
+    const user = userEvent.setup();
+    apiMock.listLoops.mockResolvedValue([makeRun({ id: 'loop-42' })]);
+    renderWithRouter(<LoopsPage />);
+
+    const row = await screen.findByTestId('loop-row-loop-42');
+    await user.click(row);
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/loops/loop-42'));
+  });
+});

--- a/src/pages/LoopsPage.tsx
+++ b/src/pages/LoopsPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loopApi, type LoopRun } from '../lib/api/loopApi';
+import { useResource } from '../lib/use-resource';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { Badge } from '../components/ui/badge';
+import { Button } from '../components/ui/button';
+import { PageHeader } from '@/components/layout/page-header';
+import { NewLoopDialog } from '../components/loop/NewLoopDialog';
+import { timeAgo } from '@/lib/time';
+
+const STATUS_VARIANT: Record<
+  LoopRun['status'],
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  running: 'secondary',
+  done: 'outline',
+  blocked: 'destructive',
+  needs_human: 'default',
+};
+
+export default function LoopsPage() {
+  const { data, loading, refresh } = useResource<LoopRun[]>('loops', () => loopApi.listLoops(), {
+    events: (event) => event.type === 'loop:emit' || event.type === 'task:updated',
+  });
+  const [newLoopOpen, setNewLoopOpen] = useState(false);
+  const runs = data ?? [];
+  const nav = useNavigate();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col p-6">
+      <PageHeader title="Loops" />
+      <div className="mt-4 flex items-center justify-end">
+        <Button size="sm" onClick={() => setNewLoopOpen(true)}>
+          New loop
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="mt-4 space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-2xl border border-glass-edge bg-glass-l1"
+            />
+          ))}
+        </div>
+      ) : runs.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">No loop runs yet.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {runs.map((r) => (
+            <li key={r.id}>
+              <GlassPanel
+                level={2}
+                specular
+                data-testid={`loop-row-${r.id}`}
+                className="group flex cursor-pointer flex-col gap-2 rounded-2xl px-4 py-3 transition-colors hover:bg-glass-l3/80 sm:flex-row sm:items-center"
+                onClick={() => nav(`/loops/${r.id}`)}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-medium text-foreground group-hover:text-primary">
+                      {r.task_id}
+                    </span>
+                    <Badge variant={STATUS_VARIANT[r.status]}>{r.status}</Badge>
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {r.iteration} / {r.max_iterations ?? '∞'}
+                    </span>
+                    <span className="text-[10px] text-muted-soft">{timeAgo(r.updated_at)}</span>
+                  </div>
+                  {r.termination_reason && (
+                    <p className="mt-1 text-xs text-muted-foreground">{r.termination_reason}</p>
+                  )}
+                </div>
+              </GlassPanel>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <NewLoopDialog
+        open={newLoopOpen}
+        onOpenChange={setNewLoopOpen}
+        onCreated={(run) => {
+          refresh();
+          nav(`/loops/${run.id}`);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -79,12 +79,14 @@ export function setupRouterNavigateMock() {
 type ApiMock = ReturnType<typeof mockTaskApi> &
   ReturnType<typeof mockReviewApi> &
   ReturnType<typeof mockConfigApi> &
+  ReturnType<typeof mockLoopApi> &
   Record<string, unknown>;
 
 export function setupApiMock(overrides: Record<string, unknown> = {}) {
   const taskApiMock = mockTaskApi(overrides);
   const reviewApiMock = mockReviewApi(overrides);
   const configApiMock = mockConfigApi(overrides);
+  const loopApiMock = mockLoopApi(overrides);
   const taskApiProxy = new Proxy(
     {},
     { get: (_target, prop: string) => taskApiMock[prop as keyof typeof taskApiMock] },
@@ -97,6 +99,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     {},
     { get: (_target, prop: string) => configApiMock[prop as keyof typeof configApiMock] },
   );
+  const loopApiProxy = new Proxy(
+    {},
+    { get: (_target, prop: string) => loopApiMock[prop as keyof typeof loopApiMock] },
+  );
   const apiMock = new Proxy(
     {},
     {
@@ -104,6 +110,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
         if (prop in taskApiMock) return taskApiMock[prop as keyof typeof taskApiMock];
         if (prop in reviewApiMock) return reviewApiMock[prop as keyof typeof reviewApiMock];
         if (prop in configApiMock) return configApiMock[prop as keyof typeof configApiMock];
+        if (prop in loopApiMock) return loopApiMock[prop as keyof typeof loopApiMock];
         return overrides[prop];
       },
       set: (_target, prop: string, value) => {
@@ -119,6 +126,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
           (configApiMock as Record<string, unknown>)[prop] = value;
           return true;
         }
+        if (prop in loopApiMock) {
+          (loopApiMock as Record<string, unknown>)[prop] = value;
+          return true;
+        }
         overrides[prop] = value;
         return true;
       },
@@ -132,9 +143,11 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     taskApiMock,
     reviewApiMock,
     configApiMock,
+    loopApiMock,
     taskApiProxy,
     reviewApiProxy,
     configApiProxy,
+    loopApiProxy,
     apiMock,
     apiProxy,
   };
@@ -377,6 +390,33 @@ export function mockConfigApi(overrides: Record<string, unknown> = {}) {
   return { ...defaults, ...overrides };
 }
 
+export function mockLoopApi(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    listLoops: vi.fn().mockResolvedValue([]),
+    getLoop: vi.fn().mockResolvedValue(null),
+    createLoop: vi.fn().mockResolvedValue({
+      id: 'loop-1',
+      task_id: 'test-task-01',
+      spec_json: '{}',
+      status: 'running',
+      iteration: 0,
+      max_iterations: 10,
+      budget_json: null,
+      termination_reason: null,
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:00',
+    }),
+    stopLoop: vi.fn().mockResolvedValue({ id: 'loop-1', status: 'needs_human' }),
+  };
+  return { ...defaults, ...overrides };
+}
+
 export function mockApi(overrides: Record<string, unknown> = {}) {
-  return { ...mockTaskApi(), ...mockReviewApi(), ...mockConfigApi(), ...overrides };
+  return {
+    ...mockTaskApi(),
+    ...mockReviewApi(),
+    ...mockConfigApi(),
+    ...mockLoopApi(),
+    ...overrides,
+  };
 }


### PR DESCRIPTION
## Summary
- `POST /api/loops/:runId/stop` — terminates a running loop and idles the task (server/routes/loops.ts), reusing the existing `terminateLoopRun`/`setRuntimeState` helpers.
- `src/lib/api/loopApi.ts` — `listLoops`/`getLoop`/`createLoop`/`stopLoop`, exported from `src/lib/api/index.ts`.
- `/loops` feed (`LoopsPage`) — status, iteration/max, termination reason, New Loop button; `/loops/:id` detail (`LoopDetailPage`) — control strip (iteration/max, budget consumed, termination reason, Stop) + an Iterations/Live-agent tab switch.
- `IterationLedger` — one row per iteration with a verify pass/fail badge and token count; clicking a row renders that iteration's diff via the existing `DiffViewer` keyed to `{ kind: 'range', from: sha_from, to: sha_to }` (no new diff plumbing).
- `NewLoopDialog` — task picker + prompt/verify/max-iterations/budget-tokens form → `createLoop`, mirroring `BulkCreateDialog`'s dialog/field patterns.
- Live-agent tab reuses `TerminalView` against the task's active agent's tmux window.
- Wired into nav (`MORE_ITEMS` + new `LoopsIcon`) and `App.tsx` routes; added `'loop:emit'` to the FE `ServerEventType` union so loop pages can refresh on emit events.
- Added `mockLoopApi` to `test-helpers.tsx`, mirroring the existing `mockReviewApi` pattern.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run format:check` — clean
- [x] `bun run test` — 3532/3536 passing; the 3 failures (`server/diff-review-state.test.ts` x2, `server/hooks.test.ts` x1) are pre-existing flakes under full-suite resource contention — confirmed passing in isolation and untouched by this change
- [x] Manual smoke test in the browser: created a real scratch task + loop via the API, verified `/loops` feed, `/loops/:id` control strip, iteration ledger empty state, the live-agent terminal tab streaming a real Claude Code session, and the Stop button flipping status to `needs_human` with `termination_reason: "stopped"`