### PR TITLE
Finish loop harness P1: reject duplicate loops, crash-resume in-flight loops

### DIFF
--- a/server/api.loops.test.ts
+++ b/server/api.loops.test.ts
@@ -116,6 +116,34 @@ describe('loop routes', () => {
         .send({ taskId: 't1', spec: { prompt: 'x', verify: 'y', maxIterations: 5 } });
       expect(res.status).toBe(400);
     });
+
+    it('returns 409 when the task already has an active loop run', async () => {
+      createLoopRun({ task_id: 't1', spec_json: '{}' });
+      db.prepare(`UPDATE tasks SET runtime_state = 'looping' WHERE id = 't1'`).run();
+
+      const res = await request(app)
+        .post('/api/loops')
+        .send({
+          taskId: 't1',
+          spec: { prompt: 'do the thing', verify: 'echo ok', maxIterations: 5 },
+        });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/already has an active loop run/);
+    });
+
+    it('returns 409 when a loop_run is running even if runtime_state has not flipped yet', async () => {
+      createLoopRun({ task_id: 't1', spec_json: '{}' });
+
+      const res = await request(app)
+        .post('/api/loops')
+        .send({
+          taskId: 't1',
+          spec: { prompt: 'do the thing', verify: 'echo ok', maxIterations: 5 },
+        });
+
+      expect(res.status).toBe(409);
+    });
   });
 
   describe('POST /api/loops/:runId/emit', () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import { createServer, type IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import path from 'path';
-import fs from 'fs';
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { createApp } from './app.js';
@@ -26,22 +25,16 @@ import { createSupervisor } from './orchestrator/supervisor.js';
 import { rehydrateConversations } from './orchestrator/runner.js';
 import { rehydratePendingCards } from './orchestrator/gate.js';
 import { startPolling, stopPolling } from './poller.js';
-import { checkTaskStatus } from './poller.js';
 import {
-  resumeTask,
   cleanupOrphanedViewerSessions,
   reconcileOrphanSettingUp,
   gcScratchDirs,
+  recoverTasks,
 } from './task-engine/index.js';
 import { ensureTmuxRuntimeDir } from './tmux-bin.js';
 import { syncAgents } from './agents.js';
 import { ensureGithubLogin } from './github-login.js';
 import { childLogger } from './logger.js';
-import {
-  listRecoverableTasks,
-  setRuntimeState,
-  setRuntimeStateSetupInterrupted,
-} from './repositories/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const logger = childLogger('index');
@@ -64,32 +57,6 @@ server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
   if (handleOrchestratorUpgrade(req, socket, head)) return;
   socket.destroy();
 });
-
-// ─── Startup Recovery ──────────────────────────────────────────────────────
-async function recoverTasks(): Promise<void> {
-  const staleTasks = listRecoverableTasks();
-
-  for (const task of staleTasks) {
-    const status = await checkTaskStatus(task);
-    if (status === 'alive') continue;
-
-    // Session is dead. Require tmux_session too — without it the task never
-    // reached the new-session step, so there's nothing for resumeTask to
-    // re-attach to; treat it as an interrupted setup instead.
-    if (task.worktree && fs.existsSync(task.worktree) && task.tmux_session) {
-      logger.warn({ task_id: task.id, title: task.title }, 'Recovery: resuming task');
-      resumeTask(task).catch((err) => {
-        logger.error({ task_id: task.id, err }, 'Recovery: resumeTask failed');
-      });
-    } else if (task.runtime_state === 'setting_up') {
-      logger.warn({ task_id: task.id, title: task.title }, 'Recovery: setup was interrupted');
-      setRuntimeStateSetupInterrupted(task.id);
-    } else {
-      logger.warn({ task_id: task.id, title: task.title }, 'Recovery: worktree missing');
-      setRuntimeState(task.id, 'error', 'Worktree missing after restart');
-    }
-  }
-}
 
 // Create the run/ dir holding the private tmux socket before any tmux call.
 ensureTmuxRuntimeDir();

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -111,12 +111,13 @@ export function listWalkthroughHandoffTasks(): Task[] {
 }
 
 /**
- * List all running/setting_up tasks regardless of tmux_session.
- * Used by startup recovery (recoverTasks).
+ * List all running/setting_up/looping tasks regardless of tmux_session.
+ * Used by startup recovery (recoverTasks) — 'looping' tasks are routed to
+ * the loop's fresh-context resume, never the normal --resume ladder.
  */
 export function listRecoverableTasks(): Task[] {
   return getDb()
-    .prepare(`${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'setting_up')`)
+    .prepare(`${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'setting_up', 'looping')`)
     .all() as Task[];
 }
 

--- a/server/routes/loops.ts
+++ b/server/routes/loops.ts
@@ -4,6 +4,7 @@ import { broadcast } from '../events.js';
 import { childLogger } from '../logger.js';
 import { checkAgentTokenExists } from '../repositories/agent-runtime.js';
 import {
+  getActiveLoopRunForTask,
   getLoopRun,
   listLoopRuns,
   listIterationsForRun,
@@ -11,7 +12,7 @@ import {
   terminateLoopRun,
 } from '../repositories/loop-runs.js';
 import { getTask, setRuntimeState } from '../repositories/tasks.js';
-import { badRequest, notFound } from '../services/errors.js';
+import { badRequest, conflict, notFound } from '../services/errors.js';
 import { startLoop } from '../task-engine/loop/engine.js';
 import type { LoopEmitStatus, LoopSpec } from '../types.js';
 
@@ -58,6 +59,11 @@ router.post('/api/loops', async (req: Request, res: Response) => {
 
   const task = getTask(body.taskId);
   if (!task) throw notFound('Task not found');
+
+  const activeRun = getActiveLoopRunForTask(body.taskId);
+  if (task.runtime_state === 'looping' || activeRun?.status === 'running') {
+    throw conflict('task already has an active loop run');
+  }
 
   try {
     const run = await startLoop(body.taskId, spec as LoopSpec);

--- a/server/task-engine/index.ts
+++ b/server/task-engine/index.ts
@@ -15,6 +15,7 @@ export {
   scratchDirFor,
   reconcileOrphanSettingUp,
   gcScratchDirs,
+  recoverTasks,
 } from './reconcile.js';
 export {
   validateRepo,

--- a/server/task-engine/lifecycle/respawn-agent.test.ts
+++ b/server/task-engine/lifecycle/respawn-agent.test.ts
@@ -24,7 +24,7 @@ vi.mock('child_process', () => ({
   execFile: vi.fn(
     (_cmd: string, args: string[], optsOrCb: Function | object, maybeCb?: Function) => {
       const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb!;
-      if (args.includes('list-windows')) {
+      if (args.includes('list-windows') || args.includes('display-message')) {
         cb(null, { stdout: String(nextWindowIndex), stderr: '' });
       } else if (args.includes('new-window')) {
         nextWindowIndex++;
@@ -210,5 +210,17 @@ describe('respawnAgentFresh', () => {
 
     const { checkAgentTokenExists } = await import('../../repositories/agent-runtime.js');
     expect(checkAgentTokenExists('real-hook-token-abc')).toBe(true);
+  });
+
+  it('opts.fresh=true creates a brand-new tmux session instead of a window, and never kill-windows', async () => {
+    const agent = makeAgentRow();
+    const task = { ...DEFAULTS.runningTask } as Task;
+
+    await respawnAgentFresh(task, agent, { fresh: true });
+
+    const calls = vi.mocked(execFile).mock.calls;
+    expect(calls.some((c) => (c[1] as string[])?.includes('new-session'))).toBe(true);
+    expect(calls.some((c) => (c[1] as string[])?.includes('new-window'))).toBe(false);
+    expect(calls.some((c) => (c[1] as string[])?.includes('kill-window'))).toBe(false);
   });
 });

--- a/server/task-engine/lifecycle/respawn-agent.ts
+++ b/server/task-engine/lifecycle/respawn-agent.ts
@@ -26,11 +26,16 @@ const logger = childLogger('task-engine/lifecycle');
  * memory of prior turns). `opts.env` is exported into the new window's shell
  * — used by the loop harness to carry OCTOMUX_ACTION_TOKEN/BASE_URL so the
  * agent's `octomux emit` CLI call can authenticate.
+ *
+ * `opts.fresh` (default false): the task's tmux session died along with it
+ * (e.g. server restart) — create a brand-new session instead of a window in
+ * the (nonexistent) old one, and skip killing the old window since there's
+ * nothing left to kill.
  */
 export async function respawnAgentFresh(
   task: Task,
   agent: Agent,
-  opts?: { prompt?: string; env?: Record<string, string> },
+  opts?: { prompt?: string; env?: Record<string, string>; fresh?: boolean },
 ): Promise<Agent> {
   logger.info(
     { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh' },
@@ -60,12 +65,13 @@ export async function respawnAgentFresh(
     env: opts?.env,
   });
 
+  const fresh = opts?.fresh ?? false;
   const oldWindowIndex = agent.window_index;
   const newWindowIndex = await launchAgentWindow({
     session: task.tmux_session!,
     cwd: task.worktree!,
     startupCmd,
-    fresh: false,
+    fresh,
   });
 
   setAgentWindowRunning(agent.id, newWindowIndex);
@@ -76,14 +82,16 @@ export async function respawnAgentFresh(
   const target = `${task.tmux_session}:${newWindowIndex}`;
   void harness.postLaunch?.(target);
 
-  await execTmux(['kill-window', '-t', `${task.tmux_session}:${oldWindowIndex}`]).catch((err) => {
-    if (!isTmuxTargetMissing(err)) {
-      logger.warn(
-        { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh', err },
-        'respawn_fresh: kill old window failed',
-      );
-    }
-  });
+  if (!fresh) {
+    await execTmux(['kill-window', '-t', `${task.tmux_session}:${oldWindowIndex}`]).catch((err) => {
+      if (!isTmuxTargetMissing(err)) {
+        logger.warn(
+          { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh', err },
+          'respawn_fresh: kill old window failed',
+        );
+      }
+    });
+  }
 
   const updated = getAgent(agent.id) as Agent;
   broadcast({ type: 'task:updated', payload: { taskId: task.id } });

--- a/server/task-engine/loop/engine.test.ts
+++ b/server/task-engine/loop/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { createTestDb, insertTask, insertAgent, DEFAULTS } from '../../test-helpers.js';
-import type { LoopRun, LoopSpec } from '../../types.js';
+import type { LoopRun, LoopSpec, Task } from '../../types.js';
 
 vi.mock('../git.js', () => ({
   revParseHead: vi.fn(),
@@ -20,12 +20,17 @@ vi.mock('../../hook-base-url.js', () => ({
   hookBaseUrl: vi.fn(() => 'http://127.0.0.1:7777'),
 }));
 
-const { buildLoopPrompt, evaluateTermination, startLoop, handleLoopIterationBoundary } =
-  await import('./engine.js');
+const {
+  buildLoopPrompt,
+  evaluateTermination,
+  startLoop,
+  handleLoopIterationBoundary,
+  resumeLoopOnStartup,
+} = await import('./engine.js');
 const { revParseHead, commitAll } = await import('../git.js');
 const { runVerify } = await import('./verify.js');
 const { respawnAgentFresh } = await import('../lifecycle/respawn-agent.js');
-const { getLoopRun, listIterationsForRun, recordEmit } =
+const { getLoopRun, listIterationsForRun, recordEmit, createLoopRun } =
   await import('../../repositories/loop-runs.js');
 
 function makeRun(overrides: Partial<LoopRun> = {}): LoopRun {
@@ -257,5 +262,58 @@ describe('handleLoopIterationBoundary', () => {
 
     expect(vi.mocked(respawnAgentFresh).mock.calls.length).toBe(callsBefore); // no new respawn
     expect(getLoopRun(run.id)?.termination_reason).toBe('budget');
+  });
+});
+
+describe('resumeLoopOnStartup', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    vi.clearAllMocks();
+    insertTask(db, { ...DEFAULTS.runningTask, id: 't1', runtime_state: 'looping' });
+    insertAgent(db, { id: 'a1', task_id: 't1', hook_token: 'tok-1', status: 'running' } as any);
+  });
+
+  it('resumes an active loop_run via a fresh respawn, not --resume', async () => {
+    const run = createLoopRun({
+      task_id: 't1',
+      spec_json: JSON.stringify(LOOP_SPEC),
+      max_iterations: LOOP_SPEC.maxIterations,
+    });
+    const task = { ...DEFAULTS.runningTask, id: 't1', runtime_state: 'looping' } as Task;
+
+    await resumeLoopOnStartup(task);
+
+    expect(respawnAgentFresh).toHaveBeenCalledTimes(1);
+    const [, , opts] = vi.mocked(respawnAgentFresh).mock.calls[0];
+    expect(opts?.fresh).toBe(true);
+    expect(opts?.prompt).toContain(`Loop run id: ${run.id}`);
+    expect(opts?.env).toMatchObject({ OCTOMUX_ACTION_TOKEN: 'tok-1', OCTOMUX_TASK_ID: 't1' });
+  });
+
+  it('idles the task when there is no active loop_run to resume', async () => {
+    const task = { ...DEFAULTS.runningTask, id: 't1', runtime_state: 'looping' } as Task;
+
+    await resumeLoopOnStartup(task);
+
+    expect(respawnAgentFresh).not.toHaveBeenCalled();
+    const updated = db.prepare('SELECT runtime_state FROM tasks WHERE id = ?').get('t1') as {
+      runtime_state: string;
+    };
+    expect(updated.runtime_state).toBe('idle');
+  });
+
+  it("still resumes when the run's last-known status is a terminal emit status (crash right after emit, before the Stop hook processed it)", async () => {
+    // recordEmit sets loop_runs.status to done/blocked/needs_human *before*
+    // the Stop hook evaluates verify and actually terminates the run — a
+    // crash in that window must not be mistaken for "already terminated".
+    const run = createLoopRun({ task_id: 't1', spec_json: JSON.stringify(LOOP_SPEC) });
+    recordEmit(run.id, { status: 'done', reason: 'looks done' });
+    const task = { ...DEFAULTS.runningTask, id: 't1', runtime_state: 'looping' } as Task;
+
+    await resumeLoopOnStartup(task);
+
+    expect(respawnAgentFresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/task-engine/loop/engine.ts
+++ b/server/task-engine/loop/engine.ts
@@ -14,7 +14,7 @@ import { runVerify } from './verify.js';
 import { respawnAgentFresh } from '../lifecycle/respawn-agent.js';
 import { broadcast } from '../../events.js';
 import { hookBaseUrl } from '../../hook-base-url.js';
-import type { LoopRun, LoopIteration, LoopSpec, LoopRunStatus } from '../../types.js';
+import type { LoopRun, LoopIteration, LoopSpec, LoopRunStatus, Task } from '../../types.js';
 
 const logger = childLogger('task-engine/loop');
 
@@ -216,4 +216,54 @@ export async function handleLoopIterationBoundary(taskId: string, agentId: strin
     prompt: buildLoopPrompt(spec, run.id, verify.passed ? null : verify.output),
     env: loopAgentEnv(taskId, agent.hook_token),
   });
+}
+
+/**
+ * Startup crash-resume for a looping task whose tmux session died with the
+ * server. Recovers controller state from the loop_run and kicks a FRESH
+ * iteration (never `--resume`s the old harness session — a loop iteration is
+ * fresh-context by design) into a brand-new tmux session, carrying the same
+ * loopAgentEnv so `octomux emit` auth keeps working.
+ *
+ * Only gates on the run existing, not `run.status === 'running'`: a crash
+ * right after an emit (which sets loop_runs.status to done/blocked/
+ * needs_human *before* the Stop hook evaluates verify — see
+ * getActiveLoopRunForTask's doc comment) must still resume. `runtime_state
+ * === 'looping'`, already checked by the caller, is the authoritative "is
+ * this loop still active" signal.
+ *
+ * ponytail: doesn't clean up orphaned user-terminal/viewer-session rows tied
+ * to the dead session (prepareResumeSession does this for normal tasks) —
+ * add if loop-crash-resume leaves visible terminal cruft.
+ */
+export async function resumeLoopOnStartup(task: Task): Promise<void> {
+  const run = getActiveLoopRunForTask(task.id);
+  if (!run) {
+    logger.warn({ task_id: task.id }, 'loop: no loop_run to resume on startup');
+    setRuntimeState(task.id, 'idle');
+    return;
+  }
+
+  const agentRef = findFirstActiveAgent(task.id);
+  const agent = agentRef ? getAgent(agentRef.id) : undefined;
+  if (!agent) {
+    logger.warn(
+      { task_id: task.id, loop_run_id: run.id },
+      'loop: no agent to resume loop on startup',
+    );
+    terminateLoopRun(run.id, 'needs_human', 'no_agent_on_startup');
+    setRuntimeState(task.id, 'idle');
+    return;
+  }
+
+  const spec = JSON.parse(run.spec_json) as LoopSpec;
+
+  await respawnAgentFresh(task, agent, {
+    prompt: buildLoopPrompt(spec, run.id),
+    env: loopAgentEnv(task.id, agent.hook_token),
+    fresh: true,
+  });
+
+  logger.info({ task_id: task.id, loop_run_id: run.id }, 'loop: resumed on startup');
+  broadcast({ type: 'task:updated', payload: { taskId: task.id } });
 }

--- a/server/task-engine/reconcile.test.ts
+++ b/server/task-engine/reconcile.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTestDb, insertTask, DEFAULTS } from '../test-helpers.js';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+// recoverTasks() only needs to route each stale task to the right resume
+// path — the internals of resumeTask (--resume/--continue ladder) and
+// resumeLoopOnStartup (fresh respawn) are covered by their own test files.
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const mocked = { ...actual, existsSync: vi.fn(() => true) };
+  return { ...mocked, default: mocked };
+});
+
+vi.mock('../poller/status.js', () => ({
+  checkTaskStatus: vi.fn(async () => 'dead'),
+}));
+
+vi.mock('./lifecycle.js', () => ({
+  resumeTask: vi.fn(async () => undefined),
+}));
+
+vi.mock('./loop/engine.js', () => ({
+  resumeLoopOnStartup: vi.fn(async () => undefined),
+}));
+
+const { recoverTasks } = await import('./reconcile.js');
+const { checkTaskStatus } = await import('../poller/status.js');
+const { resumeTask } = await import('./lifecycle.js');
+const { resumeLoopOnStartup } = await import('./loop/engine.js');
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createTestDb();
+  vi.clearAllMocks();
+  vi.mocked(checkTaskStatus).mockResolvedValue('dead');
+});
+
+describe('recoverTasks', () => {
+  it('resumes a looping task via the fresh-context loop path, never --resume', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, id: 't-loop', runtime_state: 'looping' });
+
+    await recoverTasks();
+
+    expect(resumeLoopOnStartup).toHaveBeenCalledTimes(1);
+    expect(resumeLoopOnStartup).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 't-loop', runtime_state: 'looping' }),
+    );
+    expect(resumeTask).not.toHaveBeenCalled();
+  });
+
+  it('resumes a normal running task via the existing --resume path (regression)', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask, id: 't-normal', runtime_state: 'running' });
+
+    await recoverTasks();
+
+    expect(resumeTask).toHaveBeenCalledTimes(1);
+    expect(resumeTask).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 't-normal', runtime_state: 'running' }),
+    );
+    expect(resumeLoopOnStartup).not.toHaveBeenCalled();
+  });
+
+  it('skips a looping task whose tmux session is still alive', async () => {
+    vi.mocked(checkTaskStatus).mockResolvedValue('alive');
+    insertTask(db, { ...DEFAULTS.runningTask, id: 't-alive', runtime_state: 'looping' });
+
+    await recoverTasks();
+
+    expect(resumeLoopOnStartup).not.toHaveBeenCalled();
+    expect(resumeTask).not.toHaveBeenCalled();
+  });
+});

--- a/server/task-engine/reconcile.ts
+++ b/server/task-engine/reconcile.ts
@@ -3,13 +3,57 @@ import fs from 'fs';
 import { octomuxRoot } from '../octomux-root.js';
 import { execTmux } from '../tmux-bin.js';
 import { childLogger } from '../logger.js';
+import { checkTaskStatus } from '../poller/status.js';
 import {
   listSettingUpTasks,
+  listRecoverableTasks,
   setRuntimeState,
+  setRuntimeStateSetupInterrupted,
   listActiveScratchTaskIds,
 } from '../repositories/index.js';
+import { resumeTask } from './lifecycle.js';
+import { resumeLoopOnStartup } from './loop/engine.js';
 
 const logger = childLogger('task-engine/reconcile');
+
+/**
+ * Boot-time task recovery: resume tasks whose runtime_state says they should
+ * be running/setting_up/looping but whose tmux session died with the server.
+ * Looping tasks are routed through the loop's fresh-context respawn — never
+ * the normal `--resume` ladder, which would continue the wrong (non-loop)
+ * context.
+ */
+export async function recoverTasks(): Promise<void> {
+  const staleTasks = listRecoverableTasks();
+
+  for (const task of staleTasks) {
+    const status = await checkTaskStatus(task);
+    if (status === 'alive') continue;
+
+    // Session is dead. Require tmux_session too — without it the task never
+    // reached the new-session step, so there's nothing for resumeTask to
+    // re-attach to; treat it as an interrupted setup instead.
+    if (task.worktree && fs.existsSync(task.worktree) && task.tmux_session) {
+      if (task.runtime_state === 'looping') {
+        logger.warn({ task_id: task.id, title: task.title }, 'Recovery: resuming loop');
+        resumeLoopOnStartup(task).catch((err) => {
+          logger.error({ task_id: task.id, err }, 'Recovery: resumeLoopOnStartup failed');
+        });
+      } else {
+        logger.warn({ task_id: task.id, title: task.title }, 'Recovery: resuming task');
+        resumeTask(task).catch((err) => {
+          logger.error({ task_id: task.id, err }, 'Recovery: resumeTask failed');
+        });
+      }
+    } else if (task.runtime_state === 'setting_up') {
+      logger.warn({ task_id: task.id, title: task.title }, 'Recovery: setup was interrupted');
+      setRuntimeStateSetupInterrupted(task.id);
+    } else {
+      logger.warn({ task_id: task.id, title: task.title }, 'Recovery: worktree missing');
+      setRuntimeState(task.id, 'error', 'Worktree missing after restart');
+    }
+  }
+}
 
 /** Root directory for scratch-mode task working dirs. */
 export function scratchRoot(): string {


### PR DESCRIPTION
## Summary
- **Deliverable 1** — `POST /api/loops` now rejects with **409** when the task already has an active loop run (`runtime_state === 'looping'` or its most recent `loop_run.status === 'running'`). Fixes a production bug where a double-POST created two concurrent loop runs on one task.
- **Deliverable 2** — Crash-resume for in-flight loops on server restart:
  - `listRecoverableTasks()` now includes `'looping'` tasks (previously excluded entirely, so a looping task was never recovered).
  - `recoverTasks()` moved from `server/index.ts` into `task-engine/reconcile.ts` (for testability) and now branches on `runtime_state === 'looping'` — routing looping tasks to the new `resumeLoopOnStartup()` instead of the normal `resumeTask()`, which uses `--resume`/`--continue` and would wrongly continue the old harness context.
  - `resumeLoopOnStartup()` recovers the active `loop_run` and respawns fresh via `respawnAgentFresh(..., { fresh: true })`, carrying `loopAgentEnv(taskId, hook_token)` so `octomux emit` auth keeps working post-restart. Trusts `runtime_state === 'looping'` as the authoritative "still active" signal rather than `loop_run.status`, since an emit can set a terminal status *before* the Stop hook actually evaluates verify and terminates.
  - `respawnAgentFresh` gained an `opts.fresh` flag: when the task's tmux session died with the server, it creates a brand-new session (`new-session`) instead of a window in a (nonexistent) old one, and skips the now-pointless kill-old-window step.

## Test plan
- [x] `bun run typecheck && bun run lint && bun run test` — green, except one pre-existing flaky test (`server/diff-review-state.test.ts`, a real-git-process timing test unrelated to this change) that times out under parallel load but passes reliably in isolation.
- [x] Route test: duplicate loop → 409; task with no active run → 201 (`server/api.loops.test.ts`).
- [x] `resumeLoopOnStartup` unit tests, including the "emit landed but Stop hook hadn't processed it yet" edge case (`server/task-engine/loop/engine.test.ts`).
- [x] `respawnAgentFresh({ fresh: true })` creates a new session and skips kill-window (`server/task-engine/lifecycle/respawn-agent.test.ts`).
- [x] `recoverTasks()` routing regression tests: looping task → fresh-context path (never `--resume`); normal running task → existing `resumeTask` path unchanged (`server/task-engine/reconcile.test.ts`).

```
$ bun run typecheck
$ tsc -b
(clean)

$ bun run lint
✖ 60 problems (0 errors, 60 warnings)   — all pre-existing, none in touched files

$ bun run test
 Test Files  1 failed | 275 passed (276)
      Tests  1 failed | 3536 passed (3537)
# the 1 failure (diff-review-state.test.ts) passes in isolation — see note above
```