### PR TITLE
feat(loop): curated learnings playbook seeds each fresh iteration

### DIFF
--- a/server/task-engine/git.test.ts
+++ b/server/task-engine/git.test.ts
@@ -48,6 +48,7 @@ const {
   revParseHead,
   checkDirty,
   commitAll,
+  diffNameOnly,
 } = await import('./git.js');
 const { execFile } = await import('child_process');
 
@@ -370,6 +371,50 @@ describe('addWorktreeWithBranch', () => {
       argsInclude: ['worktree', 'add', '-b', 'develop'],
     });
     expect(fallbackCall).toBeDefined();
+  });
+});
+
+// ─── diffNameOnly ─────────────────────────────────────────────────────────────
+
+describe('diffNameOnly', () => {
+  it('returns changed file paths', async () => {
+    vi.mocked(execFile).mockImplementationOnce(((
+      _cmd: any,
+      _args: any,
+      optsOrCb: any,
+      maybeCb?: any,
+    ) => {
+      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb!;
+      cb(null, { stdout: 'src/foo.ts\nsrc/bar.ts\n', stderr: '' });
+      return undefined as any;
+    }) as any);
+
+    const files = await diffNameOnly('/repo/wt', 'sha1', 'sha2');
+    expect(files).toEqual(['src/foo.ts', 'src/bar.ts']);
+  });
+
+  it('calls git diff --name-only <from>..<to>', async () => {
+    await diffNameOnly('/repo/wt', 'sha1', 'sha2');
+    const call = findExecCall(vi.mocked(execFile), {
+      cmd: 'git',
+      argsInclude: ['-C', '/repo/wt', 'diff', '--name-only', 'sha1..sha2'],
+    });
+    expect(call).toBeDefined();
+  });
+
+  it('filters blank lines', async () => {
+    vi.mocked(execFile).mockImplementationOnce(((
+      _cmd: any,
+      _args: any,
+      optsOrCb: any,
+      maybeCb?: any,
+    ) => {
+      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb!;
+      cb(null, { stdout: 'a.ts\n\nb.ts\n', stderr: '' });
+      return undefined as any;
+    }) as any);
+    const files = await diffNameOnly('/repo/wt', 'sha1', 'sha2');
+    expect(files).toHaveLength(2);
   });
 });
 

--- a/server/task-engine/git.ts
+++ b/server/task-engine/git.ts
@@ -69,6 +69,21 @@ export async function checkDirty(repoPath: string): Promise<string[]> {
     .filter(Boolean);
 }
 
+/** Files changed between two commits (`git diff --name-only <from>..<to>`). */
+export async function diffNameOnly(cwd: string, shaFrom: string, shaTo: string): Promise<string[]> {
+  const { stdout } = await execFile('git', [
+    '-C',
+    cwd,
+    'diff',
+    '--name-only',
+    `${shaFrom}..${shaTo}`,
+  ]);
+  return stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
 /** Stage and commit all changes if the worktree is dirty. Returns false (no-op) when clean. */
 export async function commitAll(cwd: string, message: string): Promise<boolean> {
   const dirty = await checkDirty(cwd);

--- a/server/task-engine/loop/engine.test.ts
+++ b/server/task-engine/loop/engine.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import Database from 'better-sqlite3';
 import { createTestDb, insertTask, insertAgent, DEFAULTS } from '../../test-helpers.js';
 import type { LoopRun, LoopSpec, Task } from '../../types.js';
@@ -6,6 +9,7 @@ import type { LoopRun, LoopSpec, Task } from '../../types.js';
 vi.mock('../git.js', () => ({
   revParseHead: vi.fn(),
   commitAll: vi.fn(async () => true),
+  diffNameOnly: vi.fn(async () => []),
 }));
 vi.mock('./verify.js', () => ({
   runVerify: vi.fn(),
@@ -27,7 +31,7 @@ const {
   handleLoopIterationBoundary,
   resumeLoopOnStartup,
 } = await import('./engine.js');
-const { revParseHead, commitAll } = await import('../git.js');
+const { revParseHead, commitAll, diffNameOnly } = await import('../git.js');
 const { runVerify } = await import('./verify.js');
 const { respawnAgentFresh } = await import('../lifecycle/respawn-agent.js');
 const { getLoopRun, listIterationsForRun, recordEmit, createLoopRun } =
@@ -67,6 +71,12 @@ describe('buildLoopPrompt', () => {
   it('omits the verify-failure section when there is none', () => {
     const prompt = buildLoopPrompt(SPEC, 'run-1', null);
     expect(prompt).not.toContain('verify command failed');
+  });
+
+  it('tells the agent to read the loop playbook first', () => {
+    const prompt = buildLoopPrompt(SPEC, 'run-1');
+    expect(prompt).toContain('.octomux/loop-playbook.md');
+    expect(prompt).toMatch(/read it first/);
   });
 });
 
@@ -262,6 +272,72 @@ describe('handleLoopIterationBoundary', () => {
 
     expect(vi.mocked(respawnAgentFresh).mock.calls.length).toBe(callsBefore); // no new respawn
     expect(getLoopRun(run.id)?.termination_reason).toBe('budget');
+  });
+});
+
+describe('loop playbook', () => {
+  let db: Database.Database;
+  let worktree: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    vi.clearAllMocks();
+    worktree = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-loop-playbook-'));
+    insertTask(db, { ...DEFAULTS.runningTask, id: 't1', runtime_state: 'running', worktree });
+    insertAgent(db, { id: 'a1', task_id: 't1', hook_token: 'tok-1', status: 'running' } as any);
+  });
+
+  afterEach(() => {
+    fs.rmSync(worktree, { recursive: true, force: true });
+  });
+
+  function readPlaybook(): string {
+    return fs.readFileSync(path.join(worktree, '.octomux', 'loop-playbook.md'), 'utf-8');
+  }
+
+  it('appends a PASS entry with changed files and no verify output on success', async () => {
+    vi.mocked(revParseHead).mockImplementation(async () => 'stable-sha');
+    vi.mocked(diffNameOnly).mockResolvedValueOnce(['src/foo.ts', 'src/bar.ts']);
+    vi.mocked(runVerify).mockResolvedValueOnce({ passed: true, output: 'all good' });
+
+    const run = await startLoop('t1', LOOP_SPEC);
+    recordEmit(run.id, { status: 'done', reason: 'iter1' });
+    await handleLoopIterationBoundary('t1', 'a1');
+
+    const playbook = readPlaybook();
+    expect(playbook).toContain('## Iteration 1 — verify PASS');
+    expect(playbook).toContain('src/foo.ts, src/bar.ts');
+    expect(playbook).not.toContain('verify output');
+  });
+
+  it('appends a FAIL entry including the verify output', async () => {
+    vi.mocked(revParseHead).mockImplementation(async () => 'stable-sha');
+    vi.mocked(diffNameOnly).mockResolvedValueOnce(['src/foo.ts']);
+    vi.mocked(runVerify).mockResolvedValueOnce({
+      passed: false,
+      output: 'assertion failed: x != y',
+    });
+
+    await startLoop('t1', LOOP_SPEC);
+    await handleLoopIterationBoundary('t1', 'a1');
+
+    const playbook = readPlaybook();
+    expect(playbook).toContain('## Iteration 1 — verify FAIL');
+    expect(playbook).toContain('verify output: assertion failed: x != y');
+  });
+
+  it('accumulates entries across iterations instead of overwriting', async () => {
+    vi.mocked(revParseHead).mockImplementation(async () => 'stable-sha');
+    vi.mocked(diffNameOnly).mockResolvedValue([]);
+    vi.mocked(runVerify).mockResolvedValue({ passed: false, output: 'still failing' });
+
+    await startLoop('t1', LOOP_SPEC);
+    await handleLoopIterationBoundary('t1', 'a1');
+    await handleLoopIterationBoundary('t1', 'a1');
+
+    const playbook = readPlaybook();
+    expect(playbook).toContain('## Iteration 1 — verify FAIL');
+    expect(playbook).toContain('## Iteration 2 — verify FAIL');
   });
 });
 

--- a/server/task-engine/loop/engine.ts
+++ b/server/task-engine/loop/engine.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { childLogger } from '../../logger.js';
 import { getTask, setRuntimeState } from '../../repositories/tasks.js';
 import { getAgent, findFirstActiveAgent } from '../../repositories/agent-runtime.js';
@@ -9,7 +11,7 @@ import {
   terminateLoopRun,
   resumeLoopRun,
 } from '../../repositories/loop-runs.js';
-import { revParseHead, commitAll } from '../git.js';
+import { revParseHead, commitAll, diffNameOnly } from '../git.js';
 import { runVerify } from './verify.js';
 import { respawnAgentFresh } from '../lifecycle/respawn-agent.js';
 import { broadcast } from '../../events.js';
@@ -33,13 +35,19 @@ function loopRunIdLines(loopRunId: string): string[] {
   ];
 }
 
+const PLAYBOOK_REL_PATH = path.join('.octomux', 'loop-playbook.md');
+const PLAYBOOK_MAX_CHANGED_FILES = 15;
+const PLAYBOOK_MAX_VERIFY_OUTPUT = 1500;
+const PLAYBOOK_READ_INSTRUCTION =
+  'Prior iterations and what failed are recorded in .octomux/loop-playbook.md — read it first and do not repeat approaches that already failed.';
+
 /** Build the prompt for a loop iteration, pinning the loop run id (mirrors reviewTaskIdLines in review-tasks.ts). */
 export function buildLoopPrompt(
   spec: LoopSpec,
   loopRunId: string,
   verifyFailureOutput?: string | null,
 ): string {
-  const lines = [spec.prompt, '', ...loopRunIdLines(loopRunId)];
+  const lines = [spec.prompt, '', PLAYBOOK_READ_INSTRUCTION, '', ...loopRunIdLines(loopRunId)];
   if (verifyFailureOutput) {
     lines.push(
       '',
@@ -104,6 +112,29 @@ export function evaluateTermination(ctx: TerminationCtx): TerminationReason | nu
     return 'no_progress';
   }
   return null;
+}
+
+/** Append one bounded, human-readable entry to the per-loop playbook file in the worktree. */
+function appendPlaybookEntry(
+  worktree: string,
+  n: number,
+  verifyPassed: boolean,
+  changedFiles: string[],
+  verifyOutput: string,
+): void {
+  const dir = path.join(worktree, '.octomux');
+  fs.mkdirSync(dir, { recursive: true });
+
+  const shown = changedFiles.slice(0, PLAYBOOK_MAX_CHANGED_FILES).join(', ') || '(none)';
+  const lines = [
+    `## Iteration ${n} — verify ${verifyPassed ? 'PASS' : 'FAIL'}`,
+    `- changed: ${shown}`,
+  ];
+  if (!verifyPassed) {
+    lines.push(`- verify output: ${verifyOutput.trim().slice(-PLAYBOOK_MAX_VERIFY_OUTPUT)}`);
+  }
+
+  fs.appendFileSync(path.join(worktree, PLAYBOOK_REL_PATH), lines.join('\n') + '\n\n');
 }
 
 function loopAgentEnv(taskId: string, hookToken: string): Record<string, string> {
@@ -188,6 +219,9 @@ export async function handleLoopIterationBoundary(taskId: string, agentId: strin
     sha_to: shaTo,
     verify_passed: verify.passed ? 1 : 0,
   });
+
+  const changedFiles = await diffNameOnly(worktree, shaFrom, shaTo);
+  appendPlaybookEntry(worktree, iteration.n, verify.passed, changedFiles, verify.output);
 
   const iterations = listIterationsForRun(run.id);
   const reason = evaluateTermination({


### PR DESCRIPTION
## Summary
- Each loop iteration boundary now appends a bounded entry to `.octomux/loop-playbook.md` in the worktree: changed files (from `sha_from..sha_to`, capped at 15), and verify `PASS`/`FAIL` — verify output (last 1500 chars) only on failure.
- The loop prompt builder (`buildLoopPrompt`) now instructs the agent to read `.octomux/loop-playbook.md` first, so every respawned fresh-context iteration inherits cumulative memory of what already failed.
- Adds `diffNameOnly(cwd, shaFrom, shaTo)` to `server/task-engine/git.ts` to compute changed files for the entry.

No new tables, no LLM reflector — just an append-only file + a prompt instruction (spec §12, P2).

## Test plan
- [x] `bun run typecheck` — green
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run test` — 276 test files / 3544 tests passed
- New tests: `git.test.ts` (`diffNameOnly`), `engine.test.ts` (playbook PASS/FAIL entries, accumulation across iterations using a real tmp worktree dir; prompt-builder instruction test)

```
$ bun run typecheck
$ tsc -b

$ bun run lint
✖ 60 problems (0 errors, 60 warnings)

$ bun run test
 Test Files  276 passed (276)
      Tests  3544 passed (3544)
```