### PR TITLE
feat(workflow): PR-extract → SQL (trigger + output contract + sql sink)

### DIFF
--- a/cli/src/commands/pr-extract-emit.test.ts
+++ b/cli/src/commands/pr-extract-emit.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerPrExtractEmit } from './pr-extract-emit.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  registerPrExtractEmit(program);
+  return program;
+}
+
+describe('pr-extract emit command', () => {
+  const origBaseUrl = process.env.OCTOMUX_ACTION_BASE_URL;
+  const origToken = process.env.OCTOMUX_ACTION_TOKEN;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env.OCTOMUX_ACTION_BASE_URL = 'http://127.0.0.1:7777';
+    process.env.OCTOMUX_ACTION_TOKEN = 'tok-1';
+  });
+
+  afterEach(() => {
+    if (origBaseUrl === undefined) delete process.env.OCTOMUX_ACTION_BASE_URL;
+    else process.env.OCTOMUX_ACTION_BASE_URL = origBaseUrl;
+    if (origToken === undefined) delete process.env.OCTOMUX_ACTION_TOKEN;
+    else process.env.OCTOMUX_ACTION_TOKEN = origToken;
+  });
+
+  it('POSTs the extract payload with a bearer token', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 201, text: async () => '' });
+
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        'pr-extract',
+        'emit',
+        '--task',
+        'task-1',
+        '--area',
+        'server',
+        '--risk',
+        'high',
+        '--has-migration',
+        'true',
+        '--surface',
+        'api',
+        '--loc',
+        '42',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:7777/api/pr-extracts/task-1/emit',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer tok-1',
+        }),
+        body: JSON.stringify({
+          area: 'server',
+          risk: 'high',
+          has_migration: true,
+          surface: 'api',
+          loc: 42,
+        }),
+      }),
+    );
+  });
+
+  it('rejects a risk value not in the fixed enum', async () => {
+    const program = buildProgram();
+
+    await expect(
+      program.parseAsync(
+        [
+          'pr-extract',
+          'emit',
+          '--task',
+          'task-1',
+          '--area',
+          'server',
+          '--risk',
+          'extreme',
+          '--has-migration',
+          'true',
+          '--surface',
+          'api',
+          '--loc',
+          '1',
+        ],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('exits with an error when OCTOMUX_ACTION_TOKEN is missing', async () => {
+    delete process.env.OCTOMUX_ACTION_TOKEN;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        'pr-extract',
+        'emit',
+        '--task',
+        'task-1',
+        '--area',
+        'server',
+        '--risk',
+        'low',
+        '--has-migration',
+        'false',
+        '--surface',
+        'api',
+        '--loc',
+        '1',
+      ],
+      { from: 'user' },
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('reports a failed HTTP response and exits 1', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, text: async () => 'bad request' });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        'pr-extract',
+        'emit',
+        '--task',
+        'task-1',
+        '--area',
+        'server',
+        '--risk',
+        'low',
+        '--has-migration',
+        'false',
+        '--surface',
+        'api',
+        '--loc',
+        '1',
+      ],
+      { from: 'user' },
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/cli/src/commands/pr-extract-emit.ts
+++ b/cli/src/commands/pr-extract-emit.ts
@@ -1,0 +1,77 @@
+import { Command, Option } from 'commander';
+import { errorMessage, success } from '../format.js';
+
+const RISK_VALUES = ['low', 'medium', 'high'] as const;
+type Risk = (typeof RISK_VALUES)[number];
+
+/**
+ * octomux pr-extract emit — reports the PR-extract workflow's structured
+ * output back to octomux. Reads OCTOMUX_ACTION_BASE_URL/TOKEN the same way
+ * `octomux emit` does (server/task-engine/launch.ts injects both into every
+ * task's agent env, not just loop tasks). The server derives repo/PR
+ * metadata from the task row itself — this command only carries the
+ * extracted fields.
+ */
+export function registerPrExtractEmit(program: Command): void {
+  const prExtract = program.command('pr-extract').description('PR-extract workflow commands');
+
+  prExtract
+    .command('emit')
+    .description('Report extracted PR metadata back to octomux')
+    .requiredOption('-t, --task <task-id>', 'extract task ID')
+    .requiredOption('--area <area>', 'primary subsystem touched')
+    .addOption(
+      new Option('--risk <risk>', 'risk assessment').choices(RISK_VALUES).makeOptionMandatory(),
+    )
+    .requiredOption('--has-migration <bool>', 'true|false — includes a DB migration')
+    .requiredOption('--surface <surface>', 'user-facing surface touched')
+    .requiredOption('--loc <n>', 'total lines changed', (v: string) => parseInt(v, 10))
+    .action(
+      async (opts: {
+        task: string;
+        area: string;
+        risk: Risk;
+        hasMigration: string;
+        surface: string;
+        loc: number;
+      }) => {
+        const baseUrl = process.env.OCTOMUX_ACTION_BASE_URL;
+        const token = process.env.OCTOMUX_ACTION_TOKEN;
+        if (!baseUrl || !token) {
+          errorMessage(
+            'octomux pr-extract emit is not configured (missing OCTOMUX_ACTION_BASE_URL / ' +
+              'OCTOMUX_ACTION_TOKEN)',
+          );
+          process.exit(1);
+          return;
+        }
+
+        const res = await fetch(
+          `${baseUrl}/api/pr-extracts/${encodeURIComponent(opts.task)}/emit`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              area: opts.area,
+              risk: opts.risk,
+              has_migration: opts.hasMigration === 'true',
+              surface: opts.surface,
+              loc: opts.loc,
+            }),
+          },
+        );
+
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          errorMessage(`pr-extract emit failed (HTTP ${res.status}): ${text}`);
+          process.exit(1);
+          return;
+        }
+
+        success(`Emitted PR extract for task ${opts.task}`);
+      },
+    );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -33,6 +33,7 @@ import { registerTeam } from './commands/team.js';
 import { registerFiles } from './commands/files.js';
 import { registerEmit } from './commands/emit.js';
 import { registerLoopStart } from './commands/loop-start.js';
+import { registerPrExtractEmit } from './commands/pr-extract-emit.js';
 
 const program = new Command();
 
@@ -77,6 +78,7 @@ registerTeam(program);
 registerFiles(program);
 registerEmit(program);
 registerLoopStart(program);
+registerPrExtractEmit(program);
 
 program.hook('preAction', (thisCommand) => {
   const opts = thisCommand.optsWithGlobals();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,7 +14,7 @@ export type AgentStatus = 'running' | 'idle' | 'waiting' | 'stopped';
 export type HookActivity = 'active' | 'idle' | 'waiting';
 export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
 
-export type TaskSource = 'auto_review' | null;
+export type TaskSource = 'auto_review' | 'pr_extract' | null;
 
 export type RunMode = 'new' | 'existing' | 'none' | 'scratch';
 

--- a/server/api.pr-extracts.test.ts
+++ b/server/api.pr-extracts.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { createTestDb, insertTask, insertAgent } from './test-helpers.js';
+
+describe('POST /api/pr-extracts/:taskId/emit', () => {
+  let app: ReturnType<typeof createApp>;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+  });
+
+  const validBody = {
+    area: 'server',
+    risk: 'low',
+    has_migration: false,
+    surface: 'api',
+    loc: 42,
+  };
+
+  function seed() {
+    insertTask(db, { id: 'task-1', source: 'pr_extract', pr_number: 7, pr_head_sha: 'sha-1' });
+    insertAgent(db, { id: 'agent-1', task_id: 'task-1', hook_token: 'tok-1' });
+  }
+
+  it('401s with no bearer token', async () => {
+    seed();
+    const res = await request(app).post('/api/pr-extracts/task-1/emit').send(validBody);
+    expect(res.status).toBe(401);
+  });
+
+  it('401s with an invalid bearer token', async () => {
+    seed();
+    const res = await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer wrong-token')
+      .send(validBody);
+    expect(res.status).toBe(401);
+  });
+
+  it('404s for an unknown task', async () => {
+    seed();
+    const res = await request(app)
+      .post('/api/pr-extracts/no-such-task/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send(validBody);
+    expect(res.status).toBe(404);
+  });
+
+  it('400s when the task has no PR metadata', async () => {
+    insertTask(db, { id: 'task-no-pr', source: 'pr_extract', pr_number: null, pr_head_sha: null });
+    insertAgent(db, { id: 'agent-no-pr', task_id: 'task-no-pr', hook_token: 'tok-no-pr' });
+    const res = await request(app)
+      .post('/api/pr-extracts/task-no-pr/emit')
+      .set('Authorization', 'Bearer tok-no-pr')
+      .send(validBody);
+    expect(res.status).toBe(400);
+  });
+
+  it('400s on a schema violation (missing required field)', async () => {
+    seed();
+    const { risk: _risk, ...rest } = validBody;
+    const res = await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send(rest);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/risk/);
+  });
+
+  it('400s on an out-of-enum risk value', async () => {
+    seed();
+    const res = await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send({ ...validBody, risk: 'extreme' });
+    expect(res.status).toBe(400);
+  });
+
+  it('201s and persists a valid payload', async () => {
+    seed();
+    const res = await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send(validBody);
+    expect(res.status).toBe(201);
+    expect(res.body.task_id).toBe('task-1');
+    expect(res.body.pr_number).toBe(7);
+    expect(res.body.has_migration).toBe(false);
+
+    const getRes = await request(app).get(`/api/pr-extracts/${res.body.id}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.area).toBe('server');
+  });
+
+  it('409s when emitting twice for the same task', async () => {
+    seed();
+    await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send(validBody);
+    const res = await request(app)
+      .post('/api/pr-extracts/task-1/emit')
+      .set('Authorization', 'Bearer tok-1')
+      .send(validBody);
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('GET /api/pr-extracts', () => {
+  it('lists created extracts', async () => {
+    const db = createTestDb();
+    const app = createApp();
+    insertTask(db, { id: 'task-2', source: 'pr_extract', pr_number: 8, pr_head_sha: 'sha-2' });
+    insertAgent(db, { id: 'agent-2', task_id: 'task-2', hook_token: 'tok-2' });
+    await request(app)
+      .post('/api/pr-extracts/task-2/emit')
+      .set('Authorization', 'Bearer tok-2')
+      .send({ area: 'cli', risk: 'high', has_migration: true, surface: 'cli', loc: 9 });
+    const res = await request(app).get('/api/pr-extracts');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('404s GET /api/pr-extracts/:id for an unknown id', async () => {
+    createTestDb();
+    const app = createApp();
+    const res = await request(app).get('/api/pr-extracts/no-such-id');
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/api.ts
+++ b/server/api.ts
@@ -19,6 +19,7 @@ import { router as integrationsRouter } from './routes/integrations.js';
 import { router as reviewsRouter } from './routes/reviews.js';
 import { router as reviewRunsRouter } from './routes/review-runs.js';
 import { router as loopsRouter } from './routes/loops.js';
+import { router as prExtractsRouter } from './routes/pr-extracts.js';
 import { router as commentsRouter } from './routes/comments.js';
 import { router as diffsRouter } from './routes/diffs.js';
 import { router as tasksRouter } from './routes/tasks.js';
@@ -48,6 +49,7 @@ export function setupRoutes(app: Express): void {
   app.use(reviewsRouter);
   app.use(reviewRunsRouter);
   app.use(loopsRouter);
+  app.use(prExtractsRouter);
   app.use(commentsRouter);
   app.use(diffsRouter);
   app.use(tasksRouter);

--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -6,6 +6,7 @@ import {
   TASKS_TABLE_COLUMNS,
   AGENTS_TABLE_COLUMNS,
   WORKTREES_TABLE_COLUMNS,
+  PR_EXTRACTS_TABLE_COLUMNS,
 } from '../test-helpers.js';
 
 describe('runMigrations (isolated)', () => {
@@ -56,6 +57,19 @@ describe('runMigrations (isolated)', () => {
         .all() as Array<{ name: string }>
     ).map((i) => i.name);
     expect(indexes).toContain('idx_tasks_active_worktree');
+
+    expect(tables).toContain('pr_extracts');
+    const extractCols = (db.pragma('table_info(pr_extracts)') as Array<{ name: string }>).map(
+      (c) => c.name,
+    );
+    expect(extractCols).toEqual(PR_EXTRACTS_TABLE_COLUMNS);
+    const extractIndexes = (
+      db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='pr_extracts'`)
+        .all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    expect(extractIndexes).toContain('idx_pr_extracts_task');
+    expect(extractIndexes).toContain('idx_pr_extracts_pr');
   });
 
   it('is idempotent when run twice on the same database', () => {

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -865,4 +865,23 @@ export function runMigrations(instance: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_loop_iterations_run ON loop_iterations(loop_run_id, n);
   `);
+
+  // ── PR-extract workflow persistence (2026-07-13, P3) ────────────────────────
+  instance.exec(`
+    CREATE TABLE IF NOT EXISTS pr_extracts (
+      id             TEXT PRIMARY KEY,
+      task_id        TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+      repo_path      TEXT NOT NULL,
+      pr_number      INTEGER NOT NULL,
+      pr_head_sha    TEXT NOT NULL,
+      area           TEXT NOT NULL,
+      risk           TEXT NOT NULL,
+      has_migration  INTEGER NOT NULL,
+      surface        TEXT NOT NULL,
+      loc            INTEGER NOT NULL,
+      created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_extracts_task ON pr_extracts(task_id);
+    CREATE INDEX IF NOT EXISTS idx_pr_extracts_pr ON pr_extracts(repo_path, pr_number);
+  `);
 }

--- a/server/events.ts
+++ b/server/events.ts
@@ -29,6 +29,10 @@ export type ServerEvent =
   | {
       type: 'loop:emit';
       payload: { taskId: string; loopRunId: string; status: string; reason: string };
+    }
+  | {
+      type: 'pr_extract:created';
+      payload: { taskId: string; extractId: string };
     };
 
 /** Event types that carry a taskId and should be persisted to the durable events log. */

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -655,6 +655,60 @@ describe('checkMergedPRs', () => {
 
     expect(execFile).not.toHaveBeenCalled();
   });
+
+  describe('pr-extract trigger', () => {
+    it('creates a pr_extract task when a tracked PR merges', async () => {
+      insertTask(db, {
+        ...DEFAULTS.runningTask,
+        pr_number: 42,
+        pr_url: 'https://github.com/org/repo/pull/42',
+        pr_head_sha: 'sha-merged',
+      });
+      mockPrStates({ pr0: 'MERGED' });
+
+      await checkMergedPRs();
+
+      const extractTask = db
+        .prepare(`SELECT * FROM tasks WHERE source = 'pr_extract' AND pr_number = ?`)
+        .get(42);
+      expect(extractTask).toBeTruthy();
+    });
+
+    it('does not create a pr_extract task when the merged task has no pr_head_sha', async () => {
+      insertTask(db, {
+        ...DEFAULTS.runningTask,
+        pr_number: 42,
+        pr_url: 'https://github.com/org/repo/pull/42',
+        pr_head_sha: null,
+      });
+      mockPrStates({ pr0: 'MERGED' });
+
+      await checkMergedPRs();
+
+      const extractTask = db
+        .prepare(`SELECT * FROM tasks WHERE source = 'pr_extract' AND pr_number = ?`)
+        .get(42);
+      expect(extractTask).toBeFalsy();
+    });
+
+    it('does not create a second pr_extract task on a repeat poll (same head sha)', async () => {
+      insertTask(db, {
+        ...DEFAULTS.runningTask,
+        pr_number: 42,
+        pr_url: 'https://github.com/org/repo/pull/42',
+        pr_head_sha: 'sha-merged',
+      });
+      mockPrStates({ pr0: 'MERGED' });
+
+      await checkMergedPRs();
+      await checkMergedPRs();
+
+      const rows = db
+        .prepare(`SELECT * FROM tasks WHERE source = 'pr_extract' AND pr_number = ?`)
+        .all(42);
+      expect(rows).toHaveLength(1);
+    });
+  });
 });
 
 // ─── pollTerminalActivity ────────────────────────────────────────────────────

--- a/server/poller/merged-pr.ts
+++ b/server/poller/merged-pr.ts
@@ -8,7 +8,9 @@ import {
   listRunningTasksWithPr,
   addTaskUpdate,
   setWorkflowStatusDone,
+  findExistingPrTask,
 } from '../repositories/tasks.js';
+import { createExtractTaskFromMergedPr } from '../services/pr-extract-service.js';
 import type { Task } from '../types.js';
 import { repoNameWithOwner } from './github-repo.js';
 
@@ -74,6 +76,29 @@ export async function checkMergedPRs(): Promise<void> {
           data: { from: prevWorkflow, to: 'done', note: 'auto: PR merged' },
         });
         broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+
+        if (task.repo_path && task.pr_number != null && task.pr_head_sha) {
+          const existingExtract = findExistingPrTask(task.repo_path, task.pr_number);
+          const alreadyExtracted =
+            existingExtract?.source === 'pr_extract' &&
+            existingExtract.pr_head_sha === task.pr_head_sha;
+          if (!alreadyExtracted) {
+            await createExtractTaskFromMergedPr({
+              repo_path: task.repo_path,
+              branch: task.base_branch ?? 'main',
+              base_branch: task.base_branch ?? 'main',
+              pr_number: task.pr_number,
+              pr_url: task.pr_url,
+              pr_head_sha: task.pr_head_sha,
+              title: task.title,
+            }).catch((err) => {
+              logger.error(
+                { task_id: task.id, err: (err as Error).message },
+                'failed to create pr-extract task for merged PR',
+              );
+            });
+          }
+        }
       } catch {
         // closeTask failure shouldn't stop processing other tasks
       }

--- a/server/pr-extract-tasks.test.ts
+++ b/server/pr-extract-tasks.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from './test-helpers.js';
+import { getDb } from './db.js';
+import { buildPrExtractPrompt, insertExtractTask } from './pr-extract-tasks.js';
+
+describe('buildPrExtractPrompt', () => {
+  it('pins the extract task id and the octomux CLI command shape', () => {
+    const prompt = buildPrExtractPrompt({
+      extractTaskId: 'extract-1',
+      title: 'Add feature X',
+      number: 42,
+      url: 'https://github.com/org/repo/pull/42',
+      headRefOid: 'sha-abc',
+      repoShort: 'octomux-agents',
+    });
+    expect(prompt).toContain('extract-1');
+    expect(prompt).toContain('octomux pr-extract emit');
+    expect(prompt).toContain('#42');
+  });
+});
+
+describe('insertExtractTask', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('inserts a task with source=pr_extract and the given PR fields', () => {
+    const id = insertExtractTask({
+      id: 'extract-1',
+      repoPath: '/repo',
+      branch: 'extract/repo-pr-42',
+      baseBranch: 'main',
+      title: 'Extract: Add feature X (#42)',
+      description: 'Extract task for merged PR #42',
+      initialPrompt: 'do the thing',
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prNumber: 42,
+      prHeadSha: 'sha-abc',
+    });
+    expect(id).toBe('extract-1');
+    const row = getDb()
+      .prepare('SELECT source, pr_number, pr_head_sha FROM tasks WHERE id = ?')
+      .get(id);
+    expect(row).toEqual({ source: 'pr_extract', pr_number: 42, pr_head_sha: 'sha-abc' });
+  });
+});

--- a/server/pr-extract-tasks.ts
+++ b/server/pr-extract-tasks.ts
@@ -1,0 +1,86 @@
+import { nanoid } from 'nanoid';
+import { insertTask, insertWorktree } from './repositories/index.js';
+
+export interface PrExtractPromptInput {
+  /** Id of THIS extract task — the id passed to `octomux pr-extract emit`. */
+  extractTaskId: string;
+  title: string;
+  number: number;
+  url: string;
+  headRefOid: string;
+  repoShort: string;
+}
+
+/** Prompt for the merged-PR structured-extraction agent. */
+export function buildPrExtractPrompt(input: PrExtractPromptInput): string {
+  return [
+    `Extract structured metadata from a merged pull request.`,
+    '',
+    `Extract task id: ${input.extractTaskId}`,
+    `PR: ${input.title} (#${input.number})`,
+    `URL: ${input.url}`,
+    `Merged head: ${input.headRefOid}`,
+    `Repo: ${input.repoShort}`,
+    '',
+    'Inspect the merged diff (already checked out at the merge head in this worktree) and determine:',
+    '  - area: the primary subsystem touched (e.g. "server", "frontend", "cli", "docs")',
+    '  - risk: "low" | "medium" | "high" — your assessment of blast radius',
+    '  - has_migration: true if the diff includes a forward-only DB migration',
+    '  - surface: the user-facing surface touched (e.g. "api", "ui", "cli", "internal")',
+    '  - loc: total lines changed (added + removed) across the diff',
+    '',
+    'Report the result with exactly one command, then stop:',
+    `  octomux pr-extract emit --task ${input.extractTaskId} --area <area> --risk <low|medium|high> ` +
+      '--has-migration <true|false> --surface <surface> --loc <n>',
+  ].join('\n');
+}
+
+export interface InsertExtractTaskParams {
+  id?: string;
+  repoPath: string;
+  branch: string;
+  baseBranch: string;
+  baseSha?: string | null;
+  title: string;
+  description: string;
+  initialPrompt: string;
+  prUrl: string | null;
+  prNumber: number;
+  prHeadSha: string;
+}
+
+/**
+ * Shared extract-task creation: materialises a worktree row and a task row in
+ * the `pr_extract` source class. Returns the new task id.
+ */
+export function insertExtractTask(params: InsertExtractTaskParams): string {
+  const id = params.id ?? nanoid(12);
+  const worktreeId = nanoid(12);
+
+  insertWorktree({
+    id: worktreeId,
+    path: '',
+    repo_path: params.repoPath,
+    branch: params.branch,
+    base_branch: params.baseBranch,
+    base_sha: params.baseSha ?? null,
+    mode: 'new',
+    status: 'available',
+  });
+
+  insertTask({
+    id,
+    title: params.title,
+    description: params.description,
+    runtime_state: 'idle',
+    workflow_status: 'backlog',
+    pr_url: params.prUrl,
+    pr_number: params.prNumber,
+    pr_head_sha: params.prHeadSha,
+    initial_prompt: params.initialPrompt,
+    source: 'pr_extract',
+    worktree_id: worktreeId,
+  });
+
+  return id;
+}

--- a/server/repositories/pr-extracts.test.ts
+++ b/server/repositories/pr-extracts.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDb, insertTask } from '../test-helpers.js';
+import { createExtract, getExtract, getExtractByTaskId, listExtracts } from './pr-extracts.js';
+
+describe('pr-extracts repository', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  function seedTask(id: string) {
+    insertTask(db, { id, source: 'pr_extract' });
+  }
+
+  it('creates and reads back an extract row', () => {
+    seedTask('task-1');
+    const row = createExtract({
+      taskId: 'task-1',
+      repoPath: '/repo',
+      prNumber: 42,
+      prHeadSha: 'sha-abc',
+      area: 'server',
+      risk: 'medium',
+      hasMigration: true,
+      surface: 'api',
+      loc: 120,
+    });
+
+    expect(row.id).toBeTruthy();
+    expect(row.has_migration).toBe(true);
+    expect(getExtract(row.id)).toEqual(row);
+    expect(getExtractByTaskId('task-1')).toEqual(row);
+  });
+
+  it('round-trips has_migration=false as boolean false, not 0', () => {
+    seedTask('task-2');
+    const row = createExtract({
+      taskId: 'task-2',
+      repoPath: '/repo',
+      prNumber: 43,
+      prHeadSha: 'sha-def',
+      area: 'server',
+      risk: 'low',
+      hasMigration: false,
+      surface: 'cli',
+      loc: 10,
+    });
+    expect(row.has_migration).toBe(false);
+    expect(getExtract(row.id)!.has_migration).toBe(false);
+  });
+
+  it('rejects a second extract for the same task', () => {
+    seedTask('task-3');
+    const base = {
+      taskId: 'task-3',
+      repoPath: '/repo',
+      prNumber: 44,
+      prHeadSha: 'sha-ghi',
+      area: 'server',
+      risk: 'low' as const,
+      hasMigration: false,
+      surface: 'cli',
+      loc: 1,
+    };
+    createExtract(base);
+    expect(() => createExtract(base)).toThrow();
+  });
+
+  it('lists extracts newest first', () => {
+    seedTask('task-4');
+    seedTask('task-5');
+    const a = createExtract({
+      taskId: 'task-4',
+      repoPath: '/repo',
+      prNumber: 1,
+      prHeadSha: 's1',
+      area: 'a',
+      risk: 'low',
+      hasMigration: false,
+      surface: 's',
+      loc: 1,
+    });
+    const b = createExtract({
+      taskId: 'task-5',
+      repoPath: '/repo',
+      prNumber: 2,
+      prHeadSha: 's2',
+      area: 'a',
+      risk: 'low',
+      hasMigration: false,
+      surface: 's',
+      loc: 1,
+    });
+    const rows = listExtracts();
+    expect(rows.map((r) => r.id)).toEqual([b.id, a.id]);
+  });
+});

--- a/server/repositories/pr-extracts.ts
+++ b/server/repositories/pr-extracts.ts
@@ -1,0 +1,94 @@
+import { nanoid } from 'nanoid';
+import { getDb } from '../db.js';
+import { childLogger } from '../logger.js';
+import type { PrExtract, PrExtractRisk } from '../types.js';
+
+const logger = childLogger('repositories/pr-extracts');
+
+interface PrExtractRow {
+  id: string;
+  task_id: string;
+  repo_path: string;
+  pr_number: number;
+  pr_head_sha: string;
+  area: string;
+  risk: string;
+  has_migration: number;
+  surface: string;
+  loc: number;
+  created_at: string;
+}
+
+function toPrExtract(row: PrExtractRow): PrExtract {
+  return {
+    id: row.id,
+    task_id: row.task_id,
+    repo_path: row.repo_path,
+    pr_number: row.pr_number,
+    pr_head_sha: row.pr_head_sha,
+    area: row.area,
+    risk: row.risk as PrExtractRisk,
+    has_migration: row.has_migration === 1,
+    surface: row.surface,
+    loc: row.loc,
+    created_at: row.created_at,
+  };
+}
+
+export interface CreateExtractInput {
+  id?: string;
+  taskId: string;
+  repoPath: string;
+  prNumber: number;
+  prHeadSha: string;
+  area: string;
+  risk: PrExtractRisk;
+  hasMigration: boolean;
+  surface: string;
+  loc: number;
+}
+
+export function createExtract(input: CreateExtractInput): PrExtract {
+  const id = input.id ?? nanoid(12);
+  getDb()
+    .prepare(
+      `INSERT INTO pr_extracts
+         (id, task_id, repo_path, pr_number, pr_head_sha, area, risk, has_migration, surface, loc)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.taskId,
+      input.repoPath,
+      input.prNumber,
+      input.prHeadSha,
+      input.area,
+      input.risk,
+      input.hasMigration ? 1 : 0,
+      input.surface,
+      input.loc,
+    );
+  logger.info({ task_id: input.taskId, extract_id: id }, 'pr_extract created');
+  return getExtract(id)!;
+}
+
+export function getExtract(id: string): PrExtract | undefined {
+  const row = getDb().prepare(`SELECT * FROM pr_extracts WHERE id = ?`).get(id) as
+    | PrExtractRow
+    | undefined;
+  return row ? toPrExtract(row) : undefined;
+}
+
+export function getExtractByTaskId(taskId: string): PrExtract | undefined {
+  const row = getDb().prepare(`SELECT * FROM pr_extracts WHERE task_id = ?`).get(taskId) as
+    | PrExtractRow
+    | undefined;
+  return row ? toPrExtract(row) : undefined;
+}
+
+export function listExtracts(): PrExtract[] {
+  const rows = getDb()
+    .prepare(`SELECT * FROM pr_extracts ORDER BY rowid DESC`)
+    .all() as PrExtractRow[];
+  return rows.map(toPrExtract);
+}

--- a/server/routes/hook-auth.ts
+++ b/server/routes/hook-auth.ts
@@ -1,0 +1,21 @@
+import type { Request, Response, NextFunction } from 'express';
+import { checkAgentTokenExists } from '../repositories/agent-runtime.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('routes/hook-auth');
+
+/**
+ * Express middleware guarding agent→server callback endpoints (the loop
+ * `/emit` route, the pr-extract `/emit` route, ...). Reuses each agent's
+ * per-agent `hook_token` — no separate secret per workflow.
+ */
+export function requireBearerHookToken(req: Request, res: Response, next: NextFunction): void {
+  const match = /^Bearer (.+)$/.exec(req.headers.authorization ?? '');
+  const token = match?.[1];
+  if (!token || !checkAgentTokenExists(token)) {
+    logger.warn({ path: req.path, ip: req.ip }, 'hook callback: missing or invalid bearer token');
+    res.status(401).send();
+    return;
+  }
+  next();
+}

--- a/server/routes/loops.ts
+++ b/server/routes/loops.ts
@@ -1,8 +1,8 @@
 import express from 'express';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 import { broadcast } from '../events.js';
 import { childLogger } from '../logger.js';
-import { checkAgentTokenExists } from '../repositories/agent-runtime.js';
+import { requireBearerHookToken } from './hook-auth.js';
 import {
   getActiveLoopRunForTask,
   getLoopRun,
@@ -21,21 +21,6 @@ const logger = childLogger('routes/loops');
 export const router = express.Router();
 
 const EMIT_STATUSES: LoopEmitStatus[] = ['done', 'blocked', 'needs_human'];
-
-/**
- * Authorize a loop emit by its `Authorization: Bearer <hook_token>` header —
- * reuses the same agent hook_token verification as server/hooks.ts.
- */
-function requireBearerHookToken(req: Request, res: Response, next: NextFunction): void {
-  const match = /^Bearer (.+)$/.exec(req.headers.authorization ?? '');
-  const token = match?.[1];
-  if (!token || !checkAgentTokenExists(token)) {
-    logger.warn({ path: req.path, ip: req.ip }, 'loop emit: missing or invalid bearer token');
-    res.status(401).send();
-    return;
-  }
-  next();
-}
 
 router.post('/api/loops', async (req: Request, res: Response) => {
   const body = req.body as { taskId?: unknown; spec?: unknown };

--- a/server/routes/pr-extracts.ts
+++ b/server/routes/pr-extracts.ts
@@ -1,0 +1,88 @@
+import { Router, type Request, type Response } from 'express';
+import { requireBearerHookToken } from './hook-auth.js';
+import { validateAgainstSchema, type JsonSchema } from '../services/output-contract.js';
+import {
+  createExtract,
+  getExtract,
+  getExtractByTaskId,
+  listExtracts,
+} from '../repositories/pr-extracts.js';
+import { getTask } from '../repositories/index.js';
+import { badRequest, notFound, conflict } from '../services/errors.js';
+import { broadcast } from '../events.js';
+import { childLogger } from '../logger.js';
+import type { PrExtractRisk } from '../types.js';
+
+const logger = childLogger('routes/pr-extracts');
+
+export const PR_EXTRACT_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['area', 'risk', 'has_migration', 'surface', 'loc'],
+  properties: {
+    area: { type: 'string', minLength: 1 },
+    risk: { type: 'string', enum: ['low', 'medium', 'high'] },
+    has_migration: { type: 'boolean' },
+    surface: { type: 'string', minLength: 1 },
+    loc: { type: 'integer', minimum: 0 },
+  },
+  additionalProperties: false,
+};
+
+export const router = Router();
+
+router.post(
+  '/api/pr-extracts/:taskId/emit',
+  requireBearerHookToken,
+  (req: Request, res: Response) => {
+    const { taskId } = req.params as Record<string, string>;
+    const task = getTask(taskId);
+    if (!task) throw notFound('Task not found');
+    if (!task.repo_path || task.pr_number == null || !task.pr_head_sha) {
+      throw badRequest('Task has no associated PR to extract from');
+    }
+
+    const result = validateAgainstSchema('pr-extract', PR_EXTRACT_SCHEMA, req.body);
+    if (!result.valid) {
+      throw badRequest(`Invalid pr-extract payload: ${(result.errors ?? []).join('; ')}`);
+    }
+
+    if (getExtractByTaskId(taskId)) {
+      throw conflict('An extract already exists for this task');
+    }
+
+    const body = req.body as {
+      area: string;
+      risk: PrExtractRisk;
+      has_migration: boolean;
+      surface: string;
+      loc: number;
+    };
+
+    const row = createExtract({
+      taskId,
+      repoPath: task.repo_path,
+      prNumber: task.pr_number,
+      prHeadSha: task.pr_head_sha,
+      area: body.area,
+      risk: body.risk,
+      hasMigration: body.has_migration,
+      surface: body.surface,
+      loc: body.loc,
+    });
+
+    logger.info({ task_id: taskId, extract_id: row.id }, 'pr-extract emit recorded');
+    broadcast({ type: 'pr_extract:created', payload: { taskId, extractId: row.id } });
+    res.status(201).json(row);
+  },
+);
+
+router.get('/api/pr-extracts', (_req: Request, res: Response) => {
+  res.json(listExtracts());
+});
+
+router.get('/api/pr-extracts/:id', (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const row = getExtract(id);
+  if (!row) throw notFound('Extract not found');
+  res.json(row);
+});

--- a/server/services/output-contract.test.ts
+++ b/server/services/output-contract.test.ts
@@ -24,7 +24,10 @@ describe('validateAgainstSchema', () => {
   });
 
   it('rejects a payload with an out-of-enum value', () => {
-    const result = validateAgainstSchema('test-schema', SCHEMA, { area: 'server', risk: 'extreme' });
+    const result = validateAgainstSchema('test-schema', SCHEMA, {
+      area: 'server',
+      risk: 'extreme',
+    });
     expect(result.valid).toBe(false);
   });
 

--- a/server/services/output-contract.test.ts
+++ b/server/services/output-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { validateAgainstSchema } from './output-contract.js';
+
+const SCHEMA = {
+  type: 'object',
+  required: ['area', 'risk'],
+  properties: {
+    area: { type: 'string', minLength: 1 },
+    risk: { type: 'string', enum: ['low', 'medium', 'high'] },
+  },
+  additionalProperties: false,
+} as const;
+
+describe('validateAgainstSchema', () => {
+  it('accepts a payload matching the schema', () => {
+    const result = validateAgainstSchema('test-schema', SCHEMA, { area: 'server', risk: 'low' });
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('rejects a payload missing a required field', () => {
+    const result = validateAgainstSchema('test-schema', SCHEMA, { area: 'server' });
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/risk/);
+  });
+
+  it('rejects a payload with an out-of-enum value', () => {
+    const result = validateAgainstSchema('test-schema', SCHEMA, { area: 'server', risk: 'extreme' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects additional properties not in the schema', () => {
+    const result = validateAgainstSchema('test-schema', SCHEMA, {
+      area: 'server',
+      risk: 'low',
+      extra: true,
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('reuses a compiled validator for the same schema key', () => {
+    const first = validateAgainstSchema('test-schema', SCHEMA, { area: 'a', risk: 'low' });
+    const second = validateAgainstSchema('test-schema', SCHEMA, { area: 'b', risk: 'high' });
+    expect(first.valid).toBe(true);
+    expect(second.valid).toBe(true);
+  });
+});

--- a/server/services/output-contract.ts
+++ b/server/services/output-contract.ts
@@ -1,0 +1,41 @@
+import Ajv, { type ValidateFunction } from 'ajv';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('output-contract');
+
+export type JsonSchema = Record<string, unknown>;
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+const ajv = new Ajv({ allErrors: true, strict: true });
+const compiled = new Map<string, ValidateFunction>();
+
+/**
+ * Validate `payload` against `schema`, compiling (and caching) the ajv validator
+ * once per `key`. `key` identifies the schema (e.g. a workflow kind) — callers
+ * must pass the same key every time for the same schema so the cache stays
+ * consistent.
+ */
+export function validateAgainstSchema(
+  key: string,
+  schema: JsonSchema,
+  payload: unknown,
+): ValidationResult {
+  let validate = compiled.get(key);
+  if (!validate) {
+    validate = ajv.compile(schema);
+    compiled.set(key, validate);
+  }
+
+  const valid = validate(payload) as boolean;
+  if (valid) return { valid: true };
+
+  const errors = (validate.errors ?? []).map(
+    (e) => `${e.instancePath || '(root)'} ${e.message ?? 'invalid'}`,
+  );
+  logger.debug({ schema_key: key, errors }, 'output contract validation failed');
+  return { valid: false, errors };
+}

--- a/server/services/pr-extract-service.test.ts
+++ b/server/services/pr-extract-service.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+
+const mockStartTask = vi.fn().mockResolvedValue(undefined);
+vi.mock('../task-engine/index.js', () => ({
+  startTask: vi.fn((...args: unknown[]) => mockStartTask(...args)),
+}));
+
+const mockBroadcast = vi.fn();
+vi.mock('../events.js', () => ({
+  broadcast: vi.fn((...args: unknown[]) => mockBroadcast(...args)),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { createExtractTaskFromMergedPr } from './pr-extract-service.js';
+
+describe('createExtractTaskFromMergedPr', () => {
+  beforeEach(() => {
+    createTestDb();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a pr_extract task with a prompt referencing the PR and the extract CLI', async () => {
+    const result = await createExtractTaskFromMergedPr({
+      repo_path: '/repo',
+      branch: 'main',
+      base_branch: 'main',
+      pr_number: 99,
+      pr_url: 'https://github.com/org/repo/pull/99',
+      pr_head_sha: 'sha-xyz',
+      title: 'Add feature X',
+    });
+
+    expect(result.task.source).toBe('pr_extract');
+    expect(result.task.pr_number).toBe(99);
+    expect(result.task.initial_prompt).toContain('octomux pr-extract emit');
+    expect(mockBroadcast).toHaveBeenCalledWith({
+      type: 'task:created',
+      payload: { taskId: result.id },
+    });
+    expect(mockStartTask).toHaveBeenCalled();
+  });
+});

--- a/server/services/pr-extract-service.ts
+++ b/server/services/pr-extract-service.ts
@@ -1,0 +1,81 @@
+/**
+ * Service layer for pr-extract task orchestration. HTTP-agnostic.
+ *
+ * De-dup boundary: callers own ALL pre-create work (PR/repo resolution,
+ * existing-extract dedup). This function is the create/trigger TAIL only.
+ */
+
+import { nanoid } from 'nanoid';
+import { buildPrExtractPrompt, insertExtractTask } from '../pr-extract-tasks.js';
+import { repoShortName } from '../review-tasks.js';
+import { getTask } from '../repositories/index.js';
+import { startTask } from '../task-engine/index.js';
+import { broadcast } from '../events.js';
+import { childLogger } from '../logger.js';
+import type { Task } from '../types.js';
+
+const logger = childLogger('pr-extract-service');
+
+export interface CreateExtractFromMergedPrInput {
+  repo_path: string;
+  branch: string;
+  base_branch: string;
+  pr_number: number;
+  pr_url: string | null;
+  pr_head_sha: string;
+  title: string;
+}
+
+export interface CreateExtractTaskResult {
+  id: string;
+  task: Task;
+}
+
+export async function createExtractTaskFromMergedPr(
+  input: CreateExtractFromMergedPrInput,
+): Promise<CreateExtractTaskResult> {
+  const id = nanoid(12);
+  const short = repoShortName(input.repo_path);
+  const branch = `extract/${short}-pr-${input.pr_number}`;
+
+  const initialPrompt = buildPrExtractPrompt({
+    extractTaskId: id,
+    title: input.title,
+    number: input.pr_number,
+    url: input.pr_url ?? '',
+    headRefOid: input.pr_head_sha,
+    repoShort: short,
+  });
+
+  insertExtractTask({
+    id,
+    repoPath: input.repo_path,
+    branch,
+    baseBranch: input.base_branch,
+    title: `Extract: ${input.title} (#${input.pr_number})`,
+    description: `PR-extract task for merged PR #${input.pr_number}`,
+    initialPrompt,
+    prUrl: input.pr_url,
+    prNumber: input.pr_number,
+    prHeadSha: input.pr_head_sha,
+  });
+
+  broadcast({ type: 'task:created', payload: { taskId: id } });
+
+  const fresh = getTask(id) as Task;
+  fresh.agents = [];
+  fresh.user_terminals = [];
+
+  startTask(fresh)
+    .then(() => broadcast({ type: 'task:updated', payload: { taskId: id } }))
+    .catch((err) => {
+      logger.error(
+        { task_id: id, err: (err as Error).message },
+        'failed to auto-start pr-extract task',
+      );
+      broadcast({ type: 'task:updated', payload: { taskId: id } });
+    });
+
+  logger.info({ task_id: id, pr_number: input.pr_number }, 'pr-extract task created');
+  return { id, task: fresh };
+}

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -365,6 +365,20 @@ export const PERMISSION_PROMPTS_TABLE_COLUMNS = [
   'resolved_at',
 ];
 
+export const PR_EXTRACTS_TABLE_COLUMNS = [
+  'id',
+  'task_id',
+  'repo_path',
+  'pr_number',
+  'pr_head_sha',
+  'area',
+  'risk',
+  'has_migration',
+  'surface',
+  'loc',
+  'created_at',
+];
+
 export const USER_TERMINALS_TABLE_COLUMNS = [
   'id',
   'task_id',

--- a/server/types.ts
+++ b/server/types.ts
@@ -118,6 +118,24 @@ export interface LoopSpec {
   noProgress?: { afterIters: number };
 }
 
+// ── PR-extract workflow types ─────────────────────────────────────────────
+
+export type PrExtractRisk = 'low' | 'medium' | 'high';
+
+export interface PrExtract {
+  id: string;
+  task_id: string;
+  repo_path: string;
+  pr_number: number;
+  pr_head_sha: string;
+  area: string;
+  risk: PrExtractRisk;
+  has_migration: boolean;
+  surface: string;
+  loc: number;
+  created_at: string;
+}
+
 export type CommentBucket = 'actionable' | 'informational';
 export type CommentSeverity = 'nit' | 'suggestion' | 'issue' | 'critical';
 export type LastCheckStatus = 'resolved' | 'still_applies' | 'partial' | 'unclear';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ const ReviewDetailPage = lazy(() => import('./pages/ReviewDetailPage'));
 const OrchestratorPage = lazy(() => import('./pages/OrchestratorPage'));
 const LoopsPage = lazy(() => import('./pages/LoopsPage'));
 const LoopDetailPage = lazy(() => import('./pages/LoopDetailPage'));
+const ExtractsPage = lazy(() => import('./pages/ExtractsPage'));
 
 /** Runs at app root so notifications fire on every page. */
 function GlobalNotifications() {
@@ -116,6 +117,7 @@ export function AppShell() {
                 <Route path="/orchestrator" element={<OrchestratorPage />} />
                 <Route path="/loops" element={<LoopsPage />} />
                 <Route path="/loops/:id" element={<LoopDetailPage />} />
+                <Route path="/extracts" element={<ExtractsPage />} />
               </Routes>
             </Suspense>
           </div>

--- a/src/lib/api/extractApi.ts
+++ b/src/lib/api/extractApi.ts
@@ -1,0 +1,16 @@
+/**
+ * src/lib/api/extractApi.ts
+ *
+ * PR-extract workflow API surface: feed of extracted-PR rows + detail.
+ * Mirrors `server/routes/pr-extracts.ts`.
+ */
+
+import type { PrExtract } from '../../../server/types';
+import { request } from './client';
+
+export type { PrExtract };
+
+export const extractApi = {
+  listExtracts: () => request<PrExtract[]>('/pr-extracts'),
+  getExtract: (id: string) => request<PrExtract>(`/pr-extracts/${id}`),
+};

--- a/src/lib/event-source.ts
+++ b/src/lib/event-source.ts
@@ -24,7 +24,8 @@ export type ServerEventType =
   | 'review:run-failed'
   | 'review:published'
   | 'review:head-advanced'
-  | 'loop:emit';
+  | 'loop:emit'
+  | 'pr_extract:created';
 
 /**
  * A real-time event delivered over `/ws/events`. The payload is intentionally a
@@ -44,6 +45,7 @@ export interface ServerEvent {
     reason?: string;
     loopRunId?: string;
     status?: string;
+    extractId?: string;
     [key: string]: unknown;
   };
 }

--- a/src/pages/ExtractsPage.test.tsx
+++ b/src/pages/ExtractsPage.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import ExtractsPage from './ExtractsPage';
+import { renderWithRouter } from '../test-helpers';
+import type { PrExtract } from '@/lib/api/extractApi';
+
+const { taskApiProxy, reviewApiProxy, configApiProxy, loopApiProxy, extractApiProxy, apiMock } =
+  await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
+vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('@/lib/api/loopApi', () => ({ loopApi: loopApiProxy }));
+vi.mock('@/lib/api/extractApi', () => ({ extractApi: extractApiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+
+function makeExtract(overrides: Partial<PrExtract> = {}): PrExtract {
+  return {
+    id: 'ext-1',
+    task_id: 'task-1',
+    repo_path: '/repo',
+    pr_number: 42,
+    pr_head_sha: 'sha-abc',
+    area: 'server',
+    risk: 'high',
+    has_migration: true,
+    surface: 'api',
+    loc: 120,
+    created_at: '2026-01-01 00:00:00',
+    ...overrides,
+  };
+}
+
+describe('ExtractsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an empty state with no extracts', async () => {
+    apiMock.listExtracts.mockResolvedValue([]);
+    renderWithRouter(<ExtractsPage />);
+    expect(await screen.findByText(/no extracts yet/i)).toBeTruthy();
+  });
+
+  it('renders a row per extract with its fields', async () => {
+    apiMock.listExtracts.mockResolvedValue([makeExtract()]);
+    renderWithRouter(<ExtractsPage />);
+
+    expect(await screen.findByTestId('extract-row-ext-1')).toBeTruthy();
+    expect(screen.getByText(/#42/)).toBeTruthy();
+    expect(screen.getByText('high')).toBeTruthy();
+    expect(screen.getByText(/area: server/i)).toBeTruthy();
+  });
+});

--- a/src/pages/ExtractsPage.tsx
+++ b/src/pages/ExtractsPage.tsx
@@ -1,0 +1,69 @@
+import { extractApi, type PrExtract } from '../lib/api/extractApi';
+import { useResource } from '../lib/use-resource';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { Badge } from '../components/ui/badge';
+import { PageHeader } from '@/components/layout/page-header';
+import { timeAgo } from '@/lib/time';
+
+const RISK_VARIANT: Record<PrExtract['risk'], 'default' | 'secondary' | 'destructive'> = {
+  low: 'secondary',
+  medium: 'default',
+  high: 'destructive',
+};
+
+export default function ExtractsPage() {
+  const { data, loading } = useResource<PrExtract[]>(
+    'pr-extracts',
+    () => extractApi.listExtracts(),
+    {
+      events: (event) => event.type === 'pr_extract:created',
+    },
+  );
+  const rows = data ?? [];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col p-6">
+      <PageHeader title="PR Extracts" description="Structured metadata extracted from merged PRs" />
+
+      {loading ? (
+        <div className="mt-4 space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-2xl border border-glass-edge bg-glass-l1"
+            />
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">No extracts yet.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <GlassPanel
+                level={2}
+                specular
+                data-testid={`extract-row-${row.id}`}
+                className="flex flex-col gap-2 rounded-2xl px-4 py-3 sm:flex-row sm:items-center"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {row.repo_path} #{row.pr_number}
+                    </span>
+                    <Badge variant={RISK_VARIANT[row.risk]}>{row.risk}</Badge>
+                    <span className="text-[10px] text-muted-soft">{timeAgo(row.created_at)}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    area: {row.area} · surface: {row.surface} · loc: {row.loc} ·{' '}
+                    {row.has_migration ? 'has migration' : 'no migration'}
+                  </p>
+                </div>
+              </GlassPanel>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -80,6 +80,7 @@ type ApiMock = ReturnType<typeof mockTaskApi> &
   ReturnType<typeof mockReviewApi> &
   ReturnType<typeof mockConfigApi> &
   ReturnType<typeof mockLoopApi> &
+  ReturnType<typeof mockExtractApi> &
   Record<string, unknown>;
 
 export function setupApiMock(overrides: Record<string, unknown> = {}) {
@@ -87,6 +88,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
   const reviewApiMock = mockReviewApi(overrides);
   const configApiMock = mockConfigApi(overrides);
   const loopApiMock = mockLoopApi(overrides);
+  const extractApiMock = mockExtractApi(overrides);
   const taskApiProxy = new Proxy(
     {},
     { get: (_target, prop: string) => taskApiMock[prop as keyof typeof taskApiMock] },
@@ -103,6 +105,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     {},
     { get: (_target, prop: string) => loopApiMock[prop as keyof typeof loopApiMock] },
   );
+  const extractApiProxy = new Proxy(
+    {},
+    { get: (_target, prop: string) => extractApiMock[prop as keyof typeof extractApiMock] },
+  );
   const apiMock = new Proxy(
     {},
     {
@@ -111,6 +117,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
         if (prop in reviewApiMock) return reviewApiMock[prop as keyof typeof reviewApiMock];
         if (prop in configApiMock) return configApiMock[prop as keyof typeof configApiMock];
         if (prop in loopApiMock) return loopApiMock[prop as keyof typeof loopApiMock];
+        if (prop in extractApiMock) return extractApiMock[prop as keyof typeof extractApiMock];
         return overrides[prop];
       },
       set: (_target, prop: string, value) => {
@@ -130,6 +137,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
           (loopApiMock as Record<string, unknown>)[prop] = value;
           return true;
         }
+        if (prop in extractApiMock) {
+          (extractApiMock as Record<string, unknown>)[prop] = value;
+          return true;
+        }
         overrides[prop] = value;
         return true;
       },
@@ -144,10 +155,12 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     reviewApiMock,
     configApiMock,
     loopApiMock,
+    extractApiMock,
     taskApiProxy,
     reviewApiProxy,
     configApiProxy,
     loopApiProxy,
+    extractApiProxy,
     apiMock,
     apiProxy,
   };
@@ -411,12 +424,21 @@ export function mockLoopApi(overrides: Record<string, unknown> = {}) {
   return { ...defaults, ...overrides };
 }
 
+export function mockExtractApi(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    listExtracts: vi.fn().mockResolvedValue([]),
+    getExtract: vi.fn().mockResolvedValue(null),
+  };
+  return { ...defaults, ...overrides };
+}
+
 export function mockApi(overrides: Record<string, unknown> = {}) {
   return {
     ...mockTaskApi(),
     ...mockReviewApi(),
     ...mockConfigApi(),
     ...mockLoopApi(),
+    ...mockExtractApi(),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- New "PR merged" trigger riding on the existing `checkMergedPRs` poller — same `(repo_path, pr_number, pr_head_sha)` dedup shape as the review poller (`findExistingPrTask` + a `source === 'pr_extract'` guard).
- Generic ajv-backed schema-validated output contract (`server/services/output-contract.ts`) — the loop harness's fixed `{status,reason}` callback (`/api/loops/:id/emit`) is untouched.
- `pr_extracts` SQL sink: forward-only migration + repository + `POST /api/pr-extracts/:taskId/emit` (schema-validated against `{ area, risk, has_migration, surface, loc }`, with repo/PR metadata derived server-side from the task row) + `GET /api/pr-extracts` / `GET /api/pr-extracts/:id`.
- Shared `requireBearerHookToken` middleware extracted out of `routes/loops.ts` into `routes/hook-auth.ts` so both the loop and pr-extract emit endpoints reuse the same per-agent `hook_token` auth.
- `octomux pr-extract emit` CLI command the extraction agent calls (mirrors `octomux emit`).
- `/extracts` feed page mirroring `LoopsPage`'s card-list pattern (no generic `/w/:kind` registry yet — that's Phase 2 / P4).

Note on base branch: `next` was merged into `main` and deleted as part of the 1.2.0 release (PR #186) right before this branch was cut, and no new `next` has been created since — targeting `main` since it's the current tip.

## Test plan
- [x] `bun run typecheck && bun run lint && bun run test` — 283 files / 3575 tests passing
- [ ] Manually verify: merge a PR in a repo with an active octomux review task, confirm a `pr_extract` task spawns and `/extracts` shows the row once the agent emits

### Gate output (final run)
```
$ tsc -b
(no errors)

$ eslint
✖ 60 problems (0 errors, 60 warnings)   — pre-existing warnings, unrelated to this change

$ vitest run
 Test Files  283 passed (283)
      Tests  3575 passed (3575)
```