### PR TITLE
fix(loop): respawn EEXIST, artifact leakage, done-requires-verify lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ packages/*/bin/*
 packages/*/share/terminfo/*
 !packages/*/share/terminfo/.gitkeep
 *.tsbuildinfo
+
+# Loop runtime state written into worktrees — not source
+.octomux/loop-playbook.md
+.octomux/loop-status.json

--- a/server/task-engine.test.ts
+++ b/server/task-engine.test.ts
@@ -191,7 +191,7 @@ describe('buildAgentStartupCommand', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
       expect.stringContaining('.claude-prompt-agent123'),
       'Do the thing',
-      { mode: 0o600, flag: 'wx' },
+      { mode: 0o600 },
     );
   });
 
@@ -273,7 +273,7 @@ describe('startTask', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
       expect.stringContaining('.claude-prompt-'),
       'Do the thing',
-      { mode: 0o600, flag: 'wx' },
+      { mode: 0o600 },
     );
   });
 
@@ -1159,7 +1159,7 @@ describe('addAgent', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
       expect.stringContaining('.claude-prompt-'),
       'Write tests',
-      { mode: 0o600, flag: 'wx' },
+      { mode: 0o600 },
     );
   });
 

--- a/server/task-engine/launch-prompt-respawn.test.ts
+++ b/server/task-engine/launch-prompt-respawn.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildAgentStartupCommand } from './launch.js';
+
+// Regression test for the respawn EEXIST bug: the prompt file is written with
+// the real fs module (not mocked) so an exclusive-create flag would actually
+// throw here, unlike in launch.test.ts where fs.writeFileSync is a no-op mock.
+
+let tmpDir: string;
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('buildAgentStartupCommand prompt file (real fs)', () => {
+  it('overwrites an existing prompt file on respawn instead of throwing EEXIST', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-launch-'));
+    const agentId = 'agent-respawn-1';
+
+    buildAgentStartupCommand({
+      baseCmd: 'claude --session-id abc',
+      prompt: 'original prompt',
+      worktreePath: tmpDir,
+      agentId,
+    });
+
+    expect(() =>
+      buildAgentStartupCommand({
+        baseCmd: 'claude --session-id abc',
+        prompt: 'respawn prompt',
+        worktreePath: tmpDir,
+        agentId,
+      }),
+    ).not.toThrow();
+
+    const promptFile = path.join(tmpDir, `.claude-prompt-${agentId}`);
+    expect(fs.readFileSync(promptFile, 'utf8')).toBe('respawn prompt');
+  });
+});

--- a/server/task-engine/launch.test.ts
+++ b/server/task-engine/launch.test.ts
@@ -136,7 +136,7 @@ describe('buildAgentStartupCommand', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
       expect.stringContaining('.claude-prompt-agent123'),
       'Do the thing',
-      { mode: 0o600, flag: 'wx' },
+      { mode: 0o600 },
     );
   });
 

--- a/server/task-engine/launch.ts
+++ b/server/task-engine/launch.ts
@@ -59,7 +59,7 @@ export function buildAgentStartupCommand(args: {
   let inner = args.baseCmd;
   if (args.prompt && args.worktreePath && args.agentId) {
     const promptFile = path.join(args.worktreePath, `.claude-prompt-${args.agentId}`);
-    fs.writeFileSync(promptFile, args.prompt, { mode: 0o600, flag: 'wx' });
+    fs.writeFileSync(promptFile, args.prompt, { mode: 0o600 });
     // `--` ends option parsing so the positional prompt can't be swallowed by a
     // preceding variadic flag. `--mcp-config` (appended for orchestrator-managed
     // tasks) is variadic in Claude Code: without the separator it consumes the

--- a/server/task-engine/loop/engine.test.ts
+++ b/server/task-engine/loop/engine.test.ts
@@ -242,6 +242,39 @@ describe('handleLoopIterationBoundary', () => {
     expect(task.runtime_state).toBe('idle');
   });
 
+  it('does not terminate done when run.status is done but verify fails — respawns for another iteration instead', async () => {
+    vi.mocked(revParseHead).mockImplementation(async () => `sha-${Math.random()}`);
+    vi.mocked(runVerify).mockResolvedValueOnce({ passed: false, output: 'still failing' });
+
+    const run = await startLoop('t1', LOOP_SPEC);
+    const respawnCallsBefore = vi.mocked(respawnAgentFresh).mock.calls.length;
+
+    recordEmit(run.id, { status: 'done', reason: 'looks done but verify disagrees' });
+    await handleLoopIterationBoundary('t1', 'a1');
+
+    expect(vi.mocked(respawnAgentFresh).mock.calls.length).toBe(respawnCallsBefore + 1);
+    // resumeLoopRun resets status back to 'running' — the emit's 'done' status
+    // never survives evaluateTermination when verify failed.
+    const finalRun = getLoopRun(run.id);
+    expect(finalRun?.status).toBe('running');
+  });
+
+  it('terminates done when run.status is done and verify passes', async () => {
+    vi.mocked(revParseHead).mockImplementation(async () => `sha-${Math.random()}`);
+    vi.mocked(runVerify).mockResolvedValueOnce({ passed: true, output: 'ok' });
+
+    const run = await startLoop('t1', LOOP_SPEC);
+    const respawnCallsBefore = vi.mocked(respawnAgentFresh).mock.calls.length;
+
+    recordEmit(run.id, { status: 'done', reason: 'iter1' });
+    await handleLoopIterationBoundary('t1', 'a1');
+
+    expect(vi.mocked(respawnAgentFresh).mock.calls.length).toBe(respawnCallsBefore); // no further respawn
+    const finalRun = getLoopRun(run.id);
+    expect(finalRun?.status).toBe('done');
+    expect(finalRun?.termination_reason).toBe('done');
+  });
+
   it('terminates max_iterations once the cap is hit, without waiting for a done emit', async () => {
     vi.mocked(revParseHead).mockImplementation(async () => 'stable-sha');
     vi.mocked(runVerify).mockResolvedValue({ passed: false, output: 'still failing' });


### PR DESCRIPTION
## Summary
Three small dogfooding fixes for the loop harness, all on `next`.

- **fix(loop):** `buildAgentStartupCommand` wrote the per-agent prompt file with exclusive-create (`flag: 'wx'`). On a loop respawn (same agent id, original file not yet consumed) this threw `EEXIST` — confirmed in production as `POST /api/loops → 400` right after `startLoop` had already flipped the task to `looping` and created the run, leaving the loop half-started. Now overwrites (drops the flag, keeps `mode: 0o600`).
- **chore(loop):** `.octomux/loop-playbook.md` and `.octomux/loop-status.json` are per-run runtime state written into the worktree, not source. The iteration-boundary auto-commit was sweeping them into task branches (observed in a cleanup PR). Added to `.gitignore`; verified `git status` no longer shows them after creating both files in this worktree.
- **test(loop):** `evaluateTermination` already gates `done` on `verifyPassed`. Added explicit `handleLoopIterationBoundary`-level regression tests locking that a `done` emit with a failing verify respawns instead of terminating, and only terminates once verify passes — so a stale build that drops the guard fails CI instead of surfacing in production.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (60 pre-existing warnings, untouched files)
- [x] `bun run format:check` — clean
- [x] `bun run test` — 300 files / 3633 tests passed
- [x] Manually verified `.gitignore` suppresses `.octomux/loop-playbook.md` and `.octomux/loop-status.json` via `git check-ignore -v`