### PR TITLE
fix(diff): stop flaky diff-engine/diff-review-state tests under CPU contention

### DIFF
--- a/packages/diff-engine/src/diff-base.ts
+++ b/packages/diff-engine/src/diff-base.ts
@@ -52,7 +52,7 @@ function isMissingRemoteRef(err: unknown): boolean {
 }
 
 const CACHE_TTL_MS = 30_000;
-const ATTEMPT_TIMEOUT_MS = 5_000;
+const ATTEMPT_TIMEOUT_MS = Number(process.env.OCTOMUX_DIFF_TIMEOUT_MS) || 5_000;
 const ATTEMPT_INTERNAL_MS = ATTEMPT_TIMEOUT_MS - 250;
 const RETRY_ATTEMPTS = 2;
 const RETRY_BACKOFF_MS = 200;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       '@octomux/api-client': path.resolve(__dirname, './packages/api-client/src/index.ts'),
       '@octomux/diff-engine': path.resolve(__dirname, './packages/diff-engine/src/index.ts'),
       '@octomux/test-fixtures': path.resolve(__dirname, './packages/test-fixtures/src/index.ts'),
+      '@octomux/types': path.resolve(__dirname, './packages/types/src/index.ts'),
     },
   },
   test: {
@@ -32,6 +33,16 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          alias: {
+            '@octomux/diff-engine': path.resolve(__dirname, './packages/diff-engine/src/index.ts'),
+            '@octomux/test-fixtures': path.resolve(
+              __dirname,
+              './packages/test-fixtures/src/index.ts',
+            ),
+            '@octomux/types': path.resolve(__dirname, './packages/types/src/index.ts'),
+          },
+        },
         test: {
           name: 'server',
           globals: true,
@@ -43,10 +54,12 @@ export default defineConfig({
         resolve: {
           alias: {
             '@': path.resolve(__dirname, './src'),
+            '@octomux/api-client': path.resolve(__dirname, './packages/api-client/src/index.ts'),
             '@octomux/test-fixtures': path.resolve(
               __dirname,
               './packages/test-fixtures/src/index.ts',
             ),
+            '@octomux/types': path.resolve(__dirname, './packages/types/src/index.ts'),
           },
         },
         test: {
@@ -58,6 +71,12 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          alias: {
+            '@octomux/api-client': path.resolve(__dirname, './packages/api-client/src/index.ts'),
+            '@octomux/types': path.resolve(__dirname, './packages/types/src/index.ts'),
+          },
+        },
         test: {
           name: 'cli',
           globals: true,
@@ -66,6 +85,16 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          alias: {
+            '@octomux/diff-engine': path.resolve(__dirname, './packages/diff-engine/src/index.ts'),
+            '@octomux/test-fixtures': path.resolve(
+              __dirname,
+              './packages/test-fixtures/src/index.ts',
+            ),
+            '@octomux/types': path.resolve(__dirname, './packages/types/src/index.ts'),
+          },
+        },
         test: {
           name: 'cli-review',
           globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
@@ -26,10 +26,29 @@ export default defineConfig({
       },
       {
         test: {
+          // diff-base.test.ts drives resolveDiffBase with mocked exec + fake
+          // timers and asserts against the real ATTEMPT_TIMEOUT_MS default —
+          // it must NOT get the test-env timeout override below.
+          name: 'diff-engine-unit',
+          globals: true,
+          environment: 'node',
+          include: ['packages/diff-engine/src/diff-base.test.ts'],
+        },
+      },
+      {
+        test: {
           name: 'diff-engine',
           globals: true,
           environment: 'node',
           include: ['packages/diff-engine/**/*.test.ts'],
+          exclude: [...defaultExclude, 'packages/diff-engine/src/diff-base.test.ts'],
+          // Real `git` subprocesses in beforeEach/tests can exceed the 5s
+          // default under CPU contention (see diff-base.ts OCTOMUX_DIFF_TIMEOUT_MS).
+          testTimeout: 20_000,
+          hookTimeout: 20_000,
+          env: {
+            OCTOMUX_DIFF_TIMEOUT_MS: '30000',
+          },
         },
       },
       {
@@ -48,6 +67,11 @@ export default defineConfig({
           globals: true,
           environment: 'node',
           include: ['server/**/*.test.ts'],
+          testTimeout: 20_000,
+          hookTimeout: 20_000,
+          env: {
+            OCTOMUX_DIFF_TIMEOUT_MS: '30000',
+          },
         },
       },
       {


### PR DESCRIPTION
## Summary

Fixes the intermittent failures in the real-git diff-engine/diff-review-state tests under CPU contention, plus a pre-existing config bug that was blocking a green full-suite run entirely.

**Root cause (verified, not assumed):** `packages/diff-engine/src/diff-base.ts`'s `ATTEMPT_TIMEOUT_MS` was suspected, but none of the affected tests actually exercise the `base_branch` fetch path (they all pass `base_branch: null`), so that 5s timeout never engages. The real failure mode is **vitest's own default `testTimeout`/`hookTimeout` (5s/10s)** — each affected test spawns ~7-13 real `git` subprocesses via `execFile`, and measured spawn overhead alone ranged from ~15ms to ~800ms per call even at rest, ballooning further under contention. Reproduced directly: `Test timed out in 5000ms` / `Hook timed out in 20000ms` on `diff.test.ts` and `server/diff-review-state.test.ts` while running under sustained CPU load.

**Bonus find:** while trying to get a clean baseline to test against, the full suite was failing 117/300 test files with `Failed to resolve entry for package "@octomux/..."`. Turns out root-level `resolve.alias` in `vitest.config.ts` isn't inherited by inline `test.projects` entries in vitest 3 — every project needs its own alias block. This was silently broken (worse after `@octomux/types` was added in #191 with no alias anywhere), unrelated to the flakiness task but blocking a green gate regardless of anything else here, so it's fixed as its own commit.

## Commits

1. `fix(diff-engine): make attempt timeout env-configurable` — `ATTEMPT_TIMEOUT_MS` now reads `OCTOMUX_DIFF_TIMEOUT_MS`, default unchanged at 5000ms for production.
2. `fix(vitest): add missing per-project @octomux/* resolve aliases` — gives `server`, `ui`, `cli`, `cli-review` projects the aliases their own (including transitive) imports need.
3. `test(diff): raise timeouts so real-git tests don't flake under load` — `testTimeout`/`hookTimeout` raised to 20s and `OCTOMUX_DIFF_TIMEOUT_MS=30000` for the `diff-engine` and `server` projects. `diff-base.test.ts` (mocked exec + fake timers, asserts on the real 5000ms default) is split into its own `diff-engine-unit` project so it doesn't inherit the override.

## Verify

Ran the affected files back-to-back under sustained CPU contention (6× `yes > /dev/null` pinning 6 of 12 cores) — first with 16 loops (133% oversubscription), which caused pathological multi-minute stalls even past the 20s hook timeout (confirms the timeout mechanism is real, not just raised past what anything would ever hit); backed off to 6 loops for realistic contention:

- **10 runs**, `diff-base-sha.test.ts` + `diff.test.ts` + `diff-range.test.ts` + `diff-blob.test.ts` + `diff-review-state.test.ts` + `api.diff-base.test.ts` + `readme-task-diff-relay.test.ts`: **7/7 files, 83/83 tests passed every run, 0 timeouts.**
- **8 more runs** with `diff-base.test.ts` added back in (confirming the unit-test split didn't regress it): **8/8 files, 95/95 tests passed every run, 0 timeouts.**

Full gate, clean (no artificial load):
- `bun run typecheck` → clean
- `bun run lint` → 0 errors (60 pre-existing warnings, untouched by this change)
- `bun run format:check` → clean
- `bun run test` → **300/300 files, 3633/3633 tests passed**

Production default for `ATTEMPT_TIMEOUT_MS` is unchanged (5000ms) — real users see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)