### PR TITLE
fix(schedules): isCronDue must match the whole minute, not exact seconds

### DIFF
--- a/server/schedules/cron.test.ts
+++ b/server/schedules/cron.test.ts
@@ -9,5 +9,10 @@ describe('isCronDue', () => {
     ['0 7 * * 1-5', new Date('2026-07-20T07:00:00Z'), true], // Mon
     ['0 7 * * 1-5', new Date('2026-07-18T07:00:00Z'), false], // Sat
     ['not a cron', new Date('2026-07-18T07:00:00Z'), false],
+    // Regression: the poller passes wall-clock `now` with non-zero seconds.
+    // A due schedule must fire anywhere within its minute, not only at :00.
+    ['* * * * *', new Date('2026-07-18T07:00:37Z'), true],
+    ['0 7 * * *', new Date('2026-07-18T07:00:45.912Z'), true],
+    ['0 7 * * *', new Date('2026-07-18T07:01:30Z'), false],
   ])('%s @ %s → %s', (e, n, d) => expect(isCronDue(e, n)).toBe(d));
 });

--- a/server/schedules/cron.ts
+++ b/server/schedules/cron.ts
@@ -2,16 +2,26 @@ import { Cron } from 'croner';
 
 const cache = new Map<string, Cron>();
 
-/** Returns true when `expr` matches `now` (UTC). Invalid expressions never match. */
+/**
+ * Returns true when 5-field `expr` is due during the minute containing `now` (UTC).
+ * Invalid expressions never match.
+ *
+ * NOTE: croner's `.match()` is second-exact, but the poller passes wall-clock
+ * `new Date()` (arbitrary seconds), so matching `now` directly would only ever
+ * fire on the rare tick that lands on `:00`. We normalize to the start of the
+ * minute so a schedule fires anywhere within its due minute.
+ */
 export function isCronDue(expr: string, now: Date): boolean {
   try {
     let job = cache.get(expr);
-    // paused:true is REQUIRED — teams.ts:231 uses it so croner doesn't arm a timer for a callback-less job
+    // paused:true is REQUIRED — croner won't arm a timer for a callback-less job
     if (!job) {
       job = new Cron(expr, { timezone: 'UTC', paused: true });
       cache.set(expr, job);
     }
-    return job?.match(now) ?? false;
+    const atMinute = new Date(now);
+    atMinute.setUTCSeconds(0, 0);
+    return job?.match(atMinute) ?? false;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Critical bug: scheduled workflows never fire

`isCronDue` used croner's `.match(now)`, which is **second-exact** — a 5-field cron like `* * * * *` only matches when the timestamp's seconds are `:00`. But the schedule poller calls `isCronDue(cron, new Date())` with wall-clock time (arbitrary seconds), so `.match()` almost always returns `false`. **In practice, no scheduled workflow ever fired.**

The unit tests all passed because every test date used `:00` seconds — the one case where the bug is invisible.

## Fix
Normalize `now` to the start of its minute before matching, so a due schedule fires anywhere within its minute.

## How it was found
Discovered via a live end-to-end run: a seeded `doc-drift` schedule (`* * * * *`) targeting the octomux repo never fired until this fix; immediately after, the poller fired it and spawned a real agent.

## Regression coverage
Added test cases with non-`:00` seconds (`07:00:37Z`, `07:00:45.912Z`) that fail on the old code and pass on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)