### PR TITLE
feat(workflows): doc-drift, log-summary, weekly-update & daily-plan verticals

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,7 +29,7 @@ export type AgentStatus = 'running' | 'idle' | 'waiting' | 'stopped';
 export type HookActivity = 'active' | 'idle' | 'waiting';
 export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
 
-export type TaskSource = 'auto_review' | 'pr_extract' | 'prod_log_triage' | null;
+export type TaskSource = 'auto_review' | 'pr_extract' | 'prod_log_triage' | 'doc_drift' | null;
 
 export type RunMode = 'new' | 'existing' | 'none' | 'scratch';
 

--- a/server/api.schedules.test.ts
+++ b/server/api.schedules.test.ts
@@ -18,6 +18,7 @@ describe('schedule routes', () => {
       const res = await request(app).get('/api/schedules/kinds');
       expect(res.status).toBe(200);
       expect(res.body.kinds).toContain('prod-log-triage');
+      expect(res.body.kinds).toContain('doc-drift');
     });
   });
 

--- a/server/api.schedules.test.ts
+++ b/server/api.schedules.test.ts
@@ -19,6 +19,8 @@ describe('schedule routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.kinds).toContain('prod-log-triage');
       expect(res.body.kinds).toContain('doc-drift');
+      expect(res.body.kinds).toContain('weekly-update');
+      expect(res.body.kinds).toContain('daily-plan');
     });
   });
 

--- a/server/api.workflow-runs.test.ts
+++ b/server/api.workflow-runs.test.ts
@@ -64,12 +64,14 @@ describe('GET /api/workflows', () => {
     const kinds = res.body.workflows.map((w: { kind: string }) => w.kind);
     expect(kinds).toEqual(
       expect.arrayContaining([
+        'daily-plan',
         'doc-drift',
         'loops',
         'overnight-log-summary',
         'pr-extract',
         'prod-log-triage',
         'reviewer',
+        'weekly-update',
       ]),
     );
 

--- a/server/api.workflow-runs.test.ts
+++ b/server/api.workflow-runs.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from './app.js';
 import { createTestDb } from './test-helpers.js';
-import { insertRun } from './repositories/runs.js';
+import { insertRun, finishRun } from './repositories/runs.js';
 import './workflows/index.js';
 
 describe('GET /api/workflows/:kind/runs', () => {
@@ -30,6 +30,20 @@ describe('GET /api/workflows/:kind/runs', () => {
     expect(res.status).toBe(200);
     expect(res.body.runs).toEqual([]);
   });
+
+  it('includes result_json for a finished session run (no task_id)', async () => {
+    const run = insertRun({ workflowKind: 'overnight-log-summary', trigger: 'cron' });
+    finishRun(run.id, { status: 'done', result: { window: 'last 12h', summary: 'all clear' } });
+
+    const res = await request(app).get('/api/workflows/overnight-log-summary/runs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.runs[0].task_id).toBeNull();
+    expect(JSON.parse(res.body.runs[0].result_json)).toEqual({
+      window: 'last 12h',
+      summary: 'all clear',
+    });
+  });
 });
 
 describe('GET /api/workflows', () => {
@@ -49,7 +63,14 @@ describe('GET /api/workflows', () => {
     expect(res.status).toBe(200);
     const kinds = res.body.workflows.map((w: { kind: string }) => w.kind);
     expect(kinds).toEqual(
-      expect.arrayContaining(['doc-drift', 'loops', 'pr-extract', 'prod-log-triage', 'reviewer']),
+      expect.arrayContaining([
+        'doc-drift',
+        'loops',
+        'overnight-log-summary',
+        'pr-extract',
+        'prod-log-triage',
+        'reviewer',
+      ]),
     );
 
     const prExtract = res.body.workflows.find((w: { kind: string }) => w.kind === 'pr-extract');
@@ -59,9 +80,21 @@ describe('GET /api/workflows', () => {
       trigger: { kind: 'github', event: 'pr_merged' },
       runCount: 2,
     });
+    expect(prExtract.output).toBeDefined();
 
     const loops = res.body.workflows.find((w: { kind: string }) => w.kind === 'loops');
     expect(loops.runCount).toBe(0);
     expect(loops.trigger).toEqual({ kind: 'manual' });
+    expect(loops.output).toBeNull();
+
+    const overnightLogSummary = res.body.workflows.find(
+      (w: { kind: string }) => w.kind === 'overnight-log-summary',
+    );
+    expect(overnightLogSummary).toMatchObject({
+      displayName: 'Overnight Log Summary',
+      surfaces: ['artifact'],
+      trigger: { kind: 'cron' },
+    });
+    expect(overnightLogSummary.output).toBeDefined();
   });
 });

--- a/server/api.workflow-runs.test.ts
+++ b/server/api.workflow-runs.test.ts
@@ -49,7 +49,7 @@ describe('GET /api/workflows', () => {
     expect(res.status).toBe(200);
     const kinds = res.body.workflows.map((w: { kind: string }) => w.kind);
     expect(kinds).toEqual(
-      expect.arrayContaining(['loops', 'pr-extract', 'prod-log-triage', 'reviewer']),
+      expect.arrayContaining(['doc-drift', 'loops', 'pr-extract', 'prod-log-triage', 'reviewer']),
     );
 
     const prExtract = res.body.workflows.find((w: { kind: string }) => w.kind === 'pr-extract');

--- a/server/doc-drift-tasks.test.ts
+++ b/server/doc-drift-tasks.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from './test-helpers.js';
+import { getDb } from './db.js';
+import { buildDocDriftPrompt, insertDocDriftTask } from './doc-drift-tasks.js';
+
+describe('buildDocDriftPrompt', () => {
+  it('pins the doc-drift task id and embeds the skill invocation', () => {
+    const prompt = buildDocDriftPrompt({
+      docDriftTaskId: 'drift-1',
+      repoShort: 'octomux-agents',
+    });
+    expect(prompt).toContain('drift-1');
+    expect(prompt).toContain('doc-drift');
+  });
+});
+
+describe('insertDocDriftTask', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('inserts a task with source=doc_drift', () => {
+    const id = insertDocDriftTask({
+      id: 'drift-1',
+      repoPath: '/repo',
+      branch: 'doc-drift/octomux-agents-2026-07-18',
+      baseBranch: 'main',
+      title: 'Doc drift: octomux-agents',
+      description: 'Scheduled doc-drift run',
+      initialPrompt: 'do the thing',
+    });
+    expect(id).toBe('drift-1');
+    const row = getDb().prepare('SELECT source FROM tasks WHERE id = ?').get(id);
+    expect(row).toEqual({ source: 'doc_drift' });
+  });
+
+  it('stamps schedule_id when scheduleId is provided', () => {
+    const id = insertDocDriftTask({
+      id: 'drift-2',
+      repoPath: '/repo',
+      branch: 'doc-drift/octomux-agents-2026-07-18',
+      baseBranch: 'main',
+      title: 'Doc drift: octomux-agents',
+      description: 'Scheduled doc-drift run',
+      initialPrompt: 'do the thing',
+      scheduleId: 'sched-1',
+    });
+    const row = getDb().prepare('SELECT schedule_id FROM tasks WHERE id = ?').get(id);
+    expect(row).toEqual({ schedule_id: 'sched-1' });
+  });
+
+  it('leaves schedule_id null when scheduleId is omitted', () => {
+    const id = insertDocDriftTask({
+      id: 'drift-3',
+      repoPath: '/repo',
+      branch: 'doc-drift/octomux-agents-2026-07-18',
+      baseBranch: 'main',
+      title: 'Doc drift: octomux-agents',
+      description: 'Scheduled doc-drift run',
+      initialPrompt: 'do the thing',
+    });
+    const row = getDb().prepare('SELECT schedule_id FROM tasks WHERE id = ?').get(id);
+    expect(row).toEqual({ schedule_id: null });
+  });
+});

--- a/server/doc-drift-tasks.ts
+++ b/server/doc-drift-tasks.ts
@@ -1,0 +1,72 @@
+import { nanoid } from 'nanoid';
+import { insertTask, insertWorktree } from './repositories/index.js';
+
+export interface DocDriftPromptInput {
+  /** Id of THIS doc-drift task — pinned in the prompt like extract/loop task ids. */
+  docDriftTaskId: string;
+  repoShort: string;
+}
+
+/** Prompt for the scheduled doc-drift agent. */
+export function buildDocDriftPrompt(input: DocDriftPromptInput): string {
+  return [
+    `Check ${input.repoShort} for drift between its docs and its code, and open a fix PR for what you find.`,
+    '',
+    `Doc-drift task id: ${input.docDriftTaskId}`,
+    '',
+    'Use the doc-drift skill to run this task:',
+    '  1. Survey the documented surface (README, docs/, CLAUDE.md).',
+    '  2. Compare it against the actual code.',
+    '  3. Fix drift you find with small, targeted doc edits.',
+    '  4. Open one doc-fix PR using your own `gh` — there is no octomux sink for this workflow.',
+    '',
+    'Read the doc-drift skill (SKILL.md) for the full verify contract before starting.',
+  ].join('\n');
+}
+
+export interface InsertDocDriftTaskParams {
+  id?: string;
+  repoPath: string;
+  branch: string;
+  baseBranch: string;
+  baseSha?: string | null;
+  title: string;
+  description: string;
+  initialPrompt: string;
+  /** Set when this task was fired by a schedule — stamps tasks.schedule_id. */
+  scheduleId?: string;
+}
+
+/**
+ * Shared doc-drift-task creation: materialises a worktree row and a task row in
+ * the `doc_drift` source class. Returns the new task id.
+ */
+export function insertDocDriftTask(params: InsertDocDriftTaskParams): string {
+  const id = params.id ?? nanoid(12);
+  const worktreeId = nanoid(12);
+
+  insertWorktree({
+    id: worktreeId,
+    path: '',
+    repo_path: params.repoPath,
+    branch: params.branch,
+    base_branch: params.baseBranch,
+    base_sha: params.baseSha ?? null,
+    mode: 'new',
+    status: 'available',
+  });
+
+  insertTask({
+    id,
+    title: params.title,
+    description: params.description,
+    runtime_state: 'idle',
+    workflow_status: 'backlog',
+    initial_prompt: params.initialPrompt,
+    source: 'doc_drift',
+    worktree_id: worktreeId,
+    schedule_id: params.scheduleId ?? null,
+  });
+
+  return id;
+}

--- a/server/routes/workflow-runs.ts
+++ b/server/routes/workflow-runs.ts
@@ -12,6 +12,7 @@ router.get('/api/workflows', (_req: Request, res: Response) => {
       displayName: w.displayName,
       surfaces: w.surfaces,
       trigger: w.trigger ?? null,
+      output: w.output ?? null,
       runCount: countRunsForWorkflow(w.kind),
     })),
   });

--- a/server/schedules/cron.test.ts
+++ b/server/schedules/cron.test.ts
@@ -9,5 +9,10 @@ describe('isCronDue', () => {
     ['0 7 * * 1-5', new Date('2026-07-20T07:00:00Z'), true], // Mon
     ['0 7 * * 1-5', new Date('2026-07-18T07:00:00Z'), false], // Sat
     ['not a cron', new Date('2026-07-18T07:00:00Z'), false],
+    // Regression: the poller passes wall-clock `now` with non-zero seconds.
+    // A due schedule must fire anywhere within its minute, not only at :00.
+    ['* * * * *', new Date('2026-07-18T07:00:37Z'), true],
+    ['0 7 * * *', new Date('2026-07-18T07:00:45.912Z'), true],
+    ['0 7 * * *', new Date('2026-07-18T07:01:30Z'), false],
   ])('%s @ %s → %s', (e, n, d) => expect(isCronDue(e, n)).toBe(d));
 });

--- a/server/schedules/cron.ts
+++ b/server/schedules/cron.ts
@@ -2,16 +2,26 @@ import { Cron } from 'croner';
 
 const cache = new Map<string, Cron>();
 
-/** Returns true when `expr` matches `now` (UTC). Invalid expressions never match. */
+/**
+ * Returns true when 5-field `expr` is due during the minute containing `now` (UTC).
+ * Invalid expressions never match.
+ *
+ * NOTE: croner's `.match()` is second-exact, but the poller passes wall-clock
+ * `new Date()` (arbitrary seconds), so matching `now` directly would only ever
+ * fire on the rare tick that lands on `:00`. We normalize to the start of the
+ * minute so a schedule fires anywhere within its due minute.
+ */
 export function isCronDue(expr: string, now: Date): boolean {
   try {
     let job = cache.get(expr);
-    // paused:true is REQUIRED — teams.ts:231 uses it so croner doesn't arm a timer for a callback-less job
+    // paused:true is REQUIRED — croner won't arm a timer for a callback-less job
     if (!job) {
       job = new Cron(expr, { timezone: 'UTC', paused: true });
       cache.set(expr, job);
     }
-    return job?.match(now) ?? false;
+    const atMinute = new Date(now);
+    atMinute.setUTCSeconds(0, 0);
+    return job?.match(atMinute) ?? false;
   } catch {
     return false;
   }

--- a/server/services/daily-plan-service.test.ts
+++ b/server/services/daily-plan-service.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { getDb } from '../db.js';
+
+const mockGetSkill = vi.fn();
+const mockCreateChat = vi.fn();
+
+vi.mock('../skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+vi.mock('../chats.js', () => ({
+  createChat: (...args: unknown[]) => mockCreateChat(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runDailyPlanFromSchedule } from './daily-plan-service.js';
+
+describe('runDailyPlanFromSchedule', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockGetSkill.mockReset();
+    mockCreateChat.mockReset();
+  });
+
+  it('starts a chat with the skill prompt and inserts a run row with chat_id set', async () => {
+    mockGetSkill.mockResolvedValue({ name: 'daily-plan', content: 'Prep the day.' });
+    mockCreateChat.mockResolvedValue({ id: 'chat-1' });
+
+    await runDailyPlanFromSchedule({ scheduleId: 'sched-1' });
+
+    expect(mockGetSkill).toHaveBeenCalledWith('daily-plan');
+    expect(mockCreateChat).toHaveBeenCalledWith({ prompt: 'Prep the day.' });
+
+    const rows = getDb()
+      .prepare(`SELECT * FROM runs WHERE workflow_kind = 'daily-plan'`)
+      .all() as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chat_id).toBe('chat-1');
+    expect(rows[0].schedule_id).toBe('sched-1');
+    expect(rows[0].trigger).toBe('cron');
+  });
+});

--- a/server/services/daily-plan-service.ts
+++ b/server/services/daily-plan-service.ts
@@ -1,0 +1,26 @@
+/**
+ * Service layer for the daily-plan vertical: loads the skill body and starts
+ * an interactive chat (not a headless session) — the agent preps the day's
+ * plan, then waits for the user to join and steer.
+ */
+import { getSkill } from '../skills.js';
+import { createChat } from '../chats.js';
+import { insertRun } from '../repositories/runs.js';
+
+export interface RunDailyPlanFromScheduleInput {
+  scheduleId: string;
+}
+
+export async function runDailyPlanFromSchedule(
+  input: RunDailyPlanFromScheduleInput,
+): Promise<void> {
+  const skill = await getSkill('daily-plan');
+  const agent = await createChat({ prompt: skill.content });
+
+  insertRun({
+    workflowKind: 'daily-plan',
+    trigger: 'cron',
+    scheduleId: input.scheduleId,
+    chatId: agent.id,
+  });
+}

--- a/server/services/doc-drift-service.test.ts
+++ b/server/services/doc-drift-service.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { getDb } from '../db.js';
+
+const mockStartTask = vi.fn();
+vi.mock('../task-engine/index.js', () => ({
+  startTask: vi.fn((...args: unknown[]) => mockStartTask(...args)),
+}));
+
+const mockStartLoop = vi.fn().mockResolvedValue(undefined);
+vi.mock('../task-engine/loop/engine.js', () => ({
+  startLoop: vi.fn((...args: unknown[]) => mockStartLoop(...args)),
+}));
+
+const mockBroadcast = vi.fn();
+vi.mock('../events.js', () => ({
+  broadcast: vi.fn((...args: unknown[]) => mockBroadcast(...args)),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { createDocDriftTaskFromSchedule } from './doc-drift-service.js';
+import { setRuntimeState } from '../repositories/tasks.js';
+import { listRunsForWorkflow } from '../repositories/runs.js';
+
+function insertActiveAgent(taskId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+       VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
+    )
+    .run(`${taskId}-agent`, taskId);
+}
+
+describe('createDocDriftTaskFromSchedule', () => {
+  beforeEach(() => {
+    createTestDb();
+    vi.clearAllMocks();
+    mockStartTask.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: inserts a task, starts it, and starts the retry loop once a live agent exists', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      repoPath: '/repo',
+      verify: 'test -n "$(git diff --name-only origin/HEAD... -- \'*.md\')" && bun run build',
+      maxIterations: 4,
+    });
+
+    expect(result.task.source).toBe('doc_drift');
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).toHaveBeenCalledWith(
+      result.id,
+      expect.objectContaining({
+        verify: 'test -n "$(git diff --name-only origin/HEAD... -- \'*.md\')" && bun run build',
+        maxIterations: 4,
+      }),
+    );
+  });
+
+  it('stamps schedule_id on the task when scheduleId is passed', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      repoPath: '/repo',
+      verify: 'bun run build',
+      maxIterations: 4,
+      scheduleId: 'sched-1',
+    });
+
+    const row = getDb().prepare('SELECT schedule_id FROM tasks WHERE id = ?').get(result.id);
+    expect(row).toEqual({ schedule_id: 'sched-1' });
+  });
+
+  it('records exactly one runs row linking the task, kind, trigger, and scheduleId', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      repoPath: '/repo',
+      verify: 'bun run build',
+      maxIterations: 4,
+      scheduleId: 'sched-1',
+    });
+
+    const rows = listRunsForWorkflow('doc-drift');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].trigger).toBe('cron');
+    expect(rows[0].task_id).toBe(result.id);
+    expect(rows[0].schedule_id).toBe('sched-1');
+  });
+
+  it('does NOT call startLoop when startTask leaves the task in runtime_state=error', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      setRuntimeState(task.id, 'error', 'setup failed');
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      repoPath: '/repo',
+      verify: 'bun run build',
+      maxIterations: 4,
+    });
+
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).not.toHaveBeenCalled();
+    expect(result.id).toBeTruthy();
+  });
+
+  it('does NOT call startLoop when startTask resolves but no active agent exists', async () => {
+    mockStartTask.mockResolvedValue(undefined); // resolves, no agent row inserted, no error state
+
+    const result = await createDocDriftTaskFromSchedule({
+      repoPath: '/repo',
+      verify: 'bun run build',
+      maxIterations: 4,
+    });
+
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).not.toHaveBeenCalled();
+    expect(result.id).toBeTruthy();
+  });
+});

--- a/server/services/doc-drift-service.ts
+++ b/server/services/doc-drift-service.ts
@@ -1,0 +1,95 @@
+/**
+ * Service layer for doc-drift run-start (cron → task → retry loop).
+ * HTTP-agnostic. Mirrors prod-log-triage-service.ts's insert→startTask shape,
+ * followed by startLoop — this vertical retries until `verify` passes instead
+ * of running once.
+ */
+
+import { nanoid } from 'nanoid';
+import { buildDocDriftPrompt, insertDocDriftTask } from '../doc-drift-tasks.js';
+import { repoShortName } from '../review-tasks.js';
+import { getTask, findFirstActiveAgent, insertRun } from '../repositories/index.js';
+import { startTask } from '../task-engine/index.js';
+import { startLoop } from '../task-engine/loop/engine.js';
+import { broadcast } from '../events.js';
+import { childLogger } from '../logger.js';
+import type { Task } from '../types.js';
+
+const logger = childLogger('doc-drift-service');
+
+export interface CreateDocDriftTaskFromScheduleInput {
+  repoPath: string;
+  verify: string;
+  maxIterations: number;
+  /** Set when this run was fired by a schedule — stamps tasks.schedule_id. */
+  scheduleId?: string;
+}
+
+export interface CreateDocDriftTaskResult {
+  id: string;
+  task: Task;
+}
+
+export async function createDocDriftTaskFromSchedule(
+  input: CreateDocDriftTaskFromScheduleInput,
+): Promise<CreateDocDriftTaskResult> {
+  const id = nanoid(12);
+  const short = repoShortName(input.repoPath);
+  const dateStamp = new Date().toISOString().slice(0, 10);
+  const branch = `doc-drift/${short}-${dateStamp}`;
+
+  const initialPrompt = buildDocDriftPrompt({
+    docDriftTaskId: id,
+    repoShort: short,
+  });
+
+  insertDocDriftTask({
+    id,
+    repoPath: input.repoPath,
+    branch,
+    baseBranch: 'main',
+    title: `Doc drift: ${short} (${dateStamp})`,
+    description: `Scheduled doc-drift run for ${short}`,
+    initialPrompt,
+    scheduleId: input.scheduleId,
+  });
+
+  broadcast({ type: 'task:created', payload: { taskId: id } });
+
+  insertRun({
+    workflowKind: 'doc-drift',
+    trigger: 'cron',
+    scheduleId: input.scheduleId,
+    taskId: id,
+  });
+
+  const fresh = getTask(id) as Task;
+  fresh.agents = [];
+  fresh.user_terminals = [];
+
+  await startTask(fresh);
+
+  // M1 guard: startTask catches its own setup failures and resolves anyway
+  // (lifecycle/start-task.ts sets runtime_state='error' and returns — it does
+  // NOT reject). Only kick off the retry loop once a live agent actually
+  // exists; otherwise startLoop would throw "no active agent" synchronously.
+  const settled = getTask(id);
+  const activeAgent = findFirstActiveAgent(id);
+  if (!settled || settled.runtime_state === 'error' || !activeAgent) {
+    logger.warn(
+      { task_id: id, runtime_state: settled?.runtime_state },
+      'doc-drift: startTask did not produce a live agent — skipping startLoop',
+    );
+    broadcast({ type: 'task:updated', payload: { taskId: id } });
+    return { id, task: settled ?? fresh };
+  }
+
+  await startLoop(id, {
+    prompt: initialPrompt,
+    verify: input.verify,
+    maxIterations: input.maxIterations,
+  });
+
+  logger.info({ task_id: id, repo_path: input.repoPath }, 'doc-drift task created');
+  return { id, task: getTask(id) ?? settled };
+}

--- a/server/services/overnight-log-summary-service.test.ts
+++ b/server/services/overnight-log-summary-service.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSkill = vi.fn();
+const mockRunSessionVertical = vi.fn();
+
+vi.mock('../skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+vi.mock('./session-vertical-service.js', () => ({
+  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runOvernightLogSummary } from './overnight-log-summary-service.js';
+import { OVERNIGHT_LOG_SUMMARY_SCHEMA } from '../workflows/overnight-log-summary/schema.js';
+
+describe('runOvernightLogSummary', () => {
+  beforeEach(() => {
+    mockGetSkill.mockReset();
+    mockRunSessionVertical.mockReset();
+  });
+
+  it('loads the skill, interpolates logCommand/repoShort, and calls runSessionVertical', async () => {
+    mockGetSkill.mockResolvedValue({
+      name: 'overnight-log-summary',
+      content: 'Run {{logCommand}} for {{repoShort}}.',
+    });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+
+    const { result } = await runOvernightLogSummary({
+      repoPath: '/repos/My App',
+      scheduleId: 'sched-1',
+      logCommand: 'gh run list --limit 30',
+    });
+
+    expect(result).toEqual({ summary: 'ok' });
+    expect(mockGetSkill).toHaveBeenCalledWith('overnight-log-summary', {
+      repoPath: '/repos/My App',
+    });
+    expect(mockRunSessionVertical).toHaveBeenCalledTimes(1);
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.kind).toBe('overnight-log-summary');
+    expect(call.scheduleId).toBe('sched-1');
+    expect(call.workspaceDir).toBe('/repos/My App');
+    expect(call.input).toBe('Run gh run list --limit 30 for my-app.');
+    expect(call.outputSchema).toBe(OVERNIGHT_LOG_SUMMARY_SCHEMA);
+  });
+});

--- a/server/services/overnight-log-summary-service.ts
+++ b/server/services/overnight-log-summary-service.ts
@@ -1,0 +1,39 @@
+/**
+ * Service layer for the overnight-log-summary vertical: loads the skill body,
+ * interpolates the schedule's log command, and runs it as a headless
+ * `runSessionVertical` call (session run — no task/worktree/loop).
+ */
+import { getSkill } from '../skills.js';
+import { repoShortName } from '../review-tasks.js';
+import { runSessionVertical } from './session-vertical-service.js';
+import { OVERNIGHT_LOG_SUMMARY_SCHEMA } from '../workflows/overnight-log-summary/schema.js';
+
+export interface RunOvernightLogSummaryInput {
+  repoPath: string;
+  scheduleId?: string | null;
+  logCommand: string;
+}
+
+export interface OvernightLogSummaryResult {
+  window: string;
+  summary: string;
+  errorClasses: Array<{ name: string; count: number; severity: 'low' | 'medium' | 'high' }>;
+  notableEvents: string[];
+}
+
+export async function runOvernightLogSummary(
+  input: RunOvernightLogSummaryInput,
+): Promise<{ result: OvernightLogSummaryResult }> {
+  const skill = await getSkill('overnight-log-summary', { repoPath: input.repoPath });
+  const prompt = skill.content
+    .replace(/\{\{logCommand\}\}/g, input.logCommand)
+    .replace(/\{\{repoShort\}\}/g, repoShortName(input.repoPath));
+
+  return runSessionVertical<OvernightLogSummaryResult>({
+    kind: 'overnight-log-summary',
+    scheduleId: input.scheduleId,
+    workspaceDir: input.repoPath,
+    input: prompt,
+    outputSchema: OVERNIGHT_LOG_SUMMARY_SCHEMA,
+  });
+}

--- a/server/services/session-vertical-service.test.ts
+++ b/server/services/session-vertical-service.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRunAgentSession = vi.fn();
+const mockGetHarness = vi.fn();
+
+vi.mock('../agent-session/session.js', () => ({
+  runAgentSession: (...args: unknown[]) => mockRunAgentSession(...args),
+}));
+vi.mock('../agent-session/substrate-pty.js', () => ({
+  ptySubstrate: { kind: 'pty', name: 'stub-pty-substrate' },
+}));
+vi.mock('../harnesses/registry.js', () => ({
+  getHarness: (...args: unknown[]) => mockGetHarness(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runSessionVertical } from './session-vertical-service.js';
+
+describe('runSessionVertical', () => {
+  beforeEach(() => {
+    mockRunAgentSession.mockReset();
+    mockGetHarness.mockReset();
+  });
+
+  it('wires harness/substrate/run and returns the result', async () => {
+    const stubHarness = { id: 'claude-code' };
+    mockGetHarness.mockReturnValue(stubHarness);
+    mockRunAgentSession.mockResolvedValue({ result: { summary: 'ok' } });
+
+    const outputSchema = { type: 'object' };
+    const { result } = await runSessionVertical({
+      kind: 'overnight-log-summary',
+      scheduleId: 'sched-1',
+      workspaceDir: '/repo',
+      input: 'do the thing',
+      outputSchema,
+      model: 'claude-opus-4-8',
+    });
+
+    expect(result).toEqual({ summary: 'ok' });
+    expect(mockGetHarness).toHaveBeenCalledWith(null);
+    expect(mockRunAgentSession).toHaveBeenCalledTimes(1);
+    const call = mockRunAgentSession.mock.calls[0][0];
+    expect(call.workspaceDir).toBe('/repo');
+    expect(call.harness).toBe(stubHarness);
+    expect(call.input).toBe('do the thing');
+    expect(call.substrate).toEqual({ kind: 'pty', name: 'stub-pty-substrate' });
+    expect(call.outputSchema).toBe(outputSchema);
+    expect(call.model).toBe('claude-opus-4-8');
+    expect(call.run).toEqual({
+      workflowKind: 'overnight-log-summary',
+      trigger: 'cron',
+      scheduleId: 'sched-1',
+    });
+  });
+
+  it('defaults model to null and scheduleId to undefined when omitted', async () => {
+    mockGetHarness.mockReturnValue({ id: 'claude-code' });
+    mockRunAgentSession.mockResolvedValue({ result: {} });
+
+    await runSessionVertical({
+      kind: 'overnight-log-summary',
+      workspaceDir: '/repo',
+      input: 'x',
+      outputSchema: {},
+    });
+
+    const call = mockRunAgentSession.mock.calls[0][0];
+    expect(call.model).toBeNull();
+    expect(call.run.scheduleId).toBeUndefined();
+  });
+});

--- a/server/services/session-vertical-service.ts
+++ b/server/services/session-vertical-service.ts
@@ -1,0 +1,34 @@
+/**
+ * server/services/session-vertical-service.ts
+ *
+ * Thin wrapper around `runAgentSession` for headless workflow verticals: fixed
+ * to the default harness + pty substrate, cron-triggered, with a `runs` row
+ * persisted per call. Verticals (e.g. overnight-log-summary) build the prompt
+ * and outputSchema, then call this instead of driving runAgentSession directly.
+ */
+import { runAgentSession } from '../agent-session/session.js';
+import { ptySubstrate } from '../agent-session/substrate-pty.js';
+import { getHarness } from '../harnesses/registry.js';
+
+export interface RunSessionVerticalInput {
+  kind: string;
+  scheduleId?: string | null;
+  workspaceDir: string;
+  input: string;
+  outputSchema: object;
+  model?: string | null;
+}
+
+export async function runSessionVertical<T = unknown>(
+  i: RunSessionVerticalInput,
+): Promise<{ result: T }> {
+  return runAgentSession<T>({
+    workspaceDir: i.workspaceDir,
+    harness: getHarness(null),
+    input: i.input,
+    substrate: ptySubstrate,
+    outputSchema: i.outputSchema,
+    model: i.model ?? null,
+    run: { workflowKind: i.kind, trigger: 'cron', scheduleId: i.scheduleId ?? undefined },
+  });
+}

--- a/server/services/weekly-update-service.test.ts
+++ b/server/services/weekly-update-service.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSkill = vi.fn();
+const mockRunSessionVertical = vi.fn();
+
+vi.mock('../skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+vi.mock('./session-vertical-service.js', () => ({
+  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runWeeklyUpdate } from './weekly-update-service.js';
+import { WEEKLY_UPDATE_SCHEMA } from '../workflows/weekly-update/schema.js';
+
+describe('runWeeklyUpdate', () => {
+  beforeEach(() => {
+    mockGetSkill.mockReset();
+    mockRunSessionVertical.mockReset();
+  });
+
+  it('loads the skill and calls runSessionVertical with its content as input', async () => {
+    mockGetSkill.mockResolvedValue({
+      name: 'weekly-update',
+      content: 'Summarize the week.',
+    });
+    mockRunSessionVertical.mockResolvedValue({ result: { period: 'Mon 1 - 5' } });
+
+    const { result } = await runWeeklyUpdate({
+      repoPath: '/repos/my-app',
+      scheduleId: 'sched-1',
+    });
+
+    expect(result).toEqual({ period: 'Mon 1 - 5' });
+    expect(mockGetSkill).toHaveBeenCalledWith('weekly-update', { repoPath: '/repos/my-app' });
+    expect(mockRunSessionVertical).toHaveBeenCalledTimes(1);
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.kind).toBe('weekly-update');
+    expect(call.scheduleId).toBe('sched-1');
+    expect(call.workspaceDir).toBe('/repos/my-app');
+    expect(call.input).toBe('Summarize the week.');
+    expect(call.outputSchema).toBe(WEEKLY_UPDATE_SCHEMA);
+  });
+});

--- a/server/services/weekly-update-service.ts
+++ b/server/services/weekly-update-service.ts
@@ -1,0 +1,33 @@
+/**
+ * Service layer for the weekly-update vertical: loads the skill body and
+ * runs it as a headless `runSessionVertical` call (session run — no
+ * task/worktree/loop).
+ */
+import { getSkill } from '../skills.js';
+import { runSessionVertical } from './session-vertical-service.js';
+import { WEEKLY_UPDATE_SCHEMA } from '../workflows/weekly-update/schema.js';
+
+export interface RunWeeklyUpdateInput {
+  repoPath: string;
+  scheduleId?: string | null;
+}
+
+export interface WeeklyUpdateResult {
+  period: string;
+  themes: Array<{ title: string; items: string[] }>;
+  highlights: string[];
+}
+
+export async function runWeeklyUpdate(
+  input: RunWeeklyUpdateInput,
+): Promise<{ result: WeeklyUpdateResult }> {
+  const skill = await getSkill('weekly-update', { repoPath: input.repoPath });
+
+  return runSessionVertical<WeeklyUpdateResult>({
+    kind: 'weekly-update',
+    scheduleId: input.scheduleId,
+    workspaceDir: input.repoPath,
+    input: skill.content,
+    outputSchema: WEEKLY_UPDATE_SCHEMA,
+  });
+}

--- a/server/workflows/daily-plan/register.test.ts
+++ b/server/workflows/daily-plan/register.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listWorkflows } from '../registry.js';
+import { SCHEDULE_HANDLERS, listScheduleKinds } from '../../schedules/handlers.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockRunDailyPlanFromSchedule = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../services/daily-plan-service.js', () => ({
+  runDailyPlanFromSchedule: (...args: unknown[]) => mockRunDailyPlanFromSchedule(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import './register.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'daily-plan',
+    repo_path: '/repo',
+    cron: '0 7 * * 1-5',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('daily-plan workflow registration', () => {
+  beforeEach(() => {
+    mockRunDailyPlanFromSchedule.mockClear();
+  });
+
+  it('registers the daily-plan kind with a session surface, no output schema, cron trigger', () => {
+    const wf = getWorkflow('daily-plan');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Daily Plan');
+    expect(wf?.surfaces).toEqual(['session']);
+    expect(wf?.output).toBeUndefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('appears in listWorkflows()', () => {
+    expect(listWorkflows().some((w) => w.kind === 'daily-plan')).toBe(true);
+  });
+
+  it('registers a schedule handler for daily-plan', () => {
+    expect(typeof SCHEDULE_HANDLERS['daily-plan']).toBe('function');
+    expect(listScheduleKinds()).toContain('daily-plan');
+  });
+
+  it('fires the run with the schedule id', async () => {
+    await SCHEDULE_HANDLERS['daily-plan'](makeRow({ id: 'sched-42' }));
+
+    expect(mockRunDailyPlanFromSchedule).toHaveBeenCalledTimes(1);
+    expect(mockRunDailyPlanFromSchedule).toHaveBeenCalledWith({ scheduleId: 'sched-42' });
+  });
+});

--- a/server/workflows/daily-plan/register.ts
+++ b/server/workflows/daily-plan/register.ts
@@ -1,0 +1,19 @@
+import { registerWorkflow } from '../registry.js';
+import { registerScheduleHandler } from '../../schedules/handlers.js';
+import { runDailyPlanFromSchedule } from '../../services/daily-plan-service.js';
+import type { WorkflowType } from '../types.js';
+
+export const dailyPlanWorkflow: WorkflowType = {
+  kind: 'daily-plan',
+  displayName: 'Daily Plan',
+  surfaces: ['session'],
+  trigger: { kind: 'cron' },
+};
+
+registerWorkflow(dailyPlanWorkflow);
+
+// createChat is a quick spawn (tmux + prompt), not a long-running blocking
+// agent session, so unlike overnight-log-summary/weekly-update we let
+// pollSchedules await this directly — its own try/catch already handles
+// failures without stalling other due schedules.
+registerScheduleHandler('daily-plan', (row) => runDailyPlanFromSchedule({ scheduleId: row.id }));

--- a/server/workflows/doc-drift.e2e.test.ts
+++ b/server/workflows/doc-drift.e2e.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { getDb } from '../db.js';
+
+const mockStartTask = vi.fn();
+vi.mock('../task-engine/index.js', () => ({
+  startTask: vi.fn((...args: unknown[]) => mockStartTask(...args)),
+}));
+
+const mockStartLoop = vi.fn().mockResolvedValue(undefined);
+vi.mock('../task-engine/loop/engine.js', () => ({
+  startLoop: vi.fn((...args: unknown[]) => mockStartLoop(...args)),
+}));
+
+const mockBroadcast = vi.fn();
+vi.mock('../events.js', () => ({
+  broadcast: vi.fn((...args: unknown[]) => mockBroadcast(...args)),
+}));
+
+// ─── Import after mocks — side-effect registers the workflow + schedule handler ──
+
+import { upsertSchedule } from '../repositories/schedules.js';
+import { pollSchedules } from '../poller/schedule-cron.js';
+import './index.js';
+
+function insertActiveAgent(taskId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+       VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
+    )
+    .run(`${taskId}-agent`, taskId);
+}
+
+describe('cron -> doc-drift e2e', () => {
+  beforeEach(() => {
+    createTestDb();
+    vi.clearAllMocks();
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fires a due schedule through the full cron -> service -> loop path', async () => {
+    upsertSchedule({ kind: 'doc-drift', repoPath: '/repo', cron: '0 7 * * *' });
+    const now = new Date('2026-07-18T07:00:00Z');
+
+    await pollSchedules(now);
+
+    const tasks = getDb()
+      .prepare(`SELECT id, source FROM tasks WHERE source = 'doc_drift'`)
+      .all() as Array<{ id: string; source: string }>;
+    expect(tasks).toHaveLength(1);
+
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).toHaveBeenCalledTimes(1);
+    expect(mockStartLoop).toHaveBeenCalledWith(
+      tasks[0].id,
+      expect.objectContaining({
+        verify: expect.any(String),
+        maxIterations: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/server/workflows/doc-drift/register.test.ts
+++ b/server/workflows/doc-drift/register.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow } from '../registry.js';
+import { SCHEDULE_HANDLERS } from '../../schedules/handlers.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockCreateDocDriftTaskFromSchedule = vi.fn().mockResolvedValue({ id: 'task1' });
+
+vi.mock('../../services/doc-drift-service.js', () => ({
+  createDocDriftTaskFromSchedule: (...args: unknown[]) =>
+    mockCreateDocDriftTaskFromSchedule(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import './register.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'doc-drift',
+    repo_path: '/repo',
+    cron: '0 7 * * *',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('doc-drift workflow registration', () => {
+  beforeEach(() => {
+    mockCreateDocDriftTaskFromSchedule.mockClear();
+  });
+
+  it('registers the doc-drift kind with feed+artifact surfaces and no output/sink', () => {
+    const wf = getWorkflow('doc-drift');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Doc Drift');
+    expect(wf?.surfaces).toEqual(['feed', 'artifact']);
+    expect(wf?.output).toBeUndefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('registers a schedule handler for doc-drift', () => {
+    expect(typeof SCHEDULE_HANDLERS['doc-drift']).toBe('function');
+  });
+
+  it('default verify is scoped to the task branch (--head), not repo-wide', async () => {
+    await SCHEDULE_HANDLERS['doc-drift'](makeRow());
+
+    expect(mockCreateDocDriftTaskFromSchedule).toHaveBeenCalledTimes(1);
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.verify).toContain('--head');
+    expect(call.verify).not.toContain('--search');
+  });
+
+  it('passes the schedule id through as scheduleId', async () => {
+    await SCHEDULE_HANDLERS['doc-drift'](makeRow({ id: 'sched-42' }));
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.scheduleId).toBe('sched-42');
+  });
+
+  it('falls back to defaults when the row has no config_json', async () => {
+    await SCHEDULE_HANDLERS['doc-drift'](makeRow({ config_json: null }));
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.maxIterations).toBe(4);
+    expect(call.verify).toContain('origin/HEAD');
+  });
+
+  it('passes through config_json overrides for verify/maxIterations', async () => {
+    const config = {
+      verify: 'bun run test',
+      maxIterations: 2,
+    };
+    await SCHEDULE_HANDLERS['doc-drift'](makeRow({ config_json: JSON.stringify(config) }));
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.verify).toBe('bun run test');
+    expect(call.maxIterations).toBe(2);
+  });
+});

--- a/server/workflows/doc-drift/register.ts
+++ b/server/workflows/doc-drift/register.ts
@@ -1,0 +1,38 @@
+import { registerWorkflow } from '../registry.js';
+import { registerScheduleHandler } from '../../schedules/handlers.js';
+import { createDocDriftTaskFromSchedule } from '../../services/doc-drift-service.js';
+import { childLogger } from '../../logger.js';
+import type { WorkflowType } from '../types.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const logger = childLogger('workflows/doc-drift');
+
+// Scoped to THIS task's branch — docs changed on the branch AND a PR already
+// open on it (mirrors prod-log-triage's --head scoping so a stale PR
+// elsewhere never satisfies this).
+const DEFAULT_VERIFY =
+  '[ -n "$(git diff --name-only origin/HEAD... -- \'*.md\' 2>/dev/null)" ] && [ -n "$(gh pr list --head "$(git rev-parse --abbrev-ref HEAD)" --state open --json number --jq \'.[0].number\')" ]';
+const DEFAULT_MAX_ITERATIONS = 4;
+
+export const docDriftWorkflow: WorkflowType = {
+  kind: 'doc-drift',
+  displayName: 'Doc Drift',
+  surfaces: ['feed', 'artifact'],
+  // No `output`/sink — the doc-fix PR opened via `gh` inside the run is the product.
+  trigger: { kind: 'cron' },
+};
+
+registerWorkflow(docDriftWorkflow);
+
+async function handleDocDriftSchedule(row: ScheduleRow): Promise<void> {
+  logger.info({ repo_path: row.repo_path, schedule_id: row.id }, 'doc-drift: schedule fired');
+  const cfg = row.config_json ? JSON.parse(row.config_json) : {};
+  await createDocDriftTaskFromSchedule({
+    repoPath: row.repo_path,
+    verify: cfg.verify ?? DEFAULT_VERIFY,
+    maxIterations: cfg.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+    scheduleId: row.id,
+  });
+}
+
+registerScheduleHandler('doc-drift', handleDocDriftSchedule);

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -1,4 +1,5 @@
 // Side-effect imports register all known workflow kinds.
+import './daily-plan/register.js';
 import './doc-drift/register.js';
 import './loops/register.js';
 import './overnight-log-summary/register.js';

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -1,6 +1,7 @@
 // Side-effect imports register all known workflow kinds.
 import './doc-drift/register.js';
 import './loops/register.js';
+import './overnight-log-summary/register.js';
 import './pr-extract/register.js';
 import './prod-log-triage/register.js';
 import './reviewer/register.js';

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -1,4 +1,5 @@
 // Side-effect imports register all known workflow kinds.
+import './doc-drift/register.js';
 import './loops/register.js';
 import './pr-extract/register.js';
 import './prod-log-triage/register.js';

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -5,5 +5,6 @@ import './overnight-log-summary/register.js';
 import './pr-extract/register.js';
 import './prod-log-triage/register.js';
 import './reviewer/register.js';
+import './weekly-update/register.js';
 
 export { registerWorkflow, getWorkflow, listWorkflows } from './registry.js';

--- a/server/workflows/overnight-log-summary/register.test.ts
+++ b/server/workflows/overnight-log-summary/register.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listWorkflows } from '../registry.js';
+import { SCHEDULE_HANDLERS, listScheduleKinds } from '../../schedules/handlers.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockRunOvernightLogSummary = vi.fn().mockResolvedValue({ result: {} });
+
+vi.mock('../../services/overnight-log-summary-service.js', () => ({
+  runOvernightLogSummary: (...args: unknown[]) => mockRunOvernightLogSummary(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import './register.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'overnight-log-summary',
+    repo_path: '/repo',
+    cron: '0 6 * * *',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('overnight-log-summary workflow registration', () => {
+  beforeEach(() => {
+    mockRunOvernightLogSummary.mockClear();
+  });
+
+  it('registers the overnight-log-summary kind with an artifact surface, output schema, cron trigger', () => {
+    const wf = getWorkflow('overnight-log-summary');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Overnight Log Summary');
+    expect(wf?.surfaces).toEqual(['artifact']);
+    expect(wf?.output).toBeDefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('appears in listWorkflows()', () => {
+    expect(listWorkflows().some((w) => w.kind === 'overnight-log-summary')).toBe(true);
+  });
+
+  it('registers a schedule handler for overnight-log-summary', () => {
+    expect(typeof SCHEDULE_HANDLERS['overnight-log-summary']).toBe('function');
+    expect(listScheduleKinds()).toContain('overnight-log-summary');
+  });
+
+  it('fires the run with the schedule id and default log command, without awaiting it', async () => {
+    // Never resolves — if the handler awaited this internally, the test would
+    // hang and fail on timeout instead of resolving cleanly.
+    mockRunOvernightLogSummary.mockReturnValue(new Promise(() => {}));
+
+    await SCHEDULE_HANDLERS['overnight-log-summary'](makeRow({ id: 'sched-42' }));
+
+    expect(mockRunOvernightLogSummary).toHaveBeenCalledTimes(1);
+    const call = mockRunOvernightLogSummary.mock.calls[0][0];
+    expect(call.repoPath).toBe('/repo');
+    expect(call.scheduleId).toBe('sched-42');
+    expect(call.logCommand).toBe('gh run list --limit 30 --json databaseId,conclusion,name,url');
+  });
+
+  it('passes through config_json overrides for logCommand', async () => {
+    await SCHEDULE_HANDLERS['overnight-log-summary'](
+      makeRow({ config_json: JSON.stringify({ logCommand: 'flyctl logs -a my-app' }) }),
+    );
+
+    const call = mockRunOvernightLogSummary.mock.calls[0][0];
+    expect(call.logCommand).toBe('flyctl logs -a my-app');
+  });
+});

--- a/server/workflows/overnight-log-summary/register.ts
+++ b/server/workflows/overnight-log-summary/register.ts
@@ -1,0 +1,46 @@
+import { registerWorkflow } from '../registry.js';
+import { registerScheduleHandler } from '../../schedules/handlers.js';
+import { runOvernightLogSummary } from '../../services/overnight-log-summary-service.js';
+import { childLogger } from '../../logger.js';
+import { OVERNIGHT_LOG_SUMMARY_SCHEMA } from './schema.js';
+import type { WorkflowType } from '../types.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const logger = childLogger('workflows/overnight-log-summary');
+
+const DEFAULT_LOG_COMMAND = 'gh run list --limit 30 --json databaseId,conclusion,name,url';
+
+export const overnightLogSummaryWorkflow: WorkflowType = {
+  kind: 'overnight-log-summary',
+  displayName: 'Overnight Log Summary',
+  surfaces: ['artifact'],
+  output: OVERNIGHT_LOG_SUMMARY_SCHEMA,
+  trigger: { kind: 'cron' },
+};
+
+registerWorkflow(overnightLogSummaryWorkflow);
+
+async function handleOvernightLogSummarySchedule(row: ScheduleRow): Promise<void> {
+  logger.info(
+    { repo_path: row.repo_path, schedule_id: row.id },
+    'overnight-log-summary: schedule fired',
+  );
+  const cfg = row.config_json ? JSON.parse(row.config_json) : {};
+
+  // Fire-and-forget: unlike task/loop verticals, runSessionVertical blocks
+  // for the full headless agent run (up to its timeout) inside this process.
+  // Awaiting it here would stall pollSchedules' sequential loop for other
+  // due schedules, so we let it run in the background and only log failure.
+  runOvernightLogSummary({
+    repoPath: row.repo_path,
+    scheduleId: row.id,
+    logCommand: cfg.logCommand ?? DEFAULT_LOG_COMMAND,
+  }).catch((err) => {
+    logger.error(
+      { err, repo_path: row.repo_path, schedule_id: row.id },
+      'overnight-log-summary: run failed',
+    );
+  });
+}
+
+registerScheduleHandler('overnight-log-summary', handleOvernightLogSummarySchedule);

--- a/server/workflows/overnight-log-summary/schema.ts
+++ b/server/workflows/overnight-log-summary/schema.ts
@@ -1,0 +1,26 @@
+/** JSON Schema for the overnight-log-summary submit_result payload. Split out
+ * from register.ts so the service can import it without a register<->service
+ * import cycle. */
+export const OVERNIGHT_LOG_SUMMARY_SCHEMA = {
+  type: 'object',
+  properties: {
+    window: { type: 'string' },
+    summary: { type: 'string' },
+    errorClasses: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          count: { type: 'number' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+        },
+        required: ['name', 'count', 'severity'],
+        additionalProperties: false,
+      },
+    },
+    notableEvents: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['window', 'summary', 'errorClasses', 'notableEvents'],
+  additionalProperties: false,
+};

--- a/server/workflows/weekly-update/register.test.ts
+++ b/server/workflows/weekly-update/register.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listWorkflows } from '../registry.js';
+import { SCHEDULE_HANDLERS, listScheduleKinds } from '../../schedules/handlers.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockRunWeeklyUpdate = vi.fn().mockResolvedValue({ result: {} });
+
+vi.mock('../../services/weekly-update-service.js', () => ({
+  runWeeklyUpdate: (...args: unknown[]) => mockRunWeeklyUpdate(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import './register.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'weekly-update',
+    repo_path: '/repo',
+    cron: '0 9 * * 1',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('weekly-update workflow registration', () => {
+  beforeEach(() => {
+    mockRunWeeklyUpdate.mockClear();
+  });
+
+  it('registers the weekly-update kind with an artifact surface, output schema, cron trigger', () => {
+    const wf = getWorkflow('weekly-update');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Weekly Update');
+    expect(wf?.surfaces).toEqual(['artifact']);
+    expect(wf?.output).toBeDefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('appears in listWorkflows()', () => {
+    expect(listWorkflows().some((w) => w.kind === 'weekly-update')).toBe(true);
+  });
+
+  it('registers a schedule handler for weekly-update', () => {
+    expect(typeof SCHEDULE_HANDLERS['weekly-update']).toBe('function');
+    expect(listScheduleKinds()).toContain('weekly-update');
+  });
+
+  it('fires the run with the schedule id and repo path, without awaiting it', async () => {
+    // Never resolves — if the handler awaited this internally, the test would
+    // hang and fail on timeout instead of resolving cleanly.
+    mockRunWeeklyUpdate.mockReturnValue(new Promise(() => {}));
+
+    await SCHEDULE_HANDLERS['weekly-update'](makeRow({ id: 'sched-42' }));
+
+    expect(mockRunWeeklyUpdate).toHaveBeenCalledTimes(1);
+    const call = mockRunWeeklyUpdate.mock.calls[0][0];
+    expect(call.repoPath).toBe('/repo');
+    expect(call.scheduleId).toBe('sched-42');
+  });
+});

--- a/server/workflows/weekly-update/register.ts
+++ b/server/workflows/weekly-update/register.ts
@@ -1,0 +1,39 @@
+import { registerWorkflow } from '../registry.js';
+import { registerScheduleHandler } from '../../schedules/handlers.js';
+import { runWeeklyUpdate } from '../../services/weekly-update-service.js';
+import { childLogger } from '../../logger.js';
+import { WEEKLY_UPDATE_SCHEMA } from './schema.js';
+import type { WorkflowType } from '../types.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const logger = childLogger('workflows/weekly-update');
+
+export const weeklyUpdateWorkflow: WorkflowType = {
+  kind: 'weekly-update',
+  displayName: 'Weekly Update',
+  surfaces: ['artifact'],
+  output: WEEKLY_UPDATE_SCHEMA,
+  trigger: { kind: 'cron' },
+};
+
+registerWorkflow(weeklyUpdateWorkflow);
+
+async function handleWeeklyUpdateSchedule(row: ScheduleRow): Promise<void> {
+  logger.info({ repo_path: row.repo_path, schedule_id: row.id }, 'weekly-update: schedule fired');
+
+  // Fire-and-forget: like overnight-log-summary, runSessionVertical blocks for
+  // the full headless agent run inside this process. Awaiting it here would
+  // stall pollSchedules' sequential loop for other due schedules, so we let it
+  // run in the background and only log failure.
+  runWeeklyUpdate({
+    repoPath: row.repo_path,
+    scheduleId: row.id,
+  }).catch((err) => {
+    logger.error(
+      { err, repo_path: row.repo_path, schedule_id: row.id },
+      'weekly-update: run failed',
+    );
+  });
+}
+
+registerScheduleHandler('weekly-update', handleWeeklyUpdateSchedule);

--- a/server/workflows/weekly-update/schema.ts
+++ b/server/workflows/weekly-update/schema.ts
@@ -1,0 +1,24 @@
+/** JSON Schema for the weekly-update submit_result payload. Split out from
+ * register.ts so the service can import it without a register<->service
+ * import cycle. */
+export const WEEKLY_UPDATE_SCHEMA = {
+  type: 'object',
+  properties: {
+    period: { type: 'string' },
+    themes: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          items: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['title', 'items'],
+        additionalProperties: false,
+      },
+    },
+    highlights: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['period', 'themes', 'highlights'],
+  additionalProperties: false,
+};

--- a/skills/daily-plan/SKILL.md
+++ b/skills/daily-plan/SKILL.md
@@ -1,0 +1,42 @@
+---
+description: Use when running a scheduled daily-plan session — pull Slack, Gmail, and Calendar context plus repo/Jira work, draft replies where warranted, propose the day's todos, and hand off to the user
+---
+
+# Daily Plan
+
+Prep the user's day, then hand off. This is an interactive session: you do
+the prep work unattended, then stop and wait for the user to join and steer.
+
+## Steps
+
+1. **Pull Slack, Gmail, and Calendar context** using your own connectors.
+   Look for anything that needs attention: unread DMs/mentions, unanswered
+   emails, and today's meetings. Summarize what needs attention across all
+   three, grouped by urgency, not by source.
+
+2. **Draft replies where warranted — draft only, NEVER send.** For messages
+   or emails that clearly need a response, prepare a draft reply the user
+   can review and send themselves. Never call a send action. If a channel's
+   drafting API doesn't exist, note the suggested reply text in the plan
+   instead.
+
+3. **Pull repo and Jira context.** Check for anything assigned to the user
+   that's due, blocked, or newly commented on — open PRs awaiting review,
+   failing CI on the user's branches, tickets in progress.
+
+4. **Propose the day's todos.** Combine everything above into a single
+   prioritized todo list. Complete the trivial ones yourself as you go (e.g.
+   closing a stale PR, archiving a dead notification) — note what you did
+   and why.
+
+5. **Present the finalized todos and wait.** Show the user the plan: what
+   needs their attention, what you drafted, what you already completed, and
+   the remaining todos. Then stop and wait for the user to join the session
+   and steer — do not keep working autonomously past this point.
+
+## Notes
+
+- Never send a message, email, or reply on the user's behalf — draft only.
+- If a connector (Slack/Gmail/Calendar/Jira) isn't available, say so plainly
+  in the plan and skip it — do not fabricate its contents.
+- Keep the finalized plan concise enough to scan in under a minute.

--- a/skills/doc-drift/SKILL.md
+++ b/skills/doc-drift/SKILL.md
@@ -1,0 +1,77 @@
+---
+description: Use when running a scheduled doc-drift task — compare the repo's docs against its code, fix drift, and open a doc-fix PR directly via `gh`
+---
+
+# Doc drift
+
+Compare a repo's documentation against its actual code on a schedule: find
+docs that describe things that no longer exist, and notable code behavior
+that's undocumented, then fix the docs and open a PR. This skill has **no
+octomux sink** — you open the PR yourself with `gh`; nothing reads a
+structured `emit` from this task.
+
+A task maps to a single PR: octomux's PR-detection poller matches on this
+task's own branch, so every doc fix you make this run goes into **one** PR,
+as separate commits, opened from the branch octomux already checked out for
+you. Do not create a separate `fix/...` branch.
+
+## Steps
+
+1. **Survey the documented surface.** Read `README.md`, `CLAUDE.md`, and
+   files under `docs/` (if present). Note every command, config option,
+   file path, env var, and API surface they claim exists.
+
+2. **Compare against the code.** For each documented claim, check it still
+   holds: does the command still exist (`package.json` scripts, CLI
+   subcommands), does the file/path still exist, does the config option
+   still get read, does the described behavior still match what the code
+   does. Also look for notable code behavior with no documentation at all
+   (a new script, a new env var, a new top-level directory) — flag it as
+   drift too, not just stale docs.
+
+3. **Fix what you find.** Make small, targeted doc edits — update stale
+   claims, remove references to deleted things, add a line for undocumented
+   surface that's clearly worth documenting. Do not restructure or rewrite
+   docs wholesale; this is drift correction, not a docs overhaul.
+
+4. **Open one doc-fix PR from this task's current branch** directly with
+   `gh` — do not use any octomux sink or emit command for this workflow, and
+   do not `git checkout -b` a new branch:
+
+   ```bash
+   # for each fix:
+   git add -A && git commit -m "docs(<scope>): <description>"
+
+   # after all fixes are committed, open (or reuse) exactly one PR:
+   branch="$(git rev-parse --abbrev-ref HEAD)"
+   git push -u origin "$branch"
+   existing="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')"
+   if [ -z "$existing" ]; then
+     gh pr create --title "docs: fix doc drift $(date +%F)" \
+       --body "<one line per drift item found + fix applied>"
+   fi
+   ```
+
+   Checking for an existing open PR on this branch first makes the step
+   idempotent — later loop iterations push more commits and refine the same
+   PR instead of creating duplicates. The PR body should summarize every
+   drift item found, whether fixed or skipped.
+
+   If nothing drifted, do **not** open a PR — write a short note (e.g. to
+   your final message) saying no drift was found, and end your turn.
+
+5. **Verify contract:** this task runs inside octomux's retry-loop (see the
+   scheduling service that launched you). Each iteration re-runs the repo's
+   configured verify command against your changes — make sure the fix you
+   commit passes it before ending your turn. The loop iterates automatically
+   on verify failure; you don't need to invoke verify yourself.
+
+## Notes
+
+- This is a scheduled, unattended run — be conservative. Prefer small,
+  reviewable doc fixes over broad rewrites.
+- Only fix drift you're confident about. If something is ambiguous (docs vs
+  code disagree but it's unclear which is right), skip it and note it rather
+  than guessing.
+- Do not fabricate findings — if you find no drift, say so plainly instead
+  of inventing something to fix.

--- a/skills/overnight-log-summary/SKILL.md
+++ b/skills/overnight-log-summary/SKILL.md
@@ -1,0 +1,50 @@
+---
+description: Use when running a scheduled overnight-log-summary session — fetch overnight logs, cluster errors, and submit a structured summary via submit_result
+---
+
+# Overnight log summary
+
+Summarize what happened overnight for a repo: fetch recent logs, cluster
+errors into classes, note anything else notable, and submit a structured
+result. This is a headless, unattended session — you do not open a PR, edit
+files, or make any changes. Your only output is the `submit_result` call.
+
+## Steps
+
+1. **Fetch overnight logs** by running this command as-is — don't invent a
+   different one:
+
+   ```
+   {{logCommand}}
+   ```
+
+2. **Cluster errors into classes.** Group by stack trace signature, error
+   message shape, or failing endpoint/job — not by raw log line. For each
+   class, note a short name, how many times it occurred, and a severity
+   (`low`, `medium`, or `high`) based on how disruptive it looks.
+
+3. **Note notable events.** Anything else worth a human's attention that
+   isn't an error class — a deploy, a restart, an unusual spike, a config
+   change. Keep each entry to one short sentence.
+
+4. **Call the `submit_result` tool exactly once** with a JSON object shaped
+   like:
+
+   ```json
+   {
+     "window": "<the time window you summarized, e.g. last 12h>",
+     "summary": "<2-4 sentence overview>",
+     "errorClasses": [{ "name": "...", "count": 0, "severity": "low" }],
+     "notableEvents": ["..."]
+   }
+   ```
+
+## Notes
+
+- Be conservative — this runs unattended with no human reviewing your
+  reasoning, only the structured result.
+- If the log command returns no output or nothing of note, say so plainly in
+  `summary` (e.g. "No errors overnight.") with empty `errorClasses` and
+  `notableEvents` arrays — do not fabricate findings.
+- Do not modify any files, commit, or open a PR. This skill only reads logs
+  and reports.

--- a/skills/weekly-update/SKILL.md
+++ b/skills/weekly-update/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: Use when running a scheduled weekly-update session — gather git commits and available Jira/Linear context for the past week, produce a themed status report, and submit it via submit_result
+---
+
+# Weekly Update
+
+Generate a themed status report summarizing the past week's work for a repo:
+pull git history, cross-reference tickets if available, group by theme, and
+submit a structured result. This is a headless, unattended session — you do
+not open a PR, edit files, or make any changes. Your only output is the
+`submit_result` call.
+
+## Steps
+
+1. **Gather git commits for the past week** by running:
+
+   ```bash
+   git log --all --since="last monday" --until="tomorrow" --pretty=format:"%h %s (%ad)" --date=short
+   ```
+
+2. **Gather ticket context, if available.** If Jira or Linear tools are
+   connected in this session, look up tickets referenced in commit messages
+   (e.g. `IN-123`) or updated this week, and note their status. If no ticket
+   tooling is available, skip this step — do not fabricate ticket data.
+
+3. **Group commits by theme**, not by ticket or commit order — e.g.
+   "Hedging Safety & Reliability", "Observability", "Infrastructure". Each
+   theme gets a short title and a list of concise, bullet-point items (bold
+   keyword, dash, short description, ticket id/status if known).
+
+4. **Note highlights.** Anything that deserves top-line visibility beyond
+   the themed breakdown — a release, a milestone, a notable metric. Keep
+   each entry to one short sentence.
+
+5. **Call the `submit_result` tool exactly once** with a JSON object shaped
+   like:
+
+   ```json
+   {
+     "period": "<the date range covered, e.g. Mon DD - DD>",
+     "themes": [
+       {
+         "title": "Theme Name",
+         "items": ["**Feature** — concise description (IN-123 — Done)"]
+       }
+     ],
+     "highlights": ["..."]
+   }
+   ```
+
+## Notes
+
+- Be conservative — this runs unattended with no human reviewing your
+  reasoning, only the structured result.
+- If there were no commits this week, say so plainly: an empty `themes`
+  array and a `highlights` entry noting the quiet week. Do not fabricate
+  activity.
+- Do not modify any files, commit, or open a PR. This skill only reads git
+  history and ticket context, then reports.

--- a/src/lib/api/workflowsApi.ts
+++ b/src/lib/api/workflowsApi.ts
@@ -17,6 +17,8 @@ export interface WorkflowRow {
   displayName: string;
   surfaces: string[];
   trigger: WorkflowTrigger | null;
+  /** JSON Schema for this workflow's result shape, or null if it has none. */
+  output: Record<string, unknown> | null;
   runCount: number;
 }
 
@@ -29,6 +31,8 @@ export interface WorkflowRunRow {
   task_id: string | null;
   loop_run_id: string | null;
   started_at: string;
+  /** Structured result from a headless session run (runAgentSession), JSON-stringified. */
+  result_json?: string | null;
 }
 
 export const workflowsApi = {

--- a/src/lib/api/workflowsApi.ts
+++ b/src/lib/api/workflowsApi.ts
@@ -30,6 +30,7 @@ export interface WorkflowRunRow {
   effective_status: string;
   task_id: string | null;
   loop_run_id: string | null;
+  chat_id: string | null;
   started_at: string;
   /** Structured result from a headless session run (runAgentSession), JSON-stringified. */
   result_json?: string | null;

--- a/src/pages/WorkflowsPage.test.tsx
+++ b/src/pages/WorkflowsPage.test.tsx
@@ -93,6 +93,7 @@ describe('WorkflowsPage', () => {
         effective_status: 'done',
         task_id: 'task-1',
         loop_run_id: null,
+        chat_id: null,
         started_at: '2026-01-01 00:00:00',
       },
     ];
@@ -120,6 +121,7 @@ describe('WorkflowsPage', () => {
           effective_status: 'done',
           task_id: 'task-1',
           loop_run_id: null,
+          chat_id: null,
           started_at: '2026-01-01 00:00:00',
         },
       ],
@@ -166,6 +168,7 @@ describe('WorkflowsPage', () => {
           effective_status: 'done',
           task_id: null,
           loop_run_id: null,
+          chat_id: null,
           started_at: '2026-01-01 00:00:00',
           result_json: JSON.stringify({
             window: 'last 12h',
@@ -207,6 +210,7 @@ describe('WorkflowsPage', () => {
           effective_status: 'running',
           task_id: 'task-2',
           loop_run_id: 'loop-2',
+          chat_id: null,
           started_at: '2026-01-01 00:00:00',
         },
       ],
@@ -219,5 +223,43 @@ describe('WorkflowsPage', () => {
     await user.click(loopLink);
 
     expect(mockNavigate).toHaveBeenCalledWith('/w/loops/loop-2');
+  });
+
+  it('a run with a chat_id links to /chats/:id', async () => {
+    const user = userEvent.setup();
+    apiMock.listWorkflows.mockResolvedValue({
+      workflows: [
+        makeWorkflow({
+          kind: 'daily-plan',
+          displayName: 'Daily Plan',
+          surfaces: ['session'],
+          trigger: { kind: 'cron' },
+          runCount: 1,
+        }),
+      ],
+    });
+    apiMock.getWorkflowRuns.mockResolvedValue({
+      runs: [
+        {
+          id: 'run-4',
+          workflow_kind: 'daily-plan',
+          trigger: 'cron',
+          status: 'running',
+          effective_status: 'running',
+          task_id: null,
+          loop_run_id: null,
+          chat_id: 'chat-4',
+          started_at: '2026-01-01 00:00:00',
+        },
+      ],
+    });
+
+    renderWithRouter(<WorkflowsPage />);
+    await user.click(await screen.findByTestId('workflow-expand-daily-plan'));
+
+    const chatLink = await screen.findByTestId('workflow-run-chat-link-run-4');
+    await user.click(chatLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/chats/chat-4');
   });
 });

--- a/src/pages/WorkflowsPage.test.tsx
+++ b/src/pages/WorkflowsPage.test.tsx
@@ -29,6 +29,7 @@ function makeWorkflow(overrides: Partial<WorkflowRow> = {}): WorkflowRow {
     displayName: 'PR Extracts',
     surfaces: ['feed', 'artifact'],
     trigger: { kind: 'github', event: 'pr_merged' },
+    output: null,
     runCount: 3,
     ...overrides,
   };
@@ -131,6 +132,66 @@ describe('WorkflowsPage', () => {
     await user.click(taskLink);
 
     expect(mockNavigate).toHaveBeenCalledWith('/tasks/task-1');
+  });
+
+  it('a session run (no task_id, with result_json) renders its result fields', async () => {
+    const user = userEvent.setup();
+    apiMock.listWorkflows.mockResolvedValue({
+      workflows: [
+        makeWorkflow({
+          kind: 'overnight-log-summary',
+          displayName: 'Overnight Log Summary',
+          surfaces: ['artifact'],
+          trigger: { kind: 'cron' },
+          runCount: 1,
+          output: {
+            type: 'object',
+            properties: {
+              window: { type: 'string' },
+              summary: { type: 'string' },
+              errorClasses: { type: 'array' },
+              notableEvents: { type: 'array' },
+            },
+          },
+        }),
+      ],
+    });
+    apiMock.getWorkflowRuns.mockResolvedValue({
+      runs: [
+        {
+          id: 'run-3',
+          workflow_kind: 'overnight-log-summary',
+          trigger: 'cron',
+          status: 'done',
+          effective_status: 'done',
+          task_id: null,
+          loop_run_id: null,
+          started_at: '2026-01-01 00:00:00',
+          result_json: JSON.stringify({
+            window: 'last 12h',
+            summary: 'One recurring timeout error.',
+            errorClasses: [{ name: 'db timeout', count: 4, severity: 'medium' }],
+            notableEvents: ['Deployed v2.3.0 at 02:00'],
+          }),
+        },
+      ],
+    });
+
+    renderWithRouter(<WorkflowsPage />);
+    await user.click(await screen.findByTestId('workflow-expand-overnight-log-summary'));
+    await screen.findByTestId('workflow-run-run-3');
+
+    // Task/loop links must not appear for a session run.
+    expect(screen.queryByTestId('workflow-run-task-link-run-3')).toBeNull();
+    expect(screen.queryByTestId('workflow-run-loop-link-run-3')).toBeNull();
+
+    await user.click(await screen.findByTestId('workflow-run-result-toggle-run-3'));
+
+    const panel = await screen.findByTestId('workflow-run-result-run-3');
+    expect(panel.textContent).toContain('last 12h');
+    expect(panel.textContent).toContain('One recurring timeout error.');
+    expect(panel.textContent).toContain('db timeout');
+    expect(panel.textContent).toContain('Deployed v2.3.0 at 02:00');
   });
 
   it('a run with a loop_run_id links to /w/loops/:id', async () => {

--- a/src/pages/WorkflowsPage.tsx
+++ b/src/pages/WorkflowsPage.tsx
@@ -131,6 +131,16 @@ function WorkflowRuns({
                   loop
                 </button>
               )}
+              {run.chat_id && (
+                <button
+                  type="button"
+                  data-testid={`workflow-run-chat-link-${run.id}`}
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                  onClick={() => nav(`/chats/${run.chat_id}`)}
+                >
+                  chat
+                </button>
+              )}
               {isSessionRun && (
                 <button
                   type="button"

--- a/src/pages/WorkflowsPage.tsx
+++ b/src/pages/WorkflowsPage.tsx
@@ -27,11 +27,73 @@ function deepLinkFor(kind: string): string | null {
   return null;
 }
 
-function WorkflowRuns({ kind }: { kind: string }) {
+/** Renders a submit_result field value: primitives inline, arrays as a bullet
+ * list (objects within an array are flattened to "key: value" pairs). */
+function formatResultField(value: unknown) {
+  if (value === null || value === undefined) return '—';
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'None';
+    return (
+      <ul className="list-disc pl-4">
+        {value.map((item, i) => (
+          <li key={i}>
+            {item !== null && typeof item === 'object'
+              ? Object.entries(item as Record<string, unknown>)
+                  .map(([k, v]) => `${k}: ${String(v)}`)
+                  .join(', ')
+              : String(item)}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+/** Session runs (runAgentSession) carry no task_id, only a JSON result_json —
+ * render one labeled row per output-schema property, schema-declaration order. */
+function SessionRunResult({
+  resultJson,
+  outputSchema,
+}: {
+  resultJson: string;
+  outputSchema: Record<string, unknown> | null;
+}) {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(resultJson) as Record<string, unknown>;
+  } catch {
+    return <p className="px-4 py-2 text-xs text-destructive">Failed to parse result.</p>;
+  }
+
+  const properties = outputSchema?.properties as Record<string, unknown> | undefined;
+  const fields = properties ? Object.keys(properties) : Object.keys(parsed);
+
+  return (
+    <GlassPanel level={1} className="flex flex-col gap-2 rounded-xl p-3 text-xs">
+      {fields.map((field) => (
+        <div key={field} data-testid={`workflow-run-result-field-${field}`}>
+          <span className="font-medium text-muted-foreground">{field}: </span>
+          <span className="text-foreground">{formatResultField(parsed[field])}</span>
+        </div>
+      ))}
+    </GlassPanel>
+  );
+}
+
+function WorkflowRuns({
+  kind,
+  outputSchema,
+}: {
+  kind: string;
+  outputSchema: Record<string, unknown> | null;
+}) {
   const nav = useNavigate();
   const { data: runs, loading } = useResource<WorkflowRunRow[]>(kind, () =>
     workflowsApi.getWorkflowRuns(kind).then((res) => res.runs),
   );
+  const [expandedResultId, setExpandedResultId] = useState<string | null>(null);
 
   if (loading) {
     return <p className="px-4 py-2 text-xs text-muted-foreground">Loading runs…</p>;
@@ -42,36 +104,55 @@ function WorkflowRuns({ kind }: { kind: string }) {
 
   return (
     <ul className="flex flex-col gap-1 px-4 py-2">
-      {runs.map((run) => (
-        <li
-          key={run.id}
-          data-testid={`workflow-run-${run.id}`}
-          className="flex items-center gap-2 text-xs"
-        >
-          <span className="text-foreground">{run.effective_status}</span>
-          <span className="text-muted-soft">{timeAgo(run.started_at)}</span>
-          {run.task_id && (
-            <button
-              type="button"
-              data-testid={`workflow-run-task-link-${run.id}`}
-              className="text-muted-foreground hover:text-primary hover:underline"
-              onClick={() => nav(`/tasks/${run.task_id}`)}
-            >
-              task
-            </button>
-          )}
-          {run.loop_run_id && (
-            <button
-              type="button"
-              data-testid={`workflow-run-loop-link-${run.id}`}
-              className="text-muted-foreground hover:text-primary hover:underline"
-              onClick={() => nav(`/w/loops/${run.loop_run_id}`)}
-            >
-              loop
-            </button>
-          )}
-        </li>
-      ))}
+      {runs.map((run) => {
+        const isSessionRun = !run.task_id && !run.loop_run_id && !!run.result_json;
+        return (
+          <li key={run.id} data-testid={`workflow-run-${run.id}`} className="flex flex-col gap-1">
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-foreground">{run.effective_status}</span>
+              <span className="text-muted-soft">{timeAgo(run.started_at)}</span>
+              {run.task_id && (
+                <button
+                  type="button"
+                  data-testid={`workflow-run-task-link-${run.id}`}
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                  onClick={() => nav(`/tasks/${run.task_id}`)}
+                >
+                  task
+                </button>
+              )}
+              {run.loop_run_id && (
+                <button
+                  type="button"
+                  data-testid={`workflow-run-loop-link-${run.id}`}
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                  onClick={() => nav(`/w/loops/${run.loop_run_id}`)}
+                >
+                  loop
+                </button>
+              )}
+              {isSessionRun && (
+                <button
+                  type="button"
+                  data-testid={`workflow-run-result-toggle-${run.id}`}
+                  className="text-muted-foreground hover:text-primary hover:underline"
+                  onClick={() => setExpandedResultId(expandedResultId === run.id ? null : run.id)}
+                >
+                  {expandedResultId === run.id ? 'hide result' : 'result'}
+                </button>
+              )}
+            </div>
+            {isSessionRun && expandedResultId === run.id && (
+              <div data-testid={`workflow-run-result-${run.id}`}>
+                <SessionRunResult
+                  resultJson={run.result_json as string}
+                  outputSchema={outputSchema}
+                />
+              </div>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -142,7 +223,9 @@ export default function WorkflowsPage() {
                       </button>
                     )}
                   </div>
-                  {expandedKind === wf.kind && <WorkflowRuns kind={wf.kind} />}
+                  {expandedKind === wf.kind && (
+                    <WorkflowRuns kind={wf.kind} outputSchema={wf.output} />
+                  )}
                 </GlassPanel>
               </li>
             );

--- a/src/workflows/doc-drift/register.test.tsx
+++ b/src/workflows/doc-drift/register.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getWorkflowUI } from '../registry';
+import './register';
+
+describe('doc-drift workflow UI registration', () => {
+  it('registers navLabel, icon, ListView, and DetailView', () => {
+    const ui = getWorkflowUI('doc-drift');
+    expect(ui?.navLabel).toBe('Doc Drift');
+    expect(ui?.icon).toBeDefined();
+    expect(ui?.ListView).toBeDefined();
+    expect(ui?.DetailView).toBeDefined();
+  });
+});

--- a/src/workflows/doc-drift/register.tsx
+++ b/src/workflows/doc-drift/register.tsx
@@ -1,0 +1,58 @@
+import { lazy, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { Task } from '@octomux/types';
+import { registerWorkflowUI } from '../registry';
+import { taskApi } from '@/lib/api/taskApi';
+import { TasksIcon } from '@/components/sidebar/glyphs';
+import { timeAgo } from '@/lib/time';
+
+// doc-drift runs are plain tasks (source='doc_drift') — there is no dedicated
+// run table, so the list view just filters GET /api/tasks client-side.
+function DocDriftListView() {
+  const nav = useNavigate();
+  const [tasks, setTasks] = useState<Task[] | null>(null);
+
+  useEffect(() => {
+    taskApi.listTasks().then((all) => setTasks(all.filter((t) => t.source === 'doc_drift')));
+  }, []);
+
+  if (tasks === null) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading…</p>;
+  }
+  if (tasks.length === 0) {
+    return <p className="p-6 text-sm text-muted-foreground">No doc-drift runs yet.</p>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col p-6">
+      <h1 className="mb-4 font-display text-2xl font-semibold text-foreground">Doc Drift</h1>
+      <ul className="flex flex-col gap-2">
+        {tasks.map((t) => (
+          <li key={t.id}>
+            <button
+              type="button"
+              data-testid={`doc-drift-row-${t.id}`}
+              className="flex w-full items-center gap-2 rounded-2xl border border-glass-edge bg-glass-l2 px-4 py-3 text-left text-sm hover:bg-glass-l3/80"
+              onClick={() => nav(`/w/doc-drift/${t.id}`)}
+            >
+              <span className="flex-1 truncate">{t.title}</span>
+              <span className="text-xs text-muted-foreground">{t.runtime_state}</span>
+              <span className="text-[10px] text-muted-soft">{timeAgo(t.created_at)}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// TaskDetail reads `:id` from useParams itself, so it plugs directly into the
+// workflow DetailView slot (which also renders under a route with an :id param).
+const TaskDetail = lazy(() => import('@/pages/TaskDetail'));
+
+registerWorkflowUI('doc-drift', {
+  navLabel: 'Doc Drift',
+  icon: TasksIcon,
+  ListView: DocDriftListView,
+  DetailView: TaskDetail,
+});

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,4 +1,5 @@
 // Side-effect imports register all known workflow UI kinds.
+import './doc-drift/register';
 import './loops/register';
 import './pr-extract/register';
 import './prod-log-triage/register';


### PR DESCRIPTION
## Four new workflow verticals on the control-plane format

Builds on the merged control plane (#195). Each vertical is the same three-part shape — a skill + a service + a `registerWorkflow` descriptor — and auto-appears in the Schedules dropdown and the Workflows page with no UI work. Proves the format: adding a feature ≈ writing a skill + registering a descriptor.

### Task/loop verticals (open PRs)
- **`doc-drift`** — cron → retry-loop: compare the repo's docs vs code, open a doc-fix PR from the task's own branch. A near-exact clone of `prod-log-triage`.

### AgentSession verticals (headless, structured result)
Introduces `runSessionVertical` (wraps the existing `runAgentSession`): cron → headless agent → JSON-Schema-typed result via `submit_result` → persisted in `runs.result_json` → rendered on the Workflows page.
- **`overnight-log-summary`** — nightly log digest as a structured artifact.
- **`weekly-update`** — themed weekly status report (adapts the existing skill).

### Session vertical
- **`daily-plan`** — the morning assistant: cron spins up a live chat (`createChat`) that pulls Slack/Gmail/Calendar, drafts replies (draft-only), proposes + completes trivial todos, and hands off to you. Surfaced as a `session`, linked from the Workflows page.

## Verified
`bun run typecheck` clean · `bun run test` 3725 tests pass · `bun run lint` 0 errors. Each vertical confirmed present in `listWorkflows()` + `listScheduleKinds()`.

## Live-validated
A live `doc-drift` run against the octomux repo exercised the whole chain end-to-end (schedule → poller → task → worktree → agent → loop), which also surfaced the cron bug fixed in #196.

## Note
Includes the `isCronDue` fix (also submitted standalone as #196 for fast-track). If #196 merges first, that commit becomes a no-op here on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)