### PR TITLE
fix: prod log triage 2026-07-20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
-      - uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
+      # electron-release.yml runs on the same v* tag and its
+      # `electron-builder --publish always` (releaseType: release) creates the
+      # release too if it gets there first. softprops/action-gh-release lost that
+      # race and hard-failed with
+      #   Validation Failed: {"resource":"Release","code":"already_exists"}.
+      # Create-or-adopt instead: both sides create a PUBLISHED release, so
+      # whichever one exists is the right one to attach artifacts to.
+      - name: Ensure GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists — adopting it"
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes \
+              || gh release view "$GITHUB_REF_NAME"
+          fi

--- a/desk/incidents/2026-07-20.md
+++ b/desk/incidents/2026-07-20.md
@@ -1,0 +1,115 @@
+# Incident triage — 2026-07-20
+
+Source: `gh run list --limit 20` on `ShreyPaharia/octomux` (runs spanning
+2026-07-03 → 2026-07-12). 20 runs examined: 9 success, 7 cancelled, 4 failure.
+
+Cancelled `Build Binaries` runs are concurrency cancellations on superseded
+commits — treated as noise, not triaged.
+
+All four classes below are fixed in this PR.
+
+## 1. `Build Binaries` / linux-arm64 — publish fails, `chmod: cannot access 'bin/tmux'`
+
+- **First seen / frequency:** 2026-07-03 (run 28669311628, tag v1.1.0) and
+  2026-07-12 (run 29206528607, tag v1.2.0). **Every release tag** — 2/2.
+- **Representative log lines:**
+  ```
+  Building tmux 3.5a for linux/aarch64
+  ==> Copying artifacts to .../packages/tmux-linux-aarch64 ...
+  -rwxr-xr-x 1 runner runner 3.0M .../packages/tmux-linux-aarch64/bin/tmux
+  Artifact tmux-linux-arm64 has been successfully uploaded! Final size is 794 bytes.
+  Target: @octomux/tmux-linux-arm64@1.2.0
+  chmod: cannot access 'bin/tmux': No such file or directory
+  ##[error]Process completed with exit code 1
+  ```
+- **Root cause:** `scripts/build-tmux.sh` normalised `uname -m` for x86_64
+  (`x86_64` → `x64`) but **not** for arm64 (`aarch64` → `arm64`). On the
+  `ubuntu-24.04-arm` runner the build therefore wrote a perfectly good binary
+  into `packages/tmux-linux-aarch64/` — a directory that does not exist in the
+  repo — while the workflow's artifact upload and publish steps both point at
+  `packages/tmux-linux-arm64/`, which still held only its checked-in
+  `package.json` (hence the 794-byte artifact). macOS is unaffected because
+  `uname -m` already returns `arm64` there. The build step exits 0, so the
+  failure only surfaces two steps later with a misleading `chmod` error.
+  Net effect: **`@octomux/tmux-linux-arm64` has never been published.**
+- **Fix:** normalise `aarch64` → `arm64` alongside the existing `x86_64` case,
+  and fail fast in the build step if `$DEST_DIR` is not a real package dir, so a
+  future unhandled arch errors at the source instead of at publish time.
+
+## 2. `Publish` — `already_exists` on release creation
+
+- **First seen / frequency:** 2026-07-12 (run 29206528619, tag v1.2.0). 1/2
+  release tags — a race, so it fires nondeterministically.
+- **Representative log lines:**
+  ```
+  👩‍🏭 Creating new GitHub release for tag v1.2.0...
+  Release 352831356 is not yet discoverable by tag v1.2.0, retrying... (2 retries remaining)
+  Finalizing release...
+  error finalizing release: HttpError: Validation Failed:
+    {"resource":"Release","code":"already_exists","field":"tag_name"}
+  ❌ Too many retries. Aborting...
+  ```
+- **Root cause:** `publish.yml` and `electron-release.yml` both trigger on `v*`
+  tags and both create the GitHub Release. `electron-release.yml` runs
+  `electron-builder --publish always` with `releaseType: release`
+  (`electron-builder.yml:71`), which creates the published release if absent —
+  and `softprops/action-gh-release@v2` hard-fails rather than adopting an
+  existing one. Note the npm publish on line 44 had already succeeded, so the
+  failure left `octomux@1.2.0` on npm with a red Publish run.
+- **Fix:** replace the action with an idempotent `gh release view || gh release
+  create` in `publish.yml`. Both workflows intend a *published* (non-draft)
+  release, so whichever wins the race produces the correct artifact and the
+  loser adopts it.
+
+## 3. `Build Binaries` / linux-x64 — ncurses download timeout
+
+- **First seen / frequency:** 2026-07-12 (run 29205952405, branch `next`).
+  1 occurrence — transient, but it fails the whole release build.
+- **Representative log lines:**
+  ```
+  ==> Building ncurses 6.5 ...
+    Downloading https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.5.tar.gz ...
+  curl: (28) Failed to connect to ftp.gnu.org port 443 after 134366 ms:
+    Couldn't connect to server
+  ##[error]Process completed with exit code 28
+  ```
+- **Root cause:** `fetch_and_extract` ran a bare `curl -fsSL` with no retry and
+  no timeout bound. `ftp.gnu.org` is a single point of failure for the release
+  build and went unreachable for the duration of the run; the job burned 134s
+  hanging before dying.
+- **Fix:** add `--retry 3 --retry-all-errors --connect-timeout 20 --max-time
+  300` to the download, and give ncurses a fallback mirror
+  (`invisible-mirror.net`, upstream ncurses' own archive) used when the primary
+  host fails. libevent and tmux both fetch from GitHub releases and are left on
+  retry-only — no second host is warranted for them yet.
+
+## 4. All workflows — `git submodule foreach` fails in post-job cleanup
+
+- **First seen / frequency:** every job of every run in the sample, including
+  the successful ones. ~20/20 runs.
+- **Representative log lines:**
+  ```
+  [command]/usr/bin/git submodule foreach --recursive sh -c "..."
+  fatal: No url found for submodule path
+    '.worktrees/ideate-next-features-for-octomux-agents-Aws99j' in .gitmodules
+  ##[warning]The process '/usr/bin/git' failed with exit code 128
+  ```
+- **Root cause:** an octomux task worktree was committed as a **gitlink**
+  (`160000 7ccf686 .worktrees/ideate-next-features-for-octomux-agents-Aws99j`)
+  with no corresponding `.gitmodules` entry. `.gitignore` already lists
+  `.worktrees/`, but gitignore does not apply to already-tracked paths, so it
+  never got cleaned up. `actions/checkout`'s post-job cleanup walks submodules
+  and errors out on the dangling gitlink.
+- **Impact:** warning-level only today — it runs in post-job cleanup, so it does
+  not fail any job. Worth fixing because it fires on every job of every run and
+  trains everyone to ignore red text in the cleanup step.
+- **Fix:** `git rm --cached` the stray gitlink. `.gitignore` already prevents
+  it from coming back.
+
+## Notes
+
+- The prompt referenced `.octomux/loop-playbook.md` for prior-iteration
+  context; that file does not exist in this worktree (only `loop-status.json`
+  and `rollup/`), so this run had no prior-failure context to work from.
+- Nothing was skipped for lack of a clear fix — all four classes had an
+  unambiguous root cause in the repo.

--- a/scripts/build-tmux.sh
+++ b/scripts/build-tmux.sh
@@ -22,6 +22,9 @@ LIBEVENT_VERSION="2.1.12"
 TMUX_VERSION="3.5a"
 
 NCURSES_URL="https://ftp.gnu.org/pub/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz"
+# invisible-mirror.net is upstream ncurses' own archive — used when ftp.gnu.org
+# is unreachable (see fetch_and_extract).
+NCURSES_MIRROR_URL="https://invisible-mirror.net/archives/ncurses/ncurses-${NCURSES_VERSION}.tar.gz"
 LIBEVENT_URL="https://github.com/libevent/libevent/releases/download/release-${LIBEVENT_VERSION}-stable/libevent-${LIBEVENT_VERSION}-stable.tar.gz"
 TMUX_URL="https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz"
 
@@ -29,10 +32,15 @@ TMUX_URL="https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"   # darwin | linux
 ARCH="$(uname -m)"                                     # arm64 | x86_64
 
-# Node uses 'x64' for x86_64; normalise to match npm package naming.
-if [ "$ARCH" = "x86_64" ]; then
-  ARCH="x64"
-fi
+# The packages/ dirs and npm package names use Node's arch naming ('x64',
+# 'arm64'); `uname -m` reports 'x86_64' / 'aarch64' on Linux. Normalise BOTH.
+# The missing aarch64 case silently built into packages/tmux-linux-aarch64/, so
+# packages/tmux-linux-arm64/ kept no bin/tmux and the publish step died on
+# `chmod: cannot access 'bin/tmux'` at every release tag.
+case "$ARCH" in
+  x86_64) ARCH="x64" ;;
+  aarch64) ARCH="arm64" ;;
+esac
 
 PKG_NAME="tmux-${PLATFORM}-${ARCH}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -42,6 +50,14 @@ DEST_DIR="$ROOT_DIR/packages/$PKG_NAME"
 echo "Building tmux ${TMUX_VERSION} for ${PLATFORM}/${ARCH}"
 echo "Destination: ${DEST_DIR}"
 
+# Fail loudly if we resolved to a package dir that isn't in the repo — that means
+# the arch normalisation above missed a case, and building on regardless just
+# defers the failure to the publish step with a much worse error.
+if [ ! -d "$DEST_DIR" ]; then
+  echo "ERROR: no package dir at $DEST_DIR — unhandled platform/arch '${PLATFORM}/${ARCH}' (uname -m: $(uname -m))" >&2
+  exit 1
+fi
+
 # ─── Working directory ────────────────────────────────────────────────────────
 BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
@@ -49,12 +65,27 @@ INSTALL_PREFIX="$BUILD_DIR/prefix"
 mkdir -p "$INSTALL_PREFIX"
 
 # ─── Helper: download and extract ────────────────────────────────────────────
+# fetch_and_extract <url> <outdir> [mirror_url]
+# ftp.gnu.org has gone unreachable mid-release before (curl exit 28 after a
+# 134s connect timeout, killing the whole build). Retry, bound the hang, then
+# fall back to the mirror if one is given.
 fetch_and_extract() {
   local url="$1"
   local outdir="$2"
+  local mirror="${3:-}"
   local tarball="$BUILD_DIR/$(basename "$url")"
+  local curl_opts=(-fsSL --retry 3 --retry-all-errors --connect-timeout 20 --max-time 300)
+
   echo "  Downloading $url ..."
-  curl -fsSL "$url" -o "$tarball"
+  if ! curl "${curl_opts[@]}" "$url" -o "$tarball"; then
+    if [ -z "$mirror" ]; then
+      echo "  ✗ download failed and no mirror configured for $url" >&2
+      return 1
+    fi
+    echo "  ⚠  primary host failed; retrying via mirror $mirror ..."
+    curl "${curl_opts[@]}" "$mirror" -o "$tarball"
+  fi
+
   mkdir -p "$outdir"
   tar -xzf "$tarball" -C "$outdir" --strip-components=1
 }
@@ -63,7 +94,7 @@ fetch_and_extract() {
 echo ""
 echo "==> Building ncurses ${NCURSES_VERSION} ..."
 NCURSES_SRC="$BUILD_DIR/ncurses"
-fetch_and_extract "$NCURSES_URL" "$NCURSES_SRC"
+fetch_and_extract "$NCURSES_URL" "$NCURSES_SRC" "$NCURSES_MIRROR_URL"
 
 (
   cd "$NCURSES_SRC"

--- a/server/diff-review-state.test.ts
+++ b/server/diff-review-state.test.ts
@@ -43,7 +43,11 @@ async function commit(dir: string, files: Record<string, string>, msg: string): 
   await execFile('git', ['-C', dir, 'commit', '-q', '-m', msg]);
 }
 
-describe('decorateDiffSummaryWithReviewState', () => {
+// Every case here drives real `git` subprocesses against a temp repo, which
+// costs ~2.5-3.7s per test on its own. Under the full suite's parallel load that
+// overruns vitest's 5s default and the file flakes. 20s leaves headroom without
+// hiding a genuine hang.
+describe('decorateDiffSummaryWithReviewState', { timeout: 20_000 }, () => {
   let repo: string;
   let baseSha: string;
 


### PR DESCRIPTION
Triage of the last 20 CI runs on `ShreyPaharia/octomux` (2026-07-03 → 2026-07-12):
9 success, 7 cancelled, 4 failure. Cancelled runs are concurrency cancellations
on superseded commits — treated as noise.

Full writeup: [`desk/incidents/2026-07-20.md`](desk/incidents/2026-07-20.md).

Four error classes found, all fixed here.

### 1. `linux-arm64` tmux package has never published — `chmod: cannot access 'bin/tmux'`

Fires at **every release tag** (v1.1.0, v1.2.0). `scripts/build-tmux.sh`
normalised `uname -m` for x86_64 (`x86_64` → `x64`) but not for arm64. On the
`ubuntu-24.04-arm` runner the build wrote a working 3.0M binary into
`packages/tmux-linux-aarch64/` — a directory that doesn't exist in the repo —
while the upload and publish steps read `packages/tmux-linux-arm64/`, which held
only its checked-in `package.json` (hence the 794-byte artifact). The build step
exits 0, so it surfaced two steps later as a misleading `chmod` error.

**Net effect: `@octomux/tmux-linux-arm64` has never been published.** macOS is
unaffected — `uname -m` already returns `arm64` there.

Fix: normalise `aarch64` → `arm64`, plus a fail-fast if `$DEST_DIR` isn't a real
package dir so a future unhandled arch errors at the source.

### 2. `Publish` aborts with `already_exists` on the release

`publish.yml` and `electron-release.yml` both trigger on `v*` and both create the
GitHub Release — electron-builder runs `--publish always` with
`releaseType: release`. `softprops/action-gh-release@v2` hard-fails instead of
adopting an existing release, so on v1.2.0 it lost the race. `npm publish` had
already succeeded, leaving `octomux@1.2.0` on npm behind a red Publish run.

Fix: `gh release view || gh release create`. Both sides intend a *published*
release, so whichever wins is correct and the loser adopts it.

### 3. ncurses download timeout kills the release build

Run 29205952405 died with `curl: (28)` after hanging 134s on an unreachable
`ftp.gnu.org`. The download had no retry and no timeout bound.

Fix: `--retry 3 --retry-all-errors --connect-timeout 20 --max-time 300`, plus an
ncurses mirror fallback (`invisible-mirror.net`, upstream's own archive).
libevent/tmux fetch from GitHub releases and stay retry-only.

### 4. `git submodule foreach` fails in post-job cleanup on every run

An octomux task worktree was committed as a gitlink (`160000`) with no
`.gitmodules` entry. `.gitignore` lists `.worktrees/`, but that doesn't apply to
already-tracked paths. Warning-level only (fails no job), but it fires on every
job of every run.

Fix: `git rm --cached` the stray gitlink.

---

### Out of scope, included to keep verify green

`test(diff-review-state)` raises the timeout on four tests that drive real `git`
subprocesses (~2.5–3.7s each against vitest's 5s default). **Pre-existing flake,
not a regression from this branch** — verified passing in isolation on clean
HEAD and failing in the full parallel run.

### Verification

`bun run lint` (0 errors, 60 pre-existing warnings) · `bun run typecheck` clean ·
`bun run test` **276 files, 3544 tests, all passing**.

The CI fixes themselves only execute on a `v*` tag, so this PR's own run does not
exercise classes 1–3.