### PR TITLE
fix(agent-session): headless submit_result works (flag spacing + tool perms + exit grace)

### DIFF
--- a/server/agent-session/session.ts
+++ b/server/agent-session/session.ts
@@ -286,7 +286,7 @@ export async function runAgentSession<T = unknown>(
   const baseCmd = harness.buildLaunchCommand({
     sessionId,
     agent: null,
-    flags: extraArgs.trim(),
+    flags: `--dangerously-skip-permissions ${extraArgs}`.trim(),
     model,
     workspacePath: workspaceDir,
   });
@@ -308,15 +308,23 @@ export async function runAgentSession<T = unknown>(
     env: captureEnv,
   });
 
-  // 6. Race: result vs early exit vs timeout
+  // 6. Race: result vs early exit vs timeout.
+  // The agent legitimately writes result.json and *then* exits. `onExit` must
+  // NOT immediately win the race against the result-poll (100ms), or a successful
+  // submit-then-exit is misreported as "exited before submitting result". Give the
+  // capture a short grace period after exit to read a just-written result; if
+  // `waitForResult` resolves during the grace, this delayed rejection is ignored.
+  const EXIT_GRACE_MS = 1_500;
   const exitPromise = new Promise<never>((_resolve, reject) => {
     handle.onExit(({ code }) => {
-      reject(
-        new Error(
-          `Agent exited before submitting result (exit code ${code}). ` +
-            'Ensure the agent calls submit_result before exiting.',
-        ),
-      );
+      setTimeout(() => {
+        reject(
+          new Error(
+            `Agent exited before submitting result (exit code ${code}). ` +
+              'Ensure the agent calls submit_result before exiting.',
+          ),
+        );
+      }, EXIT_GRACE_MS);
     });
   });
 

--- a/server/harnesses/shared.test.ts
+++ b/server/harnesses/shared.test.ts
@@ -4,11 +4,52 @@ import os from 'os';
 import path from 'path';
 import {
   applyModel,
+  buildClaudeContinueCommand,
+  buildClaudeLaunchCommand,
+  buildClaudeResumeCommand,
   formatHarnessFlags,
   formatJsonConfig,
   validateSettingsObject,
   writeJsonConfig,
 } from './shared.js';
+
+describe('buildClaudeLaunchCommand — flag spacing', () => {
+  // Regression: flags must never glue onto the session id. runAgentSession passes
+  // flags without a leading space; the builder must still separate them, or claude
+  // reads `<uuid><flags>` as the session id → "Invalid session ID" and exits.
+  it('separates session id from flags with a single space', () => {
+    const cmd = buildClaudeLaunchCommand({
+      sessionId: 'abc-123',
+      flags: '--dangerously-skip-permissions --mcp-config /x.json',
+      model: null,
+    });
+    expect(cmd).toBe(
+      'claude --session-id abc-123 --dangerously-skip-permissions --mcp-config /x.json',
+    );
+    expect(cmd).not.toContain('abc-123--');
+  });
+
+  it('handles a stray leading space in flags without doubling', () => {
+    expect(buildClaudeLaunchCommand({ sessionId: 'sid', flags: '  --print', model: null })).toBe(
+      'claude --session-id sid --print',
+    );
+  });
+
+  it('emits no trailing space when flags are empty', () => {
+    expect(buildClaudeLaunchCommand({ sessionId: 'sid', flags: '', model: null })).toBe(
+      'claude --session-id sid',
+    );
+  });
+
+  it('resume and continue commands separate flags too', () => {
+    expect(buildClaudeResumeCommand({ sessionId: 'sid', flags: '--foo', model: null })).toBe(
+      'claude --resume sid --foo',
+    );
+    expect(buildClaudeContinueCommand({ sessionId: 'sid', flags: '--foo', model: null })).toBe(
+      'claude --continue --session-id sid --foo',
+    );
+  });
+});
 
 describe('formatJsonConfig / writeJsonConfig', () => {
   it('serializes with 2-space indent and trailing newline', () => {

--- a/server/harnesses/shared.ts
+++ b/server/harnesses/shared.ts
@@ -71,6 +71,14 @@ export function validateSettingsObject(
   return out;
 }
 
+/** Normalize resolved flags to a single leading-space-separated string (or ''),
+ *  so callers can't accidentally glue flags onto the preceding token (e.g. the
+ *  session id) by passing flags without/with-stray leading whitespace. */
+function flagsSuffix(flags: string, model: string | null | undefined): string {
+  const resolved = applyModel(flags, model).trim();
+  return resolved ? ` ${resolved}` : '';
+}
+
 export function buildClaudeLaunchCommand({
   sessionId,
   agent,
@@ -78,8 +86,7 @@ export function buildClaudeLaunchCommand({
   model,
 }: HarnessLaunchOpts): string {
   const agentPart = agent ? ` --agent ${validateAgentName(agent)}` : '';
-  const resolvedFlags = applyModel(flags, model);
-  return `claude${agentPart} --session-id ${sessionId}${resolvedFlags}`;
+  return `claude${agentPart} --session-id ${sessionId}${flagsSuffix(flags, model)}`;
 }
 
 export function buildClaudeResumeCommand({
@@ -87,8 +94,7 @@ export function buildClaudeResumeCommand({
   flags = '',
   model,
 }: HarnessResumeOpts): string {
-  const resolvedFlags = applyModel(flags, model);
-  return `claude --resume ${sessionId}${resolvedFlags}`;
+  return `claude --resume ${sessionId}${flagsSuffix(flags, model)}`;
 }
 
 export function buildClaudeContinueCommand({
@@ -96,6 +102,5 @@ export function buildClaudeContinueCommand({
   flags = '',
   model,
 }: HarnessResumeOpts): string {
-  const resolvedFlags = applyModel(flags, model);
-  return `claude --continue --session-id ${sessionId}${resolvedFlags}`;
+  return `claude --continue --session-id ${sessionId}${flagsSuffix(flags, model)}`;
 }


### PR DESCRIPTION
## Bug: AgentSession verticals always fail

The two headless verticals (`overnight-log-summary`, `weekly-update`) run via `runAgentSession` and always failed with `Agent exited before submitting result`.

## Root cause (found by systematic debugging + a live repro)

`buildClaudeLaunchCommand` builds `claude --session-id ${sessionId}${resolvedFlags}` and relied on `flags` carrying a leading space. `runAgentSession` passed flags **without** one, so the command came out as:

```
claude --session-id <uuid>--mcp-config ... --print
                          ^^ glued
Error: Invalid session ID. Must be a valid UUID.
```

The agent exited immediately (invalid arg) → "exited before submitting result." Confirmed by instrumenting the exact spawned command.

## Fix (three parts)

1. **Root cause — `shared.ts`:** normalize the flag suffix in all three claude command builders (`flagsSuffix`) so flags are always separated from the preceding token by exactly one space, regardless of caller whitespace. A pure string-building regression test covers it (no agent spawn needed).
2. **`session.ts` — tool permissions:** headless AgentSession runs pass `--dangerously-skip-permissions` so the `--print` agent can actually invoke tools (Bash to fetch logs, and the `submit_result` MCP tool). Matches how octomux runs its normal tasks.
3. **`session.ts` — exit race:** the agent writes `result.json` and *then* exits; `onExit` could reject before the 100ms result-poll read the file. Added a short grace period on exit so a legitimate submit-then-exit isn't misreported as failure.

## Verified

Reproduced the failure and confirmed the fix end-to-end with a real headless agent (`runAgentSession` now returns the structured result). `bun run typecheck` clean; the agent-session + shared suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)