### PR TITLE
fix(agent-session): find submit_result MCP server in bundled prod build

### DIFF
--- a/server/agent-session/mcp/config.ts
+++ b/server/agent-session/mcp/config.ts
@@ -30,20 +30,35 @@ export function submitResultServerInvocation(): { command: string; args: string[
   const here = fileURLToPath(import.meta.url);
   const dir = path.dirname(here);
 
-  // prod: this file lives in dist-server/agent-session/mcp/config.js → server.js sibling
-  const prodServer = path.join(dir, 'submit-result-server.js');
-  if (fs.existsSync(prodServer)) {
-    return { command: process.execPath, args: [prodServer] };
+  // prod candidates. `import.meta.url` resolves to either:
+  //   - the sibling location when this module keeps its own file
+  //     (dist-server/agent-session/mcp/config.js → server.js sibling), or
+  //   - the BUNDLE root when the server is bundled into dist-server/index.js
+  //     (or a chunk in dist-server/), where `dir` is dist-server/ and the emitted
+  //     server lives one sub-path down. Both are checked so bundling can't hide it.
+  const prodCandidates = [
+    path.join(dir, 'submit-result-server.js'),
+    path.join(dir, 'agent-session', 'mcp', 'submit-result-server.js'),
+  ];
+  for (const candidate of prodCandidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: process.execPath, args: [candidate] };
+    }
   }
 
-  // dev: this file lives in server/agent-session/mcp/config.ts → server.ts sibling
-  const devServer = path.join(dir, 'submit-result-server.ts');
-  if (fs.existsSync(devServer)) {
-    try {
-      const tsxCli = createRequire(import.meta.url).resolve('tsx/cli');
-      return { command: process.execPath, args: [tsxCli, devServer] };
-    } catch {
-      return null;
+  // dev candidates: sibling .ts (unbundled) or the source sub-path, run via tsx.
+  const devCandidates = [
+    path.join(dir, 'submit-result-server.ts'),
+    path.join(dir, 'agent-session', 'mcp', 'submit-result-server.ts'),
+  ];
+  for (const candidate of devCandidates) {
+    if (fs.existsSync(candidate)) {
+      try {
+        const tsxCli = createRequire(import.meta.url).resolve('tsx/cli');
+        return { command: process.execPath, args: [tsxCli, candidate] };
+      } catch {
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
## The real reason AgentSession verticals failed in production

`overnight-log-summary` and `weekly-update` failed **only in the production build** (`node dist-server/index.js`), always with `Agent exited before submitting result (exit code 0)`. The agent ran the full task and exited cleanly — it just never called `submit_result`, because **it was never given the tool.**

## Root cause (confirmed via the prod log + built code)

`submitResultServerInvocation()` resolves the MCP server path from `import.meta.url`:
```js
const dir = path.dirname(fileURLToPath(import.meta.url));
const prodServer = path.join(dir, 'submit-result-server.js');
```
That assumes `config.js` sits **next to** `submit-result-server.js`. But in the bundled build, this code is inlined into `dist-server/index.js`, so `dir` is `dist-server/` — and it looks for `dist-server/submit-result-server.js`, while the server is actually emitted at `dist-server/agent-session/mcp/submit-result-server.js`. Path miss → returns `null` → **no `--mcp-config`** → the headless agent has no `submit_result` tool → it does the work, prints text, and exits 0.

Smoking gun from `~/.octomux/logs` on the live server:
```
module:"agent-session/session"  msg:"submit-result MCP server not found; capture will not attach"
```

Dev/tsx never hit this because unbundled paths resolve correctly — which is exactly why the earlier fix (#200) passed locally but the prod runs kept failing.

## Fix

Check both the sibling path (unbundled) **and** the emitted sub-path `agent-session/mcp/submit-result-server.js` (bundled, where `dir` is the bundle root), for prod and dev. Bundling can no longer hide the server.

## Together with #200

#200 fixed the necessary downstream pieces (flag spacing, `--dangerously-skip-permissions`, exit-race grace). This fixes the upstream blocker — the agent actually getting the tool. Both are needed for the AgentSession verticals to work in production.

## Verify

Rebuild (`bun run build`) + restart, then run an `overnight-log-summary` / `weekly-update` schedule — the run should complete `done` with a rendered structured result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)