### PR TITLE
feat(runs): surface outcome on rows and render kind-specific result output

### DIFF
--- a/src/components/runs/RunResultCard.test.tsx
+++ b/src/components/runs/RunResultCard.test.tsx
@@ -21,4 +21,35 @@ describe('RunResultCard', () => {
     );
     expect(screen.getByRole('link', { name: 'PR #12' })).toHaveAttribute('href', 'https://e/12');
   });
+
+  it('renders kind-specific output fields beyond the envelope', () => {
+    render(
+      <RunResultCard
+        result={{
+          outcome: 'done',
+          summary: 'x',
+          period: 'Jul 14 - Jul 20',
+          highlights: ['shipped runs feed'],
+        }}
+      />,
+    );
+    expect(screen.getByText('Period')).toBeInTheDocument();
+    expect(screen.getByText('Jul 14 - Jul 20')).toBeInTheDocument();
+    expect(screen.getByText('shipped runs feed')).toBeInTheDocument();
+  });
+
+  it('renders nested object arrays without printing [object Object]', () => {
+    const { container } = render(
+      <RunResultCard
+        result={{
+          outcome: 'done',
+          summary: 'x',
+          themes: [{ title: 'Automation', items: ['new cron handler'] }],
+        }}
+      />,
+    );
+    expect(screen.getByText('Automation')).toBeInTheDocument();
+    expect(screen.getByText('new cron handler')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('[object Object]');
+  });
 });

--- a/src/components/runs/RunResultCard.tsx
+++ b/src/components/runs/RunResultCard.tsx
@@ -1,10 +1,74 @@
 import type { RunResult } from '@octomux/types';
 
-const OUTCOME_TONE: Record<RunResult['outcome'], string> = {
+export const OUTCOME_TONE: Record<RunResult['outcome'], string> = {
   done: 'bg-emerald-500/15 text-emerald-400',
   blocked: 'bg-amber-500/15 text-amber-400',
   failed: 'bg-rose-500/15 text-rose-400',
 };
+
+/** Envelope keys rendered explicitly above; everything else is kind-specific `output`. */
+const ENVELOPE_KEYS = new Set(['outcome', 'summary', 'links']);
+
+/** camelCase / snake_case / kebab-case → "Title case" for field headings. */
+function humanize(key: string): string {
+  const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Render an arbitrary value from a kind's `output` schema. Bounded recursion — leaves are scalars,
+ * objects and arrays nest. Anything exotic falls back to JSON so this never prints `[object Object]`
+ * the way the old `formatResultField` did (spec §7, result-card fidelity).
+ */
+function RenderValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) return <span className="text-muted-soft">—</span>;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return <span className="whitespace-pre-wrap">{String(value)}</span>;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-muted-soft">none</span>;
+    return (
+      <ul className="ml-4 list-disc space-y-1">
+        {value.map((item, i) => (
+          <li key={i}>
+            <RenderValue value={item} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  if (typeof value === 'object') {
+    return (
+      <div className="space-y-1">
+        {Object.entries(value).map(([k, v]) => (
+          <div key={k}>
+            <span className="font-medium text-muted-foreground">{humanize(k)}: </span>
+            <RenderValue value={v} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <span>{JSON.stringify(value)}</span>;
+}
+
+/** Kind-specific output fields (everything past the universal envelope), rendered generically. */
+function RunOutputFields({ result }: { result: RunResult }) {
+  const entries = Object.entries(result).filter(([k]) => !ENVELOPE_KEYS.has(k));
+  if (entries.length === 0) return null;
+  return (
+    <div className="mt-3 space-y-2 border-t border-glass-edge pt-3 text-xs text-muted-foreground">
+      {entries.map(([k, v]) => (
+        <div key={k}>
+          <div className="font-semibold text-foreground">{humanize(k)}</div>
+          <div className="mt-0.5">
+            <RenderValue value={v} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export function RunResultCard({ result }: { result: RunResult }) {
   return (
@@ -30,6 +94,7 @@ export function RunResultCard({ result }: { result: RunResult }) {
           ))}
         </div>
       ) : null}
+      <RunOutputFields result={result} />
     </div>
   );
 }

--- a/src/components/schedules/SchemaConfigForm.test.tsx
+++ b/src/components/schedules/SchemaConfigForm.test.tsx
@@ -22,7 +22,13 @@ describe('SchemaConfigForm', () => {
   it('renders fields from the schema and calls onChange', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(<SchemaConfigForm schema={schema} value={{ logCommand: 'gh run list' }} onChange={onChange} />);
+    render(
+      <SchemaConfigForm
+        schema={schema}
+        value={{ logCommand: 'gh run list' }}
+        onChange={onChange}
+      />,
+    );
 
     expect(screen.getByLabelText('Log command')).toBeInTheDocument();
     expect(screen.getByLabelText('Max iterations')).toBeInTheDocument();

--- a/src/pages/RunsPage.test.tsx
+++ b/src/pages/RunsPage.test.tsx
@@ -104,6 +104,48 @@ describe('RunsPage', () => {
     expect(screen.getByTestId('run-row-run-1')).toBeInTheDocument();
   });
 
+  it('shows the outcome as a pill on the row without expanding it', async () => {
+    apiMock.listAllRuns.mockResolvedValue({
+      runs: [
+        makeRun({
+          id: 'run-1',
+          result_json: JSON.stringify({ outcome: 'failed', summary: 'Build broke' }),
+        }),
+      ],
+    });
+
+    renderWithRouter(<RunsPage />);
+
+    expect(await screen.findByTestId('run-outcome-run-1')).toHaveTextContent('failed');
+    // The result body itself should not be rendered until the row is expanded.
+    expect(screen.queryByText('Build broke')).not.toBeInTheDocument();
+  });
+
+  it('falls back to effective_status on the row when there is no parsed result', async () => {
+    apiMock.listAllRuns.mockResolvedValue({
+      runs: [makeRun({ id: 'run-1', effective_status: 'running', result_json: null })],
+    });
+
+    renderWithRouter(<RunsPage />);
+
+    const row = await screen.findByTestId('run-row-run-1');
+    expect(row).toHaveTextContent('running');
+    expect(screen.queryByTestId('run-outcome-run-1')).not.toBeInTheDocument();
+  });
+
+  it('shows an explanatory message instead of a silent no-op for resultless rows', async () => {
+    const user = userEvent.setup();
+    apiMock.listAllRuns.mockResolvedValue({
+      runs: [makeRun({ id: 'run-1', result_json: null })],
+    });
+
+    renderWithRouter(<RunsPage />);
+
+    await user.click(await screen.findByTestId('run-row-run-1'));
+
+    expect(await screen.findByText('No result recorded for this run.')).toBeInTheDocument();
+  });
+
   it('deep-links to the detail view when the run has a task_id and a registered kind', async () => {
     const user = userEvent.setup();
     registerWorkflowUI('loops', {

--- a/src/pages/RunsPage.tsx
+++ b/src/pages/RunsPage.tsx
@@ -9,7 +9,7 @@ import { GlassPanel } from '@/components/ui/glass-panel';
 import { Badge } from '@/components/ui/badge';
 import { PageHeader } from '@/components/layout/page-header';
 import { timeAgo } from '@/lib/time';
-import { RunResultCard } from '@/components/runs/RunResultCard';
+import { RunResultCard, OUTCOME_TONE } from '@/components/runs/RunResultCard';
 
 const ALL_KIND = '__all__';
 
@@ -43,7 +43,17 @@ function RunRow({ run }: { run: WorkflowRunRow }) {
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-medium text-foreground">{run.workflow_kind}</span>
           <Badge variant="outline">{run.trigger}</Badge>
-          <span className="text-xs text-muted-foreground">{run.effective_status}</span>
+          {result ? (
+            <span
+              data-testid={`run-outcome-${run.id}`}
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${OUTCOME_TONE[result.outcome]}`}
+            >
+              {result.outcome}
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">{run.effective_status}</span>
+          )}
+          {result && <span className="text-[10px] text-muted-soft">{run.effective_status}</span>}
           <span className="text-[10px] text-muted-soft">{timeAgo(run.started_at)}</span>
           {deepLink && (
             <button
@@ -59,7 +69,12 @@ function RunRow({ run }: { run: WorkflowRunRow }) {
             </button>
           )}
         </div>
-        {expanded && result && <RunResultCard result={result} />}
+        {expanded &&
+          (result ? (
+            <RunResultCard result={result} />
+          ) : (
+            <p className="text-xs text-muted-soft">No result recorded for this run.</p>
+          ))}
       </GlassPanel>
     </li>
   );

--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -23,13 +23,7 @@ import { PageHeader } from '@/components/layout/page-header';
 import { timeAgo } from '@/lib/time';
 import { SchemaConfigForm, defaultsFromSchema } from '@/components/schedules/SchemaConfigForm';
 
-function ScheduleForm({
-  kinds,
-  onCreated,
-}: {
-  kinds: ScheduleKindInfo[];
-  onCreated: () => void;
-}) {
+function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreated: () => void }) {
   const [kind, setKind] = useState('');
   const [repoPath, setRepoPath] = useState('');
   const [cron, setCron] = useState('');
@@ -38,10 +32,7 @@ function ScheduleForm({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const selectedKind = useMemo(
-    () => kinds.find((k) => k.kind === kind) ?? null,
-    [kinds, kind],
-  );
+  const selectedKind = useMemo(() => kinds.find((k) => k.kind === kind) ?? null, [kinds, kind]);
 
   useEffect(() => {
     if (!kind && kinds.length > 0) setKind(kinds[0].kind);


### PR DESCRIPTION
Follow-up to the workflow-consolidation waves (#202, #203). Makes the unified `/runs` feed actually usable at a glance.

## What changed
- **Outcome on the row.** Each feed row shows its `outcome` as a pill (done/blocked/failed) instead of hiding it inside the expanded card — you can scan for failures without clicking every row. `effective_status` demoted to secondary.
- **Honest empty state.** Rows with no parsed result (legacy pre-envelope rows, still-running runs) expand to "No result recorded" instead of a silent no-op.
- **Kind-specific output.** The expanded card renders each kind's `output` fields — weekly-update's `themes`/`highlights`, overnight-log-summary's `errorClasses`, etc. — via a bounded recursive renderer. Fixes the `[object Object]` flattening (spec §7 'result-card fidelity').
- **chore:** two prettier misses left by wave 2.

## Verification
- `bun run typecheck` — clean
- `bun run test` — 3763 passed (326 files)
- `bun run lint` — 0 errors
- `bun run format:check` — clean

Validated against real data: triggered live `weekly-update` and `doc-drift` runs (the latter opened PR #204); both finished with proper result envelopes and render their output fields.

## Not included
- **reviewer finishing its run** — attempted, but the drafted-is-done trigger has no `review:drafts-ready` emitter in the codebase, so it'd be dead code on the happy path. Deferred to a follow-up that adds the emitter at the real drafting-complete point.