### PR TITLE
fix(poller): don't re-auto-close a resumed task whose PR is merged

### DIFF
--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -592,6 +592,20 @@ describe('checkMergedPRs', () => {
     expect(closeTask).not.toHaveBeenCalled();
   });
 
+  it('does not re-close a task already marked done (resumed after auto-close)', async () => {
+    insertTask(db, {
+      ...DEFAULTS.runningTask,
+      pr_number: 42,
+      pr_url: 'https://github.com/org/repo/pull/42',
+      workflow_status: 'done',
+    });
+    mockPrStates({ pr0: 'MERGED' });
+
+    await checkMergedPRs();
+
+    expect(closeTask).not.toHaveBeenCalled();
+  });
+
   it('skips tasks without pr_number', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
 

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -775,7 +775,9 @@ export function listAutoReviewDrafts(
  */
 export function listRunningTasksWithPr(): Task[] {
   return getDb()
-    .prepare(`${SELECT_TASK_SQL} WHERE t.runtime_state = 'running' AND t.pr_number IS NOT NULL`)
+    .prepare(
+      `${SELECT_TASK_SQL} WHERE t.runtime_state = 'running' AND t.pr_number IS NOT NULL AND t.workflow_status != 'done'`,
+    )
     .all() as Task[];
 }
 


### PR DESCRIPTION
## Problem
When a task's PR is merged, the poller auto-closes the task and sets `workflow_status='done'`. If the user then **resumes** that task, `resumeTask` flips `runtime_state` back to `running` but leaves `workflow_status='done'`. On the next poll cycle, `checkMergedPRs` re-caught the still-merged PR and auto-closed the task again — the resume never "stuck".

## Fix
`listRunningTasksWithPr` (the merge poller's candidate query) now excludes `workflow_status='done'`. A task already auto-closed for its merge won't be re-closed after resume. Any legitimately-running task with a merged PR (status not yet `done`) is still caught.

## Test
Added `checkMergedPRs` case: a running task with a merged PR and `workflow_status='done'` is not passed to `closeTask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)