### PR TITLE
fix(reviewer): finish workflow run when review drafting completes

### DIFF
--- a/cli/review/complete.ts
+++ b/cli/review/complete.ts
@@ -1,7 +1,6 @@
 import { parseArgs } from 'node:util';
 import { completeRun, getCurrentRun } from '../../server/repositories/review-runs.js';
 import { autoResolvePublished } from '../../server/review-staleness.js';
-import { broadcast } from '../../server/events.js';
 
 export async function runComplete(argv: string[]): Promise<void> {
   const { values } = parseArgs({
@@ -31,8 +30,6 @@ export async function runComplete(argv: string[]): Promise<void> {
 
   completeRun(run.id);
   await autoResolvePublished(taskId, run.id);
-
-  broadcast({ type: 'review:drafts-ready', payload: { taskId, reviewRunId: run.id } });
 
   process.stdout.write(JSON.stringify({ ok: true, run_id: run.id }) + '\n');
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,6 +35,7 @@ import { ensureTmuxRuntimeDir } from './tmux-bin.js';
 import { syncAgents } from './agents.js';
 import { ensureGithubLogin } from './github-login.js';
 import { childLogger } from './logger.js';
+import { wireReviewerRunFinisher } from './workflows/reviewer/finish-run.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const logger = childLogger('index');
@@ -75,6 +76,9 @@ await syncAgents().catch((err: unknown) => {
 ensureGithubLogin().catch((err) => {
   logger.warn({ err }, 'ensureGithubLogin failed — reviewer polling disabled');
 });
+
+// Finish reviewer workflow runs when drafting completes (not on publish).
+wireReviewerRunFinisher();
 
 // ─── Orchestrator supervisor ───────────────────────────────────────────────
 // The supervisor is the single in-process subscriber to the durable events log.

--- a/server/repositories/inline-comments.ts
+++ b/server/repositories/inline-comments.ts
@@ -242,6 +242,14 @@ export function countCommentsByStatus(taskId: string): CommentStatusCounts {
     .get(taskId) as CommentStatusCounts;
 }
 
+/** Count inline comments drafted in a specific review run. */
+export function countCommentsForRun(reviewRunId: string): number {
+  const row = getDb()
+    .prepare(`SELECT COUNT(*) AS c FROM inline_comments WHERE review_run_id = ?`)
+    .get(reviewRunId) as { c: number };
+  return row.c;
+}
+
 // ─── Staleness helpers ────────────────────────────────────────────────────────
 
 export interface StalenessCandidate {

--- a/server/repositories/review-runs.test.ts
+++ b/server/repositories/review-runs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb } from '../test-helpers.js';
 import {
   createReviewRun,
@@ -7,6 +7,10 @@ import {
   completeRun,
   failRun,
 } from './review-runs.js';
+
+vi.mock('../events.js', () => ({ broadcast: vi.fn() }));
+
+import { broadcast } from '../events.js';
 
 const TASK_ID = 't_task1';
 
@@ -23,6 +27,7 @@ describe('review-runs', () => {
   beforeEach(() => {
     db = createTestDb();
     insertTask(db);
+    vi.mocked(broadcast).mockClear();
   });
 
   it('createReviewRun inserts a row with status=running', () => {
@@ -40,13 +45,17 @@ describe('review-runs', () => {
     expect(current?.id).toBe(newer.id);
   });
 
-  it('completeRun stores walkthrough JSON and marks completed', () => {
+  it('completeRun stores walkthrough JSON, marks completed, and broadcasts drafts-ready', () => {
     const run = createReviewRun({ task_id: TASK_ID, pr_head_sha: 'sha1' });
     completeRun(run.id, { walkthrough: '{"global":{}}' });
     const fresh = getReviewRun(run.id);
     expect(fresh?.status).toBe('completed');
     expect(fresh?.walkthrough).toBe('{"global":{}}');
     expect(fresh?.completed_at).not.toBeNull();
+    expect(broadcast).toHaveBeenCalledWith({
+      type: 'review:drafts-ready',
+      payload: { taskId: TASK_ID, reviewRunId: run.id },
+    });
   });
 
   it('failRun records error and marks failed', () => {

--- a/server/repositories/review-runs.ts
+++ b/server/repositories/review-runs.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import { getDb } from '../db.js';
+import { broadcast } from '../events.js';
 import { childLogger } from '../logger.js';
 import type { ReviewRun } from '../types.js';
 
@@ -75,6 +76,9 @@ export interface CompleteRunInput {
 }
 
 export function completeRun(id: string, input: CompleteRunInput = {}): void {
+  const existing = getReviewRun(id);
+  if (!existing || existing.status !== 'running') return;
+
   getDb()
     .prepare(
       `UPDATE review_runs
@@ -84,6 +88,15 @@ export function completeRun(id: string, input: CompleteRunInput = {}): void {
        WHERE id = ? AND status = 'running'`,
     )
     .run(input.walkthrough ?? null, id);
+
+  broadcast({
+    type: 'review:drafts-ready',
+    payload: { taskId: existing.task_id, reviewRunId: id },
+  });
+  logger.info(
+    { task_id: existing.task_id, review_run_id: id },
+    'review_run completed — drafts ready',
+  );
 }
 
 export function failRun(id: string, error: string): void {

--- a/server/workflows/reviewer/finish-run.test.ts
+++ b/server/workflows/reviewer/finish-run.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestDb, insertTestTask } from '../../test-helpers.js';
+import { getDb } from '../../db.js';
+import { insertRun, getRun } from '../../repositories/runs.js';
+import { createReviewRun, completeRun } from '../../repositories/review-runs.js';
+import { broadcast } from '../../events.js';
+import { finishReviewerRun, wireReviewerRunFinisher } from './finish-run.js';
+import type { RunResult } from '../../types.js';
+
+describe('finishReviewerRun', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('finishes the runs row with outcome done and comment count on drafts ready', () => {
+    insertTestTask({ id: 't1', pr_number: 42, pr_url: 'https://github.com/o/r/pull/42' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+
+    getDb()
+      .prepare(
+        `INSERT INTO inline_comments
+           (id, task_id, file_path, line, side, original_commit_sha, body, review_run_id)
+         VALUES ('c1', 't1', 'a.ts', 1, 'new', 'sha1', 'nit', ?),
+                ('c2', 't1', 'b.ts', 2, 'new', 'sha1', 'bug', ?)`,
+      )
+      .run(reviewRun.id, reviewRun.id);
+
+    finishReviewerRun('t1', reviewRun.id, false);
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('done');
+    expect(finished.ended_at).not.toBeNull();
+    const result = JSON.parse(finished.result_json!) as RunResult;
+    expect(result.outcome).toBe('done');
+    expect(result.summary).toBe('Drafted 2 review comments for PR #42');
+    expect(result.links).toEqual([
+      { label: 'Review', url: '/reviews/t1' },
+      { label: 'PR #42', url: 'https://github.com/o/r/pull/42' },
+    ]);
+  });
+
+  it('finishes the runs row with outcome failed and error summary', () => {
+    insertTestTask({ id: 't1' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    getDb()
+      .prepare(`UPDATE review_runs SET status = 'failed', error = ? WHERE id = ?`)
+      .run('timeout: no progress for 15 minutes', reviewRun.id);
+
+    finishReviewerRun('t1', reviewRun.id, true);
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('failed');
+    expect(finished.ended_at).not.toBeNull();
+    const result = JSON.parse(finished.result_json!) as RunResult;
+    expect(result.outcome).toBe('failed');
+    expect(result.summary).toBe('timeout: no progress for 15 minutes');
+  });
+
+  it('is a silent no-op when no runs row exists for the task', () => {
+    insertTestTask({ id: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    expect(() => finishReviewerRun('t1', reviewRun.id, false)).not.toThrow();
+    expect(getDb().prepare(`SELECT COUNT(*) AS c FROM runs`).get()).toEqual({ c: 0 });
+  });
+});
+
+describe('wireReviewerRunFinisher', () => {
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    createTestDb();
+    unsubscribe = wireReviewerRunFinisher();
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it('finishes the runs row when review:drafts-ready is broadcast', () => {
+    insertTestTask({ id: 't1', pr_number: 7, pr_url: 'https://github.com/o/r/pull/7' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    completeRun(reviewRun.id);
+
+    expect(getRun(runRow.id)?.status).toBe('done');
+  });
+
+  it('finishes the runs row when review:run-failed is broadcast', () => {
+    insertTestTask({ id: 't1' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    getDb()
+      .prepare(`UPDATE review_runs SET status = 'failed', error = ? WHERE id = ?`)
+      .run('agent crashed', reviewRun.id);
+
+    broadcast({ type: 'review:run-failed', payload: { taskId: 't1', reviewRunId: reviewRun.id } });
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('failed');
+    const result = JSON.parse(finished.result_json!) as RunResult;
+    expect(result.outcome).toBe('failed');
+    expect(result.summary).toBe('agent crashed');
+  });
+});

--- a/server/workflows/reviewer/finish-run.ts
+++ b/server/workflows/reviewer/finish-run.ts
@@ -1,0 +1,71 @@
+/**
+ * Finishes the reviewer workflow `runs` row when drafting completes or the
+ * review_run fails. Subscribes to in-process events via `wireReviewerRunFinisher`
+ * (called from server startup — never at module import time).
+ */
+import { subscribeServerEvents } from '../../events.js';
+import { getTask } from '../../repositories/index.js';
+import { getReviewRun } from '../../repositories/review-runs.js';
+import { countCommentsForRun } from '../../repositories/inline-comments.js';
+import { finishRun, listRunsForWorkflow } from '../../repositories/runs.js';
+import { childLogger } from '../../logger.js';
+import type { RunResult } from '../../types.js';
+
+const logger = childLogger('workflows/reviewer');
+
+/**
+ * Terminal update for the reviewer `runs` row tied to `taskId`. Silently a
+ * no-op when no running run row exists (e.g. manual reviews outside the
+ * github-triggered path).
+ */
+export function finishReviewerRun(taskId: string, reviewRunId: string, failed: boolean): void {
+  const run = listRunsForWorkflow('reviewer').find(
+    (r) => r.task_id === taskId && r.status === 'running',
+  );
+  if (!run) return;
+
+  if (failed) {
+    const reviewRun = getReviewRun(reviewRunId);
+    const summary = reviewRun?.error ?? 'Review run failed';
+    finishRun(run.id, {
+      status: 'failed',
+      error: summary,
+      result: { outcome: 'failed', summary } satisfies RunResult,
+    });
+    logger.info(
+      { task_id: taskId, run_id: run.id, review_run_id: reviewRunId },
+      'reviewer: run finished on failure',
+    );
+    return;
+  }
+
+  const commentCount = countCommentsForRun(reviewRunId);
+  const task = getTask(taskId);
+  const prSuffix = task?.pr_number != null ? ` for PR #${task.pr_number}` : '';
+  const summary = `Drafted ${commentCount} review comment${commentCount === 1 ? '' : 's'}${prSuffix}`;
+
+  const links: RunResult['links'] = [{ label: 'Review', url: `/reviews/${taskId}` }];
+  if (task?.pr_url && task.pr_number != null) {
+    links.push({ label: `PR #${task.pr_number}`, url: task.pr_url });
+  }
+
+  finishRun(run.id, {
+    status: 'done',
+    result: { outcome: 'done', summary, links } satisfies RunResult,
+  });
+  logger.info(
+    { task_id: taskId, run_id: run.id, review_run_id: reviewRunId, comment_count: commentCount },
+    'reviewer: run finished on drafts ready',
+  );
+}
+
+/** Subscribe to review lifecycle events. Returns unsubscribe — call from server startup only. */
+export function wireReviewerRunFinisher(): () => void {
+  return subscribeServerEvents((event) => {
+    if (event.type === 'review:drafts-ready') {
+      finishReviewerRun(event.payload.taskId, event.payload.reviewRunId, false);
+    } else if (event.type === 'review:run-failed') {
+      finishReviewerRun(event.payload.taskId, event.payload.reviewRunId, true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Emit `review:drafts-ready` from `completeRun()` when a `review_run` transitions to `completed` (single broadcaster at the drafting-complete point)
- Add `finishReviewerRun` + startup wiring via `wireReviewerRunFinisher()` so reviewer `runs` rows finish with a `RunResult` envelope on drafts-ready or timeout failure
- Remove duplicate broadcast from `cli/review/complete.ts`; publish path unchanged

## Why
Reviewer was the last workflow kind whose run never reached a terminal state on the happy path. The `review:drafts-ready` event existed but nothing finished the `runs` row — runs sat at `running` until timeout. A review run is complete when drafting finishes; publishing to GitHub is a separate human-gated step.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run test` — 327 files, 3769 tests (including `api.integrations.test.ts`, `api.task-refs.test.ts`, `poller.test.ts`, `orchestrator/stream.test.ts`)
- [x] New tests in `server/workflows/reviewer/finish-run.test.ts` cover done/failed/no-op paths and event wiring


Made with [Cursor](https://cursor.com)