### PR TITLE
feat(server): single-instance lock so two servers can't share one DB

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -34,10 +34,16 @@ import {
 import { ensureTmuxRuntimeDir } from './tmux-bin.js';
 import { syncAgents } from './agents.js';
 import { ensureGithubLogin } from './github-login.js';
+import { acquireInstanceLock } from './single-instance.js';
 import { childLogger } from './logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const logger = childLogger('index');
+
+// Refuse to boot a second server against the same database (see incident: a
+// stale dev build kept re-closing a resumed task via the merged-PR poller).
+acquireInstanceLock();
+
 const app = createApp();
 const server = createServer(app);
 const PORT = process.env.OCTOMUX_PORT || process.env.PORT || 7777;

--- a/server/single-instance.test.ts
+++ b/server/single-instance.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { checkInstanceLock, isProcessAlive } from './single-instance.js';
+
+const LOCK = 'octomux.lock';
+
+describe('single-instance lock', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-lock-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('is free when no lockfile exists', () => {
+    expect(checkInstanceLock(dir)).toEqual({ free: true });
+  });
+
+  it('reclaims a stale lock held by a dead pid', () => {
+    fs.writeFileSync(path.join(dir, LOCK), '999999');
+    expect(checkInstanceLock(dir, () => false)).toEqual({ free: true });
+  });
+
+  it('blocks when a live foreign instance holds the lock', () => {
+    fs.writeFileSync(path.join(dir, LOCK), '4242');
+    expect(checkInstanceLock(dir, () => true)).toEqual({ free: false, holderPid: 4242 });
+  });
+
+  it('ignores its own pid (restart / re-entry)', () => {
+    fs.writeFileSync(path.join(dir, LOCK), String(process.pid));
+    expect(checkInstanceLock(dir, () => true)).toEqual({ free: true });
+  });
+
+  it('isProcessAlive: true for self, false for a nonexistent pid', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+    expect(isProcessAlive(0x7fffffff)).toBe(false);
+  });
+});

--- a/server/single-instance.ts
+++ b/server/single-instance.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import { getDataDir } from './db.js';
+import { childLogger } from './logger.js';
+
+const logger = childLogger('single-instance');
+const LOCK_FILE = 'octomux.lock';
+
+/** True if a process with this pid is running (including one we don't own). */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH → gone; EPERM → alive but owned by another user.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function readPid(file: string): number | null {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(file, 'utf8').trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Probe the lock without mutating it. `alive` is injectable for tests. */
+export function checkInstanceLock(
+  dir: string,
+  alive: (pid: number) => boolean = isProcessAlive,
+): { free: boolean; holderPid?: number } {
+  const pid = readPid(path.join(dir, LOCK_FILE));
+  if (pid != null && pid !== process.pid && alive(pid)) {
+    return { free: false, holderPid: pid };
+  }
+  return { free: true };
+}
+
+/**
+ * Guarantee one octomux server per database. Two instances on one SQLite file
+ * corrupt each other's task lifecycle — e.g. a stale build's merged-PR poller
+ * re-closes a task the live server just resumed. Exits if another live instance
+ * already holds the lock; otherwise claims it and releases on process exit.
+ *
+ * ponytail: read-check-write pidfile, not atomic — a dead-heat first start could
+ * let two processes both win. Fine for a single-user local dashboard; reach for
+ * O_EXCL + stale reclaim only if that ever bites.
+ */
+export function acquireInstanceLock(dir: string = getDataDir()): void {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, LOCK_FILE);
+
+  const { free, holderPid } = checkInstanceLock(dir);
+  if (!free) {
+    logger.error(
+      { lock: file, holder_pid: holderPid, data_dir: dir },
+      'another octomux instance is already running on this database — refusing to start',
+    );
+    process.exit(1);
+  }
+
+  fs.writeFileSync(file, String(process.pid), { mode: 0o600 });
+  process.on('exit', () => {
+    try {
+      if (readPid(file) === process.pid) fs.rmSync(file, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+}


### PR DESCRIPTION
## Why

Two octomux servers running against the same SQLite file corrupt each other's task lifecycle. Live incident: a stale `bun run dev` build (pre-#206) kept re-closing task `l9gVLK7wkyBl` via its merged-PR poller every minute, right after the fixed `dist-server` had resumed it — the `done→done` "auto: PR merged" churn. Nothing stopped a second instance from attaching to the shared DB.

## What

- `server/single-instance.ts` — pidfile lock at `<dataDir>/octomux.lock`, keyed to the resolved DB path so dev (`./data`), prod (`~/.octomux/data`), and `OCTOMUX_DB_PATH` overrides each lock independently.
- Boot refuses to start (`logger.error` + `exit(1)`) when another **live** instance holds the lock. Stale locks from crashed instances are reclaimed via a `process.kill(pid, 0)` liveness check. Own pid ignored so restarts are clean. Released on process exit.
- Wired into `server/index.ts` before `createApp()`.

## Notes

- `ponytail:` read-check-write pidfile, not atomic — a dead-heat first start could let two processes both win. Fine for a single-user local dashboard; O_EXCL + stale reclaim if it ever matters.
- 5 new tests; full suite green (3769 passing).