### PR TITLE
feat(review): finding-queue cockpit for PR review triage

### DIFF
--- a/server/api.reviews.test.ts
+++ b/server/api.reviews.test.ts
@@ -92,12 +92,19 @@ describe('GET /api/reviews/:id', () => {
     app = createApp();
   });
 
-  it('returns full review detail', async () => {
+  it('returns full review detail with only actionable comments', async () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO inline_comments
+         (id, task_id, file_path, line, side, original_commit_sha, body, status, kind, review_run_id)
+       VALUES ('cc3', 'task-rev1', 'a.ts', 3, 'new', 'sha-head', 'rejected', 'rejected', 'comment', 'run-r1')`,
+    ).run();
     const res = await request(app).get('/api/reviews/task-rev1');
     expect(res.status).toBe(200);
     expect(res.body.task.id).toBe('task-rev1');
     expect(res.body.latest_run.id).toBe('run-r1');
     expect(res.body.comments).toHaveLength(2);
+    expect(res.body.comments.every((c: { status: string }) => c.status !== 'rejected')).toBe(true);
     expect(res.body.published_history).toEqual([]);
   });
 

--- a/server/repositories/inline-comments.test.ts
+++ b/server/repositories/inline-comments.test.ts
@@ -101,6 +101,42 @@ describe('inline_comments DAO', () => {
       const rows = listComments('task1', { file: 'b.ts' });
       expect(rows.map((r) => r.body)).toEqual(['B']);
     });
+
+    it('activeOnly returns draft/accepted without resolved_at', () => {
+      const draft = addComment({
+        task_id: 'task1',
+        file_path: 'a.ts',
+        line: 1,
+        side: 'new',
+        original_commit_sha: 's',
+        body: 'draft',
+      });
+      addComment({
+        task_id: 'task1',
+        file_path: 'a.ts',
+        line: 2,
+        side: 'new',
+        original_commit_sha: 's',
+        body: 'rejected',
+      });
+      getDb()
+        .prepare(`UPDATE inline_comments SET status = 'rejected' WHERE body = 'rejected'`)
+        .run();
+      getDb().prepare(`UPDATE inline_comments SET status = 'accepted' WHERE id = ?`).run(draft.id);
+      addComment({
+        task_id: 'task1',
+        file_path: 'a.ts',
+        line: 3,
+        side: 'new',
+        original_commit_sha: 's',
+        body: 'published',
+      });
+      getDb()
+        .prepare(`UPDATE inline_comments SET status = 'published' WHERE body = 'published'`)
+        .run();
+      const active = listComments('task1', { activeOnly: true });
+      expect(active.map((r) => r.body)).toEqual(['draft']);
+    });
   });
 
   describe('resolve / unresolve', () => {

--- a/server/repositories/inline-comments.ts
+++ b/server/repositories/inline-comments.ts
@@ -93,12 +93,23 @@ export function addComment(input: AddCommentInput): InlineCommentRow {
   return row;
 }
 
-export function listComments(taskId: string, opts?: { file?: string }): InlineCommentRow[] {
+export interface ListCommentsOpts {
+  file?: string;
+  /** When true, return only draft/accepted comments that are not resolved. */
+  activeOnly?: boolean;
+}
+
+function activeOnlyClause(activeOnly: boolean | undefined): string {
+  return activeOnly ? ` AND status IN ('draft', 'accepted') AND resolved_at IS NULL` : '';
+}
+
+export function listComments(taskId: string, opts?: ListCommentsOpts): InlineCommentRow[] {
+  const active = activeOnlyClause(opts?.activeOnly);
   if (opts?.file) {
     return getDb()
       .prepare(
         `SELECT * FROM inline_comments
-           WHERE task_id = ? AND file_path = ?
+           WHERE task_id = ? AND file_path = ?${active}
            ORDER BY created_at ASC, id ASC`,
       )
       .all(taskId, opts.file) as InlineCommentRow[];
@@ -106,7 +117,7 @@ export function listComments(taskId: string, opts?: { file?: string }): InlineCo
   return getDb()
     .prepare(
       `SELECT * FROM inline_comments
-         WHERE task_id = ?
+         WHERE task_id = ?${active}
          ORDER BY created_at ASC, id ASC`,
     )
     .all(taskId) as InlineCommentRow[];

--- a/server/reviews-inbox.test.ts
+++ b/server/reviews-inbox.test.ts
@@ -51,7 +51,7 @@ describe('reviews-inbox', () => {
     expect(detail).not.toBeNull();
     expect(detail!.task.id).toBe('t1');
     expect(detail!.latest_run?.id).toBe('r1');
-    expect(detail!.comments.map((c) => c.id).sort()).toEqual(['c1', 'c2', 'c3']);
+    expect(detail!.comments.map((c) => c.id).sort()).toEqual(['c1', 'c2']);
     expect(detail!.published_history).toEqual([]);
   });
 

--- a/server/reviews-inbox.ts
+++ b/server/reviews-inbox.ts
@@ -102,7 +102,7 @@ export function getReviewDetail(taskId: string): ReviewDetail | null {
 
   const runs = listRunsForTask(taskId);
   const latestRun = runs[0] ?? null;
-  const comments = listComments(taskId);
+  const comments = listComments(taskId, { activeOnly: true });
   const publishedHistory = listPublishedReviews(taskId);
 
   return {

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -135,7 +135,11 @@ router.get('/api/tasks/:id/comments', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
 
   const fileFilter = typeof req.query.file === 'string' ? req.query.file : undefined;
-  const rows = listComments(task.id, fileFilter ? { file: fileFilter } : undefined);
+  const activeOnly = req.query.active === '1' || req.query.active === 'true';
+  const rows = listComments(
+    task.id,
+    fileFilter || activeOnly ? { file: fileFilter, activeOnly } : undefined,
+  );
 
   const cwd = taskWorkingDir(task);
   const haveWorktree = !!cwd && fs.existsSync(cwd) && task.run_mode !== 'scratch';

--- a/src/components/DiffFileList.tsx
+++ b/src/components/DiffFileList.tsx
@@ -50,6 +50,8 @@ interface Props {
   groups?: RenderGroup[];
   /** Render diffs side-by-side (split) when true, unified/inline when false. */
   sideBySide?: boolean;
+  /** Hide per-file walkthrough explainers above each diff row. */
+  hideExplainers?: boolean;
 }
 
 function readHashPath(): string | null {
@@ -76,6 +78,7 @@ export const DiffFileList = forwardRef<DiffFileListHandle, Props>(function DiffF
     enableComments = false,
     groups,
     sideBySide = true,
+    hideExplainers = false,
   },
   ref,
 ) {
@@ -571,7 +574,7 @@ export const DiffFileList = forwardRef<DiffFileListHandle, Props>(function DiffF
               agents={agents}
               rangeIsBase={rangeIsBase}
               enableComments={enableComments}
-              explainer={fileSummaries.get(path)}
+              explainer={hideExplainers ? undefined : fileSummaries.get(path)}
               sideBySide={sideBySide}
             />
           </div>

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -47,6 +47,8 @@ interface Props {
   /** When provided, render sticky group-name dividers above each group's files
    *  in the diff stream. */
   groups?: import('@/lib/review-file-groups').RenderGroup[];
+  /** Hide per-file walkthrough explainers in the diff stream (review cockpit uses ReviewContextStrip). */
+  hideExplainers?: boolean;
 }
 
 export function DiffViewer({
@@ -63,6 +65,7 @@ export function DiffViewer({
   hideFileTree = false,
   fileOrder,
   groups,
+  hideExplainers = false,
 }: Props) {
   const isBaseRange = !range || range.kind === 'base';
   const [files, setFiles] = useState<DiffFileEntry[]>([]);
@@ -337,6 +340,7 @@ export function DiffViewer({
               enableComments={enableComments}
               groups={groups}
               sideBySide={sideBySide}
+              hideExplainers={hideExplainers}
             />
           )}
         </div>

--- a/src/components/review/FindingQueue.test.tsx
+++ b/src/components/review/FindingQueue.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FindingQueue } from './FindingQueue';
+import type { InlineCommentDTO } from '@/lib/api/reviewApi';
+
+const { mockPatchComment } = await vi.hoisted(async () => ({
+  mockPatchComment: vi.fn(),
+}));
+vi.mock('@/lib/api/reviewApi', () => ({
+  reviewApi: { patchComment: mockPatchComment },
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+function makeComment(overrides: Partial<InlineCommentDTO> = {}): InlineCommentDTO {
+  return {
+    id: 'c1',
+    task_id: 't1',
+    file_path: 'src/foo.ts',
+    line: 10,
+    side: 'new',
+    body: 'fix this',
+    status: 'draft',
+    kind: 'comment',
+    severity: 'issue',
+    bucket: 'actionable',
+    existing_code: null,
+    suggested_code: null,
+    re_flag_of: null,
+    auto_resolved_at: null,
+    auto_resolved_reason: null,
+    github_comment_id: null,
+    review_run_id: 'r1',
+    ...overrides,
+  };
+}
+
+describe('FindingQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPatchComment.mockImplementation(async (_t, _id, patch) => ({
+      ...makeComment(),
+      ...patch,
+    }));
+  });
+
+  it('shows severity and category on queue items', () => {
+    render(
+      <FindingQueue
+        taskId="t1"
+        comments={[makeComment()]}
+        selectedId="c1"
+        onSelect={() => {}}
+        onUpdated={() => {}}
+        onJumpToCode={() => {}}
+      />,
+    );
+    expect(screen.getAllByText('issue').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('actionable').length).toBeGreaterThan(0);
+  });
+
+  it('accept via card calls onUpdated', async () => {
+    const user = userEvent.setup();
+    const onUpdated = vi.fn();
+    render(
+      <FindingQueue
+        taskId="t1"
+        comments={[makeComment()]}
+        selectedId="c1"
+        onSelect={() => {}}
+        onUpdated={onUpdated}
+        onJumpToCode={() => {}}
+      />,
+    );
+    await user.click(screen.getByText('Accept'));
+    await vi.waitFor(() => expect(onUpdated).toHaveBeenCalled());
+  });
+});

--- a/src/components/review/FindingQueue.tsx
+++ b/src/components/review/FindingQueue.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import type { InlineCommentDTO } from '@/lib/api/reviewApi';
+import { prepareFindingQueue } from '@/lib/review-findings';
+import {
+  REVIEW_FINDING_KEYBINDS,
+  useReviewFindingKeyboard,
+} from '@/hooks/useReviewFindingKeyboard';
+import { cn } from '@/lib/utils';
+import { ReviewFilters, type CommentFilters } from './ReviewFilters';
+import { InlineCommentCard } from './InlineCommentCard';
+
+const DEFAULT_FILTERS: CommentFilters = {
+  severity: [],
+  bucket: [],
+  kind: [],
+  showResolved: false,
+};
+
+const SEVERITY_DOT: Record<string, string> = {
+  critical: 'bg-red-500',
+  issue: 'bg-orange-500',
+  suggestion: 'bg-blue-500',
+  nit: 'bg-muted-foreground',
+};
+
+interface FindingQueueProps {
+  taskId: string;
+  comments: InlineCommentDTO[];
+  selectedId: string | null;
+  onSelect: (comment: InlineCommentDTO) => void;
+  onUpdated: () => void;
+  onJumpToCode: (comment: InlineCommentDTO) => void;
+}
+
+function shortPath(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+export function FindingQueue({
+  taskId,
+  comments,
+  selectedId,
+  onSelect,
+  onUpdated,
+  onJumpToCode,
+}: FindingQueueProps) {
+  const [filters, setFilters] = useState<CommentFilters>(DEFAULT_FILTERS);
+  const queue = useMemo(() => prepareFindingQueue(comments, filters), [comments, filters]);
+  const selected = queue.find((c) => c.id === selectedId) ?? queue[0] ?? null;
+  const cardActionsRef = useRef<{ accept: () => void; reject: () => void } | null>(null);
+
+  useEffect(() => {
+    if (!selected && queue.length > 0) {
+      onSelect(queue[0]);
+    }
+  }, [queue, selected, onSelect]);
+
+  const selectByOffset = useCallback(
+    (delta: number) => {
+      if (queue.length === 0) return;
+      const idx = selected ? queue.findIndex((c) => c.id === selected.id) : -1;
+      const nextIdx = idx === -1 ? 0 : (idx + delta + queue.length) % queue.length;
+      onSelect(queue[nextIdx]);
+    },
+    [queue, selected, onSelect],
+  );
+
+  const handleError = useCallback((msg: string) => {
+    toast.error(msg);
+  }, []);
+
+  useReviewFindingKeyboard({
+    onNextFinding: () => selectByOffset(1),
+    onPrevFinding: () => selectByOffset(-1),
+    onAccept: () => cardActionsRef.current?.accept(),
+    onReject: () => cardActionsRef.current?.reject(),
+    onJumpToCode: () => {
+      if (selected) onJumpToCode(selected);
+    },
+  });
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="finding-queue">
+      <header className="shrink-0 space-y-2 border-b border-glass-edge px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Findings
+          </span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {queue.length} to triage
+          </span>
+        </div>
+        <ReviewFilters filters={filters} onChange={setFilters} />
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {queue.length === 0 ? (
+          <p className="p-4 text-xs text-muted-foreground" data-testid="finding-queue-empty">
+            No actionable findings. Accept drafts to enable publish, or re-run the review.
+          </p>
+        ) : (
+          <ul className="divide-y divide-glass-edge/60">
+            {queue.map((c, index) => {
+              const isSelected = selected?.id === c.id;
+              const dot = c.severity ? SEVERITY_DOT[c.severity] : 'bg-muted-foreground';
+              return (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    data-testid={`finding-queue-item-${c.id}`}
+                    data-selected={isSelected ? 'true' : undefined}
+                    onClick={() => onSelect(c)}
+                    className={cn(
+                      'flex w-full items-start gap-2 px-3 py-2 text-left text-xs hover:bg-glass-l2/40',
+                      isSelected && 'bg-primary/10',
+                    )}
+                  >
+                    <span className={cn('mt-1.5 size-2 shrink-0 rounded-full', dot)} aria-hidden />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex flex-wrap items-center gap-1.5">
+                        <span className="font-mono text-[10px] text-muted-foreground">
+                          {index + 1}/{queue.length}
+                        </span>
+                        {c.severity ? (
+                          <span className="rounded border border-glass-edge px-1 py-0.5 text-[10px]">
+                            {c.severity}
+                          </span>
+                        ) : null}
+                        {c.bucket ? (
+                          <span className="text-[10px] text-muted-foreground">{c.bucket}</span>
+                        ) : null}
+                        {c.status === 'accepted' ? (
+                          <span className="text-[10px] text-primary">accepted</span>
+                        ) : null}
+                      </span>
+                      <span className="mt-0.5 block truncate font-mono text-[10px] text-blue-300">
+                        {shortPath(c.file_path)}:{c.line}
+                      </span>
+                      <span className="mt-0.5 line-clamp-2 text-foreground">{c.body}</span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {selected ? (
+        <div
+          data-testid="finding-queue-detail"
+          className="shrink-0 border-t border-glass-edge bg-glass-l1/80 p-3"
+        >
+          <InlineCommentCard
+            key={selected.id}
+            comment={selected}
+            taskId={taskId}
+            onUpdated={onUpdated}
+            onError={handleError}
+            registerActions={(actions) => {
+              cardActionsRef.current = actions;
+            }}
+          />
+        </div>
+      ) : null}
+
+      <footer className="shrink-0 border-t border-glass-edge px-3 py-2">
+        <p className="text-[10px] text-muted-foreground">
+          {REVIEW_FINDING_KEYBINDS.map((b) => `${b.keys}: ${b.description}`).join(' · ')}
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/review/InlineCommentCard.tsx
+++ b/src/components/review/InlineCommentCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
@@ -9,6 +9,9 @@ interface InlineCommentCardProps {
   comment: InlineCommentDTO;
   taskId: string;
   onUpdated: () => void;
+  onError?: (message: string) => void;
+  /** Register imperative accept/reject handlers for keyboard shortcuts. */
+  registerActions?: (actions: { accept: () => void; reject: () => void }) => void;
 }
 
 const SEVERITY_STYLES: Record<string, string> = {
@@ -34,6 +37,8 @@ export function InlineCommentCard({
   comment: initialComment,
   taskId,
   onUpdated,
+  onError,
+  registerActions,
 }: InlineCommentCardProps) {
   const [comment, setComment] = useState(initialComment);
   const [editing, setEditing] = useState(false);
@@ -43,14 +48,32 @@ export function InlineCommentCard({
   const [saving, setSaving] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
 
+  useEffect(() => {
+    setComment(initialComment);
+    setEditBody(initialComment.body);
+    setEditExisting(initialComment.existing_code ?? '');
+    setEditSuggested(initialComment.suggested_code ?? '');
+    setEditing(false);
+  }, [initialComment]);
+
+  useEffect(() => {
+    if (!registerActions) return;
+    registerActions({
+      accept: () => {
+        void handleAccept();
+      },
+      reject: () => setRejectOpen(true),
+    });
+  });
+
   async function patch(data: Parameters<typeof reviewApi.patchComment>[2]) {
     setSaving(true);
     try {
       const updated = await reviewApi.patchComment(taskId, comment.id, data);
       setComment(updated);
       onUpdated();
-    } catch {
-      // ignore
+    } catch (err) {
+      onError?.((err as Error).message);
     } finally {
       setSaving(false);
     }

--- a/src/components/review/PublishBar.test.tsx
+++ b/src/components/review/PublishBar.test.tsx
@@ -37,9 +37,6 @@ function defaultProps(overrides: Partial<Parameters<typeof PublishBar>[0]> = {})
     staleCount: 0,
     reviewedDone: 0,
     reviewedTotal: 0,
-    totalCommentsCount: 0,
-    showCommentsPanel: false,
-    onToggleCommentsPanel: vi.fn(),
     isRunning: false,
     onPublished: vi.fn(),
     onReRun: vi.fn(),
@@ -90,24 +87,18 @@ describe('PublishBar', () => {
     expect(screen.queryByTestId('pr-review-progress')).toBeNull();
   });
 
-  it('renders Comments toggle button with count', () => {
-    render(<PublishBar {...defaultProps({ totalCommentsCount: 4 })} />);
-    expect(screen.getByTestId('comments-toggle')).toBeTruthy();
-    expect(screen.getByText('Comments (4)')).toBeTruthy();
-  });
-
-  it('applies active styling when showCommentsPanel=true', () => {
-    render(<PublishBar {...defaultProps({ showCommentsPanel: true })} />);
-    const btn = screen.getByTestId('comments-toggle');
-    expect(btn.dataset.active).toBe('true');
-  });
-
-  it('calls onToggleCommentsPanel when Comments button clicked', async () => {
+  it('publishes with optional summary body', async () => {
     const user = userEvent.setup();
-    const onToggleCommentsPanel = vi.fn();
-    render(<PublishBar {...defaultProps({ onToggleCommentsPanel })} />);
-    await user.click(screen.getByTestId('comments-toggle'));
-    expect(onToggleCommentsPanel).toHaveBeenCalled();
+    render(<PublishBar {...defaultProps({ acceptedCount: 2 })} />);
+    await user.click(screen.getByTestId('publish-summary-toggle'));
+    await user.type(screen.getByTestId('publish-summary-input'), 'Looks good overall');
+    await user.click(screen.getByText('Publish review'));
+    await waitFor(() => {
+      expect(mockPublishReview).toHaveBeenCalledWith('t1', {
+        verdict: 'COMMENT',
+        body: 'Looks good overall',
+      });
+    });
   });
 
   it('disables Publish button when accepted count is 0', () => {

--- a/src/components/review/PublishBar.tsx
+++ b/src/components/review/PublishBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '../ui/button';
+import { Textarea } from '../ui/textarea';
 import { reviewApi, type PublishedReviewVerdict } from '@/lib/api/reviewApi';
 import { taskApi } from '@/lib/api/taskApi';
 import { displayReviewTitle } from '@/lib/review-display';
@@ -19,9 +20,6 @@ interface PublishBarProps {
   staleCount: number;
   reviewedDone: number;
   reviewedTotal: number;
-  totalCommentsCount: number;
-  showCommentsPanel: boolean;
-  onToggleCommentsPanel: () => void;
   isRunning: boolean;
   onPublished: () => void;
   onReRun: () => void;
@@ -44,15 +42,14 @@ export function PublishBar({
   staleCount,
   reviewedDone,
   reviewedTotal,
-  totalCommentsCount,
-  showCommentsPanel,
-  onToggleCommentsPanel,
   isRunning,
   onPublished,
   onReRun,
   onDeleted,
 }: PublishBarProps) {
   const [verdict, setVerdict] = useState<PublishedReviewVerdict>('COMMENT');
+  const [summary, setSummary] = useState('');
+  const [showSummary, setShowSummary] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [reRunning, setReRunning] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -63,7 +60,10 @@ export function PublishBar({
     if (acceptedCount === 0) return;
     setPublishing(true);
     try {
-      await reviewApi.publishReview(taskId, { verdict });
+      await reviewApi.publishReview(taskId, {
+        verdict,
+        ...(summary.trim() ? { body: summary.trim() } : {}),
+      });
       toast.success('Review published to GitHub');
       onPublished();
     } catch (e) {
@@ -139,14 +139,10 @@ export function PublishBar({
           <Button
             variant="outline"
             size="sm"
-            data-testid="comments-toggle"
-            data-active={showCommentsPanel ? 'true' : undefined}
-            className={
-              showCommentsPanel ? 'border-primary/40 bg-primary/15 text-primary' : undefined
-            }
-            onClick={onToggleCommentsPanel}
+            data-testid="publish-summary-toggle"
+            onClick={() => setShowSummary((v) => !v)}
           >
-            Comments ({totalCommentsCount})
+            {showSummary ? 'Hide summary' : 'Add summary'}
           </Button>
 
           <Button
@@ -186,6 +182,19 @@ export function PublishBar({
           </Button>
         </div>
       </div>
+
+      {showSummary ? (
+        <div className="border-t border-glass-edge/50 px-4 py-2 sm:px-6">
+          <Textarea
+            data-testid="publish-summary-input"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            placeholder="Optional review summary for GitHub…"
+            rows={2}
+            className="text-sm"
+          />
+        </div>
+      ) : null}
 
       <ConfirmDeleteReviewDialog
         open={deleteOpen}

--- a/src/components/review/PublishedHistoryPanel.tsx
+++ b/src/components/review/PublishedHistoryPanel.tsx
@@ -1,0 +1,45 @@
+import type { ReviewDetail } from '@/lib/api/reviewApi';
+import { Badge } from '../ui/badge';
+
+interface PublishedHistoryPanelProps {
+  history: ReviewDetail['published_history'];
+}
+
+export function PublishedHistoryPanel({ history }: PublishedHistoryPanelProps) {
+  if (history.length === 0) return null;
+
+  return (
+    <section
+      data-testid="published-history-panel"
+      className="border-b border-glass-edge bg-glass-l1/60 px-4 py-3 sm:px-6"
+    >
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Published reviews
+      </h2>
+      <ul className="space-y-2">
+        {history.map((entry) => (
+          <li
+            key={entry.id}
+            className="flex flex-wrap items-center gap-2 rounded-lg border border-glass-edge bg-glass-l2/40 px-3 py-2 text-xs"
+          >
+            <Badge variant="outline">{entry.verdict}</Badge>
+            <span className="text-muted-foreground">
+              {entry.comment_count} comment{entry.comment_count === 1 ? '' : 's'}
+            </span>
+            <span className="text-muted-foreground">· {entry.published_at}</span>
+            {entry.github_review_url ? (
+              <a
+                href={entry.github_review_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary hover:underline"
+              >
+                View on GitHub
+              </a>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/review/ReviewFileTree.tsx
+++ b/src/components/review/ReviewFileTree.tsx
@@ -17,6 +17,7 @@ interface Props {
   reviewedFiles: Set<string>;
   onToggleReviewed: (path: string, currentlyReviewed: boolean) => void;
   onSelect: (path: string) => void;
+  hideFileSummaries?: boolean;
 }
 
 interface FileCounts {
@@ -56,6 +57,7 @@ interface FileRowProps {
   reviewedFiles: Set<string>;
   onToggleReviewed: (path: string, currentlyReviewed: boolean) => void;
   onSelect: (path: string) => void;
+  hideFileSummaries?: boolean;
 }
 
 function FileRow({
@@ -65,6 +67,7 @@ function FileRow({
   reviewedFiles,
   onToggleReviewed,
   onSelect,
+  hideFileSummaries = false,
 }: FileRowProps) {
   const open = counts?.open ?? 0;
   const stale = counts?.stale ?? 0;
@@ -116,14 +119,14 @@ function FileRow({
             </Badge>
           )}
         </span>
-        {file.summary && (
+        {file.summary && !hideFileSummaries ? (
           <ClampedExplainer
             text={file.summary}
             lines={2}
             clampChars={120}
             className="text-[10px] leading-snug text-muted-foreground"
           />
-        )}
+        ) : null}
       </button>
       {(open > 0 || stale > 0) && (
         <div className="flex shrink-0 flex-col items-end gap-1 pt-1">
@@ -163,6 +166,7 @@ export function ReviewFileTree({
   reviewedFiles,
   onToggleReviewed,
   onSelect,
+  hideFileSummaries = false,
 }: Props) {
   const groups = useMemo(() => buildGroups(files, walkthrough), [files, walkthrough]);
   const counts = useMemo(() => countsByFile(comments), [comments]);
@@ -288,6 +292,7 @@ export function ReviewFileTree({
                       reviewedFiles={reviewedFiles}
                       onToggleReviewed={onToggleReviewed}
                       onSelect={onSelect}
+                      hideFileSummaries={hideFileSummaries}
                     />
                   ))}
                 </ul>

--- a/src/hooks/useReviewFindingKeyboard.ts
+++ b/src/hooks/useReviewFindingKeyboard.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+export interface ReviewFindingKeyHandlers {
+  onNextFinding?: () => void;
+  onPrevFinding?: () => void;
+  onAccept?: () => void;
+  onReject?: () => void;
+  onJumpToCode?: () => void;
+}
+
+export interface ReviewFindingKeybind {
+  keys: string;
+  description: string;
+}
+
+export const REVIEW_FINDING_KEYBINDS: readonly ReviewFindingKeybind[] = [
+  { keys: 'j', description: 'Next finding' },
+  { keys: 'k', description: 'Previous finding' },
+  { keys: 'a', description: 'Accept finding' },
+  { keys: 'x', description: 'Reject finding' },
+  { keys: 'g', description: 'Jump to code in diff' },
+] as const;
+
+function isEditableElement(t: unknown): boolean {
+  if (!(t instanceof HTMLElement)) return false;
+  const tag = t.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (t.isContentEditable) return true;
+  return false;
+}
+
+export function useReviewFindingKeyboard(handlers: ReviewFindingKeyHandlers): void {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (isEditableElement(e.target) || isEditableElement(document.activeElement)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case 'j':
+          e.preventDefault();
+          handlers.onNextFinding?.();
+          break;
+        case 'k':
+          e.preventDefault();
+          handlers.onPrevFinding?.();
+          break;
+        case 'a':
+          e.preventDefault();
+          handlers.onAccept?.();
+          break;
+        case 'x':
+          e.preventDefault();
+          handlers.onReject?.();
+          break;
+        case 'g':
+          e.preventDefault();
+          handlers.onJumpToCode?.();
+          break;
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [handlers]);
+}

--- a/src/lib/review-findings.test.ts
+++ b/src/lib/review-findings.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type { InlineCommentDTO } from '@/lib/api/reviewApi';
+import { rankFindings, prepareFindingQueue } from './review-findings';
+import type { CommentFilters } from '@/components/review/ReviewFilters';
+
+function comment(overrides: Partial<InlineCommentDTO> = {}): InlineCommentDTO {
+  return {
+    id: 'c',
+    task_id: 't1',
+    file_path: 'a.ts',
+    line: 1,
+    side: 'new',
+    body: 'x',
+    status: 'draft',
+    kind: 'comment',
+    severity: 'nit',
+    bucket: null,
+    existing_code: null,
+    suggested_code: null,
+    re_flag_of: null,
+    auto_resolved_at: null,
+    auto_resolved_reason: null,
+    github_comment_id: null,
+    review_run_id: null,
+    ...overrides,
+  };
+}
+
+const EMPTY_FILTERS: CommentFilters = {
+  severity: [],
+  bucket: [],
+  kind: [],
+  showResolved: false,
+};
+
+describe('rankFindings', () => {
+  it('orders critical before issue before suggestion before nit', () => {
+    const ranked = rankFindings([
+      comment({ id: '1', severity: 'nit' }),
+      comment({ id: '2', severity: 'critical' }),
+      comment({ id: '3', severity: 'suggestion' }),
+      comment({ id: '4', severity: 'issue' }),
+    ]);
+    expect(ranked.map((c) => c.id)).toEqual(['2', '4', '3', '1']);
+  });
+});
+
+describe('prepareFindingQueue', () => {
+  it('applies severity filters', () => {
+    const queue = prepareFindingQueue(
+      [comment({ id: '1', severity: 'nit' }), comment({ id: '2', severity: 'critical' })],
+      { ...EMPTY_FILTERS, severity: ['critical'] },
+    );
+    expect(queue.map((c) => c.id)).toEqual(['2']);
+  });
+});

--- a/src/lib/review-findings.ts
+++ b/src/lib/review-findings.ts
@@ -1,0 +1,54 @@
+import type { InlineCommentDTO } from '@/lib/api/reviewApi';
+import type { CommentFilters } from '@/components/review/ReviewFilters';
+
+const SEVERITY_RANK: Record<NonNullable<InlineCommentDTO['severity']>, number> = {
+  critical: 0,
+  issue: 1,
+  suggestion: 2,
+  nit: 3,
+};
+
+function severityRank(severity: InlineCommentDTO['severity']): number {
+  if (!severity) return 4;
+  return SEVERITY_RANK[severity] ?? 4;
+}
+
+/** Rank findings: blocking severities first, then suggestion, then nit. */
+export function rankFindings(comments: InlineCommentDTO[]): InlineCommentDTO[] {
+  return [...comments].sort((a, b) => {
+    const sev = severityRank(a.severity) - severityRank(b.severity);
+    if (sev !== 0) return sev;
+    const file = a.file_path.localeCompare(b.file_path);
+    if (file !== 0) return file;
+    if (a.line !== b.line) return a.line - b.line;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function filterFindings(
+  comments: InlineCommentDTO[],
+  filters: CommentFilters,
+): InlineCommentDTO[] {
+  return comments.filter((c) => {
+    if (filters.severity.length > 0 && (!c.severity || !filters.severity.includes(c.severity))) {
+      return false;
+    }
+    if (filters.bucket.length > 0 && (!c.bucket || !filters.bucket.includes(c.bucket))) {
+      return false;
+    }
+    if (filters.kind.length > 0 && !filters.kind.includes(c.kind)) {
+      return false;
+    }
+    if (!filters.showResolved && c.auto_resolved_at) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function prepareFindingQueue(
+  comments: InlineCommentDTO[],
+  filters: CommentFilters,
+): InlineCommentDTO[] {
+  return rankFindings(filterFindings(comments, filters));
+}

--- a/src/pages/ReviewDetailPage.test.tsx
+++ b/src/pages/ReviewDetailPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ReviewDetailPage from './ReviewDetailPage';
 import { renderWithRouter } from '../test-helpers';
 import type { ReviewDetail, InlineCommentDTO } from '@/lib/api/reviewApi';
@@ -9,6 +10,7 @@ const { taskApiProxy, reviewApiProxy, configApiProxy, apiMock } = await vi.hoist
 );
 
 const scrollToFileSpy = vi.hoisted(() => vi.fn());
+const revealLineSpy = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
@@ -21,9 +23,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, useParams: () => ({ id: 't1' }) };
 });
-// Stub DiffViewer so the test focuses on host wiring (file-tree + walkthrough +
-// scroll-handle invocation). The real component fetches/renders Monaco and
-// pulls in a lot of unrelated machinery.
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock('@/components/DiffViewer', async () => {
   const { useEffect } = await import('react');
   return {
@@ -40,7 +40,12 @@ vi.mock('@/components/DiffViewer', async () => {
       onFilesChange?: (paths: string[]) => void;
     }) => {
       useEffect(() => {
-        if (listRef) listRef.current = { scrollToFile: scrollToFileSpy, revealLineInFile: vi.fn() };
+        if (listRef) {
+          listRef.current = {
+            scrollToFile: scrollToFileSpy,
+            revealLineInFile: revealLineSpy,
+          };
+        }
         onFilesChange?.(['server/db.ts', 'src/extra.ts']);
       }, [listRef, onFilesChange]);
       return <div data-testid="diff-viewer-stub" />;
@@ -50,16 +55,16 @@ vi.mock('@/components/DiffViewer', async () => {
 
 function comment(overrides: Partial<InlineCommentDTO> = {}): InlineCommentDTO {
   return {
-    id: 'c',
+    id: 'c1',
     task_id: 't1',
     file_path: 'server/db.ts',
-    line: 1,
+    line: 5,
     side: 'new',
-    body: '',
+    body: 'fix this please',
     status: 'draft',
     kind: 'comment',
     severity: 'issue',
-    bucket: null,
+    bucket: 'actionable',
     existing_code: null,
     suggested_code: null,
     re_flag_of: null,
@@ -108,6 +113,10 @@ const WALKTHROUGH_JSON = JSON.stringify({
 describe('ReviewDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    apiMock.patchComment.mockImplementation(async (_t, _id, patch) => ({
+      ...comment(),
+      ...patch,
+    }));
   });
 
   it('renders the PR title from review detail', async () => {
@@ -148,57 +157,7 @@ describe('ReviewDetailPage', () => {
     expect(screen.getByText('watch migration')).toBeTruthy();
   });
 
-  it('renders ReviewContextStrip with file notes when a file is selected', async () => {
-    apiMock.getReviewDetail.mockResolvedValue(
-      makeDetail({
-        latest_run: {
-          id: 'r1',
-          pr_head_sha: 'sha1',
-          walkthrough: WALKTHROUGH_JSON,
-          status: 'done',
-        },
-      }),
-    );
-    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
-    await screen.findByTestId('review-file-tree');
-    const row = await screen.findByTestId('review-file-row-server/db.ts');
-    fireEvent.click(row.querySelector('button')!);
-    const fileCtx = await screen.findByTestId('review-context-file');
-    expect(fileCtx.textContent).toMatch(/migration/);
-  });
-
-  it('renders one ReviewFileTree section per walkthrough group', async () => {
-    apiMock.getReviewDetail.mockResolvedValue(
-      makeDetail({
-        latest_run: {
-          id: 'r1',
-          pr_head_sha: 'sha1',
-          walkthrough: WALKTHROUGH_JSON,
-          status: 'done',
-        },
-      }),
-    );
-    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
-    expect(await screen.findByTestId('review-file-group-Schema')).toBeTruthy();
-  });
-
-  it('renders "Other" group for diff files not in the walkthrough', async () => {
-    apiMock.getReviewDetail.mockResolvedValue(
-      makeDetail({
-        latest_run: {
-          id: 'r1',
-          pr_head_sha: 'sha1',
-          walkthrough: WALKTHROUGH_JSON,
-          status: 'done',
-        },
-      }),
-    );
-    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
-    expect(await screen.findByTestId('review-file-group-Other')).toBeTruthy();
-    expect(screen.getByTestId('review-file-row-src/extra.ts')).toBeTruthy();
-  });
-
-  it('clicking a file invokes the DiffViewer scroll handle', async () => {
+  it('renders ReviewContextStrip with file notes when a file is selected via finding', async () => {
     apiMock.getReviewDetail.mockResolvedValue(
       makeDetail({
         latest_run: {
@@ -211,21 +170,69 @@ describe('ReviewDetailPage', () => {
       }),
     );
     renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
-    const row = await screen.findByTestId('review-file-row-server/db.ts');
-    // Row is now a <li>; the inner selection <button> wraps the filename.
-    const selectButton = row.querySelector('button');
-    if (!selectButton) throw new Error('expected selection button inside file row');
-    fireEvent.click(selectButton);
-    await waitFor(() => expect(scrollToFileSpy).toHaveBeenCalledWith('server/db.ts'));
+    await screen.findByTestId('finding-queue');
+    const item = await screen.findByTestId('finding-queue-item-c1');
+    fireEvent.click(item);
+    const fileCtx = await screen.findByTestId('review-context-file');
+    expect(fileCtx.textContent).toMatch(/migration/);
   });
 
-  it('does NOT render the legacy filters bar or inline-comment cards', async () => {
+  it('renders finding queue with draft body and triage actions', async () => {
+    apiMock.getReviewDetail.mockResolvedValue(makeDetail({ comments: [comment()] }));
+    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
+    const detail = await screen.findByTestId('finding-queue-detail');
+    expect(detail.textContent).toMatch(/fix this please/);
+    expect(screen.getByText('Accept')).toBeTruthy();
+  });
+
+  it('accepting a finding enables Publish', async () => {
+    const user = userEvent.setup();
+    apiMock.getReviewDetail
+      .mockResolvedValueOnce(makeDetail({ comments: [comment()] }))
+      .mockResolvedValue(makeDetail({ comments: [comment({ status: 'accepted' })] }));
+    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
+    const publishBtn = (await screen.findByText('Publish review')).closest('button')!;
+    expect(publishBtn.disabled).toBe(true);
+    await user.click(screen.getByText('Accept'));
+    await waitFor(() => expect(apiMock.patchComment).toHaveBeenCalled());
+    await waitFor(() => expect(publishBtn.disabled).toBe(false));
+  });
+
+  it('renders published history with GitHub link', async () => {
     apiMock.getReviewDetail.mockResolvedValue(
-      makeDetail({ comments: [comment({ body: 'fix this please' })] }),
+      makeDetail({
+        published_history: [
+          {
+            id: 'pr1',
+            github_review_url: 'https://github.com/o/r/pull/1#review-1',
+            published_at: '2026-01-01',
+            verdict: 'COMMENT',
+            comment_count: 2,
+          },
+        ],
+      }),
     );
     renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
-    await screen.findByText('Add foo');
-    expect(screen.queryByText(/^Filter:$/)).toBeNull();
-    expect(screen.queryByText('fix this please')).toBeNull();
+    const panel = await screen.findByTestId('published-history-panel');
+    expect(panel).toBeTruthy();
+    expect(screen.getByText('View on GitHub').closest('a')?.href).toContain('review-1');
+  });
+
+  it('selecting a finding reveals its line in the diff', async () => {
+    apiMock.getReviewDetail.mockResolvedValue(
+      makeDetail({
+        latest_run: {
+          id: 'r1',
+          pr_head_sha: 'sha1',
+          walkthrough: WALKTHROUGH_JSON,
+          status: 'done',
+        },
+        comments: [comment()],
+      }),
+    );
+    renderWithRouter(<ReviewDetailPage />, { route: '/reviews/t1', path: '/reviews/:id' });
+    const item = await screen.findByTestId('finding-queue-item-c1');
+    fireEvent.click(item);
+    await waitFor(() => expect(revealLineSpy).toHaveBeenCalledWith('server/db.ts', 5, 'new'));
   });
 });

--- a/src/pages/ReviewDetailPage.tsx
+++ b/src/pages/ReviewDetailPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { taskApi, type DiffSummaryResponse } from '../lib/api/taskApi';
+import type { InlineCommentDTO } from '../lib/api/reviewApi';
 import { useReviewDetail } from '../lib/hooks';
 import { WalkthroughPanel } from '../components/review/WalkthroughPanel';
 import type { Walkthrough } from '../components/review/walkthrough-types';
@@ -9,24 +10,12 @@ import { ReviewFileTree } from '../components/review/ReviewFileTree';
 import { ReviewContextStrip } from '../components/review/ReviewContextStrip';
 import { PublishBar } from '../components/review/PublishBar';
 import { HeadAdvancedBanner } from '../components/review/HeadAdvancedBanner';
+import { FindingQueue } from '../components/review/FindingQueue';
+import { PublishedHistoryPanel } from '../components/review/PublishedHistoryPanel';
 import { DiffViewer } from '../components/DiffViewer';
-import { CommentsSidePanel } from '../components/CommentsSidePanel';
-import { CommentsContext, useTaskComments } from '../hooks/useTaskComments';
 import type { DiffFileListHandle } from '../components/DiffFileList';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-const COMMENTS_PANEL_KEY = 'octomux:review:comments-panel-open';
-
-function defaultCommentsPanelOpen(): boolean {
-  if (typeof window === 'undefined') return false;
-  try {
-    const stored = localStorage.getItem(COMMENTS_PANEL_KEY);
-    if (stored !== null) return stored === 'true';
-  } catch {
-    // localStorage unavailable
-  }
-  return window.innerWidth >= 1440;
-}
 
 export default function ReviewDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -34,19 +23,10 @@ export default function ReviewDetailPage() {
   const { detail, error, refresh } = useReviewDetail(id);
   const [filesInDiff, setFilesInDiff] = useState<string[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [showCommentsPanel, setShowCommentsPanel] = useState(defaultCommentsPanelOpen);
+  const [selectedFindingId, setSelectedFindingId] = useState<string | null>(null);
+  const [showFileTree, setShowFileTree] = useState(false);
   const [mobileFileTreeOpen, setMobileFileTreeOpen] = useState(false);
   const diffListRef = useRef<DiffFileListHandle | null>(null);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(COMMENTS_PANEL_KEY, String(showCommentsPanel));
-    } catch {
-      // ignore
-    }
-  }, [showCommentsPanel]);
-
-  const taskComments = useTaskComments(id);
 
   const [reviewedFiles, setReviewedFiles] = useState<Set<string>>(new Set());
 
@@ -82,8 +62,6 @@ export default function ReviewDetailPage() {
     setReviewedFiles(set);
   }, []);
 
-  const filesInDiffSet = useMemo(() => new Set(filesInDiff), [filesInDiff]);
-
   const walkthrough = useMemo<Walkthrough | null>(() => {
     const raw = detail?.latest_run?.walkthrough;
     if (!raw) return null;
@@ -107,25 +85,24 @@ export default function ReviewDetailPage() {
     setMobileFileTreeOpen(false);
   }, []);
 
-  const handleJumpToComment = useCallback(
-    (filePath: string, line: number, side: 'old' | 'new', commentId: string) => {
-      setSelectedPath(filePath);
-      diffListRef.current?.revealLineInFile(filePath, line, side);
-      taskComments.setFocusedId(commentId);
-      setShowCommentsPanel(false);
-      window.setTimeout(() => {
-        if (taskComments.focusedId === commentId) taskComments.setFocusedId(null);
-      }, 1600);
-    },
-    [taskComments],
-  );
+  const handleSelectFinding = useCallback((comment: InlineCommentDTO) => {
+    setSelectedFindingId(comment.id);
+    setSelectedPath(comment.file_path);
+    diffListRef.current?.revealLineInFile(comment.file_path, comment.line, comment.side);
+  }, []);
+
+  const handleJumpToFindingCode = useCallback((comment: InlineCommentDTO) => {
+    setSelectedPath(comment.file_path);
+    diffListRef.current?.revealLineInFile(comment.file_path, comment.line, comment.side);
+  }, []);
 
   if (error) return <div className="p-4 text-red-500 md:p-6">{error}</div>;
   if (!detail) return <div className="p-4 text-sm text-muted-foreground md:p-6">Loading…</div>;
 
-  const draftCount = detail.comments.filter((c) => c.status === 'draft').length;
-  const acceptedCount = detail.comments.filter((c) => c.status === 'accepted').length;
-  const staleCount = detail.comments.filter((c) => c.status === 'stale').length;
+  const comments = detail.comments;
+  const draftCount = comments.filter((c) => c.status === 'draft').length;
+  const acceptedCount = comments.filter((c) => c.status === 'accepted').length;
+  const staleCount = comments.filter((c) => c.status === 'stale').length;
 
   const isRunning =
     detail.latest_run?.status === 'running' || detail.all_runs.some((r) => r.status === 'running');
@@ -134,127 +111,122 @@ export default function ReviewDetailPage() {
     <ReviewFileTree
       files={filesInDiff}
       walkthrough={walkthrough}
-      comments={detail.comments}
+      comments={comments}
       selectedPath={selectedPath}
       reviewedFiles={reviewedFiles}
       onToggleReviewed={handleToggleReviewed}
       onSelect={handleSelectFile}
-    />
-  );
-
-  const commentsPanel = (
-    <CommentsSidePanel
-      agents={[]}
-      filesInDiff={filesInDiffSet}
-      rangeIsBase={true}
-      onJumpTo={handleJumpToComment}
-      onClose={() => setShowCommentsPanel(false)}
-      className="h-full w-full max-w-none lg:w-80"
+      hideFileSummaries
     />
   );
 
   return (
-    <CommentsContext.Provider value={taskComments}>
-      <div className="flex h-full min-h-0 flex-col">
-        <HeadAdvancedBanner taskId={id!} currentSha={detail.task.pr_head_sha} onRefresh={refresh} />
+    <div className="flex h-full min-h-0 flex-col">
+      <HeadAdvancedBanner taskId={id!} currentSha={detail.task.pr_head_sha} onRefresh={refresh} />
 
-        <PublishBar
-          taskId={id!}
-          prTitle={detail.task.title}
-          prNumber={detail.task.pr_number}
-          prUrl={detail.task.pr_url ?? undefined}
-          acceptedCount={acceptedCount}
-          draftCount={draftCount}
-          staleCount={staleCount}
-          reviewedDone={reviewedFiles.size}
-          reviewedTotal={filesInDiff.length}
-          totalCommentsCount={taskComments.byId.size}
-          showCommentsPanel={showCommentsPanel}
-          onToggleCommentsPanel={() => setShowCommentsPanel((v) => !v)}
-          isRunning={isRunning}
-          onPublished={refresh}
-          onReRun={refresh}
-          onDeleted={() => navigate('/reviews')}
-        />
+      <PublishBar
+        taskId={id!}
+        prTitle={detail.task.title}
+        prNumber={detail.task.pr_number}
+        prUrl={detail.task.pr_url ?? undefined}
+        acceptedCount={acceptedCount}
+        draftCount={draftCount}
+        staleCount={staleCount}
+        reviewedDone={reviewedFiles.size}
+        reviewedTotal={filesInDiff.length}
+        isRunning={isRunning}
+        onPublished={refresh}
+        onReRun={refresh}
+        onDeleted={() => navigate('/reviews')}
+      />
 
-        {walkthrough && <WalkthroughPanel walkthrough={walkthrough} />}
+      <PublishedHistoryPanel history={detail.published_history} />
 
-        <ReviewContextStrip groups={orderedGroups} selectedPath={selectedPath} />
+      {walkthrough ? <WalkthroughPanel walkthrough={walkthrough} /> : null}
 
-        <div className="flex min-h-0 flex-1">
-          <aside
-            data-testid="review-file-tree-pane"
-            className="glass-chrome hidden w-[320px] shrink-0 flex-col overflow-hidden border-r border-glass-edge lg:flex"
-          >
-            {fileTree}
-          </aside>
+      <ReviewContextStrip groups={orderedGroups} selectedPath={selectedPath} />
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <div className="flex items-center gap-2 border-b border-glass-edge px-4 py-2 lg:hidden">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                data-testid="review-mobile-files-button"
-                onClick={() => setMobileFileTreeOpen(true)}
-              >
-                Files{filesInDiff.length > 0 ? ` (${filesInDiff.length})` : ''}
-              </Button>
-              {selectedPath ? (
-                <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
-                  {selectedPath}
-                </span>
-              ) : null}
-            </div>
+      <div className="flex min-h-0 flex-1">
+        <aside
+          data-testid="finding-queue-pane"
+          className="glass-chrome flex w-full max-w-md shrink-0 flex-col overflow-hidden border-r border-glass-edge lg:w-[360px]"
+        >
+          <FindingQueue
+            taskId={id!}
+            comments={comments}
+            selectedId={selectedFindingId}
+            onSelect={handleSelectFinding}
+            onUpdated={refresh}
+            onJumpToCode={handleJumpToFindingCode}
+          />
+        </aside>
 
-            <DiffViewer
-              taskId={id!}
-              isRunning={isRunning}
-              range={{ kind: 'base' }}
-              listRef={diffListRef}
-              enableComments
-              onFilesChange={setFilesInDiff}
-              onSelectionChange={setSelectedPath}
-              onSummaryLoaded={handleSummaryLoaded}
-              onToggleReviewed={handleToggleReviewed}
-              hideFileTree
-              fileOrder={orderedFileOrder}
-              groups={orderedGroups}
-            />
-          </div>
-
-          {showCommentsPanel ? (
-            <div className="hidden shrink-0 lg:flex">{commentsPanel}</div>
-          ) : null}
-        </div>
-
-        {showCommentsPanel ? (
-          <div
-            className="fixed inset-0 z-50 flex lg:hidden"
-            data-testid="review-mobile-comments-overlay"
-          >
-            <button
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-2 border-b border-glass-edge px-4 py-2">
+            <Button
               type="button"
-              className="absolute inset-0 bg-black/60"
-              aria-label="Close comments"
-              onClick={() => setShowCommentsPanel(false)}
-            />
-            <div className="relative ml-auto h-full w-full max-w-sm">{commentsPanel}</div>
+              size="sm"
+              variant="outline"
+              data-testid="review-files-toggle"
+              onClick={() => setShowFileTree((v) => !v)}
+              className="hidden lg:inline-flex"
+            >
+              {showFileTree ? 'Hide files' : 'Browse files'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              data-testid="review-mobile-files-button"
+              onClick={() => setMobileFileTreeOpen(true)}
+              className="lg:hidden"
+            >
+              Files{filesInDiff.length > 0 ? ` (${filesInDiff.length})` : ''}
+            </Button>
+            {selectedPath ? (
+              <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+                {selectedPath}
+              </span>
+            ) : null}
           </div>
-        ) : null}
 
-        <Dialog open={mobileFileTreeOpen} onOpenChange={setMobileFileTreeOpen}>
-          <DialogContent
-            className="flex max-h-[min(85dvh,100dvh)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"
-            showCloseButton
-          >
-            <DialogHeader className="border-b border-glass-edge px-4 py-3">
-              <DialogTitle>Changed files</DialogTitle>
-            </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-auto">{fileTree}</div>
-          </DialogContent>
-        </Dialog>
+          {showFileTree ? (
+            <div
+              data-testid="review-file-tree-inline"
+              className="hidden max-h-48 shrink-0 overflow-auto border-b border-glass-edge lg:block"
+            >
+              {fileTree}
+            </div>
+          ) : null}
+
+          <DiffViewer
+            taskId={id!}
+            isRunning={isRunning}
+            range={{ kind: 'base' }}
+            listRef={diffListRef}
+            onFilesChange={setFilesInDiff}
+            onSelectionChange={setSelectedPath}
+            onSummaryLoaded={handleSummaryLoaded}
+            onToggleReviewed={handleToggleReviewed}
+            hideFileTree
+            hideExplainers
+            fileOrder={orderedFileOrder}
+            groups={orderedGroups}
+          />
+        </div>
       </div>
-    </CommentsContext.Provider>
+
+      <Dialog open={mobileFileTreeOpen} onOpenChange={setMobileFileTreeOpen}>
+        <DialogContent
+          className="flex max-h-[min(85dvh,100dvh)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"
+          showCloseButton
+        >
+          <DialogHeader className="border-b border-glass-edge px-4 py-3">
+            <DialogTitle>Changed files</DialogTitle>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 overflow-auto">{fileTree}</div>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the broken review detail layout with a finding-queue cockpit: ranked, keyboard-navigable triage of AI-drafted findings (accept / reject / edit) driving the diff pane
- Filter review detail to actionable comments server-side (`draft`/`accepted`, not resolved); publish supports an optional GitHub summary and shows published history
- De-duplicate per-file walkthrough notes to `ReviewContextStrip` only; wire comment patch errors to toasts

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (3777 passed)
- [x] `bun run lint`
- [x] `bun run format:check`
- [ ] Open a review with draft findings → accept one → Publish enabled
- [ ] Keyboard: `j`/`k` navigate findings, `a` accept, `x` reject, `g` jump to code
- [ ] Publish with optional summary → published history shows GitHub link


Made with [Cursor](https://cursor.com)