### PR TITLE
feat(schedules): operate cron workflows fully from the UI

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -143,6 +143,8 @@ export interface Task {
   model: string | null;
   /** If set, poller sends a completion message to this task's active agent when this task finishes. */
   notify_task_id: string | null;
+  /** Set when this task was created by a cron schedule run. */
+  schedule_id?: string | null;
   harness_id: string;
   error: string | null;
   /** Summary text set by agent or user. */

--- a/server/api.schedules.test.ts
+++ b/server/api.schedules.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { createApp } from './app.js';
 import { createTestDb } from './test-helpers.js';
 import { upsertSchedule } from './repositories/schedules.js';
-import { insertTask } from './repositories/tasks.js';
+import { insertRun } from './repositories/runs.js';
 
 describe('schedule routes', () => {
   let app: ReturnType<typeof createApp>;
@@ -143,20 +143,64 @@ describe('schedule routes', () => {
   });
 
   describe('GET /api/schedules/:id/runs', () => {
-    it('returns tasks stamped with this schedule id', async () => {
+    it('returns runs stamped with this schedule id from the runs table', async () => {
       const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
-      insertTask({ id: 'run-1', title: 'T', description: 'D', schedule_id: row.id });
-      insertTask({ id: 'run-2', title: 'T', description: 'D', schedule_id: 'other-schedule' });
+      insertRun({
+        workflowKind: 'weekly-update',
+        trigger: 'manual',
+        scheduleId: row.id,
+      });
+      insertRun({
+        workflowKind: 'prod-log-triage',
+        trigger: 'cron',
+        scheduleId: 'other-schedule',
+      });
 
       const res = await request(app).get(`/api/schedules/${row.id}/runs`);
 
       expect(res.status).toBe(200);
-      expect(res.body.runs.map((t: { id: string }) => t.id)).toEqual(['run-1']);
+      expect(res.body.runs).toHaveLength(1);
+      expect(res.body.runs[0].workflow_kind).toBe('weekly-update');
+      expect(res.body.runs[0].schedule_id).toBe(row.id);
     });
 
     it('returns 404 for an unknown schedule id', async () => {
       const res = await request(app).get('/api/schedules/does-not-exist/runs');
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/schedules/:id/run', () => {
+    it('triggers a manual run via executeScheduleRun', async () => {
+      const row = upsertSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
+
+      const res = await request(app).post(`/api/schedules/${row.id}/run`);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 for an unknown schedule id', async () => {
+      const res = await request(app).post('/api/schedules/does-not-exist/run');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/schedules/prompt-default', () => {
+    it('returns the shipped SKILL.md body for a cron kind', async () => {
+      const res = await request(app).get('/api/schedules/prompt-default?kind=weekly-update');
+      expect(res.status).toBe(200);
+      expect(typeof res.body.content).toBe('string');
+      expect(res.body.content.length).toBeGreaterThan(0);
+    });
+
+    it('rejects an unknown kind with 400', async () => {
+      const res = await request(app).get('/api/schedules/prompt-default?kind=not-real');
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -918,6 +918,7 @@ export function runMigrations(instance: Database.Database): void {
   // ── Per-schedule config overrides (2026-07-18, P4) ───────────────────────
   const scheduleCols = columnsOf(instance, 'schedules');
   addColumn(instance, 'schedules', 'config_json', 'config_json TEXT', scheduleCols);
+  addColumn(instance, 'schedules', 'prompt', 'prompt TEXT', scheduleCols);
 
   // ── Link scheduled runs back to their schedule (2026-07-18, P5) ──────────
   const taskColsForSchedule = columnsOf(instance, 'tasks');

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -173,6 +173,7 @@ CREATE TABLE IF NOT EXISTS schedules (
   enabled       INTEGER NOT NULL DEFAULT 1,
   last_run_at   TEXT,
   config_json   TEXT,
+  prompt        TEXT,
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(kind, repo_path)

--- a/server/poller/execute-schedule-run.test.ts
+++ b/server/poller/execute-schedule-run.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { upsertSchedule } from '../repositories/schedules.js';
+import { insertRun, listRunsForSchedule } from '../repositories/runs.js';
+
+const mockRun = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../workflows/registry.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../workflows/registry.js')>();
+  return {
+    ...actual,
+    getWorkflow: (kind: string) =>
+      kind === 'weekly-update'
+        ? { kind, run: (...args: unknown[]) => mockRun(...args) }
+        : actual.getWorkflow(kind),
+  };
+});
+
+import { executeScheduleRun } from './execute-schedule-run.js';
+
+describe('executeScheduleRun', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockRun.mockClear();
+  });
+
+  it('calls wf.run with the same context shape as the cron poller', async () => {
+    const row = upsertSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+    });
+
+    await executeScheduleRun(row.id, { trigger: 'manual' });
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: '/repo',
+        scheduleId: row.id,
+        trigger: 'manual',
+      }),
+    );
+  });
+
+  it('creates a runs row when the workflow handler inserts one', async () => {
+    const row = upsertSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+    });
+
+    mockRun.mockImplementationOnce(async (ctx: { scheduleId?: string }) => {
+      insertRun({
+        workflowKind: 'weekly-update',
+        trigger: 'manual',
+        scheduleId: ctx.scheduleId,
+      });
+    });
+
+    await executeScheduleRun(row.id, { trigger: 'manual' });
+
+    const runs = listRunsForSchedule(row.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].workflow_kind).toBe('weekly-update');
+    expect(runs[0].trigger).toBe('manual');
+  });
+});

--- a/server/poller/execute-schedule-run.ts
+++ b/server/poller/execute-schedule-run.ts
@@ -1,0 +1,45 @@
+import { childLogger } from '../logger.js';
+import { getSchedule, touchScheduleLastRun } from '../repositories/schedules.js';
+import { getWorkflow } from '../workflows/registry.js';
+import { resolveWorkflowConfig } from '../workflows/config.js';
+import type { RunContext } from '../workflows/types.js';
+
+const logger = childLogger('poller');
+
+export type ScheduleRunTrigger = NonNullable<RunContext['trigger']>;
+
+/** Shared entry point for cron poller and manual "run now" — one run path. */
+export async function executeScheduleRun(
+  scheduleId: string,
+  options?: { trigger?: ScheduleRunTrigger },
+): Promise<void> {
+  const row = getSchedule(scheduleId);
+  if (!row) {
+    throw new Error(`Schedule not found: ${scheduleId}`);
+  }
+
+  const wf = getWorkflow(row.kind);
+  if (!wf?.run) {
+    logger.warn(
+      { schedule_id: row.id, kind: row.kind },
+      'executeScheduleRun: no run handler registered for kind',
+    );
+    return;
+  }
+
+  const config = resolveWorkflowConfig(wf, row.config_json);
+  const trigger = options?.trigger ?? 'cron';
+
+  try {
+    await wf.run({
+      repoPath: row.repo_path,
+      config,
+      scheduleId: row.id,
+      trigger,
+    });
+  } catch (err) {
+    logger.error({ err, schedule_id: row.id, kind: row.kind }, 'executeScheduleRun: run failed');
+  }
+
+  touchScheduleLastRun(row.id);
+}

--- a/server/poller/schedule-cron.ts
+++ b/server/poller/schedule-cron.ts
@@ -1,37 +1,11 @@
-import { childLogger } from '../logger.js';
-import { listEnabledSchedules, touchScheduleLastRun } from '../repositories/schedules.js';
+import { listEnabledSchedules } from '../repositories/schedules.js';
 import { isCronDue } from '../schedules/cron.js';
-import { getWorkflow } from '../workflows/registry.js';
-import { resolveWorkflowConfig } from '../workflows/config.js';
-
-const logger = childLogger('poller');
+import { executeScheduleRun } from './execute-schedule-run.js';
 
 /** Generic cron trigger: fires the registered kind's `run` for every enabled, due schedule row. */
 export async function pollSchedules(now: Date = new Date()): Promise<void> {
   for (const row of listEnabledSchedules()) {
     if (!isCronDue(row.cron, now)) continue;
-
-    const wf = getWorkflow(row.kind);
-    if (!wf?.run) {
-      logger.warn(
-        { schedule_id: row.id, kind: row.kind },
-        'pollSchedules: no run handler registered for kind',
-      );
-      continue;
-    }
-
-    const config = resolveWorkflowConfig(wf, row.config_json);
-
-    try {
-      await wf.run({
-        repoPath: row.repo_path,
-        config,
-        scheduleId: row.id,
-      });
-    } catch (err) {
-      logger.error({ err, schedule_id: row.id, kind: row.kind }, 'pollSchedules: run failed');
-    }
-
-    touchScheduleLastRun(row.id);
+    await executeScheduleRun(row.id, { trigger: 'cron' });
   }
 }

--- a/server/repositories/schedules.test.ts
+++ b/server/repositories/schedules.test.ts
@@ -132,6 +132,16 @@ describe('schedules repo', () => {
     expect(updateSchedule('nope', { cron: '0 8 * * *' })).toBeUndefined();
   });
 
+  it('updateSchedule stores and clears prompt', () => {
+    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+
+    const updated = updateSchedule(row.id, { prompt: 'Custom prompt' });
+    expect(updated?.prompt).toBe('Custom prompt');
+
+    const cleared = updateSchedule(row.id, { prompt: null });
+    expect(cleared?.prompt).toBeNull();
+  });
+
   it('deleteSchedule removes the row', () => {
     const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
 

--- a/server/repositories/schedules.ts
+++ b/server/repositories/schedules.ts
@@ -17,6 +17,7 @@ export interface ScheduleRow {
   enabled: number;
   last_run_at: string | null;
   config_json: string | null;
+  prompt: string | null;
 }
 
 export interface UpsertScheduleInput {
@@ -25,31 +26,33 @@ export interface UpsertScheduleInput {
   cron: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  prompt?: string | null;
 }
 
-/** Insert a schedule, or update cron/enabled/config on conflict for (kind, repo_path). */
+const SCHEDULE_COLUMNS = 'id, kind, repo_path, cron, enabled, last_run_at, config_json, prompt';
+
+/** Insert a schedule, or update cron/enabled/config/prompt on conflict for (kind, repo_path). */
 export function upsertSchedule(input: UpsertScheduleInput): ScheduleRow {
   const id = nanoid(12);
   const enabled = input.enabled === false ? 0 : 1;
   const configJson = input.config ? JSON.stringify(input.config) : null;
+  const prompt = input.prompt === undefined ? null : input.prompt;
 
   getDb()
     .prepare(
-      `INSERT INTO schedules (id, kind, repo_path, cron, enabled, config_json)
-       VALUES (?, ?, ?, ?, ?, ?)
+      `INSERT INTO schedules (id, kind, repo_path, cron, enabled, config_json, prompt)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(kind, repo_path) DO UPDATE SET
          cron = excluded.cron,
          enabled = excluded.enabled,
          config_json = excluded.config_json,
+         prompt = excluded.prompt,
          updated_at = datetime('now')`,
     )
-    .run(id, input.kind, input.repoPath, input.cron, enabled, configJson);
+    .run(id, input.kind, input.repoPath, input.cron, enabled, configJson, prompt);
 
   const row = getDb()
-    .prepare(
-      `SELECT id, kind, repo_path, cron, enabled, last_run_at, config_json FROM schedules
-       WHERE kind = ? AND repo_path = ?`,
-    )
+    .prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules WHERE kind = ? AND repo_path = ?`)
     .get(input.kind, input.repoPath) as ScheduleRow;
 
   logger.info({ schedule_id: row.id, kind: input.kind }, 'schedule upserted');
@@ -59,9 +62,7 @@ export function upsertSchedule(input: UpsertScheduleInput): ScheduleRow {
 /** All enabled schedules, across every kind — the poller dispatches by `kind`. */
 export function listEnabledSchedules(): ScheduleRow[] {
   return getDb()
-    .prepare(
-      `SELECT id, kind, repo_path, cron, enabled, last_run_at, config_json FROM schedules WHERE enabled = 1`,
-    )
+    .prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules WHERE enabled = 1`)
     .all() as ScheduleRow[];
 }
 
@@ -76,27 +77,25 @@ export function touchScheduleLastRun(id: string): void {
 
 /** All schedules, across every kind and enabled state — for the management UI. */
 export function listSchedules(): ScheduleRow[] {
-  return getDb()
-    .prepare(`SELECT id, kind, repo_path, cron, enabled, last_run_at, config_json FROM schedules`)
-    .all() as ScheduleRow[];
+  return getDb().prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules`).all() as ScheduleRow[];
 }
 
 /** Fetch a single schedule by id (returns undefined if not found). */
 export function getSchedule(id: string): ScheduleRow | undefined {
-  return getDb()
-    .prepare(
-      `SELECT id, kind, repo_path, cron, enabled, last_run_at, config_json FROM schedules WHERE id = ?`,
-    )
-    .get(id) as ScheduleRow | undefined;
+  return getDb().prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules WHERE id = ?`).get(id) as
+    | ScheduleRow
+    | undefined;
 }
 
 export interface UpdateScheduleInput {
   cron?: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  /** Set to null to clear the DB override and fall back to SKILL.md. */
+  prompt?: string | null;
 }
 
-/** Partially update a schedule's cron/enabled/config. Returns undefined if not found. */
+/** Partially update a schedule's cron/enabled/config/prompt. Returns undefined if not found. */
 export function updateSchedule(id: string, patch: UpdateScheduleInput): ScheduleRow | undefined {
   const existing = getSchedule(id);
   if (!existing) return undefined;
@@ -105,12 +104,13 @@ export function updateSchedule(id: string, patch: UpdateScheduleInput): Schedule
   const enabled = patch.enabled === undefined ? existing.enabled : patch.enabled ? 1 : 0;
   const configJson =
     patch.config !== undefined ? JSON.stringify(patch.config) : existing.config_json;
+  const prompt = patch.prompt !== undefined ? patch.prompt : existing.prompt;
 
   getDb()
     .prepare(
-      `UPDATE schedules SET cron = ?, enabled = ?, config_json = ?, updated_at = datetime('now') WHERE id = ?`,
+      `UPDATE schedules SET cron = ?, enabled = ?, config_json = ?, prompt = ?, updated_at = datetime('now') WHERE id = ?`,
     )
-    .run(cron, enabled, configJson, id);
+    .run(cron, enabled, configJson, prompt, id);
 
   logger.info({ schedule_id: id }, 'schedule updated');
   return getSchedule(id);

--- a/server/routes/schedules.ts
+++ b/server/routes/schedules.ts
@@ -8,9 +8,11 @@ import {
   updateSchedule,
   deleteSchedule,
 } from '../repositories/schedules.js';
+import { listRunsForSchedule } from '../repositories/runs.js';
 import { getWorkflow, listCronWorkflowKinds } from '../workflows/registry.js';
 import { validateWorkflowConfig } from '../workflows/config.js';
-import { listTasksBySchedule } from '../repositories/tasks.js';
+import { executeScheduleRun } from '../poller/execute-schedule-run.js';
+import { getDefaultPromptForKind, isCronPromptKind } from '../schedule-prompt.js';
 import { badRequest, notFound, ServiceError } from '../services/errors.js';
 
 const logger = childLogger('routes/schedules');
@@ -51,6 +53,16 @@ router.get('/api/schedules/kinds', (_req: Request, res: Response) => {
   });
 });
 
+router.get('/api/schedules/prompt-default', async (req: Request, res: Response) => {
+  const kind = req.query.kind as string | undefined;
+  const repoPath = req.query.repo_path as string | undefined;
+  if (!kind || !isCronPromptKind(kind)) {
+    throw badRequest(`kind must be one of: ${listCronWorkflowKinds().join(', ')}`);
+  }
+  const content = await getDefaultPromptForKind(kind, repoPath);
+  res.json({ content });
+});
+
 router.get('/api/schedules', (_req: Request, res: Response) => {
   res.json(listSchedules());
 });
@@ -62,6 +74,7 @@ router.post('/api/schedules', (req: Request, res: Response) => {
     cron?: unknown;
     enabled?: unknown;
     config?: unknown;
+    prompt?: unknown;
   };
 
   if (typeof body.kind !== 'string') {
@@ -74,6 +87,9 @@ router.post('/api/schedules', (req: Request, res: Response) => {
   if (typeof body.cron !== 'string' || !body.cron.trim()) {
     throw badRequest('cron is required');
   }
+  if (body.prompt !== undefined && body.prompt !== null && typeof body.prompt !== 'string') {
+    throw badRequest('prompt must be a string or null');
+  }
   validateScheduleConfig(body.kind, body.config);
 
   const row = upsertSchedule({
@@ -82,6 +98,7 @@ router.post('/api/schedules', (req: Request, res: Response) => {
     cron: body.cron,
     enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
     config: body.config as Record<string, unknown> | undefined,
+    prompt: body.prompt as string | null | undefined,
   });
 
   logger.info({ schedule_id: row.id, kind: row.kind }, 'schedule: created via API');
@@ -90,13 +107,21 @@ router.post('/api/schedules', (req: Request, res: Response) => {
 
 router.patch('/api/schedules/:id', (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
-  const body = req.body as { cron?: unknown; enabled?: unknown; config?: unknown };
+  const body = req.body as {
+    cron?: unknown;
+    enabled?: unknown;
+    config?: unknown;
+    prompt?: unknown;
+  };
 
   if (body.cron !== undefined && (typeof body.cron !== 'string' || !body.cron.trim())) {
     throw badRequest('cron must be a non-empty string');
   }
   if (body.enabled !== undefined && typeof body.enabled !== 'boolean') {
     throw badRequest('enabled must be a boolean');
+  }
+  if (body.prompt !== undefined && body.prompt !== null && typeof body.prompt !== 'string') {
+    throw badRequest('prompt must be a string or null');
   }
 
   const existing = getSchedule(id);
@@ -109,10 +134,19 @@ router.patch('/api/schedules/:id', (req: Request, res: Response) => {
     cron: body.cron as string | undefined,
     enabled: body.enabled as boolean | undefined,
     config: body.config as Record<string, unknown> | undefined,
+    prompt: body.prompt as string | null | undefined,
   });
   if (!updated) throw notFound('Schedule not found');
 
   res.json(updated);
+});
+
+router.post('/api/schedules/:id/run', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  if (!getSchedule(id)) throw notFound('Schedule not found');
+
+  await executeScheduleRun(id, { trigger: 'manual' });
+  res.status(202).json({ ok: true });
 });
 
 router.delete('/api/schedules/:id', (req: Request, res: Response) => {
@@ -127,5 +161,5 @@ router.get('/api/schedules/:id/runs', (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   if (!getSchedule(id)) throw notFound('Schedule not found');
 
-  res.json({ runs: listTasksBySchedule(id) });
+  res.json({ runs: listRunsForSchedule(id) });
 });

--- a/server/schedule-prompt.test.ts
+++ b/server/schedule-prompt.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createTestDb } from './test-helpers.js';
+import { upsertSchedule } from './repositories/schedules.js';
+
+const mockGetSkill = vi.fn();
+
+vi.mock('./skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+
+import {
+  resolveSchedulePrompt,
+  getDefaultPromptForKind,
+  skillContentOverridesForSchedule,
+} from './schedule-prompt.js';
+
+describe('schedule-prompt', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockGetSkill.mockReset();
+    mockGetSkill.mockResolvedValue({ name: 'weekly-update', content: 'Default SKILL body' });
+  });
+
+  it('getDefaultPromptForKind loads the shipped skill', async () => {
+    const content = await getDefaultPromptForKind('weekly-update', '/repo');
+    expect(content).toBe('Default SKILL body');
+    expect(mockGetSkill).toHaveBeenCalledWith('weekly-update', { repoPath: '/repo' });
+  });
+
+  it('resolveSchedulePrompt uses DB prompt when set', async () => {
+    const row = upsertSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      prompt: 'Custom DB prompt',
+    });
+
+    const content = await resolveSchedulePrompt({
+      scheduleId: row.id,
+      kind: 'weekly-update',
+      repoPath: '/repo',
+    });
+
+    expect(content).toBe('Custom DB prompt');
+    expect(mockGetSkill).not.toHaveBeenCalled();
+  });
+
+  it('resolveSchedulePrompt falls back to SKILL.md when DB prompt is null', async () => {
+    const row = upsertSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+    });
+
+    const content = await resolveSchedulePrompt({
+      scheduleId: row.id,
+      kind: 'weekly-update',
+    });
+
+    expect(content).toBe('Default SKILL body');
+    expect(mockGetSkill).toHaveBeenCalledWith('weekly-update', { repoPath: '/repo' });
+  });
+
+  it('skillContentOverridesForSchedule returns override only for task-backed kinds', () => {
+    expect(skillContentOverridesForSchedule({ kind: 'doc-drift', prompt: 'Override' })).toEqual({
+      'doc-drift': 'Override',
+    });
+    expect(
+      skillContentOverridesForSchedule({ kind: 'weekly-update', prompt: 'Override' }),
+    ).toBeUndefined();
+  });
+});

--- a/server/schedule-prompt.ts
+++ b/server/schedule-prompt.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolve workflow prompts for cron schedules: DB override when set, else the
+ * shipped SKILL.md default. Task-backed kinds also get file overrides via
+ * `syncSkills` so the agent reads the DB prompt from its worktree.
+ */
+import { getSkill } from './skills.js';
+import { getSchedule } from './repositories/schedules.js';
+
+export const CRON_PROMPT_KINDS = [
+  'doc-drift',
+  'prod-log-triage',
+  'weekly-update',
+  'overnight-log-summary',
+  'daily-plan',
+] as const;
+
+export type CronPromptKind = (typeof CRON_PROMPT_KINDS)[number];
+
+const TASK_BACKED_KINDS = new Set<string>(['doc-drift', 'prod-log-triage']);
+
+export function isCronPromptKind(kind: string): kind is CronPromptKind {
+  return (CRON_PROMPT_KINDS as readonly string[]).includes(kind);
+}
+
+/** Load the shipped SKILL.md body for a cron workflow kind. */
+export async function getDefaultPromptForKind(kind: string, repoPath?: string): Promise<string> {
+  if (!isCronPromptKind(kind)) {
+    throw new Error(`No default prompt for workflow kind: ${kind}`);
+  }
+  const skill = await getSkill(kind, repoPath ? { repoPath } : undefined);
+  return skill.content;
+}
+
+/** DB prompt when present, otherwise the SKILL.md default for this kind/repo. */
+export async function resolveSchedulePrompt(input: {
+  scheduleId?: string | null;
+  kind: string;
+  repoPath?: string;
+}): Promise<string> {
+  if (input.scheduleId) {
+    const schedule = getSchedule(input.scheduleId);
+    if (schedule?.prompt) return schedule.prompt;
+    if (schedule) {
+      return getDefaultPromptForKind(schedule.kind, schedule.repo_path);
+    }
+  }
+  return getDefaultPromptForKind(input.kind, input.repoPath);
+}
+
+/** Overrides to pass into `syncSkills` for task-backed scheduled runs. */
+export function skillContentOverridesForSchedule(schedule: {
+  kind: string;
+  prompt: string | null;
+}): Record<string, string> | undefined {
+  if (!schedule.prompt || !TASK_BACKED_KINDS.has(schedule.kind)) return undefined;
+  return { [schedule.kind]: schedule.prompt };
+}
+
+export function skillContentOverridesForScheduleId(
+  scheduleId: string | null | undefined,
+): Record<string, string> | undefined {
+  if (!scheduleId) return undefined;
+  const schedule = getSchedule(scheduleId);
+  if (!schedule) return undefined;
+  return skillContentOverridesForSchedule(schedule);
+}

--- a/server/services/session-vertical-service.ts
+++ b/server/services/session-vertical-service.ts
@@ -17,6 +17,7 @@ export interface RunSessionVerticalInput {
   input: string;
   outputSchema: object;
   model?: string | null;
+  trigger?: 'cron' | 'manual';
 }
 
 export async function runSessionVertical<T = unknown>(
@@ -29,6 +30,10 @@ export async function runSessionVertical<T = unknown>(
     substrate: ptySubstrate,
     outputSchema: i.outputSchema,
     model: i.model ?? null,
-    run: { workflowKind: i.kind, trigger: 'cron', scheduleId: i.scheduleId ?? undefined },
+    run: {
+      workflowKind: i.kind,
+      trigger: i.trigger ?? 'cron',
+      scheduleId: i.scheduleId ?? undefined,
+    },
   });
 }

--- a/server/skills.repo.test.ts
+++ b/server/skills.repo.test.ts
@@ -57,4 +57,19 @@ describe('skills repo precedence', () => {
 
     fs.rmSync(worktree, { recursive: true, force: true });
   });
+
+  it('syncSkills writes schedule prompt overrides into the worktree skill file', async () => {
+    const worktree = path.join(os.tmpdir(), `octomux-skills-override-${Date.now()}`);
+    fs.mkdirSync(worktree, { recursive: true });
+
+    await syncSkills(worktree, {
+      skillContentOverrides: { 'prod-log-triage': '# DB override prompt' },
+    });
+
+    const synced = path.join(worktree, '.claude', 'skills', 'prod-log-triage', 'SKILL.md');
+    expect(fs.existsSync(synced)).toBe(true);
+    expect(fs.readFileSync(synced, 'utf-8')).toBe('# DB override prompt');
+
+    fs.rmSync(worktree, { recursive: true, force: true });
+  });
 });

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -20,6 +20,11 @@ export interface SkillsOptions {
   repoPath?: string;
 }
 
+export interface SyncSkillsOptions extends SkillsOptions {
+  /** Per-skill SKILL.md body overrides (e.g. schedule DB prompt for task-backed kinds). */
+  skillContentOverrides?: Record<string, string>;
+}
+
 const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 function validateName(name: string): void {
@@ -177,16 +182,18 @@ export async function deleteSkill(name: string, opts?: SkillsOptions): Promise<v
  * Mirror effective skills (repo → home → built-in) into `<worktree>/.claude/skills/`
  * so Claude Code resolves them in the worktree without touching `~/.claude/skills`.
  */
-export async function syncSkills(worktreePath: string): Promise<void> {
+export async function syncSkills(worktreePath: string, opts?: SyncSkillsOptions): Promise<void> {
   const targetDir = path.join(worktreePath, '.claude', 'skills');
   await fs.promises.mkdir(targetDir, { recursive: true });
 
-  const opts: SkillsOptions = { repoPath: worktreePath };
-  const skills = await listSkills(opts);
+  const skillsOpts: SkillsOptions = { repoPath: worktreePath, ...opts };
+  const overrides = opts?.skillContentOverrides ?? {};
+  const skills = await listSkills(skillsOpts);
   for (const skill of skills) {
-    const detail = await getSkill(skill.name, opts);
+    const detail = await getSkill(skill.name, skillsOpts);
+    const content = overrides[skill.name] ?? detail.content;
     const skillDir = path.join(targetDir, skill.name);
     await fs.promises.mkdir(skillDir, { recursive: true });
-    await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), detail.content, 'utf-8');
+    await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
   }
 }

--- a/server/task-engine/lifecycle/add-agent.ts
+++ b/server/task-engine/lifecycle/add-agent.ts
@@ -6,6 +6,7 @@ import { getSettings } from '../../settings.js';
 import { getHarness } from '../../harnesses/index.js';
 import { hookBaseUrl } from '../../hook-base-url.js';
 import { syncSkills } from '../../skills.js';
+import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import { childLogger } from '../../logger.js';
 import {
   listActiveAgents,
@@ -76,7 +77,11 @@ export async function prepareAddAgentLaunch(
   const { sessionIdForDb, sessionIdForLaunch } = computeFreshSessionIds(harness);
 
   await harness.syncAgents(task.worktree!);
-  await syncSkills(task.worktree!);
+  await syncSkills(task.worktree!, {
+    skillContentOverrides: skillContentOverridesForScheduleId(
+      (task as { schedule_id?: string | null }).schedule_id,
+    ),
+  });
   await harness.installHooks(task.worktree!, hookBaseUrl(), hookToken);
 
   const baseCmd = harness.buildLaunchCommand({

--- a/server/task-engine/lifecycle/hop-agent.ts
+++ b/server/task-engine/lifecycle/hop-agent.ts
@@ -5,12 +5,12 @@ import { hookBaseUrl } from '../../hook-base-url.js';
 import { childLogger } from '../../logger.js';
 import { execTmux } from '../../tmux-bin.js';
 import { syncSkills } from '../../skills.js';
+import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import { chatDirFor, chatSessionName } from '../../chats.js';
 import type { Agent, Worktree } from '../../types.js';
 import {
   getTask as getTaskRepo,
   getTaskTmuxSession,
-  getTaskModel,
   getWorktree,
   hopAgentToTask,
   getAgent,
@@ -88,13 +88,17 @@ export async function hopAgent(agent: Agent, targetTaskId: string | null): Promi
   const flags = harness.resolveFlags(await getSettings());
 
   let hopModel: string | null = null;
-  if (targetTaskId) {
-    const hopTask = getTaskModel(targetTaskId);
-    hopModel = hopTask?.model ?? null;
+  const hopTask = targetTaskId ? getTaskRepo(targetTaskId) : null;
+  if (hopTask) {
+    hopModel = hopTask.model ?? null;
   }
 
   await harness.syncAgents(cwd);
-  await syncSkills(cwd);
+  await syncSkills(cwd, {
+    skillContentOverrides: skillContentOverridesForScheduleId(
+      (hopTask as { schedule_id?: string | null } | null)?.schedule_id,
+    ),
+  });
   await harness.installHooks(cwd, hookBaseUrl(), agent.hook_token);
 
   const baseCmd = prepareResumeLaunch({ agent, harness, flags, model: hopModel, cwd });

--- a/server/task-engine/lifecycle/respawn-agent.ts
+++ b/server/task-engine/lifecycle/respawn-agent.ts
@@ -2,6 +2,7 @@ import { getSettings } from '../../settings.js';
 import { getHarness } from '../../harnesses/index.js';
 import { hookBaseUrl } from '../../hook-base-url.js';
 import { syncSkills } from '../../skills.js';
+import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import { childLogger } from '../../logger.js';
 import { broadcast } from '../../events.js';
 import { execTmux } from '../../tmux-bin.js';
@@ -47,7 +48,11 @@ export async function respawnAgentFresh(
   const { sessionIdForDb, sessionIdForLaunch } = computeFreshSessionIds(harness);
 
   await harness.syncAgents(task.worktree!);
-  await syncSkills(task.worktree!);
+  await syncSkills(task.worktree!, {
+    skillContentOverrides: skillContentOverridesForScheduleId(
+      (task as { schedule_id?: string | null }).schedule_id,
+    ),
+  });
   await harness.installHooks(task.worktree!, hookBaseUrl(), agent.hook_token);
 
   const baseCmd = harness.buildLaunchCommand({

--- a/server/task-engine/lifecycle/resume-task.ts
+++ b/server/task-engine/lifecycle/resume-task.ts
@@ -6,6 +6,7 @@ import { childLogger } from '../../logger.js';
 import { tmuxWindowSubstrate } from '../../agent-session/substrate-tmux-windowed.js';
 import { execTmux } from '../../tmux-bin.js';
 import { syncSkills } from '../../skills.js';
+import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import type { Task, RunMode } from '../../types.js';
 import {
   setRuntimeState,
@@ -71,7 +72,11 @@ export async function bootstrapResumeHooks(
   if (agents.length > 0) {
     const bootstrapHarness = getHarness(agents[0]!.harness_id);
     await bootstrapHarness.syncAgents(cwd);
-    await syncSkills(cwd);
+    await syncSkills(cwd, {
+      skillContentOverrides: skillContentOverridesForScheduleId(
+        (task as { schedule_id?: string | null }).schedule_id,
+      ),
+    });
     await bootstrapHarness.installHooks(cwd, hookBaseUrl(), agents[0]!.hook_token);
   } else {
     await tmuxWindowSubstrate.createEmptySession({ session, cwd });

--- a/server/task-engine/lifecycle/start-task.ts
+++ b/server/task-engine/lifecycle/start-task.ts
@@ -10,6 +10,7 @@ import { inferRefs } from '../../ref-inference.js';
 import { childLogger } from '../../logger.js';
 import { broadcast } from '../../events.js';
 import { syncSkills } from '../../skills.js';
+import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import type { RepoConfig } from '../../repositories/repo-config.js';
 import type { Task, RunMode } from '../../types.js';
 import {
@@ -154,7 +155,11 @@ async function prepareFirstAgentLaunch(
   const { sessionIdForDb, sessionIdForLaunch } = computeFreshSessionIds(harness);
 
   await harness.syncAgents(setup.worktreePath);
-  await syncSkills(setup.worktreePath);
+  await syncSkills(setup.worktreePath, {
+    skillContentOverrides: skillContentOverridesForScheduleId(
+      (task as { schedule_id?: string | null }).schedule_id,
+    ),
+  });
   await harness.installHooks(setup.worktreePath, hookBaseUrl(), hookToken);
 
   flags = applyOrchestratorMcpConfig(flags, setup.worktreePath, id, hookToken);

--- a/server/workflows/daily-plan/index.ts
+++ b/server/workflows/daily-plan/index.ts
@@ -7,7 +7,8 @@ export const dailyPlanWorkflow: WorkflowType = {
   displayName: 'Daily Plan',
   surfaces: ['session'],
   trigger: { kind: 'cron' },
-  run: (ctx: RunContext) => runDailyPlanFromSchedule({ scheduleId: ctx.scheduleId! }),
+  run: (ctx: RunContext) =>
+    runDailyPlanFromSchedule({ scheduleId: ctx.scheduleId!, trigger: ctx.trigger }),
 };
 
 registerWorkflow(dailyPlanWorkflow);

--- a/server/workflows/daily-plan/run.test.ts
+++ b/server/workflows/daily-plan/run.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestDb } from '../../test-helpers.js';
 import { getDb } from '../../db.js';
 
-const mockGetSkill = vi.fn();
+const mockResolveSchedulePrompt = vi.fn();
 const mockCreateChat = vi.fn();
 
-vi.mock('../../skills.js', () => ({
-  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+vi.mock('../../schedule-prompt.js', () => ({
+  resolveSchedulePrompt: (...args: unknown[]) => mockResolveSchedulePrompt(...args),
 }));
 vi.mock('../../chats.js', () => ({
   createChat: (...args: unknown[]) => mockCreateChat(...args),
@@ -21,17 +21,20 @@ import type { RunResult } from '../../types.js';
 describe('runDailyPlanFromSchedule', () => {
   beforeEach(() => {
     createTestDb();
-    mockGetSkill.mockReset();
+    mockResolveSchedulePrompt.mockReset();
     mockCreateChat.mockReset();
   });
 
-  it('starts a chat with the skill prompt and inserts a run row with chat_id set', async () => {
-    mockGetSkill.mockResolvedValue({ name: 'daily-plan', content: 'Prep the day.' });
+  it('starts a chat with the resolved prompt and inserts a run row with chat_id set', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Prep the day.');
     mockCreateChat.mockResolvedValue({ id: 'chat-1' });
 
-    await runDailyPlanFromSchedule({ scheduleId: 'sched-1' });
+    await runDailyPlanFromSchedule({ scheduleId: 'sched-1', trigger: 'manual' });
 
-    expect(mockGetSkill).toHaveBeenCalledWith('daily-plan');
+    expect(mockResolveSchedulePrompt).toHaveBeenCalledWith({
+      scheduleId: 'sched-1',
+      kind: 'daily-plan',
+    });
     expect(mockCreateChat).toHaveBeenCalledWith({ prompt: 'Prep the day.' });
 
     const rows = getDb()
@@ -40,7 +43,7 @@ describe('runDailyPlanFromSchedule', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].chat_id).toBe('chat-1');
     expect(rows[0].schedule_id).toBe('sched-1');
-    expect(rows[0].trigger).toBe('cron');
+    expect(rows[0].trigger).toBe('manual');
   });
 });
 

--- a/server/workflows/daily-plan/run.ts
+++ b/server/workflows/daily-plan/run.ts
@@ -3,7 +3,7 @@
  * an interactive chat (not a headless session) — the agent preps the day's
  * plan, then waits for the user to join and steer.
  */
-import { getSkill } from '../../skills.js';
+import { resolveSchedulePrompt } from '../../schedule-prompt.js';
 import { createChat } from '../../chats.js';
 import { insertRun, listRunsForWorkflow, finishRun } from '../../repositories/runs.js';
 import { childLogger } from '../../logger.js';
@@ -13,17 +13,22 @@ const logger = childLogger('workflows/daily-plan');
 
 export interface RunDailyPlanFromScheduleInput {
   scheduleId: string;
+  trigger?: 'cron' | 'manual';
 }
 
 export async function runDailyPlanFromSchedule(
   input: RunDailyPlanFromScheduleInput,
 ): Promise<void> {
-  const skill = await getSkill('daily-plan');
-  const agent = await createChat({ prompt: skill.content });
+  const prompt = await resolveSchedulePrompt({
+    scheduleId: input.scheduleId,
+    kind: 'daily-plan',
+  });
+  const agent = await createChat({ prompt });
+  const trigger = input.trigger ?? 'cron';
 
   insertRun({
     workflowKind: 'daily-plan',
-    trigger: 'cron',
+    trigger,
     scheduleId: input.scheduleId,
     chatId: agent.id,
   });

--- a/server/workflows/doc-drift/index.test.ts
+++ b/server/workflows/doc-drift/index.test.ts
@@ -21,6 +21,7 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     enabled: 1,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }

--- a/server/workflows/doc-drift/index.ts
+++ b/server/workflows/doc-drift/index.ts
@@ -24,6 +24,7 @@ export const docDriftWorkflow: WorkflowType = {
       verify: cfg.verify,
       maxIterations: cfg.maxIterations,
       scheduleId: ctx.scheduleId,
+      trigger: ctx.trigger,
     });
   },
 };

--- a/server/workflows/doc-drift/run.ts
+++ b/server/workflows/doc-drift/run.ts
@@ -24,6 +24,7 @@ export interface CreateDocDriftTaskFromScheduleInput {
   maxIterations: number;
   /** Set when this run was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
+  trigger?: 'cron' | 'manual';
 }
 
 export interface CreateDocDriftTaskResult {
@@ -76,6 +77,7 @@ export async function createDocDriftTaskFromSchedule(
   // to do it for us.
   const settled = getTask(id);
   const activeAgent = findFirstActiveAgent(id);
+  const trigger = input.trigger ?? 'cron';
   if (!settled || settled.runtime_state === 'error' || !activeAgent) {
     logger.warn(
       { task_id: id, runtime_state: settled?.runtime_state },
@@ -83,7 +85,7 @@ export async function createDocDriftTaskFromSchedule(
     );
     const failedRun = insertRun({
       workflowKind: 'doc-drift',
-      trigger: 'cron',
+      trigger,
       scheduleId: input.scheduleId,
       taskId: id,
     });
@@ -101,7 +103,7 @@ export async function createDocDriftTaskFromSchedule(
   const loopRunId = nanoid(12);
   const runsRow = insertRun({
     workflowKind: 'doc-drift',
-    trigger: 'cron',
+    trigger,
     scheduleId: input.scheduleId,
     taskId: id,
     loopRunId,

--- a/server/workflows/overnight-log-summary/index.test.ts
+++ b/server/workflows/overnight-log-summary/index.test.ts
@@ -20,6 +20,7 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     enabled: 1,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }

--- a/server/workflows/overnight-log-summary/index.ts
+++ b/server/workflows/overnight-log-summary/index.ts
@@ -25,6 +25,7 @@ export const overnightLogSummaryWorkflow: WorkflowType = {
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,
       logCommand: cfg.logCommand,
+      trigger: ctx.trigger,
     }).catch((err) => {
       logger.error(
         { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },

--- a/server/workflows/overnight-log-summary/run.ts
+++ b/server/workflows/overnight-log-summary/run.ts
@@ -3,7 +3,7 @@
  * interpolates the schedule's log command, and runs it as a headless
  * `runSessionVertical` call (session run — no task/worktree/loop).
  */
-import { getSkill } from '../../skills.js';
+import { resolveSchedulePrompt } from '../../schedule-prompt.js';
 import { repoShortName } from '../../review-tasks.js';
 import { runSessionVertical } from '../../services/session-vertical-service.js';
 import { OVERNIGHT_LOG_SUMMARY_SCHEMA } from './schema.js';
@@ -12,6 +12,7 @@ export interface RunOvernightLogSummaryInput {
   repoPath: string;
   scheduleId?: string | null;
   logCommand: string;
+  trigger?: 'cron' | 'manual';
 }
 
 export interface OvernightLogSummaryResult {
@@ -24,8 +25,12 @@ export interface OvernightLogSummaryResult {
 export async function runOvernightLogSummary(
   input: RunOvernightLogSummaryInput,
 ): Promise<{ result: OvernightLogSummaryResult }> {
-  const skill = await getSkill('overnight-log-summary', { repoPath: input.repoPath });
-  const prompt = skill.content
+  const skillContent = await resolveSchedulePrompt({
+    scheduleId: input.scheduleId,
+    kind: 'overnight-log-summary',
+    repoPath: input.repoPath,
+  });
+  const prompt = skillContent
     .replace(/\{\{logCommand\}\}/g, input.logCommand)
     .replace(/\{\{repoShort\}\}/g, repoShortName(input.repoPath));
 
@@ -35,5 +40,6 @@ export async function runOvernightLogSummary(
     workspaceDir: input.repoPath,
     input: prompt,
     outputSchema: OVERNIGHT_LOG_SUMMARY_SCHEMA,
+    trigger: input.trigger ?? 'cron',
   });
 }

--- a/server/workflows/prod-log-triage/index.test.ts
+++ b/server/workflows/prod-log-triage/index.test.ts
@@ -20,6 +20,7 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     enabled: 1,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }

--- a/server/workflows/prod-log-triage/index.ts
+++ b/server/workflows/prod-log-triage/index.ts
@@ -24,6 +24,7 @@ export const prodLogTriageWorkflow: WorkflowType = {
       verify: cfg.verify,
       maxIterations: cfg.maxIterations,
       scheduleId: ctx.scheduleId,
+      trigger: ctx.trigger,
     });
   },
 };

--- a/server/workflows/prod-log-triage/run.ts
+++ b/server/workflows/prod-log-triage/run.ts
@@ -25,6 +25,7 @@ export interface CreateTriageTaskFromScheduleInput {
   maxIterations: number;
   /** Set when this run was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
+  trigger?: 'cron' | 'manual';
 }
 
 export interface CreateTriageTaskResult {
@@ -78,6 +79,7 @@ export async function createTriageTaskFromSchedule(
   // to do it for us.
   const settled = getTask(id);
   const activeAgent = findFirstActiveAgent(id);
+  const trigger = input.trigger ?? 'cron';
   if (!settled || settled.runtime_state === 'error' || !activeAgent) {
     logger.warn(
       { task_id: id, runtime_state: settled?.runtime_state },
@@ -85,7 +87,7 @@ export async function createTriageTaskFromSchedule(
     );
     const failedRun = insertRun({
       workflowKind: 'prod-log-triage',
-      trigger: 'cron',
+      trigger,
       scheduleId: input.scheduleId,
       taskId: id,
     });
@@ -103,7 +105,7 @@ export async function createTriageTaskFromSchedule(
   const loopRunId = nanoid(12);
   const runsRow = insertRun({
     workflowKind: 'prod-log-triage',
-    trigger: 'cron',
+    trigger,
     scheduleId: input.scheduleId,
     taskId: id,
     loopRunId,

--- a/server/workflows/types.ts
+++ b/server/workflows/types.ts
@@ -11,6 +11,8 @@ export interface RunContext {
   scheduleId?: string;
   /** Present for github triggers. */
   event?: unknown;
+  /** How this invocation was triggered — cron poller or manual run-now. */
+  trigger?: 'cron' | 'manual';
 }
 
 export interface WorkflowType {

--- a/server/workflows/weekly-update/index.test.ts
+++ b/server/workflows/weekly-update/index.test.ts
@@ -19,6 +19,7 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     enabled: 1,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }

--- a/server/workflows/weekly-update/index.ts
+++ b/server/workflows/weekly-update/index.ts
@@ -21,6 +21,7 @@ export const weeklyUpdateWorkflow: WorkflowType = {
     void runWeeklyUpdate({
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,
+      trigger: ctx.trigger,
     }).catch((err) => {
       logger.error(
         { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },

--- a/server/workflows/weekly-update/run.test.ts
+++ b/server/workflows/weekly-update/run.test.ts
@@ -1,46 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockGetSkill = vi.fn();
-const mockRunSessionVertical = vi.fn();
+const mockResolveSchedulePrompt = vi.fn();
 
-vi.mock('../../skills.js', () => ({
-  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+vi.mock('../../schedule-prompt.js', () => ({
+  resolveSchedulePrompt: (...args: unknown[]) => mockResolveSchedulePrompt(...args),
 }));
 vi.mock('../../services/session-vertical-service.js', () => ({
-  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+  runSessionVertical: vi.fn().mockResolvedValue({ result: { period: 'Mon 1 - 5' } }),
 }));
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
 import { runWeeklyUpdate } from './run.js';
 import { WEEKLY_UPDATE_SCHEMA } from './schema.js';
+import { runSessionVertical } from '../../services/session-vertical-service.js';
 
 describe('runWeeklyUpdate', () => {
   beforeEach(() => {
-    mockGetSkill.mockReset();
-    mockRunSessionVertical.mockReset();
+    mockResolveSchedulePrompt.mockReset();
+    vi.mocked(runSessionVertical).mockClear();
   });
 
-  it('loads the skill and calls runSessionVertical with its content as input', async () => {
-    mockGetSkill.mockResolvedValue({
-      name: 'weekly-update',
-      content: 'Summarize the week.',
-    });
-    mockRunSessionVertical.mockResolvedValue({ result: { period: 'Mon 1 - 5' } });
+  it('loads the prompt via resolveSchedulePrompt and calls runSessionVertical', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Summarize the week.');
 
     const { result } = await runWeeklyUpdate({
       repoPath: '/repos/my-app',
       scheduleId: 'sched-1',
+      trigger: 'manual',
     });
 
     expect(result).toEqual({ period: 'Mon 1 - 5' });
-    expect(mockGetSkill).toHaveBeenCalledWith('weekly-update', { repoPath: '/repos/my-app' });
-    expect(mockRunSessionVertical).toHaveBeenCalledTimes(1);
-    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(mockResolveSchedulePrompt).toHaveBeenCalledWith({
+      scheduleId: 'sched-1',
+      kind: 'weekly-update',
+      repoPath: '/repos/my-app',
+    });
+    expect(runSessionVertical).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runSessionVertical).mock.calls[0][0];
     expect(call.kind).toBe('weekly-update');
     expect(call.scheduleId).toBe('sched-1');
     expect(call.workspaceDir).toBe('/repos/my-app');
     expect(call.input).toBe('Summarize the week.');
     expect(call.outputSchema).toBe(WEEKLY_UPDATE_SCHEMA);
+    expect(call.trigger).toBe('manual');
   });
 });

--- a/server/workflows/weekly-update/run.ts
+++ b/server/workflows/weekly-update/run.ts
@@ -3,13 +3,14 @@
  * runs it as a headless `runSessionVertical` call (session run — no
  * task/worktree/loop).
  */
-import { getSkill } from '../../skills.js';
+import { resolveSchedulePrompt } from '../../schedule-prompt.js';
 import { runSessionVertical } from '../../services/session-vertical-service.js';
 import { WEEKLY_UPDATE_SCHEMA } from './schema.js';
 
 export interface RunWeeklyUpdateInput {
   repoPath: string;
   scheduleId?: string | null;
+  trigger?: 'cron' | 'manual';
 }
 
 export interface WeeklyUpdateResult {
@@ -21,13 +22,18 @@ export interface WeeklyUpdateResult {
 export async function runWeeklyUpdate(
   input: RunWeeklyUpdateInput,
 ): Promise<{ result: WeeklyUpdateResult }> {
-  const skill = await getSkill('weekly-update', { repoPath: input.repoPath });
+  const prompt = await resolveSchedulePrompt({
+    scheduleId: input.scheduleId,
+    kind: 'weekly-update',
+    repoPath: input.repoPath,
+  });
 
   return runSessionVertical<WeeklyUpdateResult>({
     kind: 'weekly-update',
     scheduleId: input.scheduleId,
     workspaceDir: input.repoPath,
-    input: skill.content,
+    input: prompt,
     outputSchema: WEEKLY_UPDATE_SCHEMA,
+    trigger: input.trigger ?? 'cron',
   });
 }

--- a/src/components/schedules/SchemaConfigForm.tsx
+++ b/src/components/schedules/SchemaConfigForm.tsx
@@ -1,5 +1,8 @@
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { FormSelect } from '@/components/ui/form-select';
 
 interface SchemaProperty {
   type?: string;
@@ -7,6 +10,7 @@ interface SchemaProperty {
   description?: string;
   default?: unknown;
   minimum?: number;
+  enum?: string[];
 }
 
 interface SchemaConfigFormProps {
@@ -64,13 +68,53 @@ export function SchemaConfigForm({ schema, value, onChange }: SchemaConfigFormPr
           );
         }
 
+        if (prop.type === 'boolean') {
+          return (
+            <div key={key} className="flex flex-col gap-1.5">
+              <Label>{label}</Label>
+              <Switch
+                data-testid={`schedule-config-${key}`}
+                checked={current === true}
+                onChange={(checked) => onChange({ ...value, [key]: checked })}
+              />
+              {prop.description ? (
+                <p className="text-[10px] text-muted-soft">{prop.description}</p>
+              ) : null}
+            </div>
+          );
+        }
+
+        if (prop.enum && prop.enum.length > 0) {
+          return (
+            <div key={key} className="flex flex-col gap-1.5">
+              <Label htmlFor={`config-${key}`}>{label}</Label>
+              <FormSelect
+                id={`config-${key}`}
+                data-testid={`schedule-config-${key}`}
+                value={typeof current === 'string' ? current : ''}
+                onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+              >
+                {prop.enum.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </FormSelect>
+              {prop.description ? (
+                <p className="text-[10px] text-muted-soft">{prop.description}</p>
+              ) : null}
+            </div>
+          );
+        }
+
         return (
           <div key={key} className="flex flex-col gap-1.5 sm:col-span-2">
             <Label htmlFor={`config-${key}`}>{label}</Label>
-            <Input
+            <Textarea
               id={`config-${key}`}
               data-testid={`schedule-config-${key}`}
               className={key === 'verify' || key === 'logCommand' ? 'font-mono text-sm' : undefined}
+              rows={key === 'verify' || key === 'logCommand' ? 3 : 4}
               value={typeof current === 'string' ? current : ''}
               onChange={(e) => onChange({ ...value, [key]: e.target.value })}
             />

--- a/src/lib/api/schedulesApi.ts
+++ b/src/lib/api/schedulesApi.ts
@@ -5,7 +5,7 @@
  * fired runs. Mirrors `server/routes/schedules.ts`.
  */
 
-import type { Task } from '@octomux/types';
+import type { WorkflowRunRow } from './workflowsApi';
 import { request } from './client';
 
 export interface ScheduleRow {
@@ -16,6 +16,7 @@ export interface ScheduleRow {
   enabled: number;
   last_run_at: string | null;
   config_json: string | null;
+  prompt: string | null;
 }
 
 export interface ScheduleKindInfo {
@@ -30,21 +31,30 @@ export interface CreateScheduleInput {
   cron: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  prompt?: string | null;
 }
 
 export interface UpdateScheduleInput {
   cron?: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  prompt?: string | null;
 }
 
 export const schedulesApi = {
   listSchedules: () => request<ScheduleRow[]>('/schedules'),
   getScheduleKinds: () => request<{ kinds: ScheduleKindInfo[] }>('/schedules/kinds'),
+  getDefaultPrompt: (kind: string, repoPath?: string) => {
+    const params = new URLSearchParams({ kind });
+    if (repoPath) params.set('repo_path', repoPath);
+    return request<{ content: string }>(`/schedules/prompt-default?${params}`);
+  },
   createSchedule: (data: CreateScheduleInput) =>
     request<ScheduleRow>('/schedules', { method: 'POST', body: JSON.stringify(data) }),
   updateSchedule: (id: string, data: UpdateScheduleInput) =>
     request<ScheduleRow>(`/schedules/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   deleteSchedule: (id: string) => request<void>(`/schedules/${id}`, { method: 'DELETE' }),
-  getScheduleRuns: (id: string) => request<{ runs: Task[] }>(`/schedules/${id}/runs`),
+  runScheduleNow: (id: string) =>
+    request<{ ok: boolean }>(`/schedules/${id}/run`, { method: 'POST' }),
+  getScheduleRuns: (id: string) => request<{ runs: WorkflowRunRow[] }>(`/schedules/${id}/runs`),
 };

--- a/src/lib/api/workflowsApi.ts
+++ b/src/lib/api/workflowsApi.ts
@@ -28,6 +28,7 @@ export interface WorkflowRunRow {
   trigger: string;
   status: string;
   effective_status: string;
+  schedule_id: string | null;
   task_id: string | null;
   loop_run_id: string | null;
   chat_id: string | null;

--- a/src/pages/RunsPage.test.tsx
+++ b/src/pages/RunsPage.test.tsx
@@ -31,6 +31,7 @@ function makeRun(overrides: Partial<WorkflowRunRow> = {}): WorkflowRunRow {
     trigger: 'cron',
     status: 'done',
     effective_status: 'done',
+    schedule_id: null,
     task_id: null,
     loop_run_id: null,
     chat_id: null,
@@ -163,5 +164,18 @@ describe('RunsPage', () => {
     await user.click(link);
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/w/loops/task-9'));
+  });
+
+  it('links back to the schedule that produced a run', async () => {
+    const user = userEvent.setup();
+    apiMock.listAllRuns.mockResolvedValue({
+      runs: [makeRun({ id: 'run-1', schedule_id: 'sched-42' })],
+    });
+
+    renderWithRouter(<RunsPage />);
+
+    await user.click(await screen.findByTestId('run-schedule-link-run-1'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/schedules?expand=sched-42');
   });
 });

--- a/src/pages/RunsPage.tsx
+++ b/src/pages/RunsPage.tsx
@@ -55,6 +55,19 @@ function RunRow({ run }: { run: WorkflowRunRow }) {
           )}
           {result && <span className="text-[10px] text-muted-soft">{run.effective_status}</span>}
           <span className="text-[10px] text-muted-soft">{timeAgo(run.started_at)}</span>
+          {run.schedule_id && (
+            <button
+              type="button"
+              data-testid={`run-schedule-link-${run.id}`}
+              className="ml-auto text-xs text-muted-foreground hover:text-primary hover:underline"
+              onClick={(e) => {
+                e.stopPropagation();
+                nav(`/schedules?expand=${run.schedule_id}`);
+              }}
+            >
+              Schedule
+            </button>
+          )}
           {deepLink && (
             <button
               type="button"

--- a/src/pages/SchedulesPage.test.tsx
+++ b/src/pages/SchedulesPage.test.tsx
@@ -32,6 +32,7 @@ function makeSchedule(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     enabled: 1,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }
@@ -54,6 +55,7 @@ describe('SchedulesPage', () => {
         },
       ],
     });
+    apiMock.getDefaultPrompt.mockResolvedValue({ content: 'Default skill prompt' });
     apiMock.listLoops.mockResolvedValue([]);
   });
 
@@ -116,9 +118,16 @@ describe('SchedulesPage', () => {
     apiMock.getScheduleRuns.mockResolvedValue({
       runs: [
         {
-          id: 'task-1',
-          title: 'Prod log triage: repo',
-          created_at: '2026-01-01 00:00:00',
+          id: 'run-1',
+          workflow_kind: 'prod-log-triage',
+          trigger: 'cron',
+          status: 'done',
+          effective_status: 'done',
+          schedule_id: 'sched-1',
+          task_id: 'task-1',
+          loop_run_id: null,
+          chat_id: null,
+          started_at: '2026-01-01 00:00:00',
         },
       ],
     });
@@ -127,10 +136,43 @@ describe('SchedulesPage', () => {
 
     await user.click(await screen.findByTestId('schedule-expand-sched-1'));
 
-    const runLink = await screen.findByText('Prod log triage: repo');
+    const runLink = await screen.findByText('prod-log-triage · cron');
     await user.click(runLink);
 
     expect(mockNavigate).toHaveBeenCalledWith('/tasks/task-1');
+  });
+
+  it('saves schedule edits from the expanded detail panel', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([makeSchedule({ id: 'sched-1' })]);
+    apiMock.getScheduleRuns.mockResolvedValue({ runs: [] });
+
+    renderWithRouter(<SchedulesPage />);
+    await user.click(await screen.findByTestId('schedule-expand-sched-1'));
+
+    const cronInput = await screen.findByTestId('schedule-edit-cron-sched-1');
+    await user.clear(cronInput);
+    await user.type(cronInput, '0 9 * * *');
+    await user.click(screen.getByTestId('schedule-save-sched-1'));
+
+    await waitFor(() =>
+      expect(apiMock.updateSchedule).toHaveBeenCalledWith(
+        'sched-1',
+        expect.objectContaining({ cron: '0 9 * * *' }),
+      ),
+    );
+  });
+
+  it('triggers run now from the expanded detail panel', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([makeSchedule({ id: 'sched-1' })]);
+    apiMock.getScheduleRuns.mockResolvedValue({ runs: [] });
+
+    renderWithRouter(<SchedulesPage />);
+    await user.click(await screen.findByTestId('schedule-expand-sched-1'));
+    await user.click(await screen.findByTestId('schedule-run-now-sched-1'));
+
+    await waitFor(() => expect(apiMock.runScheduleNow).toHaveBeenCalledWith('sched-1'));
   });
 
   it('deletes a schedule via the inline confirm dialog (no window.confirm)', async () => {

--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import type { Task } from '@octomux/types';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { schedulesApi, type ScheduleKindInfo, type ScheduleRow } from '@/lib/api/schedulesApi';
-import { loopApi } from '@/lib/api/loopApi';
+import type { WorkflowRunRow } from '@/lib/api/workflowsApi';
 import { useResource } from '@/lib/use-resource';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import { FormSelect } from '@/components/ui/form-select';
 import { Switch } from '@/components/ui/switch';
 import {
@@ -22,6 +22,15 @@ import {
 import { PageHeader } from '@/components/layout/page-header';
 import { timeAgo } from '@/lib/time';
 import { SchemaConfigForm, defaultsFromSchema } from '@/components/schedules/SchemaConfigForm';
+
+function parseConfigJson(configJson: string | null): Record<string, unknown> {
+  if (!configJson) return {};
+  try {
+    return JSON.parse(configJson) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
 
 function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreated: () => void }) {
   const [kind, setKind] = useState('');
@@ -162,26 +171,24 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
   );
 }
 
+function runDestination(run: WorkflowRunRow): string | null {
+  if (run.task_id) return `/tasks/${run.task_id}`;
+  if (run.chat_id) return `/chats/${run.chat_id}`;
+  if (run.loop_run_id) return `/w/loops/${run.loop_run_id}`;
+  return null;
+}
+
 function ScheduleRuns({ scheduleId }: { scheduleId: string }) {
   const nav = useNavigate();
-  const [runs, setRuns] = useState<Task[] | null>(null);
-  const [loopRunByTask, setLoopRunByTask] = useState<Record<string, string>>({});
+  const [runs, setRuns] = useState<WorkflowRunRow[] | null>(null);
+
+  const refresh = useCallback(() => {
+    schedulesApi.getScheduleRuns(scheduleId).then((res) => setRuns(res.runs));
+  }, [scheduleId]);
 
   useEffect(() => {
-    let cancelled = false;
-    Promise.all([schedulesApi.getScheduleRuns(scheduleId), loopApi.listLoops()]).then(
-      ([runsRes, loops]) => {
-        if (cancelled) return;
-        setRuns(runsRes.runs);
-        const map: Record<string, string> = {};
-        for (const l of loops) map[l.task_id] = l.id;
-        setLoopRunByTask(map);
-      },
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [scheduleId]);
+    refresh();
+  }, [refresh]);
 
   if (runs === null) {
     return <p className="px-4 py-2 text-xs text-muted-foreground">Loading runs…</p>;
@@ -192,32 +199,196 @@ function ScheduleRuns({ scheduleId }: { scheduleId: string }) {
 
   return (
     <ul className="flex flex-col gap-1 px-4 py-2">
-      {runs.map((run) => (
-        <li
-          key={run.id}
-          data-testid={`schedule-run-${run.id}`}
-          className="flex items-center gap-2 text-xs"
-        >
-          <button
-            type="button"
-            className="truncate text-foreground hover:text-primary hover:underline"
-            onClick={() => nav(`/tasks/${run.id}`)}
+      {runs.map((run) => {
+        const dest = runDestination(run);
+        const label = `${run.workflow_kind} · ${run.trigger}`;
+        return (
+          <li
+            key={run.id}
+            data-testid={`schedule-run-${run.id}`}
+            className="flex items-center gap-2 text-xs"
           >
-            {run.title || run.id}
-          </button>
-          <span className="text-muted-soft">{timeAgo(run.created_at)}</span>
-          {loopRunByTask[run.id] && (
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-primary hover:underline"
-              onClick={() => nav(`/w/loops/${loopRunByTask[run.id]}`)}
-            >
-              loop
-            </button>
-          )}
-        </li>
-      ))}
+            {dest ? (
+              <button
+                type="button"
+                className="truncate text-foreground hover:text-primary hover:underline"
+                onClick={() => nav(dest)}
+              >
+                {label}
+              </button>
+            ) : (
+              <span className="truncate text-foreground">{label}</span>
+            )}
+            <Badge variant="outline" className="text-[10px]">
+              {run.effective_status}
+            </Badge>
+            <span className="text-muted-soft">{timeAgo(run.started_at)}</span>
+          </li>
+        );
+      })}
     </ul>
+  );
+}
+
+function ScheduleDetail({
+  row,
+  kindInfo,
+  onSaved,
+  onRunStarted,
+}: {
+  row: ScheduleRow;
+  kindInfo: ScheduleKindInfo | null;
+  onSaved: () => void;
+  onRunStarted: () => void;
+}) {
+  const [cron, setCron] = useState(row.cron);
+  const [enabled, setEnabled] = useState(row.enabled === 1);
+  const [config, setConfig] = useState<Record<string, unknown>>(() =>
+    parseConfigJson(row.config_json),
+  );
+  const [prompt, setPrompt] = useState(row.prompt ?? '');
+  const [defaultPrompt, setDefaultPrompt] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCron(row.cron);
+    setEnabled(row.enabled === 1);
+    setConfig(parseConfigJson(row.config_json));
+    setPrompt(row.prompt ?? '');
+  }, [row]);
+
+  useEffect(() => {
+    let cancelled = false;
+    schedulesApi.getDefaultPrompt(row.kind, row.repo_path).then((res) => {
+      if (!cancelled) setDefaultPrompt(res.content);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [row.kind, row.repo_path]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await schedulesApi.updateSchedule(row.id, {
+        cron: cron.trim(),
+        enabled,
+        ...(kindInfo?.configSchema ? { config } : {}),
+        prompt: prompt.trim() ? prompt : null,
+      });
+      onSaved();
+    } catch (err) {
+      setError((err as Error).message || 'Failed to save schedule');
+    } finally {
+      setSaving(false);
+    }
+  }, [row.id, cron, enabled, config, prompt, kindInfo, onSaved]);
+
+  const handleRunNow = useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      await schedulesApi.runScheduleNow(row.id);
+      onRunStarted();
+    } catch (err) {
+      setError((err as Error).message || 'Failed to trigger run');
+    } finally {
+      setRunning(false);
+    }
+  }, [row.id, onRunStarted]);
+
+  const handleResetPrompt = useCallback(() => {
+    if (defaultPrompt !== null) setPrompt(defaultPrompt);
+  }, [defaultPrompt]);
+
+  return (
+    <div className="flex flex-col gap-4 border-t border-glass-edge pt-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`schedule-edit-cron-${row.id}`}>Cron</Label>
+          <Input
+            id={`schedule-edit-cron-${row.id}`}
+            data-testid={`schedule-edit-cron-${row.id}`}
+            className="font-mono text-sm"
+            value={cron}
+            onChange={(e) => setCron(e.target.value)}
+          />
+        </div>
+        <div className="flex items-end gap-3 pb-1">
+          <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+            <Switch
+              checked={enabled}
+              onChange={setEnabled}
+              aria-label={`Enable ${row.kind} schedule`}
+            />
+            Enabled
+          </label>
+        </div>
+      </div>
+
+      {kindInfo?.configSchema ? (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium text-muted-foreground">Workflow config</p>
+          <SchemaConfigForm schema={kindInfo.configSchema} value={config} onChange={setConfig} />
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-medium text-muted-foreground">Agent prompt</p>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            data-testid={`schedule-reset-prompt-${row.id}`}
+            disabled={defaultPrompt === null}
+            onClick={handleResetPrompt}
+          >
+            Reset to default
+          </Button>
+        </div>
+        <Textarea
+          data-testid={`schedule-prompt-${row.id}`}
+          className="min-h-48 font-mono text-xs"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder={defaultPrompt ?? 'Loading default prompt…'}
+        />
+        <p className="text-[10px] text-muted-soft">
+          Stored in the database. Leave empty to use the shipped SKILL.md default on the next run.
+        </p>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          data-testid={`schedule-save-${row.id}`}
+          disabled={saving || !cron.trim()}
+          onClick={handleSave}
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          data-testid={`schedule-run-now-${row.id}`}
+          disabled={running}
+          onClick={handleRunNow}
+        >
+          {running ? 'Starting…' : 'Run now'}
+        </Button>
+      </div>
+
+      <div>
+        <p className="px-4 pb-1 text-xs font-medium text-muted-foreground">Run history</p>
+        <ScheduleRuns scheduleId={row.id} />
+      </div>
+    </div>
   );
 }
 
@@ -271,13 +442,17 @@ function ScheduleDeleteDialog({
 }
 
 export default function SchedulesPage() {
+  const [searchParams] = useSearchParams();
   const { data, loading, refresh } = useResource<ScheduleRow[]>('schedules', () =>
     schedulesApi.listSchedules(),
   );
   const [kinds, setKinds] = useState<ScheduleKindInfo[]>([]);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(() => searchParams.get('expand'));
   const [deleteTarget, setDeleteTarget] = useState<ScheduleRow | null>(null);
+  const [runsKey, setRunsKey] = useState(0);
   const schedules = data ?? [];
+
+  const kindByName = useMemo(() => new Map(kinds.map((k) => [k.kind, k])), [kinds]);
 
   useEffect(() => {
     schedulesApi.getScheduleKinds().then((res) => setKinds(res.kinds));
@@ -353,7 +528,18 @@ export default function SchedulesPage() {
                     </button>
                   </div>
                 </div>
-                {expandedId === row.id && <ScheduleRuns scheduleId={row.id} />}
+                {expandedId === row.id && (
+                  <ScheduleDetail
+                    key={`${row.id}-${runsKey}`}
+                    row={row}
+                    kindInfo={kindByName.get(row.kind) ?? null}
+                    onSaved={refresh}
+                    onRunStarted={() => {
+                      setRunsKey((k) => k + 1);
+                      refresh();
+                    }}
+                  />
+                )}
               </GlassPanel>
             </li>
           ))}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -516,6 +516,7 @@ export function mockSchedulesApi(overrides: Record<string, unknown> = {}) {
       enabled: 1,
       last_run_at: null,
       config_json: null,
+      prompt: null,
     }),
     updateSchedule: vi.fn().mockResolvedValue({
       id: 'sched-1',
@@ -525,8 +526,11 @@ export function mockSchedulesApi(overrides: Record<string, unknown> = {}) {
       enabled: 0,
       last_run_at: null,
       config_json: null,
+      prompt: null,
     }),
     deleteSchedule: vi.fn().mockResolvedValue(undefined),
+    getDefaultPrompt: vi.fn().mockResolvedValue({ content: 'Default prompt' }),
+    runScheduleNow: vi.fn().mockResolvedValue({ ok: true }),
     getScheduleRuns: vi.fn().mockResolvedValue({ runs: [] }),
   };
   return { ...defaults, ...overrides };


### PR DESCRIPTION
## Summary
- Add full schedule management in the UI: create, edit (cron/config/enabled/prompt), delete, and run-now for all five cron workflow kinds
- Store per-schedule prompts in the DB (seeded from SKILL.md, with reset-to-default); task-backed kinds get overrides written into synced worktree skill files before agent launch
- Unify manual runs with the cron poller via `executeScheduleRun` → `wf.run(ctx)`; fix schedule run history to read the `runs` table and link runs back to their schedule

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (3789 passed)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `server/poller/execute-schedule-run.test.ts` — run-now uses shared path, creates `runs` row with `trigger: manual`
- [x] `server/schedule-prompt.test.ts` — DB prompt override + SKILL.md fallback
- [x] `server/skills.repo.test.ts` — task-backed prompt written into synced SKILL.md
- [x] `server/workflows/weekly-update/run.test.ts` — session-vertical prompt from DB
- [x] `src/pages/SchedulesPage.test.tsx` — edit, run-now, run history
- [x] `src/pages/RunsPage.test.tsx` — schedule link from run row


Made with [Cursor](https://cursor.com)