### PR TITLE
feat(schedules): simplify create/edit form with repo picker and cron presets

### DIFF
--- a/src/components/schedules/CronPresetField.tsx
+++ b/src/components/schedules/CronPresetField.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { FormSelect } from '@/components/ui/form-select';
+import {
+  CRON_PRESETS,
+  cronPresetFromExpression,
+  cronSummary,
+  type CronPresetId,
+} from './cronPresets';
+
+interface CronPresetFieldProps {
+  value: string;
+  onChange: (cron: string) => void;
+  id?: string;
+  presetTestId?: string;
+  customTestId?: string;
+}
+
+export function CronPresetField({
+  value,
+  onChange,
+  id = 'schedule-cron',
+  presetTestId = 'schedule-cron-preset',
+  customTestId = 'schedule-cron-custom',
+}: CronPresetFieldProps) {
+  const [presetId, setPresetId] = useState<CronPresetId>(() => cronPresetFromExpression(value));
+
+  useEffect(() => {
+    setPresetId(cronPresetFromExpression(value));
+  }, [value]);
+
+  const summary = cronSummary(value);
+  const isCustom = presetId === 'custom';
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id}>Schedule</Label>
+      <FormSelect
+        id={id}
+        data-testid={presetTestId}
+        value={presetId}
+        onChange={(e) => {
+          const next = e.target.value as CronPresetId;
+          setPresetId(next);
+          if (next !== 'custom') {
+            const preset = CRON_PRESETS.find((p) => p.id === next);
+            if (preset) onChange(preset.cron);
+          }
+        }}
+      >
+        {CRON_PRESETS.map((preset) => (
+          <option key={preset.id} value={preset.id}>
+            {preset.label}
+          </option>
+        ))}
+      </FormSelect>
+      {isCustom ? (
+        <Input
+          data-testid={customTestId}
+          className="font-mono text-sm"
+          placeholder="0 7 * * 1-5"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      ) : null}
+      {summary ? <p className="text-[10px] text-muted-soft">{summary}</p> : null}
+    </div>
+  );
+}

--- a/src/components/schedules/cronPresets.test.ts
+++ b/src/components/schedules/cronPresets.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { cronPresetFromExpression, cronSummary } from './cronPresets';
+
+describe('cronPresets', () => {
+  it('maps known expressions to presets', () => {
+    expect(cronPresetFromExpression('0 9 * * 1-5')).toBe('weekday');
+    expect(cronPresetFromExpression('0 9 * * *')).toBe('daily');
+    expect(cronPresetFromExpression('0 9 * * 1')).toBe('weekly');
+    expect(cronPresetFromExpression('0 * * * *')).toBe('hourly');
+  });
+
+  it('treats unknown expressions as custom', () => {
+    expect(cronPresetFromExpression('0 8 * * *')).toBe('custom');
+  });
+
+  it('returns human-readable summaries', () => {
+    expect(cronSummary('0 9 * * 1-5')).toBe('Every weekday at 09:00');
+    expect(cronSummary('0 12 * * *')).toBe('Custom: 0 12 * * *');
+  });
+});

--- a/src/components/schedules/cronPresets.ts
+++ b/src/components/schedules/cronPresets.ts
@@ -1,0 +1,55 @@
+export type CronPresetId = 'weekday' | 'daily' | 'weekly' | 'hourly' | 'custom';
+
+export interface CronPreset {
+  id: CronPresetId;
+  label: string;
+  cron: string;
+  summary: string;
+}
+
+export const CRON_PRESETS: CronPreset[] = [
+  {
+    id: 'weekday',
+    label: 'Every weekday',
+    cron: '0 9 * * 1-5',
+    summary: 'Every weekday at 09:00',
+  },
+  {
+    id: 'daily',
+    label: 'Daily',
+    cron: '0 9 * * *',
+    summary: 'Every day at 09:00',
+  },
+  {
+    id: 'weekly',
+    label: 'Weekly',
+    cron: '0 9 * * 1',
+    summary: 'Every Monday at 09:00',
+  },
+  {
+    id: 'hourly',
+    label: 'Hourly',
+    cron: '0 * * * *',
+    summary: 'Every hour at :00',
+  },
+  {
+    id: 'custom',
+    label: 'Custom',
+    cron: '',
+    summary: '',
+  },
+];
+
+export function cronPresetFromExpression(cron: string): CronPresetId {
+  const trimmed = cron.trim();
+  const match = CRON_PRESETS.find((p) => p.id !== 'custom' && p.cron === trimmed);
+  return match?.id ?? 'custom';
+}
+
+export function cronSummary(cron: string): string {
+  const trimmed = cron.trim();
+  if (!trimmed) return '';
+  const preset = CRON_PRESETS.find((p) => p.id !== 'custom' && p.cron === trimmed);
+  if (preset) return preset.summary;
+  return `Custom: ${trimmed}`;
+}

--- a/src/components/schedules/schedulePrompt.test.ts
+++ b/src/components/schedules/schedulePrompt.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStoredPrompt } from './schedulePrompt';
+
+describe('resolveStoredPrompt', () => {
+  const defaultPrompt = 'Default skill prompt';
+
+  it('stores null when prompt matches the default', () => {
+    expect(resolveStoredPrompt('Default skill prompt', defaultPrompt)).toBeNull();
+    expect(resolveStoredPrompt('  Default skill prompt  ', defaultPrompt)).toBeNull();
+  });
+
+  it('stores null when prompt is empty', () => {
+    expect(resolveStoredPrompt('', defaultPrompt)).toBeNull();
+    expect(resolveStoredPrompt('   ', defaultPrompt)).toBeNull();
+  });
+
+  it('stores edited text when prompt differs from default', () => {
+    expect(resolveStoredPrompt('Custom prompt', defaultPrompt)).toBe('Custom prompt');
+  });
+});

--- a/src/components/schedules/schedulePrompt.ts
+++ b/src/components/schedules/schedulePrompt.ts
@@ -1,0 +1,13 @@
+/**
+ * When the textarea still matches the shipped default, store null so the schedule
+ * keeps tracking future SKILL.md updates instead of freezing a copy.
+ */
+export function resolveStoredPrompt(
+  promptText: string,
+  defaultPrompt: string | null,
+): string | null {
+  const trimmed = promptText.trim();
+  if (!trimmed) return null;
+  if (defaultPrompt !== null && trimmed === defaultPrompt.trim()) return null;
+  return trimmed;
+}

--- a/src/pages/SchedulesPage.test.tsx
+++ b/src/pages/SchedulesPage.test.tsx
@@ -13,6 +13,15 @@ vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
 vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
 vi.mock('@/lib/api/loopApi', () => ({ loopApi: loopApiProxy }));
 vi.mock('@/lib/api/schedulesApi', () => ({ schedulesApi: schedulesApiProxy }));
+vi.mock('@/components/fields/RepoPickerField', () => ({
+  RepoPickerField: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <input
+      data-testid="schedule-repo-path"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
 vi.mock('@/lib/event-source', () => ({
   subscribe: vi.fn(() => () => {}),
   subscribeConnectionState: vi.fn(() => () => {}),
@@ -84,7 +93,7 @@ describe('SchedulesPage', () => {
     await screen.findByText(/no schedules yet/i);
 
     await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
-    await user.type(screen.getByTestId('schedule-cron'), '0 8 * * *');
+    await waitFor(() => expect(apiMock.getDefaultPrompt).toHaveBeenCalled());
     await user.click(screen.getByTestId('schedule-submit'));
 
     await waitFor(() => expect(apiMock.createSchedule).toHaveBeenCalledTimes(1));
@@ -92,9 +101,47 @@ describe('SchedulesPage', () => {
       expect.objectContaining({
         kind: 'prod-log-triage',
         repoPath: '/my/repo',
-        cron: '0 8 * * *',
+        cron: '0 9 * * 1-5',
         enabled: true,
+        prompt: null,
       }),
+    );
+  });
+
+  it('stores null prompt when create form default is left unchanged', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([]);
+    apiMock.getDefaultPrompt.mockResolvedValue({ content: 'Default skill prompt' });
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+    await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
+    await waitFor(() =>
+      expect(screen.getByTestId('schedule-prompt-create')).toHaveValue('Default skill prompt'),
+    );
+    await user.click(screen.getByTestId('schedule-submit'));
+
+    await waitFor(() => expect(apiMock.createSchedule).toHaveBeenCalledTimes(1));
+    expect(apiMock.createSchedule).toHaveBeenCalledWith(expect.objectContaining({ prompt: null }));
+  });
+
+  it('stores edited prompt when create form prompt is customized', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([]);
+    apiMock.getDefaultPrompt.mockResolvedValue({ content: 'Default skill prompt' });
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+    await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
+    const promptField = await screen.findByTestId('schedule-prompt-create');
+    await waitFor(() => expect(promptField).toHaveValue('Default skill prompt'));
+    await user.clear(promptField);
+    await user.type(promptField, 'Custom triage prompt');
+    await user.click(screen.getByTestId('schedule-submit'));
+
+    await waitFor(() => expect(apiMock.createSchedule).toHaveBeenCalledTimes(1));
+    expect(apiMock.createSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'Custom triage prompt' }),
     );
   });
 
@@ -150,15 +197,14 @@ describe('SchedulesPage', () => {
     renderWithRouter(<SchedulesPage />);
     await user.click(await screen.findByTestId('schedule-expand-sched-1'));
 
-    const cronInput = await screen.findByTestId('schedule-edit-cron-sched-1');
-    await user.clear(cronInput);
-    await user.type(cronInput, '0 9 * * *');
+    const presetSelect = await screen.findByTestId('schedule-edit-cron-preset-sched-1');
+    await user.selectOptions(presetSelect, 'daily');
     await user.click(screen.getByTestId('schedule-save-sched-1'));
 
     await waitFor(() =>
       expect(apiMock.updateSchedule).toHaveBeenCalledWith(
         'sched-1',
-        expect.objectContaining({ cron: '0 9 * * *' }),
+        expect.objectContaining({ cron: '0 9 * * *', prompt: null }),
       ),
     );
   });

--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -6,7 +6,6 @@ import { useResource } from '@/lib/use-resource';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { FormSelect } from '@/components/ui/form-select';
@@ -22,6 +21,10 @@ import {
 import { PageHeader } from '@/components/layout/page-header';
 import { timeAgo } from '@/lib/time';
 import { SchemaConfigForm, defaultsFromSchema } from '@/components/schedules/SchemaConfigForm';
+import { CronPresetField } from '@/components/schedules/CronPresetField';
+import { CRON_PRESETS } from '@/components/schedules/cronPresets';
+import { resolveStoredPrompt } from '@/components/schedules/schedulePrompt';
+import { RepoPickerField } from '@/components/fields/RepoPickerField';
 
 function parseConfigJson(configJson: string | null): Record<string, unknown> {
   if (!configJson) return {};
@@ -35,9 +38,11 @@ function parseConfigJson(configJson: string | null): Record<string, unknown> {
 function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreated: () => void }) {
   const [kind, setKind] = useState('');
   const [repoPath, setRepoPath] = useState('');
-  const [cron, setCron] = useState('');
+  const [cron, setCron] = useState(CRON_PRESETS[0].cron);
   const [enabled, setEnabled] = useState(true);
   const [config, setConfig] = useState<Record<string, unknown>>({});
+  const [prompt, setPrompt] = useState('');
+  const [defaultPrompt, setDefaultPrompt] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,6 +60,25 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     setConfig(defaultsFromSchema(selectedKind.configSchema));
   }, [selectedKind]);
 
+  useEffect(() => {
+    if (!kind || !repoPath.trim()) {
+      setDefaultPrompt(null);
+      setPrompt('');
+      return;
+    }
+
+    let cancelled = false;
+    schedulesApi.getDefaultPrompt(kind, repoPath.trim()).then((res) => {
+      if (!cancelled) {
+        setDefaultPrompt(res.content);
+        setPrompt(res.content);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, repoPath]);
+
   const canSubmit = kind.length > 0 && repoPath.trim().length > 0 && cron.trim().length > 0;
 
   const handleSubmit = useCallback(async () => {
@@ -64,17 +88,21 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     try {
       const payloadConfig =
         selectedKind?.configSchema && Object.keys(config).length > 0 ? config : undefined;
+      const storedPrompt = resolveStoredPrompt(prompt, defaultPrompt);
 
       await schedulesApi.createSchedule({
         kind,
         repoPath: repoPath.trim(),
         cron: cron.trim(),
         enabled,
+        prompt: storedPrompt,
         ...(payloadConfig ? { config: payloadConfig } : {}),
       });
 
       setRepoPath('');
-      setCron('');
+      setCron(CRON_PRESETS[0].cron);
+      setPrompt('');
+      setDefaultPrompt(null);
       setEnabled(true);
       if (selectedKind?.configSchema) {
         setConfig(defaultsFromSchema(selectedKind.configSchema));
@@ -87,7 +115,18 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     } finally {
       setSubmitting(false);
     }
-  }, [canSubmit, kind, repoPath, cron, enabled, config, selectedKind, onCreated]);
+  }, [
+    canSubmit,
+    kind,
+    repoPath,
+    cron,
+    enabled,
+    config,
+    prompt,
+    defaultPrompt,
+    selectedKind,
+    onCreated,
+  ]);
 
   return (
     <GlassPanel level={2} className="flex flex-col gap-3 rounded-2xl p-4">
@@ -108,26 +147,10 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
           </FormSelect>
         </div>
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="schedule-repo-path">Repo path</Label>
-          <Input
-            id="schedule-repo-path"
-            data-testid="schedule-repo-path"
-            placeholder="/path/to/repo"
-            value={repoPath}
-            onChange={(e) => setRepoPath(e.target.value)}
-          />
+          <Label htmlFor="repo-path">Repository</Label>
+          <RepoPickerField value={repoPath} onChange={setRepoPath} />
         </div>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="schedule-cron">Cron</Label>
-          <Input
-            id="schedule-cron"
-            data-testid="schedule-cron"
-            className="font-mono text-sm"
-            placeholder="0 7 * * 1-5"
-            value={cron}
-            onChange={(e) => setCron(e.target.value)}
-          />
-        </div>
+        <CronPresetField value={cron} onChange={setCron} />
       </div>
 
       <label className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
@@ -151,6 +174,27 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
               value={config}
               onChange={setConfig}
             />
+          </div>
+        </details>
+      ) : null}
+
+      {repoPath.trim() ? (
+        <details className="group">
+          <summary className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+            Customize prompt
+          </summary>
+          <div className="mt-3 flex flex-col gap-2">
+            <Textarea
+              data-testid="schedule-prompt-create"
+              className="min-h-48 font-mono text-xs"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder={defaultPrompt === null ? 'Loading default prompt…' : undefined}
+            />
+            <p className="text-[10px] text-muted-soft">
+              Pre-filled with the shipped default. Edit only if you need a custom prompt; unchanged
+              text tracks future SKILL.md updates.
+            </p>
           </div>
         </details>
       ) : null}
@@ -262,12 +306,15 @@ function ScheduleDetail({
   useEffect(() => {
     let cancelled = false;
     schedulesApi.getDefaultPrompt(row.kind, row.repo_path).then((res) => {
-      if (!cancelled) setDefaultPrompt(res.content);
+      if (!cancelled) {
+        setDefaultPrompt(res.content);
+        if (row.prompt === null) setPrompt(res.content);
+      }
     });
     return () => {
       cancelled = true;
     };
-  }, [row.kind, row.repo_path]);
+  }, [row.id, row.kind, row.repo_path, row.prompt]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -277,7 +324,7 @@ function ScheduleDetail({
         cron: cron.trim(),
         enabled,
         ...(kindInfo?.configSchema ? { config } : {}),
-        prompt: prompt.trim() ? prompt : null,
+        prompt: resolveStoredPrompt(prompt, defaultPrompt),
       });
       onSaved();
     } catch (err) {
@@ -285,7 +332,7 @@ function ScheduleDetail({
     } finally {
       setSaving(false);
     }
-  }, [row.id, cron, enabled, config, prompt, kindInfo, onSaved]);
+  }, [row.id, cron, enabled, config, prompt, defaultPrompt, kindInfo, onSaved]);
 
   const handleRunNow = useCallback(async () => {
     setRunning(true);
@@ -307,16 +354,13 @@ function ScheduleDetail({
   return (
     <div className="flex flex-col gap-4 border-t border-glass-edge pt-3">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor={`schedule-edit-cron-${row.id}`}>Cron</Label>
-          <Input
-            id={`schedule-edit-cron-${row.id}`}
-            data-testid={`schedule-edit-cron-${row.id}`}
-            className="font-mono text-sm"
-            value={cron}
-            onChange={(e) => setCron(e.target.value)}
-          />
-        </div>
+        <CronPresetField
+          id={`schedule-edit-cron-${row.id}`}
+          value={cron}
+          onChange={setCron}
+          presetTestId={`schedule-edit-cron-preset-${row.id}`}
+          customTestId={`schedule-edit-cron-${row.id}`}
+        />
         <div className="flex items-end gap-3 pb-1">
           <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
             <Switch
@@ -355,10 +399,11 @@ function ScheduleDetail({
           className="min-h-48 font-mono text-xs"
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          placeholder={defaultPrompt ?? 'Loading default prompt…'}
+          placeholder={defaultPrompt === null ? 'Loading default prompt…' : undefined}
         />
         <p className="text-[10px] text-muted-soft">
-          Stored in the database. Leave empty to use the shipped SKILL.md default on the next run.
+          Pre-filled with the shipped default. Edit only for a custom override; unchanged text
+          tracks future SKILL.md updates.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- Replace free-text repo path with `RepoPickerField` (recent repos + browse fallback)
- Replace hand-written cron with preset cadences (weekday/daily/weekly/hourly/custom) and a human-readable summary
- Surface the workflow prompt inline at create time (and consistently in edit), prepopulated from `GET /api/schedules/prompt-default`
- Store `prompt: null` when the user leaves the default unchanged so schedules keep tracking future SKILL.md updates

## Why

The schedules feature shipped in #210 works end-to-end, but the create form required absolute repo paths, cron syntax knowledge, and a separate edit step to discover/set a custom prompt. The backend already supports everything needed — this is a focused frontend UX simplification.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (includes prompt null-vs-custom semantics tests)
- [x] `bun run lint`
- [x] `bun run format:check`
- [ ] Manual: create a schedule via repo picker + preset, confirm run history / Run now / edit still work

Made with [Cursor](https://cursor.com)