### PR TITLE
fix(orchestrator): don't resume a booting conductor (duplicate session)

### DIFF
--- a/server/orchestrator/runner.test.ts
+++ b/server/orchestrator/runner.test.ts
@@ -490,6 +490,30 @@ describe('orchestrator runner', () => {
       expect(seq).toEqual(['paste:AAA', 'enter', 'paste:BBB', 'enter']);
     });
 
+    it('waits for a booting session (pane shell→claude) instead of resuming', async () => {
+      // A just-launched conductor: the tmux session exists but claude is still
+      // booting, so the pane briefly runs the launch shell. sendTurn must WAIT
+      // for claude to take the foreground and then paste — it must NOT resume
+      // (which would new-session an existing name → "duplicate session", the bug
+      // that dropped the first real Telegram turn).
+      const convId = createConversation({ title: 'Booting', claude_session_id: 'sess-boot' });
+      updateConversation(convId, { tmux_window: 'octomux-orch-boot:1' });
+      _paneCommand = 'zsh'; // claude still launching
+
+      const p = sendTurn(convId, 'hello there');
+      await vi.advanceTimersByTimeAsync(100); // a couple of alive-polls, still booting
+      _paneCommand = 'node'; // claude took the pane foreground
+      await vi.advanceTimersByTimeAsync(1000);
+      await p;
+
+      // No resume happened — it waited, then pasted.
+      expect(findTmuxCall('new-session')).toBeUndefined();
+      const pasteCall = mockedExecFile.mock.calls.find(
+        (c) => c[0] === 'tmux' && stripSocketArgs(c[1] as string[]).includes('-l'),
+      );
+      expect(pasteCall).toBeDefined();
+    });
+
     it('resumes (does not paste blind) when the pane fell back to a shell', async () => {
       // Session exists but claude crashed — the pane's foreground command is the
       // holding shell, not node/claude. Liveness must report DEAD so sendTurn

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -58,6 +58,16 @@ const CAPTURE_PANE_POLL_MS = 50;
 const PASTE_TO_ENTER_MIN_DELAY_MS = 50;
 /** Delay after --resume auto-turn before we allow real turns to be sent. */
 export const RESUME_QUIET_WINDOW_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
+/**
+ * How long `sendTurn` waits for a freshly-launched conductor to become alive
+ * (claude taking the pane foreground) before treating it as dead and resuming.
+ * A cold `claude` start in tmux takes a few seconds during which the pane is
+ * still the launch shell; without this wait, sendTurn would resume a session
+ * that's merely booting and hit "duplicate session".
+ */
+const SESSION_BOOT_WAIT_MS = process.env.NODE_ENV === 'test' ? 300 : 10000;
+/** Poll interval while waiting for a booting session to become alive. */
+const SESSION_ALIVE_POLL_MS = process.env.NODE_ENV === 'test' ? 20 : 150;
 
 // ─── Config dir ───────────────────────────────────────────────────────────────
 
@@ -408,6 +418,15 @@ export async function resumeConversation(
 
   const startupCmd = buildConductorStartupCmd(claudeCmd);
 
+  // Resume RECREATES the session — kill any lingering one with this name first so
+  // `new-session` can't fail with "duplicate session" (a crashed conductor whose
+  // tmux session outlived it, or a racing caller).
+  try {
+    await execTmux(['kill-session', '-t', sessionName]);
+  } catch {
+    // No existing session — expected on a normal resume.
+  }
+
   await execTmux(['new-session', '-d', '-s', sessionName, '-c', cwd, startupCmd]);
   await execTmux(['set-option', '-t', sessionName, 'aggressive-resize', 'on']);
 
@@ -557,16 +576,25 @@ async function deliverTurn(convId: string, text: string): Promise<void> {
   // sending a turn must transparently restart it via `--resume <session_id>`
   // (same session id → same transcript, history intact) before delivering.
   if (!(await isConversationSessionAlive(conv))) {
-    logger.info(
-      { conversation_id: convId, operation: 'sendTurn' },
-      'sendTurn: session not alive — resuming before delivering turn',
-    );
-    await resumeConversation(convId, conv.cwd ?? process.cwd());
-    // Let the --resume continuation settle before injecting the real turn.
-    if (RESUME_QUIET_WINDOW_MS > 0) {
-      await new Promise<void>((resolve) => setTimeout(resolve, RESUME_QUIET_WINDOW_MS));
+    // A freshly-launched conductor's pane is briefly the launch shell while
+    // claude boots — that reads as "not alive" but must NOT trigger a resume
+    // (which would `new-session` a name that already exists → "duplicate
+    // session"). If the session EXISTS, wait for claude to take the foreground;
+    // only resume when the session is genuinely absent or never comes alive.
+    const exists = await tmuxSessionExists(conv);
+    const becameAlive = exists ? await waitForSessionAlive(conv, SESSION_BOOT_WAIT_MS) : false;
+    if (!becameAlive) {
+      logger.info(
+        { conversation_id: convId, operation: 'sendTurn', session_exists: exists },
+        'sendTurn: session not alive — resuming before delivering turn',
+      );
+      await resumeConversation(convId, conv.cwd ?? process.cwd());
+      // Let the --resume continuation settle before injecting the real turn.
+      if (RESUME_QUIET_WINDOW_MS > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, RESUME_QUIET_WINDOW_MS));
+      }
+      conv = getConversation(convId); // reload — resume updated tmux_window
     }
-    conv = getConversation(convId); // reload — resume updated tmux_window
   }
 
   if (!conv?.tmux_window) {
@@ -627,6 +655,37 @@ async function isConversationSessionAlive(conv: OrchestratorConversation): Promi
     return cmd === 'node' || cmd === 'claude';
   } catch {
     return false;
+  }
+}
+
+/** Whether the conversation's tmux session exists at all (booting or alive). */
+async function tmuxSessionExists(conv: OrchestratorConversation): Promise<boolean> {
+  if (!conv.tmux_window) return false;
+  const session = conv.tmux_window.split(':')[0];
+  if (!session) return false;
+  try {
+    await execTmux(['has-session', '-t', session]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll until the conductor's claude process takes the pane foreground, or the
+ * timeout elapses. Distinguishes a session that's still BOOTING (claude
+ * launching, pane briefly the shell) from one that's genuinely dead — so
+ * `sendTurn` doesn't resume (and duplicate) a session that just needs a moment.
+ */
+async function waitForSessionAlive(
+  conv: OrchestratorConversation,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await isConversationSessionAlive(conv)) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, SESSION_ALIVE_POLL_MS));
   }
 }
 


### PR DESCRIPTION
## The bug (found in live smoke)

First real Telegram turn: the gateway saw the message, passed allowlist + dedup, created the conversation and launched the conductor — then **dropped the turn** with `duplicate session: octomux-orch-<id>`, so no reply.

Root cause is in the T9 liveness change (#216): a just-launched session's pane is briefly the launch shell while `claude` boots, so `pane_current_command` is `zsh`, not `node`. `isConversationSessionAlive` reads that as **dead** → `sendTurn` falls back to `resumeConversation` → `tmux new-session` on a name that already exists → error → turn lost. A race between "claude is starting" and "claude is alive."

## Fix

- **`sendTurn`** now distinguishes *booting* from *dead*: if the tmux session exists, wait (poll `pane_current_command`, up to 10s) for claude to take the foreground, then paste. Only resume when the session is genuinely absent or never comes alive (real crash).
- **`resumeConversation`** kills any lingering same-named session before `new-session`, so resume is idempotent and can't `duplicate session` on its own.

Preserves T9's safety guarantee (never paste a chat turn into a fallback shell).

## Testing

New regression test: a booting session (pane `shell → claude`) waits and pastes, with **no resume**. Existing crashed-pane and dead-session tests still resume as before. Full suite green (**3854**), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)