### PR TITLE
fix(orchestrator): correct conductor liveness (real claude reports a version string)

### DIFF
--- a/scripts/gateway-e2e-smoke.ts
+++ b/scripts/gateway-e2e-smoke.ts
@@ -1,0 +1,147 @@
+/* eslint-disable no-console -- CLI smoke script: console output is the interface */
+/**
+ * scripts/gateway-e2e-smoke.ts
+ *
+ * End-to-end smoke test for the Telegram gateway with ONLY the Telegram
+ * transport mocked — everything downstream is REAL: the gateway glue, an
+ * isolated SQLite DB, and a live `claude` conductor in tmux with its transcript
+ * tail. It injects a fake inbound message and waits for the conductor's reply to
+ * come back out through the outbound path.
+ *
+ * This exercises exactly the parts that unit tests (mocked conductor) cannot:
+ * session launch, the boot-race liveness wait, the transcript tail, the
+ * stop-hook turn boundary, redaction, and the outbound queue.
+ *
+ * Run:  npx tsx scripts/gateway-e2e-smoke.ts
+ * Needs: an authed `claude` CLI + tmux (same as running octomux normally).
+ * Exit:  0 = a reply came back; 1 = timed out / no reply.
+ */
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+// Isolate: throwaway DB + a known allowlisted sender. MUST be set before any
+// server module (db.ts resolves the DB path at import time).
+const TMP_DB = path.join(os.tmpdir(), `octomux-gw-e2e-${process.pid}.db`);
+process.env.OCTOMUX_DB_PATH = TMP_DB;
+const SENDER = 'e2e-user';
+process.env.OCTOMUX_GATEWAY_TELEGRAM_ALLOW = SENDER;
+
+const TIMEOUT_MS = 75_000;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function main(): Promise<number> {
+  const { createGateway } = await import('../server/gateway/gateway.js');
+  const { getDb } = await import('../server/db.js');
+  const { getThreadConv } = await import('../server/repositories/gateway.js');
+  const { stopConversation } = await import('../server/orchestrator/runner.js');
+  const { getConversation } = await import('../server/orchestrator/store.js');
+  const { execTmux } = await import('../server/tmux-bin.js');
+  const type = await import('../server/gateway/adapter.js');
+
+  const tmuxCap = async (t: string, fmt: string) =>
+    execTmux(['display-message', '-t', t, '-p', fmt])
+      .then((r) => r.stdout.trim())
+      .catch((e) => `ERR(${(e as Error).message.slice(0, 40)})`);
+
+  getDb(); // force schema + migrations on the throwaway DB
+  console.log(`[e2e] isolated DB: ${TMP_DB}`);
+
+  // ── Mock ONLY the Telegram transport ──────────────────────────────────────
+  const sent: Array<{ threadKey: string; text: string }> = [];
+  let onMessage: ((m: type.InboundMessage) => Promise<void>) | null = null;
+  const adapter: type.ChannelAdapter = {
+    id: 'telegram',
+    start: async (h) => {
+      onMessage = h;
+    },
+    send: async (threadKey, text) => {
+      sent.push({ threadKey, text });
+      console.log(`[e2e] ◀ OUTBOUND reply (${text.length} chars):\n${text}\n`);
+    },
+    sendTyping: async () => {},
+  };
+
+  const gateway = createGateway(adapter);
+  await gateway.start();
+  if (!onMessage) throw new Error('adapter.start did not register a handler');
+
+  // ── Inject a fake inbound message ─────────────────────────────────────────
+  const threadKey = `e2e-${Date.now()}`;
+  console.log('[e2e] ▶ injecting inbound message…');
+  await onMessage({
+    channel: 'telegram',
+    threadKey,
+    senderId: SENDER,
+    externalId: 'e2e-update-1',
+    text: 'Reply with a short greeting so I know you are alive — one sentence, no task needed.',
+  });
+
+  // ── Diagnostics: what did the conductor actually do? ──────────────────────
+  const convId = getThreadConv('telegram', threadKey);
+  const conv = convId ? getConversation(convId) : null;
+  console.log('[e2e] conversation:', {
+    convId,
+    tmux: conv?.tmux_window,
+    session: conv?.claude_session_id?.slice(0, 12),
+    transcript: conv?.transcript_path,
+  });
+
+  // ── Wait for the conductor's reply to flow back out ───────────────────────
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline && sent.length === 0) {
+    await sleep(5000);
+    const pane = conv?.tmux_window
+      ? await tmuxCap(conv.tmux_window, '#{pane_current_command}')
+      : 'n/a';
+    const tp = conv?.transcript_path;
+    const tExists = tp ? fs.existsSync(tp) : false;
+    const tLines = tExists ? fs.readFileSync(tp!, 'utf8').split('\n').filter(Boolean).length : 0;
+    console.log(
+      `[e2e] pane=${pane} transcript=${tExists ? tLines + ' lines' : 'MISSING'} outbound=${sent.length}`,
+    );
+  }
+
+  // Dump what claude is showing in its pane (reveals auth / MCP / prompt errors).
+  if (conv?.tmux_window) {
+    const pane = await execTmux(['capture-pane', '-t', conv.tmux_window, '-p'])
+      .then((r) => r.stdout)
+      .catch((e) => `capture failed: ${(e as Error).message}`);
+    console.log('[e2e] ── conductor pane (last 25 lines) ──');
+    console.log(pane.split('\n').slice(-25).join('\n'));
+    console.log('[e2e] ────────────────────────────────────');
+  }
+
+  const ok = sent.length > 0;
+  console.log(
+    ok ? '[e2e] ✅ PASS — reply received end to end' : '[e2e] ❌ FAIL — no reply in time',
+  );
+
+  // ── Cleanup: stop the conductor session, drop the temp DB ─────────────────
+  try {
+    const convId = getThreadConv('telegram', threadKey);
+    if (convId) {
+      await stopConversation(convId);
+      console.log('[e2e] stopped conductor session for', convId);
+    }
+  } catch (err) {
+    console.log('[e2e] cleanup warning:', (err as Error).message);
+  }
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      fs.unlinkSync(TMP_DB + suffix);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return ok ? 0 : 1;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error('[e2e] ERROR:', err);
+    process.exit(1);
+  });

--- a/server/orchestrator/runner.test.ts
+++ b/server/orchestrator/runner.test.ts
@@ -32,7 +32,9 @@ let _windowIndex = '1';
  * Defaults to 'node' (a live claude conductor is a node process → alive). A test
  * sets it to a shell name to simulate a crashed conductor (→ not alive → resume).
  */
-let _paneCommand = 'node';
+// A live claude reports a VERSION-like pane_current_command (e.g. '2.1.218'),
+// NOT 'node'/'claude' — liveness must treat that as alive. Tests default to it.
+let _paneCommand = '2.1.218';
 
 vi.mock('child_process', () => ({
   execFile: vi.fn((_cmd: string, args: string[], optsOrCb: unknown, maybeCb?: unknown) => {
@@ -109,7 +111,7 @@ describe('orchestrator runner', () => {
     mockedExecFile.mockClear();
     _lastPastedText = '';
     _windowIndex = '1';
-    _paneCommand = 'node';
+    _paneCommand = '2.1.218';
     vi.useFakeTimers();
   });
 

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -630,14 +630,36 @@ async function deliverTurn(convId: string, text: string): Promise<void> {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
+ * Shell process names that mean the pane is NOT running claude — either the
+ * booting launch shell, or the post-crash holding shell (`; echo CONDUCTOR_EXITED;
+ * read -r _`, where `read` is a builtin so the pane's command is the shell).
+ * Leading-dash forms (`-zsh`) are login shells.
+ */
+const HOLDING_SHELL_COMMANDS = new Set([
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'dash',
+  'ksh',
+  'tcsh',
+  'csh',
+  '-sh',
+  '-bash',
+  '-zsh',
+  '-fish',
+]);
+
+/**
  * Whether the conductor's `claude` process is currently alive in the pane —
  * NOT merely "the tmux session exists."
  *
  * `has-session` is true even when claude has crashed and the pane fell back to
- * the holding shell. Pasting a chat turn into that shell would run it as a
- * command, so liveness must mean the pane's foreground process is claude
- * (reported as `node` — the CLI is a node process — or `claude`). Anything else
- * (the shell, `read`) means dead → `sendTurn` resumes instead of pasting.
+ * the holding shell; pasting a chat turn into that shell would run it as a
+ * command. So liveness = the pane's foreground command is NOT a shell. We can't
+ * match claude by name — its `pane_current_command` is not `claude`/`node` but a
+ * version-like string (e.g. `2.1.218`) — so we invert: anything that isn't the
+ * booting/holding shell (or empty) is treated as a live conductor.
  *
  * A failed `display-message` (no such session) also means not-alive.
  */
@@ -652,7 +674,8 @@ async function isConversationSessionAlive(conv: OrchestratorConversation): Promi
       '#{pane_current_command}',
     ]);
     const cmd = stdout.trim().toLowerCase();
-    return cmd === 'node' || cmd === 'claude';
+    if (!cmd) return false;
+    return !HOLDING_SHELL_COMMANDS.has(cmd);
   } catch {
     return false;
   }


### PR DESCRIPTION
## The bug (caught by a real end-to-end test)

The T9 liveness check tested `pane_current_command === 'node' || 'claude'`. But a **live claude reports a version-like command** — `2.1.218` — so liveness *always* returned false. Every gateway turn concluded the conductor was dead → endless resume → **no turn ever delivered, no reply**. The unit tests passed only because they mocked the value as `'node'`, which never happens in reality.

Proven with a new end-to-end smoke (`scripts/gateway-e2e-smoke.ts`) that mocks *only* Telegram and drives a **real claude conductor**:

```
before:  pane=2.1.218  transcript=MISSING  outbound=0   → FAIL (never alive)
after:   pane=2.1.218  transcript=21 lines outbound=1   → PASS (reply round-trips)
```

## Fix

- **Invert the check:** liveness = the pane's foreground command is **not** the booting/holding shell (`sh`/`bash`/`zsh`/…). Any non-shell command (claude's version string, `node`, etc.) means a live conductor. This still preserves T9's real guarantee — never paste a chat turn into a fallback shell.
- Tests now default the mocked `pane_current_command` to a version string (`2.1.218`) so the real-world case is locked in.
- Adds `scripts/gateway-e2e-smoke.ts` — the harness that caught this (mocked-conductor unit tests structurally could not).

## Testing

New e2e smoke passes against a live conductor (reply round-trips). Full unit suite green (**3854**), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)