### PR TITLE
fix(harness): force editorMode emacs for worker agents (turns weren't submitting)

### DIFF
--- a/server/harnesses/claude-code.test.ts
+++ b/server/harnesses/claude-code.test.ts
@@ -142,4 +142,27 @@ describe('claudeCodeHarness.installHooks', () => {
       'http://127.0.0.1:7777/api/hooks/stop?token=tok%26special%3Dvalue',
     );
   });
+
+  it('forces editorMode: emacs so send-keys Enter submits (defeats global vim mode)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
+    await claudeCodeHarness.installHooks(tmp, 'http://127.0.0.1:7777', 'tok');
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmp, '.claude', 'settings.local.json'), 'utf-8'),
+    );
+    expect(written.editorMode).toBe('emacs');
+  });
+
+  it('preserves an explicit worktree editorMode', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
+    fs.mkdirSync(path.join(tmp, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.claude', 'settings.local.json'),
+      JSON.stringify({ editorMode: 'vim' }),
+    );
+    await claudeCodeHarness.installHooks(tmp, 'http://127.0.0.1:7777', 'tok');
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmp, '.claude', 'settings.local.json'), 'utf-8'),
+    );
+    expect(written.editorMode).toBe('vim');
+  });
 });

--- a/server/harnesses/claude-code.ts
+++ b/server/harnesses/claude-code.ts
@@ -76,7 +76,15 @@ export const claudeCodeHarness: Harness = {
     const mergedDeny = [...new Set([...DENIED_TOOLS, ...existingDeny])];
     const mergedPermissions = { ...existingPerms, allow: mergedAllow, deny: mergedDeny };
 
-    const merged = { ...existing, permissions: mergedPermissions, hooks: mergedHooks };
+    // Force NON-vim keybindings unless the worktree explicitly chose one. octomux
+    // drives agents with tmux `send-keys` (paste → Enter to submit). If the
+    // operator's global config has `editorMode: vim`, the agent's TUI starts in
+    // vim INSERT mode where Enter's submit behavior is mode-dependent and
+    // unreliable — turns (incl. plan approvals) get pasted but never submitted.
+    // emacs keybindings make `send-keys Enter` submit deterministically.
+    const editorMode = typeof existing.editorMode === 'string' ? existing.editorMode : 'emacs';
+
+    const merged = { ...existing, editorMode, permissions: mergedPermissions, hooks: mergedHooks };
     writeJsonConfig(settingsPath, merged);
   },
 

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -56,6 +56,14 @@ const CAPTURE_PANE_MAX_WAIT_MS = 3000;
 const CAPTURE_PANE_POLL_MS = 50;
 /** Delay between the paste send-keys and Enter, if capture-pane confirm succeeds quickly. */
 const PASTE_TO_ENTER_MIN_DELAY_MS = 50;
+/** How many times to (re)paste a turn if the pane confirm doesn't see it land. */
+const PASTE_ATTEMPTS = 3;
+/** Backoff between paste retries. */
+const PASTE_RETRY_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
+/** Max wait for the conductor TUI composer to become input-ready before pasting. */
+const CONDUCTOR_READY_WAIT_MS = process.env.NODE_ENV === 'test' ? 0 : 15000;
+/** Poll interval while waiting for the composer to be ready. */
+const CONDUCTOR_READY_POLL_MS = process.env.NODE_ENV === 'test' ? 10 : 300;
 /** Delay after --resume auto-turn before we allow real turns to be sent. */
 export const RESUME_QUIET_WINDOW_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
 /**
@@ -120,6 +128,13 @@ function writeOrchestratorsettings(convId: string): string {
     // onboarding already done), and an object `tui` value is rejected by claude
     // ("Invalid value. Expected one of: default, fullscreen") which blocks the
     // session on a settings-error dialog.
+    //
+    // Force NON-vim keybindings for the conductor. We drive the TUI with tmux
+    // `send-keys Enter` to submit each turn; if the operator's global config has
+    // `editorMode: vim`, the pane starts in vim INSERT mode where Enter inserts a
+    // newline instead of submitting — so pasted turns sit unsent forever. The
+    // conductor is non-interactive, so emacs (default) keybindings are correct.
+    editorMode: 'emacs',
     permissions: {
       // CONDUCTOR IS NON-INTERACTIVE — nobody is at its tmux TUI (the user talks
       // to it via the web chat). A permission prompt there hangs the session
@@ -608,23 +623,36 @@ async function deliverTurn(convId: string, text: string): Promise<void> {
     'sendTurn: pasting text',
   );
 
-  // Step 1: paste the text (bracketed paste — preserves newlines)
-  await execTmux(['send-keys', '-t', target, '-l', text]);
+  // Step 0: wait for the TUI composer to be interactive. `waitForSessionAlive`
+  // only proves the claude PROCESS is up — its TUI takes a moment more to render
+  // an input-ready composer. Pasting before then silently drops the keystrokes
+  // (the cold-start race that left turns unsubmitted), so wait for the prompt.
+  await waitForConductorReady(target);
 
-  // Step 2: capture-pane confirm — wait until the pasted text appears in the buffer
-  const confirmed = await waitForPaneContent(target, text);
-  if (!confirmed) {
-    logger.warn(
-      { conversation_id: convId, operation: 'sendTurn', target },
-      'sendTurn: capture-pane confirm timed out; sending Enter anyway',
-    );
+  // Steps 1–2: paste, then confirm the text landed in the composer — retrying the
+  // paste (not just the Enter) if it didn't, since a dropped paste is why a turn
+  // never submits. Only send Enter once the paste is confirmed present.
+  let confirmed = false;
+  for (let attempt = 1; attempt <= PASTE_ATTEMPTS && !confirmed; attempt++) {
+    await execTmux(['send-keys', '-t', target, '-l', text]);
+    confirmed = await waitForPaneContent(target, text);
+    if (!confirmed) {
+      logger.warn(
+        { conversation_id: convId, operation: 'sendTurn', target, attempt },
+        'sendTurn: paste not confirmed in pane; retrying',
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, PASTE_RETRY_DELAY_MS));
+    }
   }
 
-  // Step 3: brief minimum delay then Enter
+  // Step 3: brief minimum delay then Enter to submit.
   await new Promise<void>((resolve) => setTimeout(resolve, PASTE_TO_ENTER_MIN_DELAY_MS));
   await execTmux(['send-keys', '-t', target, 'Enter']);
 
-  logger.debug({ conversation_id: convId, operation: 'sendTurn' }, 'sendTurn: Enter sent');
+  logger.debug(
+    { conversation_id: convId, operation: 'sendTurn', paste_confirmed: confirmed },
+    'sendTurn: Enter sent',
+  );
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -678,6 +706,27 @@ async function isConversationSessionAlive(conv: OrchestratorConversation): Promi
     return !HOLDING_SHELL_COMMANDS.has(cmd);
   } catch {
     return false;
+  }
+}
+
+/**
+ * Wait for the conductor's TUI composer to be input-ready before pasting a turn.
+ * `claude` prints its prompt marker (`❯`) once the composer is interactive; until
+ * then keystrokes are dropped. Returns true once the marker appears, false on
+ * timeout (caller pastes anyway as a best effort).
+ */
+async function waitForConductorReady(target: string): Promise<boolean> {
+  const deadline = Date.now() + CONDUCTOR_READY_WAIT_MS;
+  for (;;) {
+    try {
+      const { stdout } = await execTmux(['capture-pane', '-t', target, '-p']);
+      // `❯` = composer prompt; the shortcuts hint also only shows once ready.
+      if (stdout.includes('❯') || /for shortcuts/i.test(stdout)) return true;
+    } catch {
+      // ignore — retry until deadline
+    }
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, CONDUCTOR_READY_POLL_MS));
   }
 }
 


### PR DESCRIPTION
## Why

Found while debugging "the conductor can't tell what the agent is doing / says it's running when it stopped." The agent hadn't stopped — it was **paused awaiting plan approval**, and the approval (`go ahead and implement`) was sitting **unsubmitted** in the worker's composer (`-- INSERT --`).

Root cause is the same vim bug fixed for the conductor in #220, but on the **worker** launch path: `installHooks` never set `editorMode`, so every worker inherits the operator's global `editorMode: vim`. octomux drives agents with tmux `send-keys` (paste → Enter); in vim insert mode Enter's submit behavior is mode-dependent and unreliable, so **plan approvals and `send_message` deliveries silently stall**. The agent then looks `running` forever while actually blocked on an input that never lands.

## Fix

`installHooks` writes `editorMode: "emacs"` into the worktree `settings.local.json` (preserving an explicit per-worktree value if one exists), matching what the conductor now does. `send-keys Enter` then submits deterministically — proven for the conductor at 3/3 in the e2e.

## Testing

New tests: `installHooks` sets `editorMode: emacs`, and preserves an explicit `vim` if the worktree set it. Full suite green (**3856**), typecheck + lint clean.

## Related (separate, not in this PR)

The user's other two observations point at follow-ups worth filing:
- **No agent-output read tool** — the conductor's read tools (`get_task`, `get_task_output`) return status + artifact pointers only, never the agent's actual output/last message, so it can't report what an agent is doing.
- **Status semantics** — `runtime_state: running` doesn't distinguish "actively working" from "paused at a review gate"; a task that hits a plan-approval gate stays `running/in_progress` with a stale `updated_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)