### PR TITLE
feat(agents): first-class long-running agents (page, config, live sessions)

### DIFF
--- a/plans/2026-07-24-agents-feature.md
+++ b/plans/2026-07-24-agents-feature.md
@@ -1,0 +1,264 @@
+# Agents feature — Implementation Plan
+
+> **For agentic workers:** implement task-by-task. Each task lists exact files, the interface it
+> produces/consumes, and an independently testable deliverable. Mirror existing neighbours — do not
+> invent patterns. Run `bun run test <files>` + `bun run typecheck` per task.
+
+**Goal:** A first-class **Agents** surface — create long-running agents (name + system prompt +
+channel binding), see them as status cards, open one to configure it or watch its live conductor
+session; each agent has the full orchestrator toolset and hears back from worker subagents.
+
+**Architecture:** Reuse the conductor runtime (tmux/claude/transcript + MCP tools + gateway). Add an
+`agents` config table; an agent's session is an `orchestrator_conversations` row tagged with
+`agent_id`, launched with the agent's system prompt. The existing orchestrator page and its
+`agent_id = NULL` conversations are untouched. Spec: `spec/agents-feature.md`.
+
+**Tech Stack:** Express 5 + better-sqlite3, React 19 + React Router 7 + Tailwind/shadcn, vitest.
+
+## ⚠️ Naming correction (discovered during Task 1 — applies to ALL later tasks)
+
+A table named `agents` **already exists** (per-task tmux-window workers, `repositories/agent-runtime.ts`).
+The new config table is therefore **`agent_configs`**, and `orchestrator_conversations.agent_id`
+references `agent_configs(id)`. `agent-runtime.ts` also already exports `getAgent`, so:
+
+- Import agent-config functions **directly**: `from '../repositories/agents-config.js'`
+  (`createAgent`, `getAgent`, `listAgents`, `updateAgent`, `deleteAgent`, `getAgentByChannel`), **or**
+- use the barrel alias `getAgentConfig` from `repositories/index.js` (only the colliding `getAgent`
+  is aliased; everything else passes through unaliased).
+
+`getAgentByChannel(channel, threadKey)`: `channel_config` is JSON `{ threadKey?: string }`. An agent
+with no `threadKey` binds to the whole channel; a specific `threadKey` match wins over channel-wide.
+
+**Route namespace (discovered during Task 4):** `/api/agents` is ALSO already taken
+(`routes/agent-defs.ts` = agent role definitions; `routes/chats.ts` = `PATCH /api/agents/:id/task`).
+Mounting there silently shadows them. The new CRUD is therefore at **`/api/agent-configs`**:
+
+- `GET|POST /api/agent-configs`, `GET|PATCH|DELETE /api/agent-configs/:id`
+- `POST /api/agent-configs/:id/session` → ensures + returns the agent's persistent conversation
+- Exported from `routes/agents-crud.ts`: `type AgentStatus = 'stopped'|'idle'|'working'`,
+  `deriveAgentStatus(agentId): Promise<{ status: AgentStatus; session_id: string|null }>`,
+  and the `AgentWithStatus` response type.
+- `isConversationSessionAlive(conv)` is now exported from `orchestrator/runner.ts` — reuse it.
+
+**Frontend must call `/api/agent-configs`, NOT `/api/agents`.**
+
+## Global Constraints
+
+- **Do NOT modify `src/pages/OrchestratorPage.tsx` or orchestrator behaviour.** Agents is a separate
+  surface; the orchestrator stays intact.
+- DB migrations are **forward-only**; append to `server/db/migrations.ts`.
+- All server logs via `childLogger`; every agent/session line includes ids.
+- Conventional commits; no `Co-Authored-By`. Do not commit unless told.
+- Reuse liveness (`isConversationSessionAlive`-style) and `get_agent_output` primitives — do not
+  reinvent tmux probing.
+
+---
+
+### Task 1: DB migration — `agents` table + `agent_id` on conversations
+
+**Files:** Modify `server/db/migrations.ts` (append), `server/db/schema.ts` (if new-DB schema lives
+there — check; else migration only). Test: `server/db.test.ts` or a new migration test.
+
+**Produces:** table `agents(id TEXT PK, name TEXT, system_prompt TEXT, channel TEXT NULL,
+channel_config TEXT NULL, created_at TEXT, updated_at TEXT)`; column
+`orchestrator_conversations.agent_id TEXT NULL`.
+
+- [ ] Append a migration creating `agents` and `ALTER TABLE orchestrator_conversations ADD COLUMN
+agent_id TEXT` (guard with the existing "column exists?" helper pattern already used in this file).
+- [ ] Add matching `CREATE TABLE`/column to `schema.ts` if that's where fresh DBs are built (mirror
+      how `channel_threads` was added).
+- [ ] Test: fresh `createTestDb()` has an `agents` table and `orchestrator_conversations.agent_id`.
+- [ ] Run `bun run test server/db.test.ts` + typecheck. Commit `feat(db): agents table + conversation agent_id`.
+
+---
+
+### Task 2: `agents` repository (CRUD)
+
+**Files:** Create `server/repositories/agents-config.ts`; export from `server/repositories/index.ts`.
+Test: `server/repositories/agents-config.test.ts`.
+
+**Consumes:** Task 1 schema. **Produces:**
+
+```ts
+export interface AgentConfig {
+  id: string;
+  name: string;
+  system_prompt: string;
+  channel: string | null;
+  channel_config: string | null;
+  created_at: string;
+  updated_at: string;
+}
+export function createAgent(input: {
+  name: string;
+  system_prompt: string;
+  channel?: string | null;
+  channel_config?: string | null;
+}): string; // nanoid(12)
+export function getAgent(id: string): AgentConfig | undefined;
+export function listAgents(): AgentConfig[];
+export function updateAgent(
+  id: string,
+  patch: Partial<Pick<AgentConfig, 'name' | 'system_prompt' | 'channel' | 'channel_config'>>,
+): void;
+export function deleteAgent(id: string): void;
+export function getAgentByChannel(channel: string, threadKey: string): AgentConfig | undefined; // matches channel + channel_config thread binding
+```
+
+- [ ] TDD each function against `createTestDb()`; `updated_at` bumps on update (template-literal `datetime('now')`).
+- [ ] Run tests + typecheck. Commit `feat(agents): agents-config repository`.
+
+---
+
+### Task 3: Per-agent system prompt in the conductor launch
+
+**Files:** Modify `server/orchestrator/conductor-flags.ts` (accept an optional `systemPrompt`),
+`server/orchestrator/runner.ts` (`startConversation`/`resumeConversation` opts thread it through).
+Tests: extend `server/orchestrator/conductor-flags.test.ts`, `runner.test.ts`.
+
+**Consumes:** none. **Produces:** `buildOrchestratorConductorFlags({ ..., systemPrompt?: string })`
+uses the given prompt (default = existing `ORCHESTRATOR_SYSTEM_PROMPT`). `StartConversationOpts`
+gains `systemPrompt?: string`; when the conversation has an `agent_id`, the caller passes the
+agent's `system_prompt`.
+
+- [ ] Failing test: flags include a custom `--append-system-prompt` when `systemPrompt` given.
+- [ ] Implement (default unchanged so orchestrator conversations are byte-identical).
+- [ ] Full suite (touches the runner) + typecheck. Commit `feat(orchestrator): per-conversation system prompt`.
+
+---
+
+### Task 4: `/api/agents` CRUD + derived status
+
+**Files:** Create `server/routes/agents-crud.ts`; mount in `server/api.ts` (shared — one-line add).
+Also `server/orchestrator/store.ts`: add `listConversationsByAgent(agentId)` /
+`getPrimaryAgentConversation(agentId)`. Test: `server/api.agents.test.ts` (supertest against `createApp()`).
+
+**Consumes:** Tasks 2, 3. **Produces:** REST:
+
+- `GET /api/agents` → `[{...AgentConfig, status: 'working'|'idle'|'stopped', session_id: string|null }]`
+- `POST /api/agents` `{name, system_prompt, channel?, channel_config?}` → `{id}` (creates the agent;
+  lazily starts its one session on first message rather than here).
+- `GET /api/agents/:id`, `PATCH /api/agents/:id`, `DELETE /api/agents/:id` (delete stops its session).
+- `POST /api/agents/:id/session` → ensure/return the agent's persistent conversation (starts one
+  via `startConversation` with the agent's prompt + `agent_id`).
+
+Status derivation: find the agent's conversation; `stopped` if none/tmux gone; else reuse the
+liveness probe — `working` if pane shows claude actively generating (approx: no idle prompt) else
+`idle`. Keep it a lean helper; don't block the list on many tmux calls (cap/parallelise).
+
+- [ ] TDD the routes (create → list shows it; delete removes; status shape).
+- [ ] Full suite + typecheck. Commit `feat(agents): CRUD API + status`.
+
+---
+
+### Task 5: Gateway — bind a channel thread to an agent's session
+
+**Files:** Modify `server/gateway/gateway.ts` (in `ensureThread`, if the channel/thread resolves to
+an agent via `getAgentByChannel`, use that agent's persistent conversation + system prompt instead
+of creating a throwaway). Test: extend `server/gateway/gateway.test.ts`.
+
+**Consumes:** Tasks 2, 3, 4 (`getPrimaryAgentConversation`, `startConversation({agentId, systemPrompt})`).
+**Produces:** inbound on a bound channel → the agent's persistent session; unbound channel → today's
+behaviour (unchanged). One session per agent (reused across messages/restarts).
+
+- [ ] Failing test: an inbound telegram msg whose (channel, threadKey) matches an agent binding
+      dispatches to that agent's conversation (assert conv reused, agent's prompt used).
+- [ ] Implement; keep the existing non-agent path intact.
+- [ ] `bun run test server/gateway/` + typecheck. Commit `feat(gateway): route bound channels to their agent session`.
+
+---
+
+### Task 6: Replace worker `report_complete` with `send_message` to the owner
+
+**Files:** Modify `server/orchestrator/mcp/write.ts` (drop `report_complete`/`callPhaseComplete`
+worker path OR make it delegate to send_message to the owning conversation), `server/orchestrator/mcp/server.ts`
+(tool registration), `server/orchestrator/command-registry.ts` (+ test), and the worker-launch
+MCP-config that enabled `report_complete`. Tests: `write` + `command-registry` + a routing test.
+
+**Consumes:** the managed_task `conversation_id` (owner). **Produces:** a worker that finishes/needs
+review calls `send_message` (or an internal equivalent) whose text + artifact link is delivered to
+the **owning agent's conversation** so the session AND any bound channel receive it (verify it flows
+through the transcript/gateway path, not only `pushToConversation`). For agent-dispatched tasks, **no
+approval cards** — a message with the artifact URL (`/api/orchestrator/artifact?task=…&path=…`).
+Keep the orchestrator page's own managed-task card flow working (only change the worker→owner report path).
+
+- [ ] Failing test: worker report on task owned by conv X results in a message delivered to conv X
+      that a gateway consumer would see (not WS-only).
+- [ ] Implement. Full suite + typecheck. Commit `fix(orchestrator): worker reports reach the owning agent via send_message`.
+
+---
+
+### Task 7: API client for agents (frontend data layer)
+
+**Files:** `src/lib/api.ts` (add `agentsApi`: list/create/get/update/delete/ensureSession) mirroring
+`orchestratorApi`. Test: extend the api client test if one exists, else a light unit test.
+
+**Consumes:** Task 4 REST. **Produces:** typed `agentsApi` used by Tasks 8–9.
+
+- [ ] Add typed methods + types; typecheck. Commit `feat(agents): frontend api client`.
+
+---
+
+### Task 8: Agents page — status cards
+
+**Files:** Create `src/pages/AgentsPage.tsx` + `src/pages/AgentsPage.test.tsx`. Uses `agentsApi.list`.
+
+**Consumes:** Task 7. **Produces:** `/agents` — a grid of agent **cards** (name, status pill
+working/idle/stopped, channel badge, last activity) + a "New agent" dialog (name, system prompt,
+channel + allow-list). Card click → `/agents/:id`. Follow `TasksPage`/`LoopsPage` card patterns +
+`makeTask`-style test helpers.
+
+- [ ] Component test: renders cards from mocked api; create dialog posts; empty state.
+- [ ] `bun run test src/pages/AgentsPage.test.tsx` + typecheck. Commit `feat(agents): agents cards page`.
+
+---
+
+### Task 9: Agent detail — Config + Sessions (chat) tabs
+
+**Files:** Create `src/pages/AgentDetailPage.tsx`, `src/components/AgentSessionChat.tsx` (+ tests).
+**Do not import from OrchestratorPage** — build the chat from the same lower-level pieces it uses
+(the orchestrator WS endpoint/hook, message list, send box). If a reusable chat hook/component
+doesn't exist yet, create `AgentSessionChat` standalone (may mirror OrchestratorPage internals, but
+as new files).
+
+**Consumes:** Task 7. **Produces:** `/agents/:id` with two tabs:
+
+- **Config** — edit name/system_prompt/channel(+allow-list); Save (PATCH), Delete.
+- **Sessions** — ensure/open the agent's session (`agentsApi.ensureSession`) and render the live
+  chat/CLI (WS stream to `/ws/orchestrator/:convId`, transcript render, send box) — same behaviour
+  as the orchestrator tab.
+- [ ] Component tests: Config save/delete; Sessions tab mounts the chat against a mocked WS/api.
+- [ ] Tests + typecheck. Commit `feat(agents): agent detail config + sessions tabs`.
+
+---
+
+### Task 10: Navigation + routes
+
+**Files:** Modify `src/App.tsx` (routes `/agents`, `/agents/:id`), the nav components
+(`src/components/MobileBottomNav.tsx` + the desktop sidebar/nav — find the orchestrator nav entry and
+add an **Agents** entry next to it; leave orchestrator intact). Tests: extend nav tests if present.
+
+**Consumes:** Tasks 8, 9. **Produces:** an **Agents** nav entry routing to `/agents`; orchestrator
+entry unchanged.
+
+- [ ] Add lazy routes + nav entries. Component/route smoke test.
+- [ ] Full suite + typecheck + lint. Commit `feat(agents): navigation + routes`.
+
+---
+
+## Self-Review
+
+- Spec coverage: agents table+status → T1,T2,T4; per-agent prompt → T3; channel trigger → T5;
+  report-back fix → T6; cards page → T8; config+sessions tabs → T9; nav (orchestrator intact) → T10. ✓
+- Orchestrator untouched: only T10 edits shared nav/App to ADD entries; OrchestratorPage.tsx is never
+  modified (global constraint). ✓
+- Shared-file bottlenecks (`migrations.ts` T1, `api.ts` T4, `index.ts` T2, `server.ts`/registry T6,
+  `App.tsx`/nav T10) are each isolated to one task → safe to parallelise the rest.
+
+## Execution / dispatch order
+
+- **Wave 1 (sequential foundation):** T1 → T2 → T3 (T2 needs T1; T3 independent but touches runner).
+- **Wave 2 (parallel, disjoint files):** T4, T5, T6 — T4 owns `api.ts`+store; T5 owns `gateway.ts`;
+  T6 owns `write.ts`/`server.ts`/registry. Disjoint. (T5 consumes T4's store helper — land T4 first
+  or stub the helper.)
+- **Wave 3:** T7 → then parallel T8, T9 (disjoint pages) → T10 (nav, last).

--- a/server/api.agents.test.ts
+++ b/server/api.agents.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { createTestDb } from './test-helpers.js';
+import { updateConversation } from './orchestrator/store.js';
+
+/**
+ * Fake conductor runtime: no real tmux. `startConversation` stamps a
+ * tmux_window (as the real one does after `new-session`) so the status
+ * helper's liveness probe has something to evaluate; `isConversationSessionAlive`
+ * is controllable per-test via `aliveOverride`.
+ */
+let aliveOverride: (() => Promise<boolean>) | null = null;
+
+vi.mock('./orchestrator/runner.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./orchestrator/runner.js')>();
+  return {
+    ...actual,
+    startConversation: vi.fn(async (convId: string) => {
+      updateConversation(convId, { tmux_window: `octomux-orch-${convId}:0` });
+    }),
+    stopConversation: vi.fn(async (convId: string) => {
+      updateConversation(convId, { status: 'stopped', tmux_window: null });
+    }),
+    isConversationSessionAlive: vi.fn(async () => (aliveOverride ? aliveOverride() : true)),
+  };
+});
+
+describe('agents CRUD routes', () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    aliveOverride = null;
+    createTestDb();
+    app = createApp();
+  });
+
+  describe('POST /api/agent-configs', () => {
+    it('creates an agent and returns it with derived status/session_id', async () => {
+      const res = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Ops Agent', system_prompt: 'You watch prod.' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe('Ops Agent');
+      expect(res.body.system_prompt).toBe('You watch prod.');
+      expect(res.body.status).toBe('stopped');
+      expect(res.body.session_id).toBeNull();
+      expect(res.body.id).toHaveLength(12);
+    });
+
+    it('accepts an optional channel + object channel_config (stored as JSON)', async () => {
+      const res = await request(app)
+        .post('/api/agent-configs')
+        .send({
+          name: 'Telegram Agent',
+          system_prompt: 'p',
+          channel: 'telegram',
+          channel_config: { threadKey: 'chat-1' },
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.channel).toBe('telegram');
+      expect(JSON.parse(res.body.channel_config)).toEqual({ threadKey: 'chat-1' });
+    });
+
+    it('rejects a missing name with 400', async () => {
+      const res = await request(app).post('/api/agent-configs').send({ system_prompt: 'p' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a blank system_prompt with 400', async () => {
+      const res = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'X', system_prompt: '   ' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/agent-configs', () => {
+    it('lists all agents with status', async () => {
+      await request(app).post('/api/agent-configs').send({ name: 'A', system_prompt: 'p1' });
+      await request(app).post('/api/agent-configs').send({ name: 'B', system_prompt: 'p2' });
+
+      const res = await request(app).get('/api/agent-configs');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(2);
+      expect(res.body.every((a: { status: string }) => a.status === 'stopped')).toBe(true);
+    });
+
+    it('returns an empty list when there are no agents', async () => {
+      const res = await request(app).get('/api/agent-configs');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('never throws even if the liveness probe errors (defaults to stopped)', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'A', system_prompt: 'p' });
+      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+
+      aliveOverride = () => Promise.reject(new Error('tmux exploded'));
+
+      const res = await request(app).get('/api/agent-configs');
+      expect(res.status).toBe(200);
+      expect(res.body[0].status).toBe('stopped');
+    });
+  });
+
+  describe('GET /api/agent-configs/:id', () => {
+    it('returns 404 for an unknown id', async () => {
+      const res = await request(app).get('/api/agent-configs/does-not-exist');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns the agent with status idle once its session is alive', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'A', system_prompt: 'p' });
+      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+
+      const res = await request(app).get(`/api/agent-configs/${create.body.id}`);
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('idle');
+      expect(res.body.session_id).toEqual(expect.any(String));
+    });
+  });
+
+  describe('PATCH /api/agent-configs/:id', () => {
+    it('updates given fields and leaves others untouched', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Original', system_prompt: 'orig' });
+
+      const res = await request(app)
+        .patch(`/api/agent-configs/${create.body.id}`)
+        .send({ name: 'Renamed' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('Renamed');
+      expect(res.body.system_prompt).toBe('orig');
+    });
+
+    it('rejects an empty name with 400', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Original', system_prompt: 'orig' });
+
+      const res = await request(app)
+        .patch(`/api/agent-configs/${create.body.id}`)
+        .send({ name: '   ' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for an unknown id', async () => {
+      const res = await request(app).patch('/api/agent-configs/does-not-exist').send({ name: 'X' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/agent-configs/:id', () => {
+    it('deletes the agent and stops its session if it has one', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Doomed', system_prompt: 'p' });
+      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+
+      const runner = await import('./orchestrator/runner.js');
+
+      const res = await request(app).delete(`/api/agent-configs/${create.body.id}`);
+      expect(res.status).toBe(204);
+      expect(runner.stopConversation).toHaveBeenCalledTimes(1);
+
+      const getRes = await request(app).get(`/api/agent-configs/${create.body.id}`);
+      expect(getRes.status).toBe(404);
+    });
+
+    it('deletes an agent that never had a session without calling stopConversation', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Never started', system_prompt: 'p' });
+
+      const runner = await import('./orchestrator/runner.js');
+
+      const res = await request(app).delete(`/api/agent-configs/${create.body.id}`);
+      expect(res.status).toBe(204);
+      expect(runner.stopConversation).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 for an unknown id', async () => {
+      const res = await request(app).delete('/api/agent-configs/does-not-exist');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/agent-configs/:id/session', () => {
+    it('returns 404 for an unknown agent', async () => {
+      const res = await request(app).post('/api/agent-configs/does-not-exist/session');
+      expect(res.status).toBe(404);
+    });
+
+    it('starts a fresh session with the agent name + system prompt', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Ops Agent', system_prompt: 'You watch prod.' });
+
+      const res = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('Ops Agent');
+      expect(res.body.agent_id).toBe(create.body.id);
+
+      const runner = await import('./orchestrator/runner.js');
+      expect(runner.startConversation).toHaveBeenCalledTimes(1);
+      const [, , opts] = (runner.startConversation as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(opts).toMatchObject({ systemPrompt: 'You watch prod.' });
+    });
+
+    it('reuses the existing session on a second call instead of starting another', async () => {
+      const create = await request(app)
+        .post('/api/agent-configs')
+        .send({ name: 'Ops Agent', system_prompt: 'p' });
+
+      const first = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      const second = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+
+      expect(second.body.id).toBe(first.body.id);
+
+      const runner = await import('./orchestrator/runner.js');
+      expect(runner.startConversation).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/server/api.ts
+++ b/server/api.ts
@@ -26,6 +26,7 @@ import { router as worktreesRouter } from './routes/worktrees.js';
 import { router as schedulesRouter } from './routes/schedules.js';
 import { router as scheduleSkillsRouter } from './routes/schedule-skills.js';
 import { router as workflowRunsRouter } from './routes/workflow-runs.js';
+import { router as agentsCrudRouter } from './routes/agents-crud.js';
 import { listWorkflows } from './workflows/registry.js';
 
 import { insertWorktreeIfAbsent, insertTaskIfAbsent, inTransaction } from './repositories/index.js';
@@ -59,6 +60,7 @@ export function setupRoutes(app: Express): void {
   app.use(schedulesRouter);
   app.use(scheduleSkillsRouter);
   app.use(workflowRunsRouter);
+  app.use(agentsCrudRouter);
 
   // ─── Test-only seed endpoint ─────────────────────────────────────────────────
   // Gated strictly on NODE_ENV=test. Never exposed in production.

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -664,3 +664,38 @@ describe('claude_session_id rename', () => {
     expect(indexes.map((i) => i.name)).not.toContain('idx_agents_claude_session_id');
   });
 });
+
+describe('agents feature: agent_configs table + orchestrator_conversations.agent_id', () => {
+  it('creates the agent_configs table on a fresh DB', () => {
+    const db = createTestDb();
+    const tables = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`)
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).toContain('agent_configs');
+
+    const cols = db.pragma('table_info(agent_configs)') as Array<{ name: string }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'id',
+        'name',
+        'system_prompt',
+        'channel',
+        'channel_config',
+        'created_at',
+        'updated_at',
+      ]),
+    );
+  });
+
+  it('adds a nullable agent_id column to orchestrator_conversations', () => {
+    const db = createTestDb();
+    const cols = db.pragma('table_info(orchestrator_conversations)') as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const agentIdCol = cols.find((c) => c.name === 'agent_id');
+    expect(agentIdCol).toBeDefined();
+    expect(agentIdCol!.notnull).toBe(0);
+  });
+});

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -970,4 +970,29 @@ export function runMigrations(instance: Database.Database): void {
       PRIMARY KEY (channel, external_id)
     );
   `);
+
+  // ── Agents feature: long-running agent config + owning conversation link
+  // (2026-07-24) ─────────────────────────────────────────────────────────────
+  // Named `agent_configs` (not `agents`) — the `agents` table already exists
+  // and means something different (a per-task tmux-window worker). An agent's
+  // live session is an `orchestrator_conversations` row tagged with agent_id.
+  instance.exec(`
+    CREATE TABLE IF NOT EXISTS agent_configs (
+      id             TEXT PRIMARY KEY,
+      name           TEXT NOT NULL,
+      system_prompt  TEXT NOT NULL,
+      channel        TEXT,
+      channel_config TEXT,
+      created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  const orchConvColsForAgent = columnsOf(instance, 'orchestrator_conversations');
+  addColumn(
+    instance,
+    'orchestrator_conversations',
+    'agent_id',
+    'agent_id TEXT REFERENCES agent_configs(id) ON DELETE SET NULL',
+    orchConvColsForAgent,
+  );
 }

--- a/server/gateway/gateway.test.ts
+++ b/server/gateway/gateway.test.ts
@@ -3,7 +3,9 @@ import { createTestDb } from '../test-helpers.js';
 import { createGateway, type GatewayConductor } from './gateway.js';
 import type { ChannelAdapter, InboundMessage } from './adapter.js';
 import type { ChatEvent } from '../orchestrator/transcript.js';
-import { updateConversation } from '../orchestrator/store.js';
+import { updateConversation, getPrimaryAgentConversation } from '../orchestrator/store.js';
+import { createAgent } from '../repositories/agents-config.js';
+import { pushToConversation } from '../orchestrator/stream.js';
 
 /** A fake adapter that records outbound sends / typing indicators. */
 function fakeAdapter() {
@@ -33,9 +35,11 @@ function fakeConductor() {
   const consumers = new Map<string, (e: ChatEvent) => void>();
 
   const conductor: GatewayConductor = {
-    startConversation: vi.fn(async (convId: string) => {
-      updateConversation(convId, { transcript_path: `/fake/${convId}.jsonl` });
-    }),
+    startConversation: vi.fn(
+      async (convId: string, _cwd: string, _opts?: { systemPrompt?: string }) => {
+        updateConversation(convId, { transcript_path: `/fake/${convId}.jsonl` });
+      },
+    ),
     sendTurn,
     interruptTurn,
     registerConsumer: vi.fn((convId, _path, consumer) => {
@@ -147,5 +151,122 @@ describe('gateway glue', () => {
 
     expect(interruptTurn).toHaveBeenCalledWith(convId);
     expect(sendTurn).toHaveBeenCalledTimes(2);
+  });
+
+  it("routes an inbound message on a channel bound to an agent to that agent's persistent session", async () => {
+    const agentId = createAgent({
+      name: 'Ops Agent',
+      system_prompt: 'You watch prod and page on-call.',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-1' }),
+    });
+
+    const { adapter } = fakeAdapter();
+    const { conductor, sendTurn } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    await gw.handleInbound(inbound());
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    const convId = sendTurn.mock.calls[0]![0] as string;
+
+    // The agent now has exactly one persistent conversation, and it's the one dispatched to.
+    const agentConv = getPrimaryAgentConversation(agentId);
+    expect(agentConv?.id).toBe(convId);
+
+    // The session was started with the agent's system prompt.
+    expect(conductor.startConversation).toHaveBeenCalledWith(
+      convId,
+      expect.any(String),
+      expect.objectContaining({ systemPrompt: 'You watch prod and page on-call.' }),
+    );
+  });
+
+  it('reuses the same agent conversation across messages and does not restart the session', async () => {
+    createAgent({
+      name: 'Ops Agent',
+      system_prompt: 'You watch prod.',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-1' }),
+    });
+
+    const { adapter } = fakeAdapter();
+    const { conductor, sendTurn, emit } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    await gw.handleInbound(inbound({ externalId: 'm1' }));
+    const convId = sendTurn.mock.calls[0]![0] as string;
+    emit(convId, { type: 'system', subtype: 'stop_hook_summary', uuid: 's1', timestamp: 't' });
+
+    await gw.handleInbound(inbound({ externalId: 'm2', text: 'follow up' }));
+
+    expect(sendTurn).toHaveBeenCalledTimes(2);
+    expect(sendTurn.mock.calls[1]![0]).toBe(convId);
+    expect(conductor.startConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('an unbound channel keeps the throwaway-conversation behaviour (no agent involved)', async () => {
+    // No agent bound to this channel/thread at all.
+    const { adapter } = fakeAdapter();
+    const { conductor, sendTurn } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    await gw.handleInbound(inbound());
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+
+    // No agent involved — the conductor is started with no systemPrompt override
+    // (today's throwaway-conversation behaviour, unchanged).
+    const startCall = (conductor.startConversation as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(startCall[2]).toBeUndefined();
+  });
+
+  it('worker report_complete (relayed via pushToConversation) reaches a bound channel (Task 6)', async () => {
+    createAgent({
+      name: 'Ops Agent',
+      system_prompt: 'You watch prod.',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-1' }),
+    });
+
+    const { adapter, sent } = fakeAdapter();
+    const { conductor, sendTurn } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    // Establish the thread (registers the gateway's conversation-message listener).
+    await gw.handleInbound(inbound());
+    const convId = sendTurn.mock.calls[0]![0] as string;
+
+    // Simulate the supervisor relaying a worker's phase-complete report — the
+    // exact path that used to be WS-only (`pushToConversation`) and never
+    // reached the gateway before this fix.
+    pushToConversation(
+      convId,
+      JSON.stringify({
+        type: 'message',
+        role: 'assistant',
+        text: '[supervisor] task `t1` plan ready — review and approve to begin implementation.',
+      }),
+    );
+    pushToConversation(
+      convId,
+      JSON.stringify({
+        type: 'card',
+        id: 'card-1',
+        command: 'approve-plan',
+        args: {
+          task_id: 't1',
+          plan_path: 'plan.json',
+          artifact_url: '/api/orchestrator/artifact?task=t1&path=plan.json',
+        },
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sent.map((s) => s.text)).toEqual([
+      '[supervisor] task `t1` plan ready — review and approve to begin implementation.',
+      '[t1] plan ready for review: /api/orchestrator/artifact?task=t1&path=plan.json',
+    ]);
   });
 });

--- a/server/gateway/gateway.ts
+++ b/server/gateway/gateway.ts
@@ -20,9 +20,19 @@ import { redactSecrets } from './redact.js';
 import { OutboundQueue } from './outbound.js';
 import type { ChannelAdapter, InboundMessage } from './adapter.js';
 import { getThreadConv, setThreadConv, seenInbound, markInbound } from '../repositories/gateway.js';
-import { createConversation, getConversation } from '../orchestrator/store.js';
+import {
+  createConversation,
+  getConversation,
+  getPrimaryAgentConversation,
+} from '../orchestrator/store.js';
+import { getAgentByChannel } from '../repositories/agents-config.js';
 import { startConversation, sendTurn, interruptTurn } from '../orchestrator/runner.js';
-import { registerTranscriptConsumer } from '../orchestrator/stream.js';
+import type { StartConversationOpts } from '../orchestrator/runner.js';
+import {
+  registerTranscriptConsumer,
+  registerConversationMessageListener,
+} from '../orchestrator/stream.js';
+import type { OrchestratorWsEvent } from '../orchestrator/stream.js';
 import { isTurnDone, type ChatEvent } from '../orchestrator/transcript.js';
 
 const logger = childLogger('gateway');
@@ -41,6 +51,8 @@ interface ThreadState {
   /** True between sending a turn and its stop_hook_summary boundary. */
   inFlight: boolean;
   unregister: () => void;
+  /** Unregisters the conversation-message listener (worker reports; Task 6). */
+  unregisterMessages: () => void;
 }
 
 /**
@@ -50,7 +62,7 @@ interface ThreadState {
  * real. Production uses `realConductor` (the module functions above).
  */
 export interface GatewayConductor {
-  startConversation(convId: string, cwd: string): Promise<void>;
+  startConversation(convId: string, cwd: string, opts?: StartConversationOpts): Promise<void>;
   sendTurn(convId: string, text: string): Promise<void>;
   interruptTurn(convId: string): Promise<void>;
   registerConsumer(
@@ -61,7 +73,7 @@ export interface GatewayConductor {
 }
 
 const realConductor: GatewayConductor = {
-  startConversation: (convId, cwd) => startConversation(convId, cwd),
+  startConversation: (convId, cwd, opts) => startConversation(convId, cwd, opts),
   sendTurn,
   interruptTurn,
   registerConsumer: registerTranscriptConsumer,
@@ -97,17 +109,79 @@ export function createGateway(
     };
   }
 
+  /**
+   * Format a supervisor-pushed `card` event as plain text with a tappable
+   * artifact link, for channels (Telegram) that have no card UI.
+   */
+  function formatCardEvent(event: Extract<OrchestratorWsEvent, { type: 'card' }>): string {
+    const args = event.args;
+    const taskId = typeof args.task_id === 'string' ? args.task_id : undefined;
+    const artifactUrl = typeof args.artifact_url === 'string' ? args.artifact_url : undefined;
+    const label =
+      event.command === 'approve-plan'
+        ? 'plan ready for review'
+        : event.command === 'view-spec'
+          ? 'spec ready for review'
+          : event.command;
+    const prefix = taskId ? `[${taskId}] ` : '';
+    return artifactUrl ? `${prefix}${label}: ${artifactUrl}` : `${prefix}${label}`;
+  }
+
+  /**
+   * Worker reports reach the owning agent (Task 6): the supervisor relays a
+   * worker's `task:phase_complete` (and other notes) via `pushToConversation`,
+   * which only reached WS clients before. This listener is the gateway's other
+   * ear on that same conversation, so a bound channel gets the report too —
+   * with the artifact URL as a tappable link. It's a distinct source from the
+   * live transcript tail (`makeConsumer` above), so nothing here is
+   * double-delivered by the transcript path.
+   */
+  function makeMessageListener(state: ThreadState): (event: OrchestratorWsEvent) => void {
+    return (event) => {
+      if (event.type === 'message') {
+        if (event.role !== 'assistant') return;
+        const text = redactSecrets(event.text.trim());
+        if (text) outbound.enqueue(state.threadKey, text);
+        return;
+      }
+      if (event.type === 'card') {
+        const text = redactSecrets(formatCardEvent(event));
+        if (text) outbound.enqueue(state.threadKey, text);
+      }
+    };
+  }
+
   async function ensureThread(msg: InboundMessage): Promise<ThreadState> {
     const k = key(msg.channel, msg.threadKey);
     const existing = threads.get(k);
     if (existing) return existing;
 
-    // Reconnect to a mapped conversation across restarts, or create a new one.
-    let convId = getThreadConv(msg.channel, msg.threadKey);
-    if (!convId || !getConversation(convId)) {
-      convId = createConversation({ title: `${msg.channel}:${msg.threadKey}` });
-      await conductor.startConversation(convId, gatewayCwd());
-      setThreadConv(msg.channel, msg.threadKey, convId);
+    // Agents feature: if this (channel, threadKey) is bound to an agent, route
+    // to that agent's ONE persistent session — reused across every message and
+    // every thread bound to it, and across restarts (found again next time via
+    // getPrimaryAgentConversation, no thread-map row needed). Falls through to
+    // today's throwaway-conversation behaviour when unbound.
+    const agent = getAgentByChannel(msg.channel, msg.threadKey);
+
+    let convId: string;
+    if (agent) {
+      const existingConv = getPrimaryAgentConversation(agent.id);
+      if (existingConv) {
+        convId = existingConv.id;
+      } else {
+        convId = createConversation({ title: agent.name, agent_id: agent.id });
+        await conductor.startConversation(convId, gatewayCwd(), {
+          systemPrompt: agent.system_prompt,
+        });
+      }
+    } else {
+      // Reconnect to a mapped conversation across restarts, or create a new one.
+      convId = getThreadConv(msg.channel, msg.threadKey) ?? '';
+      if (!convId || !getConversation(convId)) {
+        convId = createConversation({ title: `${msg.channel}:${msg.threadKey}` });
+        await conductor.startConversation(convId, gatewayCwd());
+        setThreadConv(msg.channel, msg.threadKey, convId);
+      }
     }
 
     const transcriptPath = getConversation(convId)?.transcript_path;
@@ -122,8 +196,16 @@ export function createGateway(
       buffer: [],
       inFlight: false,
       unregister: () => {},
+      unregisterMessages: () => {},
     };
     state.unregister = conductor.registerConsumer(convId, transcriptPath, makeConsumer(state));
+    // Not part of the conductor injection seam — it touches no tmux/transcript,
+    // just an in-process listener registry (see stream.ts), so it runs for real
+    // in tests too.
+    state.unregisterMessages = registerConversationMessageListener(
+      convId,
+      makeMessageListener(state),
+    );
     threads.set(k, state);
     return state;
   }

--- a/server/orchestrator/conductor-flags.test.ts
+++ b/server/orchestrator/conductor-flags.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { claudeCodeHarness } from '../harnesses/claude-code.js';
+import { shellQuoteSingle } from '../shell-quote.js';
 import { buildOrchestratorConductorFlags, ORCHESTRATOR_SYSTEM_PROMPT } from './conductor-flags.js';
 
 describe('buildOrchestratorConductorFlags', () => {
@@ -40,6 +41,34 @@ describe('buildOrchestratorConductorFlags', () => {
     expect(cmd).toBe(
       `claude --session-id sess-1 --settings '/tmp/settings.local.json' --mcp-config '/tmp/mcp-config.json' --strict-mcp-config --append-system-prompt '${ORCHESTRATOR_SYSTEM_PROMPT.replace(/'/g, `'\\''`)}'`,
     );
+  });
+
+  it('defaults to ORCHESTRATOR_SYSTEM_PROMPT when systemPrompt is omitted (byte-identical flags)', () => {
+    const withDefault = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: '/tmp/mcp-config.json',
+    });
+    const withExplicitDefault = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: '/tmp/mcp-config.json',
+      systemPrompt: ORCHESTRATOR_SYSTEM_PROMPT,
+    });
+
+    expect(withDefault).toBe(withExplicitDefault);
+    expect(withDefault).toContain(shellQuoteSingle(ORCHESTRATOR_SYSTEM_PROMPT));
+  });
+
+  it('uses a custom systemPrompt in --append-system-prompt when given', () => {
+    const customPrompt = 'You are AGENT Foo. Only do X.';
+    const flags = buildOrchestratorConductorFlags({
+      settingsPath: '/tmp/settings.local.json',
+      mcpConfigPath: '/tmp/mcp-config.json',
+      systemPrompt: customPrompt,
+    });
+
+    expect(flags).toContain('--append-system-prompt');
+    expect(flags).toContain(shellQuoteSingle(customPrompt));
+    expect(flags).not.toContain(ORCHESTRATOR_SYSTEM_PROMPT);
   });
 
   it('routes through harness buildResumeCommand with orchestrator flags', () => {

--- a/server/orchestrator/conductor-flags.ts
+++ b/server/orchestrator/conductor-flags.ts
@@ -38,6 +38,13 @@ export interface OrchestratorConductorFlagsOpts {
   /** Path to the conductor mcp-config.json (octomux read tools), or null. */
   mcpConfigPath?: string | null;
   extraFlags?: string;
+  /**
+   * Overrides `ORCHESTRATOR_SYSTEM_PROMPT` in `--append-system-prompt`. Used
+   * by the Agents feature so a long-running agent's session runs with its own
+   * configured prompt. Defaults to `ORCHESTRATOR_SYSTEM_PROMPT` — omitting
+   * this must produce byte-identical flags for existing orchestrator conversations.
+   */
+  systemPrompt?: string;
 }
 
 /**
@@ -52,12 +59,13 @@ export function buildOrchestratorConductorFlags({
   settingsPath,
   mcpConfigPath,
   extraFlags = '',
+  systemPrompt = ORCHESTRATOR_SYSTEM_PROMPT,
 }: OrchestratorConductorFlagsOpts): string {
   let flags = ` --settings ${shellQuoteSingle(settingsPath)}`;
   if (mcpConfigPath) {
     flags += ` --mcp-config ${shellQuoteSingle(mcpConfigPath)} --strict-mcp-config`;
   }
-  flags += ` --append-system-prompt ${shellQuoteSingle(ORCHESTRATOR_SYSTEM_PROMPT)}`;
+  flags += ` --append-system-prompt ${shellQuoteSingle(systemPrompt)}`;
   if (extraFlags) {
     flags += extraFlags.startsWith(' ') ? extraFlags : ` ${extraFlags}`;
   }

--- a/server/orchestrator/runner.test.ts
+++ b/server/orchestrator/runner.test.ts
@@ -85,6 +85,7 @@ import {
   conversationTmuxTarget,
 } from './runner.js';
 import { createConversation, getConversation, updateConversation } from './store.js';
+import { ORCHESTRATOR_SYSTEM_PROMPT } from './conductor-flags.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -286,6 +287,28 @@ describe('orchestrator runner', () => {
       expect(cwdIndex).toBeGreaterThan(-1);
       expect(newSession![cwdIndex + 1]).toBe('/tmp/test-repo');
     });
+
+    it('defaults to the orchestrator system prompt when opts.systemPrompt is omitted', async () => {
+      const convId = createConversation({ title: 'Default prompt test' });
+      await startConversation(convId, '/tmp/test-repo');
+
+      const newSession = findTmuxCall('new-session');
+      const startupCmdArg = newSession!.find((a) => a.includes('claude'));
+      expect(startupCmdArg!).toContain('--append-system-prompt');
+      expect(startupCmdArg!).toContain(ORCHESTRATOR_SYSTEM_PROMPT.slice(0, 40));
+    });
+
+    it('uses opts.systemPrompt for --append-system-prompt when given (Agents feature)', async () => {
+      const convId = createConversation({ title: 'Agent prompt test' });
+      await startConversation(convId, '/tmp/test-repo', {
+        systemPrompt: 'You are Agent One. Only do X.',
+      });
+
+      const newSession = findTmuxCall('new-session');
+      const startupCmdArg = newSession!.find((a) => a.includes('claude'));
+      expect(startupCmdArg!).toContain('You are Agent One. Only do X.');
+      expect(startupCmdArg!).not.toContain(ORCHESTRATOR_SYSTEM_PROMPT.slice(0, 40));
+    });
   });
 
   // ── resumeConversation ─────────────────────────────────────────────────────
@@ -318,6 +341,18 @@ describe('orchestrator runner', () => {
       expect(cmdArg).toBeDefined();
       // Should launch a new session (no --resume) since no session_id
       expect(cmdArg!).not.toContain('--resume');
+    });
+
+    it('uses opts.systemPrompt for --append-system-prompt when given (Agents feature)', async () => {
+      const convId = createConversation({ title: 'Resume with agent prompt' });
+      await resumeConversation(convId, '/tmp/test-repo', {
+        systemPrompt: 'You are Agent One. Only do X.',
+      });
+
+      const newSession = findTmuxCall('new-session');
+      const cmdArg = newSession!.find((a) => a.includes('claude'));
+      expect(cmdArg!).toContain('You are Agent One. Only do X.');
+      expect(cmdArg!).not.toContain(ORCHESTRATOR_SYSTEM_PROMPT.slice(0, 40));
     });
   });
 

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -316,6 +316,13 @@ export interface StartConversationOpts {
   claudeSessionId?: string;
   /** Additional claude CLI flags. */
   extraFlags?: string;
+  /**
+   * Overrides the default `ORCHESTRATOR_SYSTEM_PROMPT` for this conversation's
+   * conductor session. Used by the Agents feature: an `agent_id`-tagged
+   * conversation is launched with its agent's configured system prompt.
+   * Omitting it keeps today's orchestrator behaviour unchanged.
+   */
+  systemPrompt?: string;
 }
 
 /**
@@ -346,6 +353,7 @@ export async function startConversation(
     settingsPath,
     mcpConfigPath,
     extraFlags: opts.extraFlags,
+    systemPrompt: opts.systemPrompt,
   });
 
   const claudeCmd = harness.buildLaunchCommand({ sessionId, flags });
@@ -415,6 +423,7 @@ export async function resumeConversation(
     settingsPath,
     mcpConfigPath,
     extraFlags: opts.extraFlags,
+    systemPrompt: opts.systemPrompt,
   });
 
   const claudeSessionId = opts.claudeSessionId ?? conv.claude_session_id;
@@ -691,8 +700,12 @@ const HOLDING_SHELL_COMMANDS = new Set([
  * booting/holding shell (or empty) is treated as a live conductor.
  *
  * A failed `display-message` (no such session) also means not-alive.
+ *
+ * Exported so callers outside this module (e.g. the Agents-feature status
+ * helper in `routes/agents-crud.ts`) reuse this one tmux probe instead of
+ * re-implementing pane-liveness detection.
  */
-async function isConversationSessionAlive(conv: OrchestratorConversation): Promise<boolean> {
+export async function isConversationSessionAlive(conv: OrchestratorConversation): Promise<boolean> {
   if (!conv.tmux_window) return false;
   try {
     const { stdout } = await execTmux([

--- a/server/orchestrator/store.ts
+++ b/server/orchestrator/store.ts
@@ -16,6 +16,8 @@ export interface OrchestratorConversation {
   hook_token: string | null;
   /** The cwd the conductor session was launched from (used to resume a dead session). */
   cwd: string | null;
+  /** Agents feature: the `agent_configs` row this session belongs to, or null for an orchestrator-page conversation. */
+  agent_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -67,6 +69,8 @@ export interface CreateConversationInput {
   tmux_window?: string;
   claude_session_id?: string;
   transcript_path?: string;
+  /** Agents feature: tag this conversation as the persistent session of an `agent_configs` row. */
+  agent_id?: string;
 }
 
 /** Create a new orchestrator conversation. Returns the new id. */
@@ -74,8 +78,8 @@ export function createConversation(input: CreateConversationInput): string {
   const id = nanoid(12);
   getDb()
     .prepare(
-      `INSERT INTO orchestrator_conversations (id, title, tmux_window, claude_session_id, transcript_path)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO orchestrator_conversations (id, title, tmux_window, claude_session_id, transcript_path, agent_id)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -83,6 +87,7 @@ export function createConversation(input: CreateConversationInput): string {
       input.tmux_window ?? null,
       input.claude_session_id ?? null,
       input.transcript_path ?? null,
+      input.agent_id ?? null,
     );
   return id;
 }
@@ -116,6 +121,29 @@ export function listConversations(): OrchestratorConversation[] {
       `SELECT * FROM orchestrator_conversations WHERE status != 'deleted' ORDER BY updated_at DESC`,
     )
     .all() as OrchestratorConversation[];
+}
+
+/**
+ * List all (non-deleted) conversations tagged with a given agent, most recently
+ * updated first. Agents feature: an agent's conversations are the sessions
+ * launched with its `agent_id` (see `getPrimaryAgentConversation` for the single
+ * persistent one).
+ */
+export function listConversationsByAgent(agentId: string): OrchestratorConversation[] {
+  return getDb()
+    .prepare(
+      `SELECT * FROM orchestrator_conversations WHERE agent_id = ? AND status != 'deleted' ORDER BY updated_at DESC`,
+    )
+    .all(agentId) as OrchestratorConversation[];
+}
+
+/**
+ * The agent's single persistent conductor session — the most recently updated
+ * conversation tagged with this `agent_id`, or undefined if the agent has never
+ * had one started.
+ */
+export function getPrimaryAgentConversation(agentId: string): OrchestratorConversation | undefined {
+  return listConversationsByAgent(agentId)[0];
 }
 
 /** Update conversation fields (partial). */

--- a/server/orchestrator/stream.test.ts
+++ b/server/orchestrator/stream.test.ts
@@ -16,6 +16,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
+import { createServer, type Server } from 'http';
+import { WebSocket } from 'ws';
 import { createApp } from '../app.js';
 import { createTestDb } from '../test-helpers.js';
 import {
@@ -35,7 +37,11 @@ import {
   cardRowToWsEvent,
   replayConnectionState,
   registerTranscriptConsumer,
+  registerConversationMessageListener,
+  pushToConversation,
+  cleanupOrchestratorClients,
 } from './stream.js';
+import type { OrchestratorWsEvent } from './stream.js';
 import { tailTranscript } from './transcript.js';
 import type { ActionCard } from './store.js';
 import type { ChatEvent } from './transcript.js';
@@ -454,6 +460,119 @@ describe('handleOrchestratorUpgrade', () => {
       result = true;
     }
     expect(result).toBe(true);
+  });
+});
+
+// ─── pushToConversation → gateway listener + web WS (agents-feature Task 6) ───
+
+describe('pushToConversation delivers to both a gateway listener and web WS clients', () => {
+  let server: Server;
+  let port: number;
+
+  function connectWs(convId: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${port}/ws/orchestrator/${convId}`);
+      ws.on('open', () => resolve(ws));
+      ws.on('error', reject);
+    });
+  }
+
+  beforeEach(async () => {
+    createTestDb();
+    setupOrchestratorWebSocket();
+    server = createServer();
+    server.on('upgrade', (req, socket, head) => {
+      if (!handleOrchestratorUpgrade(req, socket, head)) socket.destroy();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        const addr = server.address();
+        port = typeof addr === 'object' && addr ? addr.port : 0;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    cleanupOrchestratorClients();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('forwards a worker-report message to a registered listener (the gateway) AND the connected web WS client', async () => {
+    const convId = createConversation({ title: 'agent session' });
+    const ws = await connectWs(convId);
+    const received: string[] = [];
+    ws.on('message', (data) => received.push(data.toString()));
+
+    const forwarded: OrchestratorWsEvent[] = [];
+    registerConversationMessageListener(convId, (event) => forwarded.push(event));
+
+    pushToConversation(
+      convId,
+      JSON.stringify({ type: 'message', role: 'assistant', text: 'worker report: done' }),
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The gateway-style listener saw it (this is the fix — it did not before).
+    expect(forwarded).toEqual([
+      { type: 'message', role: 'assistant', text: 'worker report: done' },
+    ]);
+    // The web WS path still receives it exactly as before (additive change, not a replacement).
+    expect(
+      received.some((m) => (JSON.parse(m) as { text?: string }).text === 'worker report: done'),
+    ).toBe(true);
+
+    ws.close();
+  });
+
+  it('forwards a card event (with its artifact_url) to the registered listener', async () => {
+    const convId = createConversation({ title: 'agent session' });
+    const forwarded: OrchestratorWsEvent[] = [];
+    registerConversationMessageListener(convId, (event) => forwarded.push(event));
+
+    pushToConversation(
+      convId,
+      JSON.stringify({
+        type: 'card',
+        id: 'card-1',
+        command: 'approve-plan',
+        args: {
+          task_id: 't1',
+          plan_path: 'plan.json',
+          artifact_url: '/api/orchestrator/artifact?task=t1&path=plan.json',
+        },
+      }),
+    );
+
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0]).toMatchObject({ type: 'card', command: 'approve-plan' });
+  });
+
+  it('does not notify the listener for non message/card events (e.g. status)', () => {
+    const convId = createConversation({ title: 'agent session' });
+    const forwarded: OrchestratorWsEvent[] = [];
+    registerConversationMessageListener(convId, (event) => forwarded.push(event));
+
+    pushToConversation(convId, JSON.stringify({ type: 'status', status: 'thinking' }));
+
+    expect(forwarded).toHaveLength(0);
+  });
+
+  it('unregister stops further delivery to that listener', async () => {
+    const convId = createConversation({ title: 'agent session' });
+    const forwarded: OrchestratorWsEvent[] = [];
+    const unregister = registerConversationMessageListener(convId, (event) =>
+      forwarded.push(event),
+    );
+    unregister();
+
+    pushToConversation(
+      convId,
+      JSON.stringify({ type: 'message', role: 'assistant', text: 'should not arrive' }),
+    );
+
+    expect(forwarded).toHaveLength(0);
   });
 });
 

--- a/server/orchestrator/stream.ts
+++ b/server/orchestrator/stream.ts
@@ -140,6 +140,43 @@ const convTailStarting = new Map<string, Promise<void>>();
 /** conversation_id → unregister fn for the shared WS-bridge consumer. */
 const convWsUnregister = new Map<string, () => void>();
 
+/**
+ * conversation_id → listeners notified whenever `pushToConversation` fires a
+ * `message` or `card` event (SHR agents-feature Task 6). This is a SEPARATE
+ * registry from `convConsumers`: those carry raw ChatEvents off the live
+ * transcript tail (the conductor's own turn); this one carries supervisor-
+ * injected notes/cards, which are synthesized at the app layer and never
+ * written into the transcript JSONL, so the two never double-deliver the same
+ * event. The gateway is the intended consumer — it lets a worker's
+ * `task:phase_complete` report (relayed via `pushToConversation`) reach a
+ * bound channel, not just connected WS clients.
+ */
+const convMessageListeners = new Map<string, Set<(event: OrchestratorWsEvent) => void>>();
+
+/**
+ * Register a listener notified of every `message`/`card` event pushed to a
+ * conversation via `pushToConversation` (additive to, and independent of, the
+ * WS client fan-out below). Returns an unregister fn.
+ */
+export function registerConversationMessageListener(
+  convId: string,
+  listener: (event: OrchestratorWsEvent) => void,
+): () => void {
+  let set = convMessageListeners.get(convId);
+  if (!set) {
+    set = new Set();
+    convMessageListeners.set(convId, set);
+  }
+  set.add(listener);
+
+  return () => {
+    const s = convMessageListeners.get(convId);
+    if (!s) return;
+    s.delete(listener);
+    if (s.size === 0) convMessageListeners.delete(convId);
+  };
+}
+
 function addClient(convId: string, push: PushFn, transcriptPath: string | null): void {
   let set = convClients.get(convId);
   if (!set) {
@@ -610,30 +647,55 @@ export function getOrchestratorClientCount(convId: string): number {
 /**
  * Push a serialized ws message to all connected clients for a conversation.
  * Used by the supervisor to inject concise notes without going through the
- * transcript tail. Also persists message-type events to orchestrator_messages.
+ * transcript tail. Also persists message-type events to orchestrator_messages,
+ * and notifies any registered conversation-message listeners (the gateway) —
+ * this is what lets a worker's report reach a bound channel, not just the web
+ * dashboard's WS clients.
  *
  * The `message` parameter must be a serialized JSON string (OrchestratorWsEvent).
  */
 export function pushToConversation(convId: string, message: string): void {
-  // Persist if it's a message-type event
+  let event: OrchestratorWsEvent | undefined;
   try {
-    const event = JSON.parse(message) as OrchestratorWsEvent;
-    if (event.type === 'message') {
-      const contentBlocks = [{ type: 'text', text: event.text }];
-      appendMessage({
-        conversation_id: convId,
-        role: event.role,
-        content: JSON.stringify(contentBlocks),
-      });
-    }
+    event = JSON.parse(message) as OrchestratorWsEvent;
   } catch {
-    // ignore parse errors — still push to clients
+    // ignore parse errors — still push to WS clients below
   }
 
-  const set = convClients.get(convId);
-  if (!set || set.size === 0) return;
-  for (const push of set) {
-    push(message);
+  // Persist if it's a message-type event
+  if (event?.type === 'message') {
+    const contentBlocks = [{ type: 'text', text: event.text }];
+    appendMessage({
+      conversation_id: convId,
+      role: event.role,
+      content: JSON.stringify(contentBlocks),
+    });
+  }
+
+  const clients = convClients.get(convId);
+  if (clients && clients.size > 0) {
+    for (const push of clients) {
+      push(message);
+    }
+  }
+
+  // Additive: notify any registered conversation-message listeners (e.g. the
+  // gateway) so a bound channel also sees message/card events, independent of
+  // whether any WS client is connected.
+  if (event && (event.type === 'message' || event.type === 'card')) {
+    const listeners = convMessageListeners.get(convId);
+    if (listeners) {
+      for (const listener of listeners) {
+        try {
+          listener(event);
+        } catch (err) {
+          logger.warn(
+            { conversation_id: convId, err },
+            'stream: conversation message listener threw',
+          );
+        }
+      }
+    }
   }
 }
 
@@ -652,4 +714,5 @@ export function cleanupOrchestratorClients(): void {
   convClients.clear();
   convConsumers.clear();
   convWsUnregister.clear();
+  convMessageListeners.clear();
 }

--- a/server/repositories/agents-config.test.ts
+++ b/server/repositories/agents-config.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from '../test-helpers.js';
+import { getDb } from '../db.js';
+import {
+  createAgent,
+  getAgent,
+  listAgents,
+  updateAgent,
+  deleteAgent,
+  getAgentByChannel,
+} from './agents-config.js';
+
+describe('agents-config repo', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('createAgent inserts a row and returns a nanoid(12) id', () => {
+    const id = createAgent({ name: 'Ops Agent', system_prompt: 'You watch prod.' });
+
+    expect(id).toHaveLength(12);
+    const row = getAgent(id);
+    expect(row).toBeDefined();
+    expect(row!.name).toBe('Ops Agent');
+    expect(row!.system_prompt).toBe('You watch prod.');
+    expect(row!.channel).toBeNull();
+    expect(row!.channel_config).toBeNull();
+    expect(row!.created_at).toBeTruthy();
+    expect(row!.updated_at).toBeTruthy();
+  });
+
+  it('createAgent stores an optional channel + channel_config', () => {
+    const id = createAgent({
+      name: 'Telegram Agent',
+      system_prompt: 'Chat prompt.',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-1' }),
+    });
+
+    const row = getAgent(id);
+    expect(row!.channel).toBe('telegram');
+    expect(JSON.parse(row!.channel_config!)).toEqual({ threadKey: 'chat-1' });
+  });
+
+  it('getAgent returns undefined for an unknown id', () => {
+    expect(getAgent('does-not-exist')).toBeUndefined();
+  });
+
+  it('listAgents returns all agent configs', () => {
+    createAgent({ name: 'A', system_prompt: 'p1' });
+    createAgent({ name: 'B', system_prompt: 'p2' });
+
+    const rows = listAgents();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.name).sort()).toEqual(['A', 'B']);
+  });
+
+  it('updateAgent patches given fields and leaves others untouched', () => {
+    const id = createAgent({ name: 'Original', system_prompt: 'orig prompt' });
+    const before = getAgent(id)!;
+
+    updateAgent(id, { name: 'Renamed' });
+
+    const after = getAgent(id)!;
+    expect(after.name).toBe('Renamed');
+    expect(after.system_prompt).toBe('orig prompt');
+    expect(after.created_at).toBe(before.created_at);
+  });
+
+  it('updateAgent bumps updated_at', () => {
+    const id = createAgent({ name: 'Original', system_prompt: 'orig prompt' });
+
+    // Force a distinguishable updated_at by backdating the row first.
+    getDb()
+      .prepare(`UPDATE agent_configs SET updated_at = '2000-01-01 00:00:00' WHERE id = ?`)
+      .run(id);
+    expect(getAgent(id)!.updated_at).toBe('2000-01-01 00:00:00');
+
+    updateAgent(id, { system_prompt: 'new prompt' });
+
+    const after = getAgent(id)!;
+    expect(after.updated_at).not.toBe('2000-01-01 00:00:00');
+    expect(after.system_prompt).toBe('new prompt');
+  });
+
+  it('updateAgent is a no-op for an unknown id', () => {
+    expect(() => updateAgent('nope', { name: 'X' })).not.toThrow();
+  });
+
+  it('deleteAgent removes the row', () => {
+    const id = createAgent({ name: 'Doomed', system_prompt: 'p' });
+    deleteAgent(id);
+    expect(getAgent(id)).toBeUndefined();
+  });
+
+  it('deleteAgent is a no-op for an unknown id', () => {
+    expect(() => deleteAgent('nope')).not.toThrow();
+  });
+
+  it('getAgentByChannel matches a channel-wide binding (no threadKey)', () => {
+    const id = createAgent({
+      name: 'Channel-wide',
+      system_prompt: 'p',
+      channel: 'telegram',
+      channel_config: JSON.stringify({}),
+    });
+
+    expect(getAgentByChannel('telegram', 'any-thread')?.id).toBe(id);
+    expect(getAgentByChannel('slack', 'any-thread')).toBeUndefined();
+  });
+
+  it('getAgentByChannel matches a specific threadKey binding only for that thread', () => {
+    const id = createAgent({
+      name: 'Thread-bound',
+      system_prompt: 'p',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-42' }),
+    });
+
+    expect(getAgentByChannel('telegram', 'chat-42')?.id).toBe(id);
+    expect(getAgentByChannel('telegram', 'chat-99')).toBeUndefined();
+  });
+
+  it('getAgentByChannel prefers a specific threadKey match over a channel-wide binding', () => {
+    createAgent({
+      name: 'Channel-wide',
+      system_prompt: 'p',
+      channel: 'telegram',
+      channel_config: JSON.stringify({}),
+    });
+    const specific = createAgent({
+      name: 'Thread-bound',
+      system_prompt: 'p',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-42' }),
+    });
+
+    expect(getAgentByChannel('telegram', 'chat-42')?.id).toBe(specific);
+  });
+
+  it('getAgentByChannel returns undefined with no channel_config at all', () => {
+    createAgent({ name: 'No channel', system_prompt: 'p' });
+    expect(getAgentByChannel('telegram', 'chat-1')).toBeUndefined();
+  });
+});

--- a/server/repositories/agents-config.ts
+++ b/server/repositories/agents-config.ts
@@ -1,0 +1,117 @@
+/**
+ * Repository layer for the `agent_configs` table — long-running "Agents
+ * feature" config rows (name, system prompt, channel binding). Not to be
+ * confused with the `agents` table (per-task tmux-window workers).
+ * Plain exported functions — no base class, no ORM.
+ */
+import { nanoid } from 'nanoid';
+import { getDb } from '../db.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('repositories/agents-config');
+
+export interface AgentConfig {
+  id: string;
+  name: string;
+  system_prompt: string;
+  channel: string | null;
+  channel_config: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateAgentInput {
+  name: string;
+  system_prompt: string;
+  channel?: string | null;
+  channel_config?: string | null;
+}
+
+const AGENT_CONFIG_COLUMNS =
+  'id, name, system_prompt, channel, channel_config, created_at, updated_at';
+
+/** Create an agent config row. Returns the new agent's id. */
+export function createAgent(input: CreateAgentInput): string {
+  const id = nanoid(12);
+  getDb()
+    .prepare(
+      `INSERT INTO agent_configs (id, name, system_prompt, channel, channel_config)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(id, input.name, input.system_prompt, input.channel ?? null, input.channel_config ?? null);
+
+  logger.info({ agent_id: id, name: input.name }, 'agent config created');
+  return id;
+}
+
+/** Fetch a single agent config by id (returns undefined if not found). */
+export function getAgent(id: string): AgentConfig | undefined {
+  return getDb()
+    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs WHERE id = ?`)
+    .get(id) as AgentConfig | undefined;
+}
+
+/** All agent configs, newest first. */
+export function listAgents(): AgentConfig[] {
+  return getDb()
+    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs ORDER BY created_at DESC`)
+    .all() as AgentConfig[];
+}
+
+export type UpdateAgentInput = Partial<
+  Pick<AgentConfig, 'name' | 'system_prompt' | 'channel' | 'channel_config'>
+>;
+
+/** Partially update an agent config's name/system_prompt/channel binding. Bumps updated_at. */
+export function updateAgent(id: string, patch: UpdateAgentInput): void {
+  const existing = getAgent(id);
+  if (!existing) return;
+
+  const name = patch.name ?? existing.name;
+  const systemPrompt = patch.system_prompt ?? existing.system_prompt;
+  const channel = patch.channel !== undefined ? patch.channel : existing.channel;
+  const channelConfig =
+    patch.channel_config !== undefined ? patch.channel_config : existing.channel_config;
+
+  getDb()
+    .prepare(
+      `UPDATE agent_configs
+       SET name = ?, system_prompt = ?, channel = ?, channel_config = ?, updated_at = datetime('now')
+       WHERE id = ?`,
+    )
+    .run(name, systemPrompt, channel, channelConfig, id);
+
+  logger.info({ agent_id: id }, 'agent config updated');
+}
+
+/** Delete an agent config by id. No-op if it doesn't exist. */
+export function deleteAgent(id: string): void {
+  getDb().prepare(`DELETE FROM agent_configs WHERE id = ?`).run(id);
+  logger.info({ agent_id: id }, 'agent config deleted');
+}
+
+/**
+ * Find the agent bound to an inbound (channel, threadKey), if any.
+ *
+ * `channel_config` is a JSON blob shaped `{ threadKey?: string }`. An agent
+ * bound with no `threadKey` matches ANY thread on that channel (channel-wide
+ * binding); an agent bound with a specific `threadKey` matches only that
+ * thread. A specific-thread match wins over a channel-wide one. The config
+ * table is small (a handful of agents) so filtering in JS after one indexed
+ * lookup is simpler than JSON1 SQL predicates.
+ */
+export function getAgentByChannel(channel: string, threadKey: string): AgentConfig | undefined {
+  const candidates = getDb()
+    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs WHERE channel = ?`)
+    .all(channel) as AgentConfig[];
+
+  let channelWide: AgentConfig | undefined;
+  for (const agent of candidates) {
+    const config = agent.channel_config
+      ? (JSON.parse(agent.channel_config) as { threadKey?: string })
+      : {};
+    if (config.threadKey === threadKey) return agent;
+    if (!config.threadKey && !channelWide) channelWide = agent;
+  }
+  return channelWide;
+}

--- a/server/repositories/index.ts
+++ b/server/repositories/index.ts
@@ -13,5 +13,19 @@ export * from './loop-runs.js';
 export * from './schedules.js';
 export * from './schedule-skills.js';
 export * from './runs.js';
+// agents-config.ts (the Agents-feature config table) exports `getAgent`, which
+// collides with agent-runtime.ts's `getAgent` (the per-task tmux-window
+// agent) — re-export the colliding name under an alias; import the other
+// functions/type as-is, or import `getAgent` directly from
+// './agents-config.js' when unaliased access is needed.
+export {
+  createAgent,
+  listAgents,
+  updateAgent,
+  deleteAgent,
+  getAgentByChannel,
+  getAgent as getAgentConfig,
+} from './agents-config.js';
+export type { AgentConfig } from './agents-config.js';
 export * from '../orchestrator/store.js';
 export * from '../integrations/store.js';

--- a/server/routes/agents-crud.ts
+++ b/server/routes/agents-crud.ts
@@ -1,0 +1,200 @@
+/**
+ * `/api/agent-configs` — CRUD for the Agents-feature `agent_configs` table,
+ * plus derived live status and the endpoint that ensures/opens an agent's
+ * persistent conductor session.
+ *
+ * NAMING CORRECTION (mirrors the `agents` → `agent_configs` table rename from
+ * Task 1): `/api/agents` was NOT available for this feature — it's already
+ * `GET /api/agents` + `GET /api/agents/:name` in `routes/agent-defs.ts` (agent
+ * *role* definitions: orchestrator/planner/reviewer) and
+ * `PATCH /api/agents/:id/task` in `routes/chats.ts` (moving a per-task
+ * tmux-window worker between tasks — the pre-existing `agents` table). Reusing
+ * that path would have silently shadowed those routes. `/api/agent-configs`
+ * matches the already-adopted `agent_configs` table/repository naming.
+ */
+import express from 'express';
+import type { Request, Response } from 'express';
+import {
+  createAgent,
+  getAgent,
+  listAgents,
+  updateAgent,
+  deleteAgent,
+  type AgentConfig,
+  type UpdateAgentInput,
+} from '../repositories/agents-config.js';
+import { createConversation, getPrimaryAgentConversation } from '../orchestrator/store.js';
+import {
+  startConversation,
+  stopConversation,
+  isConversationSessionAlive,
+} from '../orchestrator/runner.js';
+import { badRequest, notFound } from '../services/errors.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('routes/agents-crud');
+
+export const router = express.Router();
+
+export type AgentStatus = 'stopped' | 'idle' | 'working';
+
+export interface AgentWithStatus extends AgentConfig {
+  status: AgentStatus;
+  session_id: string | null;
+}
+
+/**
+ * Derive an agent's live status from its primary conversation.
+ *
+ * No conversation, or its tmux session is gone → 'stopped'. Session alive →
+ * 'idle' (v1 does not attempt to detect "actively generating" — that needs a
+ * pane-content heuristic that isn't cheap/reliable enough yet; 'working' is
+ * reserved for a later pass). Never throws: a tmux probe failure is treated as
+ * 'stopped' so `GET /api/agent-configs` can't be taken down by a flaky tmux call.
+ */
+export async function deriveAgentStatus(
+  agentId: string,
+): Promise<{ status: AgentStatus; session_id: string | null }> {
+  const conv = getPrimaryAgentConversation(agentId);
+  if (!conv) return { status: 'stopped', session_id: null };
+
+  let alive = false;
+  try {
+    alive = await isConversationSessionAlive(conv);
+  } catch (err) {
+    logger.warn(
+      { agent_id: agentId, conversation_id: conv.id, err },
+      'agents: liveness probe failed',
+    );
+    alive = false;
+  }
+  return { status: alive ? 'idle' : 'stopped', session_id: conv.id };
+}
+
+async function withStatus(agent: AgentConfig): Promise<AgentWithStatus> {
+  const { status, session_id } = await deriveAgentStatus(agent.id);
+  return { ...agent, status, session_id };
+}
+
+/** JSON-stringify an incoming channel_config value that may already be a JSON string, an object, or absent. */
+function normalizeChannelConfig(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+// GET /api/agent-configs — list all agents with derived status + session_id
+router.get('/api/agent-configs', async (_req: Request, res: Response) => {
+  const agents = listAgents();
+  res.json(await Promise.all(agents.map(withStatus)));
+});
+
+// POST /api/agent-configs — create an agent config
+router.post('/api/agent-configs', async (req: Request, res: Response) => {
+  const body = req.body as {
+    name?: unknown;
+    system_prompt?: unknown;
+    channel?: unknown;
+    channel_config?: unknown;
+  };
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name) throw badRequest('name is required');
+
+  const systemPrompt = typeof body.system_prompt === 'string' ? body.system_prompt.trim() : '';
+  if (!systemPrompt) throw badRequest('system_prompt is required');
+
+  const channel = typeof body.channel === 'string' ? body.channel : null;
+  const channelConfig = normalizeChannelConfig(body.channel_config);
+
+  const id = createAgent({
+    name,
+    system_prompt: systemPrompt,
+    channel,
+    channel_config: channelConfig,
+  });
+  logger.info({ agent_id: id, name }, 'agents: created');
+
+  res.status(201).json(await withStatus(getAgent(id)!));
+});
+
+// GET /api/agent-configs/:id — a single agent with derived status + session_id
+router.get('/api/agent-configs/:id', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const agent = getAgent(id);
+  if (!agent) throw notFound('Agent not found');
+  res.json(await withStatus(agent));
+});
+
+// PATCH /api/agent-configs/:id — update name/system_prompt/channel/channel_config
+router.patch('/api/agent-configs/:id', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const agent = getAgent(id);
+  if (!agent) throw notFound('Agent not found');
+
+  const body = req.body as {
+    name?: unknown;
+    system_prompt?: unknown;
+    channel?: unknown;
+    channel_config?: unknown;
+  };
+  const patch: UpdateAgentInput = {};
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== 'string' || !body.name.trim()) {
+      throw badRequest('name must be a non-empty string');
+    }
+    patch.name = body.name.trim();
+  }
+  if (body.system_prompt !== undefined) {
+    if (typeof body.system_prompt !== 'string' || !body.system_prompt.trim()) {
+      throw badRequest('system_prompt must be a non-empty string');
+    }
+    patch.system_prompt = body.system_prompt.trim();
+  }
+  if (body.channel !== undefined) {
+    patch.channel = body.channel === null ? null : String(body.channel);
+  }
+  if (body.channel_config !== undefined) {
+    patch.channel_config = normalizeChannelConfig(body.channel_config);
+  }
+
+  updateAgent(id, patch);
+  logger.info({ agent_id: id }, 'agents: updated');
+
+  res.json(await withStatus(getAgent(id)!));
+});
+
+// DELETE /api/agent-configs/:id — delete the agent, stopping its session first
+router.delete('/api/agent-configs/:id', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const agent = getAgent(id);
+  if (!agent) throw notFound('Agent not found');
+
+  const conv = getPrimaryAgentConversation(id);
+  if (conv) {
+    await stopConversation(conv.id);
+  }
+  deleteAgent(id);
+  logger.info({ agent_id: id, had_session: !!conv }, 'agents: deleted');
+
+  res.status(204).end();
+});
+
+// POST /api/agent-configs/:id/session — ensure + return the agent's persistent conversation
+router.post('/api/agent-configs/:id/session', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const agent = getAgent(id);
+  if (!agent) throw notFound('Agent not found');
+
+  let conv = getPrimaryAgentConversation(id);
+  if (!conv) {
+    const convId = createConversation({ title: agent.name, agent_id: id });
+    const cwd = process.env.OCTOMUX_GATEWAY_CWD || process.cwd();
+    await startConversation(convId, cwd, { systemPrompt: agent.system_prompt });
+    conv = getPrimaryAgentConversation(id);
+    logger.info({ agent_id: id, conversation_id: convId }, 'agents: session started');
+  }
+
+  res.status(200).json(conv);
+});

--- a/spec/agents-feature.md
+++ b/spec/agents-feature.md
@@ -1,0 +1,76 @@
+# Agents — first-class long-running agents
+
+> A dedicated **Agents** surface: create long-running agents (name + system prompt + channel
+> trigger), see them as cards with live status, and open one to configure it or watch its running
+> session (a conductor CLI chat). Each agent has the full octomux orchestrator toolset and can
+> dispatch, message, and hear back from worker subagents. The existing **orchestrator page is left
+> untouched** — this is a separate surface built on the same conductor runtime.
+
+## Model (decided)
+
+- **Agent** = a config record (name, system prompt, channel binding) + **one persistent conductor
+  session** — a long-running interactive `claude` in tmux, launched with the agent's system prompt
+  and the octomux MCP toolset (same runtime as the orchestrator conductor; not the orchestrator's
+  conversations).
+- **Session** = the agent's live conductor conversation. One primary persistent session per agent;
+  the Sessions tab shows it (and any prior ones).
+- **Trigger (v1)** = a **channel binding**: Telegram now, Slack later. The gateway routes that
+  channel's messages to the bound agent's session instead of a throwaway conversation. (No manual /
+  cron / event triggers in v1.)
+- **Abilities** = the full orchestrator MCP toolset (create_task, send_message, monitor, reads,
+  search_learnings, get_agent_output, …) — identical to the conductor.
+
+## Subagent communication (the report-back fix)
+
+Bidirectional, both via `send_message`:
+
+- **Agent → subagent**: `mcp__octomux__send_message` (exists).
+- **Subagent → agent**: replace the worker `report_complete` tool with `send_message` targeted at
+  the **owning agent's session**. It lands as a real message the session — and any bound channel —
+  sees. This closes the bug where `report_complete` fired `task:phase_complete` and the supervisor
+  delivered it via `pushToConversation` (WS/web only), which the gateway (transcript-tail only)
+  never received.
+- **Review gates**: for agent-dispatched tasks, no approval **cards** — the worker sends back a
+  message with a **tappable artifact link** (plan/spec/diff URL via the existing
+  `/api/orchestrator/artifact` endpoint); the owner approves by replying in chat/Telegram.
+
+## Backend
+
+- New `agents` table: `id`, `name`, `system_prompt`, `channel` (nullable: `telegram`/`slack`),
+  `channel_config` (JSON: allow-list/thread key), `created_at`, `updated_at`.
+- `orchestrator_conversations` gains a nullable `agent_id` FK — an agent's session is a conversation
+  tagged with its `agent_id`. Orchestrator-page conversations keep `agent_id = NULL` (untouched).
+- Conductor launch accepts a **custom system prompt** (today `ORCHESTRATOR_SYSTEM_PROMPT` is
+  hardcoded in `conductor-flags.ts`) — the agent's prompt is used for its session.
+- CRUD API under `/api/agents`: list (with derived status), create, get, patch, delete. Status is
+  derived: `working` if the session's pane shows claude actively generating, else `idle`, else
+  `stopped` (no live session) — reuse the liveness/`get_agent_output` primitives.
+- Gateway change: when an inbound channel/thread is bound to an agent, route to that agent's
+  persistent session; otherwise fall back to today's behavior.
+- Replace `report_complete` registration/handler with `send_message` back to the owning
+  conversation; drop the `phase_complete`→card choreography for agent-dispatched tasks (keep it for
+  the orchestrator page's own managed tasks so that surface is unchanged).
+
+## Frontend (all new; orchestrator page unchanged)
+
+- `/agents` — **cards**: name, status pill (working/idle/stopped), channel badge, last-activity,
+  quick actions (open, stop). A "New agent" action.
+- `/agents/:id` — two tabs:
+  - **Config** — edit name, system prompt, channel binding (+ allow-list). Save/delete.
+  - **Sessions** — the live session as a **chat/CLI view** with the same behavior as the
+    orchestrator tab, built from shared chat components (WS stream, transcript render, send box).
+- Nav: add an **Agents** entry. The orchestrator entry stays as-is (kept aside, not removed).
+
+## Reuse vs new
+
+- **Reuse (runtime):** the conductor runner (tmux/claude/transcript), the MCP tools, the gateway,
+  the artifact endpoint, liveness + `get_agent_output`, and the chat WS/render **components**.
+- **New (surface + config):** the `agents` table + CRUD, `agent_id` on conversations, per-agent
+  system prompt, the `/agents` cards page and detail tabs, the channel→agent binding, and the
+  `report_complete`→`send_message` swap.
+
+## Non-goals (v1)
+
+Manual/cron/event triggers · multiple concurrent sessions per agent · approval cards for
+agent-dispatched tasks · touching or migrating the existing orchestrator page · Slack transport
+(the binding shape is there; the Slack adapter itself is a later fast-follow).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ const IntegrationsPage = lazy(() => import('./pages/IntegrationsPage'));
 const SetupPage = lazy(() => import('./pages/SetupPage'));
 const ReviewDetailPage = lazy(() => import('./pages/ReviewDetailPage'));
 const OrchestratorPage = lazy(() => import('./pages/OrchestratorPage'));
+const AgentsPage = lazy(() => import('./pages/AgentsPage'));
+const AgentDetailPage = lazy(() => import('./pages/AgentDetailPage'));
 const WorkflowDetailRoute = lazy(() => import('./workflows/WorkflowDetailRoute'));
 const LoopsPage = lazy(() => import('./pages/LoopsPage'));
 const LoopGroupDetailPage = lazy(() => import('./pages/LoopGroupDetailPage'));
@@ -120,6 +122,8 @@ export function AppShell() {
                 <Route path="/integrations" element={<IntegrationsPage />} />
                 <Route path="/setup" element={<SetupPage />} />
                 <Route path="/orchestrator" element={<OrchestratorPage />} />
+                <Route path="/agents" element={<AgentsPage />} />
+                <Route path="/agents/:id" element={<AgentDetailPage />} />
                 <Route path="/w/:kind/:id" element={<WorkflowDetailRoute />} />
                 <Route path="/loops" element={<LoopsPage />} />
                 <Route path="/loops/:id" element={<LoopsRedirect />} />

--- a/src/components/AgentSessionChat.test.tsx
+++ b/src/components/AgentSessionChat.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * src/components/AgentSessionChat.test.tsx
+ *
+ * Component tests for the standalone agent-session chat view.
+ * Mirrors the WS mock pattern from src/pages/OrchestratorPage.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { AgentSessionChat } from './AgentSessionChat';
+import { renderWithRouter } from '../test-helpers';
+
+// ─── WS mock ─────────────────────────────────────────────────────────────────
+
+interface MockWs {
+  readyState: number;
+  sentMessages: string[];
+  onmessage: ((event: { data: string }) => void) | null;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((err: Event) => void) | null;
+  send: (data: string) => void;
+  close: () => void;
+  simulateMessage: (data: object) => void;
+  simulateOpen: () => void;
+}
+
+let lastWs: MockWs | null = null;
+
+function makeWsMock(): MockWs {
+  const mock: MockWs = {
+    readyState: 0,
+    sentMessages: [],
+    onmessage: null,
+    onopen: null,
+    onclose: null,
+    onerror: null,
+    send(data: string) {
+      this.sentMessages.push(data);
+    },
+    close() {
+      this.readyState = 3;
+      this.onclose?.();
+    },
+    simulateMessage(data: object) {
+      this.onmessage?.({ data: JSON.stringify(data) });
+    },
+    simulateOpen() {
+      this.readyState = 1;
+      this.onopen?.();
+    },
+  };
+  return mock;
+}
+
+vi.stubGlobal(
+  'WebSocket',
+  Object.assign(
+    vi.fn(() => {
+      lastWs = makeWsMock();
+      return lastWs;
+    }),
+    { OPEN: 1, CONNECTING: 0, CLOSING: 2, CLOSED: 3 },
+  ),
+);
+
+function makeFetchMock(messages: unknown[] = []) {
+  return vi.fn(async (url: string) => {
+    if (url.match(/^\/api\/orchestrator\/conversations\/[^/]+\/messages$/)) {
+      return { ok: true, status: 200, json: async () => messages } as Response;
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+}
+
+describe('AgentSessionChat', () => {
+  beforeEach(() => {
+    lastWs = null;
+    vi.stubGlobal('fetch', makeFetchMock());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads prior history from the orchestrator messages endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      makeFetchMock([
+        {
+          id: 'msg-1',
+          conversation_id: 'conv-1',
+          role: 'user',
+          content: JSON.stringify([{ type: 'text', text: 'hey agent' }]),
+          created_at: '2026-01-01 00:00:00',
+        },
+      ]),
+    );
+
+    renderWithRouter(<AgentSessionChat convId="conv-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('hey agent')).toBeInTheDocument();
+    });
+  });
+
+  it('opens a websocket to /ws/orchestrator/:convId', async () => {
+    renderWithRouter(<AgentSessionChat convId="conv-1" />);
+    await waitFor(() => expect(lastWs).not.toBeNull());
+    expect(globalThis.WebSocket).toHaveBeenCalledWith(
+      expect.stringContaining('/ws/orchestrator/conv-1'),
+    );
+  });
+
+  it('renders incoming assistant messages and ignores card/tool/status events', async () => {
+    renderWithRouter(<AgentSessionChat convId="conv-1" />);
+    await waitFor(() => expect(lastWs).not.toBeNull());
+
+    act(() => {
+      lastWs!.simulateOpen();
+      lastWs!.simulateMessage({ type: 'tool', id: 't1', tool_name: 'search', input: {} });
+      lastWs!.simulateMessage({ type: 'card', id: 'c1', command: 'approve-plan', args: {} });
+      lastWs!.simulateMessage({ type: 'status', status: 'working' });
+      lastWs!.simulateMessage({ type: 'message', role: 'assistant', text: 'Hello from agent' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello from agent')).toBeInTheDocument();
+    });
+  });
+
+  it('sends a user_turn ws frame when the form is submitted', async () => {
+    renderWithRouter(<AgentSessionChat convId="conv-1" />);
+    await waitFor(() => expect(lastWs).not.toBeNull());
+
+    act(() => {
+      lastWs!.simulateOpen();
+    });
+
+    const input = await screen.findByPlaceholderText(/message this agent/i);
+    fireEvent.change(input, { target: { value: 'do the thing' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(lastWs?.sentMessages.some((m) => JSON.parse(m).type === 'user_turn')).toBe(true);
+    });
+    const turn = lastWs!.sentMessages
+      .map((m) => JSON.parse(m) as { type: string; text?: string })
+      .find((m) => m.type === 'user_turn');
+    expect(turn?.text).toBe('do the thing');
+
+    // Optimistic local echo of the user's message.
+    expect(screen.getByText('do the thing')).toBeInTheDocument();
+  });
+});

--- a/src/components/AgentSessionChat.tsx
+++ b/src/components/AgentSessionChat.tsx
@@ -1,0 +1,218 @@
+/**
+ * src/components/AgentSessionChat.tsx
+ *
+ * Standalone live chat/CLI view for one agent conductor session.
+ *
+ * Deliberately NOT built from `src/components/orchestrator/*` or
+ * `src/pages/OrchestratorPage.tsx` — those stay untouched for the orchestrator
+ * surface. This is a new, self-contained component; duplication vs. the
+ * orchestrator page's chat rendering is intentional (spec/agents-feature.md).
+ *
+ * It does reuse the plain data-layer client (`orchestratorApi`, `parseMessage`)
+ * from `src/lib/orchestrator-api.ts` — that file is a REST/WS client, not a
+ * page or a rendering component, so pulling history/parsing off it here does
+ * not couple this component to the orchestrator page.
+ *
+ * Protocol (mirrors `/ws/orchestrator/:convId`, see OrchestratorPage.tsx):
+ *   server->client: { type:'message', role, text, id? }
+ *                   { type:'card'|'tool'|'status', ... } — collapsed/ignored here
+ *                   { type:'error', error }
+ *   client->server: { type:'user_turn', text }
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { cn } from '@/lib/utils';
+import { orchestratorApi, parseMessage, type DisplayMessage } from '@/lib/orchestrator-api';
+
+type ConnectionState = 'connecting' | 'open' | 'closed';
+
+// WebSocket.OPEN as a literal so test mocks don't need to define the static
+// property (mirrors the convention in src/lib/orchestrator-api.ts).
+const WS_OPEN = 1;
+
+interface WsIncomingEvent {
+  type: 'message' | 'card' | 'tool' | 'status' | 'error';
+  role?: 'user' | 'assistant';
+  text?: string;
+  id?: string;
+  error?: string;
+}
+
+export interface AgentSessionChatProps {
+  convId: string;
+}
+
+export function AgentSessionChat({ convId }: AgentSessionChatProps) {
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [connection, setConnection] = useState<ConnectionState>('connecting');
+  const [input, setInput] = useState('');
+  const wsRef = useRef<WebSocket | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    orchestratorApi
+      .listMessages(convId)
+      .then((history) => {
+        if (!cancelled) setMessages(history.map(parseMessage));
+      })
+      .catch(() => {
+        // history is best-effort; the live socket carries new messages regardless
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [convId]);
+
+  useEffect(() => {
+    setConnection('connecting');
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}/ws/orchestrator/${convId}`);
+    wsRef.current = ws;
+
+    ws.onopen = () => setConnection('open');
+    ws.onclose = () => setConnection('closed');
+    ws.onerror = () => setConnection('closed');
+    ws.onmessage = (ev) => {
+      let event: WsIncomingEvent;
+      try {
+        event = JSON.parse(ev.data as string) as WsIncomingEvent;
+      } catch {
+        return;
+      }
+      if (event.type === 'message' && event.role) {
+        const msg: DisplayMessage = {
+          id: event.id ?? `ws-${Date.now()}-${Math.random()}`,
+          role: event.role,
+          text: event.text ?? '',
+        };
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === msg.id)) return prev;
+          return [...prev, msg];
+        });
+      } else if (event.type === 'error') {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `error-${Date.now()}-${Math.random()}`,
+            role: 'assistant',
+            text: `⚠️ ${event.error ?? 'Unknown error'}`,
+          },
+        ]);
+      }
+      // 'card' / 'tool' / 'status' events are gracefully ignored here — the
+      // agent session view is a plain chat/CLI, no action-card choreography.
+    };
+
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [convId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' });
+  }, [messages]);
+
+  const send = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WS_OPEN) return;
+    ws.send(JSON.stringify({ type: 'user_turn', text }));
+    setMessages((prev) => [...prev, { id: `local-${Date.now()}`, role: 'user', text }]);
+    setInput('');
+  }, [input]);
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      send();
+    },
+    [send],
+  );
+
+  const connectionLabel = useMemo(
+    () => ({ connecting: 'connecting', open: 'live', closed: 'offline' })[connection],
+    [connection],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="agent-session-chat">
+      <div className="flex items-center justify-between border-b border-glass-edge px-4 py-2">
+        <span className="text-xs font-medium text-muted-foreground">Session</span>
+        <span
+          role="status"
+          data-testid="agent-session-connection"
+          className="flex items-center gap-1.5 text-[11px] text-muted-soft"
+        >
+          <span
+            className={cn(
+              'h-2 w-2 rounded-full',
+              connection === 'open' && 'bg-emerald-500',
+              connection === 'connecting' && 'animate-pulse bg-amber-500',
+              connection === 'closed' && 'bg-muted-foreground',
+            )}
+          />
+          {connectionLabel}
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-auto px-4 py-3">
+        <div className="flex flex-col gap-3">
+          {messages.map((msg) => (
+            <div
+              key={msg.id}
+              data-role={msg.role}
+              className={cn(
+                'max-w-[85%] whitespace-pre-wrap rounded-xl px-4 py-2.5 text-sm leading-relaxed',
+                msg.role === 'user'
+                  ? 'ml-auto bg-primary text-primary-foreground'
+                  : 'mr-auto bg-glass-l1 text-foreground',
+              )}
+            >
+              {msg.text}
+            </div>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="flex items-end gap-2 border-t border-glass-edge px-4 py-3"
+      >
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          placeholder="Message this agent (Enter to send, Shift+Enter for newline)"
+          rows={1}
+          aria-label="Message input"
+          className="flex-1 resize-none rounded-xl border border-glass-edge bg-glass-l1 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+        <button
+          type="submit"
+          disabled={!input.trim()}
+          aria-label="Send message"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M2 8h12M10 4l4 4-4 4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/sidebar/glyphs.tsx
+++ b/src/components/sidebar/glyphs.tsx
@@ -268,6 +268,29 @@ export function OrchestratorIcon({ color }: { color: string }) {
   );
 }
 
+export function AgentsIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <rect x="3" y="8" width="18" height="12" rx="2" />
+      <path d="M12 8V4M8 4h8" />
+      <circle cx="8.5" cy="14" r="1" fill={color} stroke="none" />
+      <circle cx="15.5" cy="14" r="1" fill={color} stroke="none" />
+      <path d="M9 18h6" />
+    </svg>
+  );
+}
+
 export function LoopsIcon({ color }: { color: string }) {
   return (
     <svg

--- a/src/components/sidebar/nav-items.test.ts
+++ b/src/components/sidebar/nav-items.test.ts
@@ -4,7 +4,7 @@ import { MORE_ITEMS, NAV_ITEMS, deriveActiveNav } from './nav-items';
 describe('MORE_ITEMS', () => {
   it('is the static list — no per-workflow-kind rows', () => {
     const keys = MORE_ITEMS.map((item) => item.key);
-    expect(keys).toEqual(['monitor', 'workspaces', 'orchestrator', 'schedules']);
+    expect(keys).toEqual(['monitor', 'workspaces', 'orchestrator', 'agents', 'schedules']);
   });
 
   it('does not list a workflow kind twice', () => {

--- a/src/components/sidebar/nav-items.ts
+++ b/src/components/sidebar/nav-items.ts
@@ -6,6 +6,7 @@ import {
   MonitorIcon,
   WorkspacesIcon,
   OrchestratorIcon,
+  AgentsIcon,
   SchedulesIcon,
   WorkflowsIcon,
   SettingsIcon,
@@ -35,6 +36,7 @@ export const MORE_ITEMS = [
   { key: 'monitor', label: 'Monitor', to: '/monitor', Icon: MonitorIcon },
   { key: 'workspaces', label: 'Workspaces', to: '/workspaces', Icon: WorkspacesIcon },
   { key: 'orchestrator', label: 'Orchestrator', to: '/orchestrator', Icon: OrchestratorIcon },
+  { key: 'agents', label: 'Agents', to: '/agents', Icon: AgentsIcon },
   { key: 'schedules', label: 'Schedules', to: '/schedules', Icon: SchedulesIcon },
 ] as const;
 

--- a/src/lib/api/agentsApi.ts
+++ b/src/lib/api/agentsApi.ts
@@ -1,0 +1,66 @@
+/**
+ * src/lib/api/agentsApi.ts
+ *
+ * Agents-feature API surface: CRUD for long-running agent configs plus the
+ * derived live status and the endpoint that ensures/opens an agent's
+ * persistent conductor session. Mirrors `server/routes/agents-crud.ts`.
+ *
+ * NAMING: the REST base is `/api/agent-configs`, not `/api/agents` — that path
+ * is already taken by agent *role* definitions (`routes/agent-defs.ts`) and the
+ * per-task tmux-window worker hop (`routes/chats.ts`). See
+ * `plans/2026-07-24-agents-feature.md` ("Naming correction").
+ */
+
+import type { OrchestratorConversation } from '../orchestrator-api';
+import { request } from './client';
+
+export interface AgentConfig {
+  id: string;
+  name: string;
+  system_prompt: string;
+  channel: string | null;
+  channel_config: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type AgentStatus = 'stopped' | 'idle' | 'working';
+
+export interface AgentWithStatus extends AgentConfig {
+  status: AgentStatus;
+  session_id: string | null;
+}
+
+export interface CreateAgentInput {
+  name: string;
+  system_prompt: string;
+  channel?: string | null;
+  channel_config?: string | null;
+}
+
+export interface UpdateAgentInput {
+  name?: string;
+  system_prompt?: string;
+  channel?: string | null;
+  channel_config?: string | null;
+}
+
+/** The agent's persistent conductor session, tagged with the owning agent_id. */
+export interface AgentSession extends OrchestratorConversation {
+  agent_id: string | null;
+}
+
+export const agentsApi = {
+  list: () => request<AgentWithStatus[]>('/agent-configs'),
+  create: (data: CreateAgentInput) =>
+    request<AgentWithStatus>('/agent-configs', { method: 'POST', body: JSON.stringify(data) }),
+  get: (id: string) => request<AgentWithStatus>(`/agent-configs/${id}`),
+  update: (id: string, data: UpdateAgentInput) =>
+    request<AgentWithStatus>(`/agent-configs/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  remove: (id: string) => request<void>(`/agent-configs/${id}`, { method: 'DELETE' }),
+  ensureSession: (id: string) =>
+    request<AgentSession>(`/agent-configs/${id}/session`, { method: 'POST' }),
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -16,6 +16,7 @@ export * from './reviewApi';
 export * from './configApi';
 export * from './loopApi';
 export * from './schedulesApi';
+export * from './agentsApi';
 
 // Re-export the orchestrator REST + WebSocket client. It stays a separate,
 // incompatibly-shaped surface (its `/ws/orchestrator/:id` socket is not folded

--- a/src/pages/AgentDetailPage.test.tsx
+++ b/src/pages/AgentDetailPage.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AgentDetailPage from './AgentDetailPage';
+import { renderWithRouter } from '../test-helpers';
+import type { AgentWithStatus } from '@/lib/api/agentsApi';
+
+const { taskApiProxy, reviewApiProxy, configApiProxy, agentsApiProxy, apiMock } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
+vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('@/lib/api/agentsApi', () => ({ agentsApi: agentsApiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+
+const { routerMockFactory, mockNavigate } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', async (importOriginal) => {
+  const withNav = await routerMockFactory(importOriginal);
+  return { ...withNav, useParams: () => ({ id: 'agent-1' }) };
+});
+
+// ─── WS mock (AgentSessionChat opens its own socket in the Sessions tab) ─────
+
+interface MockWs {
+  readyState: number;
+  sentMessages: string[];
+  onmessage: ((event: { data: string }) => void) | null;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((err: Event) => void) | null;
+  send: (data: string) => void;
+  close: () => void;
+}
+
+function makeWsMock(): MockWs {
+  return {
+    readyState: 0,
+    sentMessages: [],
+    onmessage: null,
+    onopen: null,
+    onclose: null,
+    onerror: null,
+    send(data: string) {
+      this.sentMessages.push(data);
+    },
+    close() {
+      this.readyState = 3;
+      this.onclose?.();
+    },
+  };
+}
+
+vi.stubGlobal(
+  'WebSocket',
+  vi.fn(() => makeWsMock()),
+);
+
+function makeAgent(overrides: Partial<AgentWithStatus> = {}): AgentWithStatus {
+  return {
+    id: 'agent-1',
+    name: 'support-bot',
+    system_prompt: 'You help customers.',
+    channel: null,
+    channel_config: null,
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    status: 'stopped',
+    session_id: null,
+    ...overrides,
+  };
+}
+
+describe('AgentDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.match(/\/messages$/)) {
+          return { ok: true, status: 200, json: async () => [] } as Response;
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Config tab', () => {
+    it('loads the agent config into the form', async () => {
+      apiMock.get.mockResolvedValue(
+        makeAgent({ name: 'support-bot', system_prompt: 'Be nice.', status: 'working' }),
+      );
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('agent-detail-name')).toHaveValue('support-bot');
+      });
+      expect(screen.getByTestId('agent-detail-system-prompt')).toHaveValue('Be nice.');
+      expect(screen.getByText('working')).toBeInTheDocument();
+    });
+
+    it('saves edits via agentsApi.update', async () => {
+      const user = userEvent.setup();
+      apiMock.get.mockResolvedValue(makeAgent());
+      apiMock.update.mockResolvedValue(makeAgent({ name: 'renamed-bot' }));
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('agent-detail-name')).toHaveValue('support-bot'),
+      );
+
+      await user.clear(screen.getByTestId('agent-detail-name'));
+      await user.type(screen.getByTestId('agent-detail-name'), 'renamed-bot');
+      await user.click(screen.getByTestId('agent-detail-save'));
+
+      await waitFor(() =>
+        expect(apiMock.update).toHaveBeenCalledWith('agent-1', {
+          name: 'renamed-bot',
+          system_prompt: 'You help customers.',
+          channel: null,
+          channel_config: null,
+        }),
+      );
+    });
+
+    it('serializes a thread key into channel_config JSON on save', async () => {
+      const user = userEvent.setup();
+      apiMock.get.mockResolvedValue(makeAgent({ channel: 'telegram' }));
+      apiMock.update.mockResolvedValue(makeAgent({ channel: 'telegram' }));
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('agent-detail-channel')).toHaveValue('telegram'),
+      );
+      await user.type(screen.getByTestId('agent-detail-thread-key'), 'thread-9');
+      await user.click(screen.getByTestId('agent-detail-save'));
+
+      await waitFor(() =>
+        expect(apiMock.update).toHaveBeenCalledWith(
+          'agent-1',
+          expect.objectContaining({
+            channel: 'telegram',
+            channel_config: JSON.stringify({ threadKey: 'thread-9' }),
+          }),
+        ),
+      );
+    });
+
+    it('deletes the agent and navigates back to /agents after confirm', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      apiMock.get.mockResolvedValue(makeAgent());
+      apiMock.remove.mockResolvedValue(undefined);
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('agent-detail-name')).toHaveValue('support-bot'),
+      );
+      await user.click(screen.getByTestId('agent-detail-delete'));
+
+      await waitFor(() => expect(apiMock.remove).toHaveBeenCalledWith('agent-1'));
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/agents'));
+    });
+
+    it('does not delete when the confirm dialog is dismissed', async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      apiMock.get.mockResolvedValue(makeAgent());
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('agent-detail-name')).toHaveValue('support-bot'),
+      );
+      await user.click(screen.getByTestId('agent-detail-delete'));
+
+      expect(apiMock.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Sessions tab', () => {
+    it('ensures the session and mounts the chat view', async () => {
+      const user = userEvent.setup();
+      apiMock.get.mockResolvedValue(makeAgent());
+      apiMock.ensureSession.mockResolvedValue({
+        id: 'conv-77',
+        title: 'support-bot',
+        tmux_window: null,
+        claude_session_id: null,
+        transcript_path: null,
+        status: 'running',
+        is_global_monitor: 0,
+        agent_id: 'agent-1',
+        created_at: '2026-01-01 00:00:00',
+        updated_at: '2026-01-01 00:00:00',
+      });
+      renderWithRouter(<AgentDetailPage />);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('agent-detail-name')).toHaveValue('support-bot'),
+      );
+      await user.click(screen.getByTestId('agent-tab-sessions'));
+
+      await waitFor(() => expect(apiMock.ensureSession).toHaveBeenCalledWith('agent-1'));
+      await waitFor(() => {
+        expect(screen.getByTestId('agent-session-chat')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/pages/AgentDetailPage.tsx
+++ b/src/pages/AgentDetailPage.tsx
@@ -1,0 +1,282 @@
+/**
+ * src/pages/AgentDetailPage.tsx
+ *
+ * Route: /agents/:id
+ *
+ * Two tabs for a single long-running agent:
+ *  - Config   — edit name/system prompt/channel binding, save, delete.
+ *  - Sessions — ensure + render the agent's persistent conductor session
+ *               via <AgentSessionChat>.
+ *
+ * Standalone page — does not import from OrchestratorPage.tsx (kept untouched).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { agentsApi, type AgentStatus, type AgentWithStatus } from '@/lib/api/agentsApi';
+import { useResource } from '@/lib/use-resource';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { FormSelect } from '@/components/ui/form-select';
+import { SegmentedControl } from '@/components/ui/segmented-control';
+import { PageHeader } from '@/components/layout/page-header';
+import { ChevronLeftIcon } from '@/components/icons';
+import { AgentSessionChat } from '@/components/AgentSessionChat';
+
+const STATUS_STYLE: Record<AgentStatus, string> = {
+  working: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  idle: 'border-amber-500/30 bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  stopped: 'border-border bg-transparent text-muted-foreground',
+};
+
+const CHANNEL_OPTIONS = [
+  { value: '', label: 'None' },
+  { value: 'telegram', label: 'Telegram' },
+  { value: 'slack', label: 'Slack' },
+];
+
+function parseThreadKey(channelConfig: string | null): string {
+  if (!channelConfig) return '';
+  try {
+    const parsed = JSON.parse(channelConfig) as { threadKey?: string };
+    return parsed.threadKey ?? '';
+  } catch {
+    return '';
+  }
+}
+
+interface ConfigTabProps {
+  agent: AgentWithStatus;
+  onSaved: (agent: AgentWithStatus) => void;
+  onDeleted: () => void;
+}
+
+function ConfigTab({ agent, onSaved, onDeleted }: ConfigTabProps) {
+  const [name, setName] = useState(agent.name);
+  const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt);
+  const [channel, setChannel] = useState(agent.channel ?? '');
+  const [threadKey, setThreadKey] = useState(parseThreadKey(agent.channel_config));
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setName(agent.name);
+    setSystemPrompt(agent.system_prompt);
+    setChannel(agent.channel ?? '');
+    setThreadKey(parseThreadKey(agent.channel_config));
+  }, [agent]);
+
+  const canSave = name.trim().length > 0 && systemPrompt.trim().length > 0 && !saving;
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await agentsApi.update(agent.id, {
+        name: name.trim(),
+        system_prompt: systemPrompt.trim(),
+        channel: channel || null,
+        channel_config: threadKey.trim() ? JSON.stringify({ threadKey: threadKey.trim() }) : null,
+      });
+      onSaved(updated);
+    } catch (err) {
+      setError((err as Error).message || 'Failed to save agent');
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, agent.id, name, systemPrompt, channel, threadKey, onSaved]);
+
+  const handleDelete = useCallback(async () => {
+    if (!window.confirm(`Delete agent "${agent.name}"? This stops its session too.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await agentsApi.remove(agent.id);
+      onDeleted();
+    } catch (err) {
+      setError((err as Error).message || 'Failed to delete agent');
+      setDeleting(false);
+    }
+  }, [agent.id, agent.name, onDeleted]);
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="agent-detail-name">Name</Label>
+        <Input
+          id="agent-detail-name"
+          data-testid="agent-detail-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="agent-detail-system-prompt">System prompt</Label>
+        <Textarea
+          id="agent-detail-system-prompt"
+          data-testid="agent-detail-system-prompt"
+          rows={8}
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+        />
+      </div>
+
+      <div className="flex items-end gap-3">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="agent-detail-channel">Channel</Label>
+          <FormSelect
+            id="agent-detail-channel"
+            data-testid="agent-detail-channel"
+            value={channel}
+            onChange={(e) => setChannel(e.target.value)}
+          >
+            {CHANNEL_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </FormSelect>
+        </div>
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="agent-detail-thread-key">Thread key (optional)</Label>
+          <Input
+            id="agent-detail-thread-key"
+            data-testid="agent-detail-thread-key"
+            placeholder="none — binds whole channel"
+            value={threadKey}
+            onChange={(e) => setThreadKey(e.target.value)}
+            disabled={!channel}
+          />
+        </div>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button
+          variant="outline"
+          onClick={handleDelete}
+          disabled={deleting}
+          data-testid="agent-detail-delete"
+        >
+          {deleting ? 'Deleting…' : 'Delete agent'}
+        </Button>
+        <Button onClick={handleSave} disabled={!canSave} data-testid="agent-detail-save">
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SessionsTab({ agentId }: { agentId: string }) {
+  const [convId, setConvId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    agentsApi
+      .ensureSession(agentId)
+      .then((session) => {
+        if (!cancelled) setConvId(session.id);
+      })
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message || 'Failed to start session');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  if (error) {
+    return <p className="p-6 text-sm text-destructive">Failed to load session: {error}</p>;
+  }
+
+  if (!convId) {
+    return <p className="p-6 text-sm text-muted-foreground">Starting session…</p>;
+  }
+
+  return <AgentSessionChat convId={convId} />;
+}
+
+export default function AgentDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<'config' | 'sessions'>('config');
+
+  const {
+    data: agent,
+    loading,
+    error,
+    refresh,
+  } = useResource<AgentWithStatus>(id ?? null, () => agentsApi.get(id!));
+
+  if (loading || !agent) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        {error ? `Failed to load agent: ${error}` : 'Loading…'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="p-6 pb-0">
+        <button
+          onClick={() => navigate('/agents')}
+          className="mb-3 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          data-testid="agent-detail-back"
+        >
+          <ChevronLeftIcon />
+          All agents
+        </button>
+
+        <PageHeader
+          title={agent.name}
+          eyebrowContent={
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className={STATUS_STYLE[agent.status]}>
+                {agent.status}
+              </Badge>
+              {agent.session_id && (
+                <span className="font-mono text-[11px] text-muted-soft">
+                  session {agent.session_id}
+                </span>
+              )}
+            </div>
+          }
+        />
+
+        <SegmentedControl
+          className="mt-4"
+          value={tab}
+          onChange={setTab}
+          options={[
+            { value: 'config', label: 'Config', testId: 'agent-tab-config' },
+            { value: 'sessions', label: 'Sessions', testId: 'agent-tab-sessions' },
+          ]}
+        />
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {tab === 'config' ? (
+          <div className="overflow-auto">
+            <ConfigTab
+              agent={agent}
+              onSaved={() => refresh()}
+              onDeleted={() => navigate('/agents')}
+            />
+          </div>
+        ) : (
+          <SessionsTab agentId={agent.id} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AgentsPage.test.tsx
+++ b/src/pages/AgentsPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AgentsPage from './AgentsPage';
+import { renderWithRouter } from '../test-helpers';
+import type { AgentWithStatus } from '@/lib/api/agentsApi';
+
+const { taskApiProxy, reviewApiProxy, configApiProxy, agentsApiProxy, apiMock } = await vi.hoisted(
+  async () => (await import('../test-helpers')).setupApiMock(),
+);
+
+vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
+vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
+vi.mock('@/lib/api/configApi', () => ({ configApi: configApiProxy }));
+vi.mock('@/lib/api/agentsApi', () => ({ agentsApi: agentsApiProxy }));
+vi.mock('@/lib/event-source', () => ({
+  subscribe: vi.fn(() => () => {}),
+  subscribeConnectionState: vi.fn(() => () => {}),
+}));
+
+const { routerMockFactory, mockNavigate } = await vi.hoisted(async () =>
+  (await import('../test-helpers')).setupRouterNavigateMock(),
+);
+vi.mock('react-router-dom', routerMockFactory);
+
+function makeAgent(overrides: Partial<AgentWithStatus> = {}): AgentWithStatus {
+  return {
+    id: 'agent-1',
+    name: 'support-bot',
+    system_prompt: 'You help customers.',
+    channel: null,
+    channel_config: null,
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    status: 'stopped',
+    session_id: null,
+    ...overrides,
+  };
+}
+
+describe('AgentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows empty state when no agents', async () => {
+    apiMock.list.mockResolvedValue([]);
+    renderWithRouter(<AgentsPage />);
+    expect(await screen.findByText(/no agents yet/i)).toBeTruthy();
+  });
+
+  it('renders agent cards with status pill, channel badge, and updated_at', async () => {
+    apiMock.list.mockResolvedValue([
+      makeAgent({ id: 'agent-1', name: 'support-bot', status: 'working', channel: 'telegram' }),
+      makeAgent({ id: 'agent-2', name: 'idle-bot', status: 'idle', channel: null }),
+      makeAgent({ id: 'agent-3', name: 'stopped-bot', status: 'stopped', channel: null }),
+    ]);
+    renderWithRouter(<AgentsPage />);
+
+    expect(await screen.findByTestId('agent-card-agent-1')).toBeTruthy();
+    expect(screen.getByTestId('agent-card-agent-2')).toBeTruthy();
+    expect(screen.getByTestId('agent-card-agent-3')).toBeTruthy();
+
+    expect(screen.getByText('support-bot')).toBeTruthy();
+    expect(screen.getByText('working')).toBeTruthy();
+    expect(screen.getByText('idle')).toBeTruthy();
+    expect(screen.getByText('stopped')).toBeTruthy();
+
+    expect(screen.getByTestId('agent-channel-agent-1')).toHaveTextContent('telegram');
+    expect(screen.getByTestId('agent-channel-agent-2')).toHaveTextContent('no channel');
+  });
+
+  it('navigates to /agents/:id on card click', async () => {
+    const user = userEvent.setup();
+    apiMock.list.mockResolvedValue([makeAgent({ id: 'agent-42' })]);
+    renderWithRouter(<AgentsPage />);
+
+    const card = await screen.findByTestId('agent-card-agent-42');
+    await user.click(card);
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/agents/agent-42'));
+  });
+
+  it('opens the new agent dialog and submits, then refreshes the list', async () => {
+    const user = userEvent.setup();
+    apiMock.list.mockResolvedValue([]);
+    apiMock.create.mockResolvedValue(makeAgent({ id: 'agent-new', name: 'new-agent' }));
+    renderWithRouter(<AgentsPage />);
+
+    await user.click(await screen.findByTestId('new-agent-button'));
+    expect(await screen.findByTestId('new-agent-dialog')).toBeInTheDocument();
+
+    await user.type(screen.getByTestId('agent-name'), 'new-agent');
+    await user.type(screen.getByTestId('agent-system-prompt'), 'Be helpful.');
+    await user.selectOptions(screen.getByTestId('agent-channel'), 'telegram');
+    await user.type(screen.getByTestId('agent-thread-key'), 'thread-123');
+
+    await user.click(screen.getByTestId('new-agent-submit'));
+
+    await waitFor(() =>
+      expect(apiMock.create).toHaveBeenCalledWith({
+        name: 'new-agent',
+        system_prompt: 'Be helpful.',
+        channel: 'telegram',
+        channel_config: JSON.stringify({ threadKey: 'thread-123' }),
+      }),
+    );
+    await waitFor(() => expect(apiMock.list).toHaveBeenCalledTimes(2));
+  });
+
+  it('disables submit until name and system prompt are filled', async () => {
+    const user = userEvent.setup();
+    apiMock.list.mockResolvedValue([]);
+    renderWithRouter(<AgentsPage />);
+
+    await user.click(await screen.findByTestId('new-agent-button'));
+    expect(screen.getByTestId('new-agent-submit')).toBeDisabled();
+
+    await user.type(screen.getByTestId('agent-name'), 'x');
+    expect(screen.getByTestId('new-agent-submit')).toBeDisabled();
+
+    await user.type(screen.getByTestId('agent-system-prompt'), 'y');
+    expect(screen.getByTestId('new-agent-submit')).not.toBeDisabled();
+  });
+});

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  agentsApi,
+  type AgentStatus,
+  type AgentWithStatus,
+  type CreateAgentInput,
+} from '@/lib/api/agentsApi';
+import { useResource } from '@/lib/use-resource';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { FormSelect } from '@/components/ui/form-select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { PageHeader } from '@/components/layout/page-header';
+import { PlusIcon } from '@/components/icons';
+import { timeAgo } from '@/lib/time';
+
+const STATUS_STYLE: Record<AgentStatus, string> = {
+  working: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  idle: 'border-amber-500/30 bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  stopped: 'border-border bg-transparent text-muted-foreground',
+};
+
+const CHANNEL_OPTIONS = [
+  { value: '', label: 'None' },
+  { value: 'telegram', label: 'Telegram' },
+  { value: 'slack', label: 'Slack' },
+];
+
+function StatusPill({ status }: { status: AgentStatus }) {
+  return (
+    <Badge variant="outline" className={STATUS_STYLE[status]} data-testid="agent-status-pill">
+      {status}
+    </Badge>
+  );
+}
+
+interface NewAgentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (agent: AgentWithStatus) => void;
+}
+
+function NewAgentDialog({ open, onOpenChange, onCreated }: NewAgentDialogProps) {
+  const [name, setName] = useState('');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [channel, setChannel] = useState('');
+  const [threadKey, setThreadKey] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setName('');
+    setSystemPrompt('');
+    setChannel('');
+    setThreadKey('');
+    setError(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (submitting) return;
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [submitting, reset, onOpenChange],
+  );
+
+  const canSubmit = !submitting && name.trim().length > 0 && systemPrompt.trim().length > 0;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const input: CreateAgentInput = {
+        name: name.trim(),
+        system_prompt: systemPrompt.trim(),
+        channel: channel || null,
+        channel_config: threadKey.trim() ? JSON.stringify({ threadKey: threadKey.trim() }) : null,
+      };
+      const agent = await agentsApi.create(input);
+      reset();
+      onOpenChange(false);
+      onCreated(agent);
+    } catch (err) {
+      setError((err as Error).message || 'Failed to create agent');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canSubmit, name, systemPrompt, channel, threadKey, reset, onOpenChange, onCreated]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent data-testid="new-agent-dialog" className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New agent</DialogTitle>
+          <DialogDescription>
+            Create a long-running agent with its own system prompt and, optionally, a channel it
+            listens on.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="agent-name">Name</Label>
+            <Input
+              id="agent-name"
+              data-testid="agent-name"
+              placeholder="e.g. support-bot"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="agent-system-prompt">System prompt</Label>
+            <Textarea
+              id="agent-system-prompt"
+              data-testid="agent-system-prompt"
+              rows={5}
+              placeholder="What should this agent do?"
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+            />
+          </div>
+
+          <div className="flex items-end gap-3">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="agent-channel">Channel</Label>
+              <FormSelect
+                id="agent-channel"
+                data-testid="agent-channel"
+                value={channel}
+                onChange={(e) => setChannel(e.target.value)}
+              >
+                {CHANNEL_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </FormSelect>
+            </div>
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="agent-thread-key">Thread key (optional)</Label>
+              <Input
+                id="agent-thread-key"
+                data-testid="agent-thread-key"
+                placeholder="none — binds whole channel"
+                value={threadKey}
+                onChange={(e) => setThreadKey(e.target.value)}
+                disabled={!channel}
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button data-testid="new-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? 'Creating…' : 'Create agent'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function AgentsPage() {
+  const { data, loading, error, refresh } = useResource<AgentWithStatus[]>('agents', () =>
+    agentsApi.list(),
+  );
+  const [newAgentOpen, setNewAgentOpen] = useState(false);
+  const agents = data ?? [];
+  const nav = useNavigate();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col p-6">
+      <PageHeader
+        title="Agents"
+        description="Long-running agents with their own system prompt and channel binding."
+        actions={
+          <Button size="sm" onClick={() => setNewAgentOpen(true)} data-testid="new-agent-button">
+            <PlusIcon data-icon="inline-start" />
+            New agent
+          </Button>
+        }
+      />
+
+      {loading ? (
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-32 animate-pulse rounded-2xl border border-glass-edge bg-glass-l1"
+            />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="mt-4 text-sm text-destructive">Failed to load agents: {error}</p>
+      ) : agents.length === 0 ? (
+        <p className="mt-4 text-sm text-muted-foreground">No agents yet.</p>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {agents.map((agent) => (
+            <GlassPanel
+              key={agent.id}
+              level={2}
+              specular
+              data-testid={`agent-card-${agent.id}`}
+              className="group flex cursor-pointer flex-col gap-3 rounded-2xl p-4 transition-colors hover:bg-glass-l3/80"
+              onClick={() => nav(`/agents/${agent.id}`)}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="min-w-0 truncate text-sm font-medium text-foreground group-hover:text-primary">
+                  {agent.name}
+                </h3>
+                <StatusPill status={agent.status} />
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary" data-testid={`agent-channel-${agent.id}`}>
+                  {agent.channel ?? 'no channel'}
+                </Badge>
+              </div>
+              <p className="mt-auto text-[10px] text-muted-soft">
+                Updated {timeAgo(agent.updated_at)}
+              </p>
+            </GlassPanel>
+          ))}
+        </div>
+      )}
+
+      <NewAgentDialog
+        open={newAgentOpen}
+        onOpenChange={setNewAgentOpen}
+        onCreated={() => {
+          refresh();
+        }}
+      />
+    </div>
+  );
+}

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -84,6 +84,7 @@ type ApiMock = ReturnType<typeof mockTaskApi> &
   ReturnType<typeof mockLoopGroupApi> &
   ReturnType<typeof mockSchedulesApi> &
   ReturnType<typeof mockWorkflowsApi> &
+  ReturnType<typeof mockAgentsApi> &
   Record<string, unknown>;
 
 export function setupApiMock(overrides: Record<string, unknown> = {}) {
@@ -95,6 +96,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
   const loopGroupApiMock = mockLoopGroupApi(overrides);
   const schedulesApiMock = mockSchedulesApi(overrides);
   const workflowsApiMock = mockWorkflowsApi(overrides);
+  const agentsApiMock = mockAgentsApi(overrides);
   const taskApiProxy = new Proxy(
     {},
     { get: (_target, prop: string) => taskApiMock[prop as keyof typeof taskApiMock] },
@@ -127,6 +129,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     {},
     { get: (_target, prop: string) => workflowsApiMock[prop as keyof typeof workflowsApiMock] },
   );
+  const agentsApiProxy = new Proxy(
+    {},
+    { get: (_target, prop: string) => agentsApiMock[prop as keyof typeof agentsApiMock] },
+  );
   const apiMock = new Proxy(
     {},
     {
@@ -142,6 +148,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
           return schedulesApiMock[prop as keyof typeof schedulesApiMock];
         if (prop in workflowsApiMock)
           return workflowsApiMock[prop as keyof typeof workflowsApiMock];
+        if (prop in agentsApiMock) return agentsApiMock[prop as keyof typeof agentsApiMock];
         return overrides[prop];
       },
       set: (_target, prop: string, value) => {
@@ -177,6 +184,10 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
           (workflowsApiMock as Record<string, unknown>)[prop] = value;
           return true;
         }
+        if (prop in agentsApiMock) {
+          (agentsApiMock as Record<string, unknown>)[prop] = value;
+          return true;
+        }
         overrides[prop] = value;
         return true;
       },
@@ -195,6 +206,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     loopGroupApiMock,
     schedulesApiMock,
     workflowsApiMock,
+    agentsApiMock,
     taskApiProxy,
     reviewApiProxy,
     configApiProxy,
@@ -203,6 +215,7 @@ export function setupApiMock(overrides: Record<string, unknown> = {}) {
     loopGroupApiProxy,
     schedulesApiProxy,
     workflowsApiProxy,
+    agentsApiProxy,
     apiMock,
     apiProxy,
   };
@@ -525,6 +538,59 @@ export function mockWorkflowsApi(overrides: Record<string, unknown> = {}) {
   return { ...defaults, ...overrides };
 }
 
+export function mockAgentsApi(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockResolvedValue({
+      id: 'agent-1',
+      name: 'test-agent',
+      system_prompt: 'You are a helpful agent.',
+      channel: null,
+      channel_config: null,
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:00',
+      status: 'stopped',
+      session_id: null,
+    }),
+    get: vi.fn().mockResolvedValue({
+      id: 'agent-1',
+      name: 'test-agent',
+      system_prompt: 'You are a helpful agent.',
+      channel: null,
+      channel_config: null,
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:00',
+      status: 'stopped',
+      session_id: null,
+    }),
+    update: vi.fn().mockResolvedValue({
+      id: 'agent-1',
+      name: 'test-agent',
+      system_prompt: 'You are a helpful agent.',
+      channel: null,
+      channel_config: null,
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:00',
+      status: 'stopped',
+      session_id: null,
+    }),
+    remove: vi.fn().mockResolvedValue(undefined),
+    ensureSession: vi.fn().mockResolvedValue({
+      id: 'conv-1',
+      title: 'test-agent',
+      tmux_window: null,
+      claude_session_id: null,
+      transcript_path: null,
+      status: 'running',
+      is_global_monitor: 0,
+      agent_id: 'agent-1',
+      created_at: '2026-01-01 00:00:00',
+      updated_at: '2026-01-01 00:00:00',
+    }),
+  };
+  return { ...defaults, ...overrides };
+}
+
 export function mockApi(overrides: Record<string, unknown> = {}) {
   return {
     ...mockTaskApi(),
@@ -535,6 +601,7 @@ export function mockApi(overrides: Record<string, unknown> = {}) {
     ...mockLoopGroupApi(),
     ...mockSchedulesApi(),
     ...mockWorkflowsApi(),
+    ...mockAgentsApi(),
     ...overrides,
   };
 }


### PR DESCRIPTION
## What

A dedicated **Agents** surface. Create a long-running agent (name + system prompt + channel binding); it gets **one persistent conductor session** with the full orchestrator toolset. See every agent as a status card, open one to edit its config or watch its live CLI chat.

The existing **orchestrator page is completely untouched** — this is a separate surface on the same conductor runtime. (`git status` on `OrchestratorPage.tsx`, `src/components/orchestrator/`, and `MobileBottomNav.tsx` is empty.)

Spec: `spec/agents-feature.md` · Plan: `plans/2026-07-24-agents-feature.md`

## Included: the worker report-back fix

A worker calling `report_complete` fired `task:phase_complete`, which the supervisor relayed via `pushToConversation` — that only fans out to **WebSocket clients**. The gateway consumes the **transcript tail**. Same conversation, two delivery channels, gateway subscribed to the wrong one, so **Telegram never saw worker reports** while the dashboard did.

Fix is additive: `registerConversationMessageListener` in `stream.ts`; `pushToConversation` now also notifies listeners for `message`/`card` events, and the gateway forwards them to its channel with the **artifact URL as a tappable link**. WS clients and the orchestrator page behave exactly as before, and the two sources are disjoint so nothing double-delivers.

## Two naming collisions (deliberate)

Both were found by a failing test before renaming, rather than silently shadowing working features:
- **`agents` table already exists** (per-task tmux workers) → new table is **`agent_configs`**
- **`/api/agents` already routed** (`agent-defs.ts` role definitions, `chats.ts`) → CRUD is at **`/api/agent-configs`**

So the UI says "Agents" while the table/API say `agent_configs`. Easy to rename later if the inconsistency grates.

## Changes

**Backend** — `agent_configs` table + `orchestrator_conversations.agent_id` · agents-config repository · optional per-conversation `systemPrompt` (default path byte-identical, so orchestrator conversations are unchanged) · `/api/agent-configs` CRUD + `POST /:id/session` + derived status · gateway routes a bound channel to its agent's session (unbound path untouched).

**Frontend** — `agentsApi` client · `/agents` cards page + create dialog · `/agents/:id` Config + Sessions tabs · `AgentSessionChat` (standalone WS chat, intentionally self-contained rather than refactored out of the orchestrator) · sidebar **Agents** entry beside the untouched orchestrator entry.

## Testing

Full suite **3922 passing (352 files)**, typecheck clean, **0 lint errors**. New coverage: agents repository, `/api/agent-configs` routes, gateway agent-binding + report-forwarding, conversation-message listener, and all four new UI surfaces.

## Not in v1

Manual/cron/event triggers (channel binding only) · multiple sessions per agent · approval cards for agent-dispatched tasks (text + artifact links instead) · the Slack adapter (binding shape is there) · `agents` in the 5-item mobile bottom bar (desktop sidebar only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)