### PR TITLE
feat(workflows): slack-watcher proactive inbox digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ row is `(kind, repo_path)`-unique with a 5-field cron; `poller/schedule-cron.ts`
 - ESLint: `@typescript-eslint/no-explicit-any` is warn (off in test files)
 - Conventional commits enforced: `feat(scope): message`, `fix(scope): message`, etc.
 - Kebab-case scopes, 100 char header max
+- Never add any AI attribution to commits or PRs — no `Co-Authored-By: Claude …` trailers,
+  no "Generated with Claude Code" footers, nothing of the kind
 - Use template literals for SQL with `datetime('now')` — single quotes inside backticks
 
 ## Gotchas

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -23,12 +23,14 @@
 ### Task 1: Config + output schemas
 
 **Files:**
+
 - Create: `server/workflows/slack-watcher/schema.ts`
 - Test: `server/workflows/slack-watcher/schema.test.ts`
 
 **Interfaces:**
+
 - Consumes: nothing.
-- Produces: `SLACK_WATCHER_CONFIG_SCHEMA` (object schema with `slackUserId: string` default `''` — member id in the **watched** workspace, `digestUserId: string` default `''` — member id in the **bot's** workspace, `lookbackMinutes: number` default `40`, `digestChannel: string` default `''`) and `SLACK_WATCHER_SCHEMA` (submit_result payload: required `outcome`, `window`, `summary`, `digestSent`, `items`; optional `links`). Item shape: `{ channel, from, about, urgency: 'low'|'medium'|'high', suggestedReply?, permalink? }`.
+- Produces: `SLACK_WATCHER_CONFIG_SCHEMA` (object schema with `slackUserId: string` default `''` — member id in the **watched** workspace, `digestTarget: 'slack'|'telegram'` default `'slack'`, `telegramChatId: string` default `''`, `digestUserId: string` default `''` — member id in the **bot's** workspace, `lookbackMinutes: number` default `40`, `digestChannel: string` default `''`) and `SLACK_WATCHER_SCHEMA` (submit_result payload: required `outcome`, `window`, `summary`, `digestSent`, `items`; optional `links`). Item shape: `{ channel, from, about, urgency: 'low'|'medium'|'high', suggestedReply?, permalink? }`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -81,9 +83,16 @@ describe('SLACK_WATCHER_SCHEMA', () => {
     const cfg: Record<string, unknown> = { slackUserId: 'U01ABCDEF' };
 
     expect(validate(cfg)).toBe(true);
+    expect(cfg.digestTarget).toBe('slack');
+    expect(cfg.telegramChatId).toBe('');
     expect(cfg.digestUserId).toBe('');
     expect(cfg.lookbackMinutes).toBe(40);
     expect(cfg.digestChannel).toBe('');
+  });
+
+  it('rejects an unknown digestTarget', () => {
+    const validate = new Ajv().compile(SLACK_WATCHER_CONFIG_SCHEMA);
+    expect(validate({ slackUserId: 'U01ABCDEF', digestTarget: 'email' })).toBe(false);
   });
 });
 ```
@@ -111,6 +120,19 @@ export const SLACK_WATCHER_CONFIG_SCHEMA = {
       title: 'Watched member id',
       description:
         "The owner's member id in the watched workspace (e.g. U01ABCDEF) — whose inbox to search.",
+      default: '',
+    },
+    digestTarget: {
+      type: 'string',
+      enum: ['slack', 'telegram'],
+      title: 'Digest destination',
+      description: 'Where the digest goes: a Slack DM/channel via the bot, or Telegram.',
+      default: 'slack',
+    },
+    telegramChatId: {
+      type: 'string',
+      title: 'Telegram chat id',
+      description: "Numeric Telegram chat id (the gateway allowlist id). Required for the 'telegram' target.",
       default: '',
     },
     digestUserId: {
@@ -177,7 +199,7 @@ export const SLACK_WATCHER_SCHEMA = {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `bun run vitest run server/workflows/slack-watcher/schema.test.ts`
-Expected: PASS (3 tests).
+Expected: PASS (4 tests).
 
 - [ ] **Step 5: Commit**
 
@@ -191,13 +213,15 @@ git commit -m "feat(workflows): slack-watcher config and output schemas"
 ### Task 2: Run service with dedup memory
 
 **Files:**
+
 - Create: `server/workflows/slack-watcher/run.ts`
 - Modify: `server/schedule-prompt.ts:13-19` (add `'slack-watcher'` to `CRON_PROMPT_KINDS`)
 - Test: `server/workflows/slack-watcher/run.test.ts`
 
 **Interfaces:**
+
 - Consumes: `SLACK_WATCHER_SCHEMA` from Task 1; existing `resolveSchedulePrompt({ scheduleId, kind })`, `runSessionVertical(input)`, `listRunsForWorkflow(kind)`, `insertRun` / `finishRun` (tests only).
-- Produces: `runSlackWatcher(input: RunSlackWatcherInput): Promise<{ result: SlackWatcherResult }>` with `RunSlackWatcherInput = { repoPath: string; scheduleId?: string | null; slackUserId: string; digestUserId: string; lookbackMinutes: number; digestChannel: string; trigger?: 'cron' | 'manual' }`, plus exported `SlackWatcherResult` / `SlackWatcherItem` types and `previousItemsJson(): string`.
+- Produces: `runSlackWatcher(input: RunSlackWatcherInput): Promise<{ result: SlackWatcherResult }>` with `RunSlackWatcherInput = { repoPath: string; scheduleId?: string | null; slackUserId: string; digestTarget: string; telegramChatId: string; digestUserId: string; lookbackMinutes: number; digestChannel: string; trigger?: 'cron' | 'manual' }`, plus exported `SlackWatcherResult` / `SlackWatcherItem` types and `previousItemsJson(): string`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -224,7 +248,7 @@ import { runSlackWatcher, previousItemsJson } from './run.js';
 import { SLACK_WATCHER_SCHEMA } from './schema.js';
 
 const SKILL_BODY =
-  'Watch {{slackUserId}} back {{lookbackMinutes}}m, DM {{digestUserId}} at "{{digestChannel}}", skip {{previousItems}}.';
+  'Watch {{slackUserId}} back {{lookbackMinutes}}m, via {{digestTarget}} tg:{{telegramChatId}} DM {{digestUserId}} at "{{digestChannel}}", skip {{previousItems}}.';
 
 describe('runSlackWatcher', () => {
   beforeEach(() => {
@@ -240,6 +264,8 @@ describe('runSlackWatcher', () => {
       repoPath: '/repos/octomux',
       scheduleId: 'sched-1',
       slackUserId: 'U01ABCDEF',
+      digestTarget: 'slack',
+      telegramChatId: '',
       digestUserId: 'U0PERSONAL',
       lookbackMinutes: 40,
       digestChannel: '',
@@ -251,7 +277,9 @@ describe('runSlackWatcher', () => {
     expect(call.kind).toBe('slack-watcher');
     expect(call.scheduleId).toBe('sched-1');
     expect(call.workspaceDir).toBe('/repos/octomux');
-    expect(call.input).toBe('Watch U01ABCDEF back 40m, DM U0PERSONAL at "", skip [].');
+    expect(call.input).toBe(
+      'Watch U01ABCDEF back 40m, via slack tg: DM U0PERSONAL at "", skip [].',
+    );
     expect(call.outputSchema).toBe(SLACK_WATCHER_SCHEMA);
   });
 
@@ -268,13 +296,15 @@ describe('runSlackWatcher', () => {
     await runSlackWatcher({
       repoPath: '/repos/octomux',
       slackUserId: 'U01ABCDEF',
+      digestTarget: 'telegram',
+      telegramChatId: '555123',
       digestUserId: 'U0PERSONAL',
       lookbackMinutes: 40,
       digestChannel: 'C123',
     });
     const call = mockRunSessionVertical.mock.calls[0][0];
     expect(call.input).toContain(JSON.stringify(items));
-    expect(call.input).toContain('DM U0PERSONAL at "C123"');
+    expect(call.input).toContain('via telegram tg:555123 DM U0PERSONAL at "C123"');
   });
 
   it('falls back to [] for missing, unfinished, or malformed previous runs', () => {
@@ -333,6 +363,10 @@ export interface RunSlackWatcherInput {
   scheduleId?: string | null;
   /** Owner's member id in the watched workspace — whose inbox to search. */
   slackUserId: string;
+  /** Digest destination: 'slack' (DM/channel via the bot) or 'telegram'. */
+  digestTarget: string;
+  /** Telegram numeric chat id — used when digestTarget is 'telegram'. */
+  telegramChatId: string;
   /** Owner's member id in the bot's workspace — whom the bot DMs. */
   digestUserId: string;
   lookbackMinutes: number;
@@ -380,6 +414,8 @@ export async function runSlackWatcher(
   });
   const prompt = skillContent
     .replace(/\{\{slackUserId\}\}/g, input.slackUserId)
+    .replace(/\{\{digestTarget\}\}/g, input.digestTarget)
+    .replace(/\{\{telegramChatId\}\}/g, input.telegramChatId)
     .replace(/\{\{digestUserId\}\}/g, input.digestUserId)
     .replace(/\{\{lookbackMinutes\}\}/g, String(input.lookbackMinutes))
     .replace(/\{\{digestChannel\}\}/g, input.digestChannel)
@@ -413,9 +449,11 @@ git commit -m "feat(workflows): slack-watcher run service with previous-run dedu
 ### Task 3: Shipped skill prompt
 
 **Files:**
+
 - Create: `plugin/skills/slack-watcher/SKILL.md`
 
 **Interfaces:**
+
 - Consumes: placeholders `{{slackUserId}}`, `{{digestUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, `{{previousItems}}` (interpolated by Task 2), the Slack MCP connector tools for reads, and `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (inherited from the server process) for posting.
 - Produces: the prompt body that `getSkill('slack-watcher')` returns and `resolveScheduleSkillContent` seeds into the `schedule_skills` table. Its `submit_result` payload must match `SLACK_WATCHER_SCHEMA` from Task 1.
 
@@ -432,14 +470,15 @@ description: Use when running a scheduled slack-watcher session — scan the own
 # Slack watcher
 
 Scan the owner's Slack inbox for the last {{lookbackMinutes}} minutes and, only if
-something needs them, send one concise digest DM through the octomux bot. This is a
+something needs them, send one concise digest to the configured destination. This is a
 headless, unattended session — you do not edit files, commit, or open PRs. Your only
-side effects are Slack MCP reads, at most one bot-token `chat.postMessage`, and one
+side effects are Slack MCP reads, at most one outbound digest message, and one
 `submit_result` call.
 
 The owner's member id in the **watched** workspace is `{{slackUserId}}` (use it for all
 inbox searches). Their member id in the **bot's** workspace is `{{digestUserId}}` (use
 it only to open the digest DM) — the two workspaces may differ, so never mix the ids up.
+The digest destination is `{{digestTarget}}`.
 
 ## Slack access
 
@@ -448,13 +487,15 @@ Reads and writes use **different credentials in different workspaces** — never
 - **Inbox reads (watched workspace):** your Slack MCP connector tools —
   `slack_search_public_and_private`, `slack_read_thread`, `slack_read_channel`,
   `slack_search_users`. You must never call the connector's send/draft/canvas tools.
-- **Posting the digest (bot's workspace):** `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-,
-  inherited from the server env) via `curl` — this is the only send you ever perform.
+- **Posting the digest:** via `curl`, using the env token for `{{digestTarget}}` —
+  `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-, bot's workspace) for `slack`,
+  `OCTOMUX_GATEWAY_TELEGRAM_TOKEN` for `telegram`. This is the only send you ever
+  perform.
 
 Before anything else, confirm the Slack MCP tools are available. If they are not, or the
-bot token is missing, or a Slack call fails with an auth error: do not retry endlessly —
-call `submit_result` with `outcome: "blocked"`, name exactly what was missing or the
-exact Slack error string in `summary`, and stop.
+token for `{{digestTarget}}` is missing, or an API call fails with an auth error: do not
+retry endlessly — call `submit_result` with `outcome: "blocked"`, name exactly what was
+missing or the exact error string in `summary`, and stop.
 
 ## Steps
 
@@ -462,7 +503,6 @@ exact Slack error string in `summary`, and stop.
    only messages with `ts >= $SINCE` count.
 
 2. **Collect candidates** with the Slack MCP tools (watched workspace):
-
    - Mentions: `slack_search_public_and_private` with a query for `<@{{slackUserId}}>`,
      newest first.
    - DMs to the owner: the same search tool with an `is:dm` query (and `is:mpim` for
@@ -484,27 +524,48 @@ exact Slack error string in `summary`, and stop.
 
 4. **Compose the digest** — natural, human, concise. For each item (max 10, ordered
    by urgency): who and where, what it's about in plain language, and a suggested
-   reply written in the owner's voice — short, direct, no corporate filler, ready to
-   paste as-is. Format:
+   reply ready to paste as-is. Format:
 
    ```
    *Slack digest — <n> things need you*
 
    1. *Priya · #deploys* — blocked on the staging deploy config, asking if she
       should wait for your chart fix.
-      ↳ suggested: "Use the staging override for now — I'll land the chart fix
-      tomorrow morning."
+      ↳ suggested: "use the staging override for now, I'll land the chart fix
+      tomorrow morning"
    ```
+
+   **Suggested replies must sound like the owner dashed them off, not like an
+   assistant wrote them.** Rules:
+
+   - Before writing a reply, look at the owner's own messages in that thread or
+     channel (they're in the context you already fetched) and mirror how they write
+     there: formality, capitalization, emoji or none, greeting or none.
+   - 1–2 sentences. Contractions. Plain words. Answer the actual question; when
+     relevant, give a concrete next step or time ("I'll look after standup") instead
+     of vague reassurance.
+   - Banned: greetings and sign-offs the thread doesn't use, "I hope this helps",
+     "it's worth noting", "thanks for reaching out", "absolutely!", "great question",
+     "delve", "seamless", "robust", "leverage", "furthermore", and "it's not just X,
+     it's Y" constructions. If a reply reads like a support ticket response, rewrite
+     it shorter.
+   - Vary the shape between replies — identical sentence patterns across items is an
+     assistant tell.
 
    Never include token values, API keys, connection strings, or other secret shapes
    in the digest — refer to them ("the staging token") without quoting them.
 
-5. **Send it** with the bot token — only if at least one item survived filtering.
-   Resolve the channel: use `{{digestChannel}}` if non-empty, otherwise
-   `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
-   and take `.channel.id`. Then one
-   `chat.postMessage` with the digest as `text`. **Zero items → send nothing.**
-   Silence is the correct output for a quiet window.
+5. **Send it** — only if at least one item survived filtering, and only to the
+   `{{digestTarget}}` destination:
+
+   - `telegram`: one
+     `curl -s -X POST "https://api.telegram.org/bot$OCTOMUX_GATEWAY_TELEGRAM_TOKEN/sendMessage" -d "chat_id={{telegramChatId}}" --data-urlencode "text=<digest>"`
+     (plain text — drop the `*bold*` markers for Telegram).
+   - `slack`: resolve the channel — `{{digestChannel}}` if non-empty, otherwise
+     `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
+     and take `.channel.id` — then one `chat.postMessage` with the digest as `text`.
+
+   **Zero items → send nothing.** Silence is the correct output for a quiet window.
 
 6. **Call `submit_result` exactly once** with:
 
@@ -538,7 +599,7 @@ exact Slack error string in `summary`, and stop.
   owner, prefer including it at `low` urgency over silently dropping it.
 - Never send any message other than the single digest, and never post as the owner —
   reads happen through the connector, but its send/draft tools are off-limits; the only
-  send you perform is the one bot-token `chat.postMessage`. Do not look for workarounds.
+  send you perform is the one gateway-token digest message. Do not look for workarounds.
 - Suggested replies are suggestions. The owner sends them; you never do.
 ````
 
@@ -559,11 +620,13 @@ git commit -m "feat(skills): slack-watcher digest skill"
 ### Task 4: Workflow registration
 
 **Files:**
+
 - Create: `server/workflows/slack-watcher/index.ts`
 - Modify: `server/workflows/index.ts:1-9` (side-effect import, alphabetical)
 - Test: `server/workflows/slack-watcher/index.test.ts`
 
 **Interfaces:**
+
 - Consumes: `runSlackWatcher` (Task 2), both schemas (Task 1), `registerWorkflow` / `RunContext` / `WorkflowType`, `resolveWorkflowConfig` (tests).
 - Produces: registered kind `slack-watcher` (displayName `Slack Watcher`, `surfaces: ['artifact']`, cron trigger) — visible to the /schedules form and `listCronWorkflowKinds()`.
 
@@ -634,6 +697,8 @@ describe('slack-watcher workflow registration', () => {
     expect(call.repoPath).toBe('/repo');
     expect(call.scheduleId).toBe('sched-42');
     expect(call.slackUserId).toBe('U07X');
+    expect(call.digestTarget).toBe('slack');
+    expect(call.telegramChatId).toBe('');
     expect(call.digestUserId).toBe('');
     expect(call.lookbackMinutes).toBe(40);
     expect(call.digestChannel).toBe('');
@@ -644,6 +709,8 @@ describe('slack-watcher workflow registration', () => {
     const row = makeRow({
       config_json: JSON.stringify({
         slackUserId: 'U07X',
+        digestTarget: 'telegram',
+        telegramChatId: '555123',
         digestUserId: 'U0PERSONAL',
         lookbackMinutes: 20,
         digestChannel: 'C9',
@@ -656,6 +723,8 @@ describe('slack-watcher workflow registration', () => {
     });
 
     const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.digestTarget).toBe('telegram');
+    expect(call.telegramChatId).toBe('555123');
     expect(call.digestUserId).toBe('U0PERSONAL');
     expect(call.lookbackMinutes).toBe(20);
     expect(call.digestChannel).toBe('C9');
@@ -695,6 +764,9 @@ export const slackWatcherWorkflow: WorkflowType = {
     );
     const cfg = ctx.config as {
       slackUserId: string;
+      digestTarget: string;
+      telegramChatId: string;
+      digestUserId: string;
       lookbackMinutes: number;
       digestChannel: string;
     };
@@ -704,6 +776,9 @@ export const slackWatcherWorkflow: WorkflowType = {
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,
       slackUserId: cfg.slackUserId,
+      digestTarget: cfg.digestTarget,
+      telegramChatId: cfg.telegramChatId,
+      digestUserId: cfg.digestUserId,
       lookbackMinutes: cfg.lookbackMinutes,
       digestChannel: cfg.digestChannel,
       trigger: ctx.trigger,
@@ -743,9 +818,11 @@ git commit -m "feat(workflows): register slack-watcher cron workflow kind"
 ### Task 5: Gateway README — watcher setup docs
 
 **Files:**
+
 - Modify: `server/gateway/README.md` (new section after the Slack smoke test + "Not in v1" footer). The conductor manifest is untouched — v1 reads via the claude.ai Slack MCP connector, not a user token.
 
 **Interfaces:**
+
 - Consumes: nothing from earlier tasks.
 - Produces: operator docs for the two-workspace model and the v1.1 reader-app hardening path.
 
@@ -762,16 +839,22 @@ The `slack-watcher` scheduled workflow (spec: [`spec/slack-watcher.md`](../../sp
 scans the **owner's** inbox on a cron and has this same bot DM a concise digest with
 suggested replies. Reads and writes are split across workspaces:
 
-- **Inbox reads** happen in the *watched* workspace through the claude.ai Slack MCP
+- **Inbox reads** happen in the _watched_ workspace through the claude.ai Slack MCP
   connector the headless session inherits — no app install in that workspace. If the
   connector is unavailable in headless runs, watcher runs land as `blocked` on the
   /runs feed naming the missing tools.
-- **Digest posting** uses this gateway's bot (`OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`) in the
-  bot's own workspace — no extra env vars.
+- **Digest posting** goes to the destination picked in the schedule config
+  (`digestTarget`): the owner's **Telegram** chat via `OCTOMUX_GATEWAY_TELEGRAM_TOKEN`,
+  or a **Slack DM/channel** in the bot's own workspace via
+  `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` — no extra env vars either way. Telegram and
+  Slack-DM digests land in a gateway conversation, so replying to the digest reaches
+  the conductor.
 
 Create the schedule at `/schedules` (kind **Slack Watcher**, cron e.g.
-`*/30 3-18 * * *` — cron is UTC) with two member ids in the config: `slackUserId`
-(watched workspace — whose inbox) and `digestUserId` (bot's workspace — whom to DM).
+`*/30 3-18 * * *` — cron is UTC). All knobs are in the schedule form: `slackUserId`
+(watched workspace — whose inbox), `digestTarget` + `telegramChatId` or
+`digestUserId`/`digestChannel` (where the digest goes). The prompt itself is editable
+per kind in the UI (schedule skills — the shipped SKILL.md is only the seed).
 
 Hardening (v1.1, once the watched workspace allows an app install): a minimal
 user-scopes-only reader app (`search:read`, `im:history`, `mpim:history`,
@@ -798,6 +881,7 @@ git commit -m "docs(gateway): slack-watcher digest setup and two-workspace model
 ### Task 6: Full verification + PR
 
 **Files:**
+
 - No new files. Gates over the whole branch.
 
 - [ ] **Step 1: Run the full gates**
@@ -805,6 +889,7 @@ git commit -m "docs(gateway): slack-watcher digest setup and two-workspace model
 ```bash
 bun run typecheck && bun run lint && bun run test
 ```
+
 Expected: all pass. Fix anything that fails before proceeding (prettier width on the new files is the usual culprit — `bun run format`).
 
 - [ ] **Step 2: Open the PR**
@@ -819,8 +904,8 @@ Push the branch and open a PR against `next` titled `feat(workflows): slack-watc
 
 This task is checklist-style, not TDD — it configures the live instance at `~/.octomux/`.
 
-- [ ] **Step 1: Conductor app in the personal workspace.** Only the Telegram gateway is live today. Send the owner (Slack self-DM, per user rules) the api.slack.com/apps link + the conductor manifest with instructions: create the app **in their personal workspace** from `server/gateway/slack-app-manifest.yaml`, enable Socket Mode, install, and hand back the `xoxb-` + `xapp-` tokens and their personal-workspace member id (profile → ⋯ → Copy member ID).
+- [ ] **Step 1: Conductor app in the personal workspace** *(optional if going Telegram-first — deferrable until a Slack digest target is wanted)*. Only the Telegram gateway is live today. Send the owner (Slack self-DM, per user rules) the api.slack.com/apps link + the conductor manifest with instructions: create the app **in their personal workspace** from `server/gateway/slack-app-manifest.yaml`, enable Socket Mode, install, and hand back the `xoxb-` + `xapp-` tokens and their personal-workspace member id (profile → ⋯ → Copy member ID).
 - [ ] **Step 2: Env.** Add to the `.env` octomux boots from: `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`, `OCTOMUX_GATEWAY_SLACK_ALLOW=<personal-workspace member id>`. Restart octomux; verify `gateway: Slack gateway started` in `~/.octomux/logs/octomux.log`. No watcher-specific env vars — inbox reads use the claude.ai Slack connector.
 - [ ] **Step 3: Stop hook.** Verify the no-op Stop hook exists in `~/.claude/settings.json` (known requirement: without it, gateway replies buffer forever).
-- [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<watched-workspace member id>", "digestUserId": "<personal-workspace member id>" }`.
+- [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<watched-workspace member id>", "digestTarget": "telegram", "telegramChatId": "<numeric id from the Telegram allowlist>" }` — the Telegram gateway is already live, so this works before Steps 1–2; switch `digestTarget` to `slack` with `digestUserId`/`digestChannel` in the UI once the conductor app exists.
 - [ ] **Step 5: Smoke test.** `POST /api/schedules/:id/run` → watch the run on the /runs feed. This first run doubles as the **MCP-in-headless check**: a `blocked` result naming missing Slack tools means the claude.ai connector isn't reachable headless, and the v1.1 reader app becomes the unblocker. Otherwise: digest DM arrives (or a clean `digestSent: false` result on a quiet window) → reply to the digest DM and confirm the gateway conductor responds → check `grep slack-watcher ~/.octomux/logs/octomux.log` for a clean run. Record the result in the README smoke-test table.

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -771,7 +771,7 @@ export const slackWatcherWorkflow: WorkflowType = {
       digestChannel: string;
     };
 
-    // Fire-and-forget: runSessionVertical blocks for the full headless agent run.
+    // Fire-and-forget: runSlackWatcher blocks for the full headless agent run.
     void runSlackWatcher({
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** A cron-scheduled headless workflow (`slack-watcher`) that reads the owner's Slack inbox with a read-only user token and has the gateway bot DM a concise digest with suggested replies — only when something needs the owner.
+**Goal:** A cron-scheduled headless workflow (`slack-watcher`) that reads the owner's inbox in the watched (company) workspace via the claude.ai Slack MCP connector and has the gateway bot — in the owner's personal workspace — DM a concise digest with suggested replies, only when something needs the owner.
 
-**Architecture:** New workflow kind modeled exactly on `overnight-log-summary`: `schema.ts` (config + output JSON Schemas), `run.ts` (skill-body interpolation + `runSessionVertical`), `index.ts` (registry entry), shipped skill at `plugin/skills/slack-watcher/SKILL.md` seeded into the `schedule_skills` DB table on first read. The skill drives the Slack Web API via `curl` using tokens inherited from the server's env. Spec: `spec/slack-watcher.md`.
+**Architecture:** New workflow kind modeled exactly on `overnight-log-summary`: `schema.ts` (config + output JSON Schemas), `run.ts` (skill-body interpolation + `runSessionVertical`), `index.ts` (registry entry), shipped skill at `plugin/skills/slack-watcher/SKILL.md` seeded into the `schedule_skills` DB table on first read. The skill reads via the Slack MCP connector tools and posts via `curl` with the gateway bot token inherited from the server's env. Spec: `spec/slack-watcher.md`.
 
 **Tech Stack:** TypeScript (Express 5 server), vitest, better-sqlite3 test DB via `createTestDb()`, Ajv for schema tests, Slack Web API over curl (no new npm deps).
 
@@ -28,7 +28,7 @@
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `SLACK_WATCHER_CONFIG_SCHEMA` (object schema with `slackUserId: string` default `''`, `lookbackMinutes: number` default `40`, `digestChannel: string` default `''`) and `SLACK_WATCHER_SCHEMA` (submit_result payload: required `outcome`, `window`, `summary`, `digestSent`, `items`; optional `links`). Item shape: `{ channel, from, about, urgency: 'low'|'medium'|'high', suggestedReply?, permalink? }`.
+- Produces: `SLACK_WATCHER_CONFIG_SCHEMA` (object schema with `slackUserId: string` default `''` — member id in the **watched** workspace, `digestUserId: string` default `''` — member id in the **bot's** workspace, `lookbackMinutes: number` default `40`, `digestChannel: string` default `''`) and `SLACK_WATCHER_SCHEMA` (submit_result payload: required `outcome`, `window`, `summary`, `digestSent`, `items`; optional `links`). Item shape: `{ channel, from, about, urgency: 'low'|'medium'|'high', suggestedReply?, permalink? }`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -76,11 +76,12 @@ describe('SLACK_WATCHER_SCHEMA', () => {
     ).toBe(false);
   });
 
-  it('applies config defaults for lookbackMinutes and digestChannel', () => {
+  it('applies config defaults for digestUserId, lookbackMinutes, and digestChannel', () => {
     const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_CONFIG_SCHEMA);
     const cfg: Record<string, unknown> = { slackUserId: 'U01ABCDEF' };
 
     expect(validate(cfg)).toBe(true);
+    expect(cfg.digestUserId).toBe('');
     expect(cfg.lookbackMinutes).toBe(40);
     expect(cfg.digestChannel).toBe('');
   });
@@ -107,8 +108,16 @@ export const SLACK_WATCHER_CONFIG_SCHEMA = {
   properties: {
     slackUserId: {
       type: 'string',
-      title: 'Slack member id',
-      description: "The owner's Slack member id (e.g. U01ABCDEF) — whose inbox to watch.",
+      title: 'Watched member id',
+      description:
+        "The owner's member id in the watched workspace (e.g. U01ABCDEF) — whose inbox to search.",
+      default: '',
+    },
+    digestUserId: {
+      type: 'string',
+      title: 'Digest member id',
+      description:
+        "The owner's member id in the bot's workspace — whom the bot DMs. Same as the watched id when both halves share a workspace.",
       default: '',
     },
     lookbackMinutes: {
@@ -188,7 +197,7 @@ git commit -m "feat(workflows): slack-watcher config and output schemas"
 
 **Interfaces:**
 - Consumes: `SLACK_WATCHER_SCHEMA` from Task 1; existing `resolveSchedulePrompt({ scheduleId, kind })`, `runSessionVertical(input)`, `listRunsForWorkflow(kind)`, `insertRun` / `finishRun` (tests only).
-- Produces: `runSlackWatcher(input: RunSlackWatcherInput): Promise<{ result: SlackWatcherResult }>` with `RunSlackWatcherInput = { repoPath: string; scheduleId?: string | null; slackUserId: string; lookbackMinutes: number; digestChannel: string; trigger?: 'cron' | 'manual' }`, plus exported `SlackWatcherResult` / `SlackWatcherItem` types and `previousItemsJson(): string`.
+- Produces: `runSlackWatcher(input: RunSlackWatcherInput): Promise<{ result: SlackWatcherResult }>` with `RunSlackWatcherInput = { repoPath: string; scheduleId?: string | null; slackUserId: string; digestUserId: string; lookbackMinutes: number; digestChannel: string; trigger?: 'cron' | 'manual' }`, plus exported `SlackWatcherResult` / `SlackWatcherItem` types and `previousItemsJson(): string`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -215,7 +224,7 @@ import { runSlackWatcher, previousItemsJson } from './run.js';
 import { SLACK_WATCHER_SCHEMA } from './schema.js';
 
 const SKILL_BODY =
-  'Watch {{slackUserId}} back {{lookbackMinutes}}m, post to "{{digestChannel}}", skip {{previousItems}}.';
+  'Watch {{slackUserId}} back {{lookbackMinutes}}m, DM {{digestUserId}} at "{{digestChannel}}", skip {{previousItems}}.';
 
 describe('runSlackWatcher', () => {
   beforeEach(() => {
@@ -231,6 +240,7 @@ describe('runSlackWatcher', () => {
       repoPath: '/repos/octomux',
       scheduleId: 'sched-1',
       slackUserId: 'U01ABCDEF',
+      digestUserId: 'U0PERSONAL',
       lookbackMinutes: 40,
       digestChannel: '',
     });
@@ -241,7 +251,7 @@ describe('runSlackWatcher', () => {
     expect(call.kind).toBe('slack-watcher');
     expect(call.scheduleId).toBe('sched-1');
     expect(call.workspaceDir).toBe('/repos/octomux');
-    expect(call.input).toBe('Watch U01ABCDEF back 40m, post to "", skip [].');
+    expect(call.input).toBe('Watch U01ABCDEF back 40m, DM U0PERSONAL at "", skip [].');
     expect(call.outputSchema).toBe(SLACK_WATCHER_SCHEMA);
   });
 
@@ -258,12 +268,13 @@ describe('runSlackWatcher', () => {
     await runSlackWatcher({
       repoPath: '/repos/octomux',
       slackUserId: 'U01ABCDEF',
+      digestUserId: 'U0PERSONAL',
       lookbackMinutes: 40,
       digestChannel: 'C123',
     });
     const call = mockRunSessionVertical.mock.calls[0][0];
     expect(call.input).toContain(JSON.stringify(items));
-    expect(call.input).toContain('post to "C123"');
+    expect(call.input).toContain('DM U0PERSONAL at "C123"');
   });
 
   it('falls back to [] for missing, unfinished, or malformed previous runs', () => {
@@ -320,7 +331,10 @@ import { SLACK_WATCHER_SCHEMA } from './schema.js';
 export interface RunSlackWatcherInput {
   repoPath: string;
   scheduleId?: string | null;
+  /** Owner's member id in the watched workspace — whose inbox to search. */
   slackUserId: string;
+  /** Owner's member id in the bot's workspace — whom the bot DMs. */
+  digestUserId: string;
   lookbackMinutes: number;
   digestChannel: string;
   trigger?: 'cron' | 'manual';
@@ -366,6 +380,7 @@ export async function runSlackWatcher(
   });
   const prompt = skillContent
     .replace(/\{\{slackUserId\}\}/g, input.slackUserId)
+    .replace(/\{\{digestUserId\}\}/g, input.digestUserId)
     .replace(/\{\{lookbackMinutes\}\}/g, String(input.lookbackMinutes))
     .replace(/\{\{digestChannel\}\}/g, input.digestChannel)
     .replace(/\{\{previousItems\}\}/g, previousItemsJson());
@@ -401,7 +416,7 @@ git commit -m "feat(workflows): slack-watcher run service with previous-run dedu
 - Create: `plugin/skills/slack-watcher/SKILL.md`
 
 **Interfaces:**
-- Consumes: placeholders `{{slackUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, `{{previousItems}}` (interpolated by Task 2) and env vars `OCTOMUX_SLACK_USER_TOKEN` / `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (inherited from the server process).
+- Consumes: placeholders `{{slackUserId}}`, `{{digestUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, `{{previousItems}}` (interpolated by Task 2), the Slack MCP connector tools for reads, and `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (inherited from the server process) for posting.
 - Produces: the prompt body that `getSkill('slack-watcher')` returns and `resolveScheduleSkillContent` seeds into the `schedule_skills` table. Its `submit_result` payload must match `SLACK_WATCHER_SCHEMA` from Task 1.
 
 - [ ] **Step 1: Write the skill**
@@ -419,36 +434,43 @@ description: Use when running a scheduled slack-watcher session — scan the own
 Scan the owner's Slack inbox for the last {{lookbackMinutes}} minutes and, only if
 something needs them, send one concise digest DM through the octomux bot. This is a
 headless, unattended session — you do not edit files, commit, or open PRs. Your only
-side effects are Slack Web API reads, at most one `chat.postMessage`, and one
+side effects are Slack MCP reads, at most one bot-token `chat.postMessage`, and one
 `submit_result` call.
 
-The owner's Slack member id is `{{slackUserId}}`.
+The owner's member id in the **watched** workspace is `{{slackUserId}}` (use it for all
+inbox searches). Their member id in the **bot's** workspace is `{{digestUserId}}` (use
+it only to open the digest DM) — the two workspaces may differ, so never mix the ids up.
 
-## Tokens
+## Slack access
 
-Two env vars, both inherited from the server:
+Reads and writes use **different credentials in different workspaces** — never mix them:
 
-- `OCTOMUX_SLACK_USER_TOKEN` (xoxp-, read-only) — all inbox **reads**.
-- `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-) — **posting** the digest only.
+- **Inbox reads (watched workspace):** your Slack MCP connector tools —
+  `slack_search_public_and_private`, `slack_read_thread`, `slack_read_channel`,
+  `slack_search_users`. You must never call the connector's send/draft/canvas tools.
+- **Posting the digest (bot's workspace):** `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-,
+  inherited from the server env) via `curl` — this is the only send you ever perform.
 
-If either is missing or a Slack call returns `"ok": false` with an auth error, do not
-retry endlessly: call `submit_result` with `outcome: "blocked"` and the exact Slack
-error string in `summary`, then stop.
+Before anything else, confirm the Slack MCP tools are available. If they are not, or the
+bot token is missing, or a Slack call fails with an auth error: do not retry endlessly —
+call `submit_result` with `outcome: "blocked"`, name exactly what was missing or the
+exact Slack error string in `summary`, and stop.
 
 ## Steps
 
 1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)` —
    only messages with `ts >= $SINCE` count.
 
-2. **Collect candidates** with the user token (add
-   `-H "Authorization: Bearer $OCTOMUX_SLACK_USER_TOKEN"` to every read):
+2. **Collect candidates** with the Slack MCP tools (watched workspace):
 
-   - Mentions: `curl -s -G https://slack.com/api/search.messages --data-urlencode "query=<@{{slackUserId}}>" --data-urlencode "sort=timestamp" --data-urlencode "sort_dir=desc" --data-urlencode "count=50"`
-   - DMs to the owner: same endpoint with `--data-urlencode "query=is:dm"`.
-   - For each hit inside the window, pull thread context with
-     `conversations.replies` (params `channel`, `ts`) or nearby history with
-     `conversations.history` (params `channel`, `oldest=$SINCE`) so you understand
-     what is actually being asked.
+   - Mentions: `slack_search_public_and_private` with a query for `<@{{slackUserId}}>`,
+     newest first.
+   - DMs to the owner: the same search tool with an `is:dm` query (and `is:mpim` for
+     group DMs).
+   - Keep only hits inside the window, then pull thread context with
+     `slack_read_thread` (or nearby channel history with `slack_read_channel`) so you
+     understand what is actually being asked. Use `slack_search_users` to resolve
+     display names when a hit only gives you a user id.
 
 3. **Filter ruthlessly.** Drop: messages authored by `{{slackUserId}}`; bot and app
    messages; joins/leaves and other channel noise; FYI-only chatter with no question
@@ -479,7 +501,7 @@ error string in `summary`, then stop.
 
 5. **Send it** with the bot token — only if at least one item survived filtering.
    Resolve the channel: use `{{digestChannel}}` if non-empty, otherwise
-   `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{slackUserId}}"`
+   `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
    and take `.channel.id`. Then one
    `chat.postMessage` with the digest as `text`. **Zero items → send nothing.**
    Silence is the correct output for a quiet window.
@@ -515,7 +537,8 @@ error string in `summary`, then stop.
 - Be conservative — this runs unattended. When unsure whether something needs the
   owner, prefer including it at `low` urgency over silently dropping it.
 - Never send any message other than the single digest, and never post as the owner —
-  the user token has no write scopes by design; do not look for workarounds.
+  reads happen through the connector, but its send/draft tools are off-limits; the only
+  send you perform is the one bot-token `chat.postMessage`. Do not look for workarounds.
 - Suggested replies are suggestions. The owner sends them; you never do.
 ````
 
@@ -611,14 +634,20 @@ describe('slack-watcher workflow registration', () => {
     expect(call.repoPath).toBe('/repo');
     expect(call.scheduleId).toBe('sched-42');
     expect(call.slackUserId).toBe('U07X');
+    expect(call.digestUserId).toBe('');
     expect(call.lookbackMinutes).toBe(40);
     expect(call.digestChannel).toBe('');
   });
 
-  it('passes through config overrides for lookback and digest channel', async () => {
+  it('passes through config overrides for digest user, lookback, and digest channel', async () => {
     const wf = getWorkflow('slack-watcher')!;
     const row = makeRow({
-      config_json: JSON.stringify({ slackUserId: 'U07X', lookbackMinutes: 20, digestChannel: 'C9' }),
+      config_json: JSON.stringify({
+        slackUserId: 'U07X',
+        digestUserId: 'U0PERSONAL',
+        lookbackMinutes: 20,
+        digestChannel: 'C9',
+      }),
     });
     await wf.run!({
       repoPath: row.repo_path,
@@ -627,6 +656,7 @@ describe('slack-watcher workflow registration', () => {
     });
 
     const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.digestUserId).toBe('U0PERSONAL');
     expect(call.lookbackMinutes).toBe(20);
     expect(call.digestChannel).toBe('C9');
   });
@@ -710,38 +740,16 @@ git commit -m "feat(workflows): register slack-watcher cron workflow kind"
 
 ---
 
-### Task 5: Slack app manifest user scopes + gateway README
+### Task 5: Gateway README — watcher setup docs
 
 **Files:**
-- Modify: `server/gateway/slack-app-manifest.yaml:18-23`
-- Modify: `server/gateway/README.md` (Slack section + "Not in v1" footer)
+- Modify: `server/gateway/README.md` (new section after the Slack smoke test + "Not in v1" footer). The conductor manifest is untouched — v1 reads via the claude.ai Slack MCP connector, not a user token.
 
 **Interfaces:**
 - Consumes: nothing from earlier tasks.
-- Produces: the manifest the owner re-applies to mint the `xoxp-` user token; docs for `OCTOMUX_SLACK_USER_TOKEN`.
+- Produces: operator docs for the two-workspace model and the v1.1 reader-app hardening path.
 
-- [ ] **Step 1: Add user scopes to the manifest**
-
-In `server/gateway/slack-app-manifest.yaml`, extend `oauth_config.scopes`:
-
-```yaml
-oauth_config:
-  scopes:
-    bot:
-      - chat:write # post the conductor's replies
-      - im:history # read the DMs sent to the bot
-      - channels:history # optional: read messages in channels the bot is in
-    user:
-      # Read-only inbox scopes for the slack-watcher workflow (spec/slack-watcher.md).
-      # Reinstalling the app after adding these mints an xoxp- user token.
-      - search:read # search the owner's messages (mentions, DMs)
-      - im:history # DM context
-      - mpim:history # group-DM context
-      - channels:history # public-channel thread context
-      - groups:history # private-channel thread context
-```
-
-- [ ] **Step 2: Document the watcher in the README**
+- [ ] **Step 1: Document the watcher in the README**
 
 In `server/gateway/README.md`:
 
@@ -752,19 +760,23 @@ a. After the Slack "§7 smoke test" section, add:
 
 The `slack-watcher` scheduled workflow (spec: [`spec/slack-watcher.md`](../../spec/slack-watcher.md))
 scans the **owner's** inbox on a cron and has this same bot DM a concise digest with
-suggested replies. It needs one extra token beyond the gateway's:
+suggested replies. Reads and writes are split across workspaces:
 
-```bash
-OCTOMUX_SLACK_USER_TOKEN=xoxp-your-user-token   # read-only user token; watcher inbox reads
-```
+- **Inbox reads** happen in the *watched* workspace through the claude.ai Slack MCP
+  connector the headless session inherits — no app install in that workspace. If the
+  connector is unavailable in headless runs, watcher runs land as `blocked` on the
+  /runs feed naming the missing tools.
+- **Digest posting** uses this gateway's bot (`OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`) in the
+  bot's own workspace — no extra env vars.
 
-The manifest above already includes the read-only **user** scopes (`search:read`,
-`im:history`, `mpim:history`, `channels:history`, `groups:history`). Reinstall the app
-after applying them (**Settings → Install App → Reinstall**) and copy the **User OAuth
-Token** (`xoxp-`) from the same page. The user token has no write scopes — the watcher
-reads with it and posts only via the bot token. Create the schedule at `/schedules`
-(kind **Slack Watcher**, cron e.g. `*/30 3-18 * * *` — cron is UTC) with your member id
-in the config.
+Create the schedule at `/schedules` (kind **Slack Watcher**, cron e.g.
+`*/30 3-18 * * *` — cron is UTC) with two member ids in the config: `slackUserId`
+(watched workspace — whose inbox) and `digestUserId` (bot's workspace — whom to DM).
+
+Hardening (v1.1, once the watched workspace allows an app install): a minimal
+user-scopes-only reader app (`search:read`, `im:history`, `mpim:history`,
+`channels:history`, `groups:history`) minting a read-only `xoxp-` token in
+`OCTOMUX_SLACK_USER_TOKEN` replaces the MCP dependency.
 ```
 
 b. In the final "## Not in v1" section, remove "proactive nudges (fast-follow)" and note it:
@@ -774,16 +786,11 @@ The per-action approval button (v2) · full streaming/rich rendering (v1.1). Pro
 nudges shipped as the `slack-watcher` scheduled workflow — see above.
 ```
 
-- [ ] **Step 3: Verify YAML parses**
-
-Run: `bun -e "const y=require('yaml');const fs=require('fs');console.log(Object.keys(y.parse(fs.readFileSync('server/gateway/slack-app-manifest.yaml','utf8')).oauth_config.scopes))"`
-Expected: `[ "bot", "user" ]` (if the `yaml` package is unavailable, paste the manifest into api.slack.com's manifest validator during live setup instead).
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 2: Commit**
 
 ```bash
-git add server/gateway/slack-app-manifest.yaml server/gateway/README.md
-git commit -m "docs(gateway): user-token scopes and setup for the slack-watcher digest"
+git add server/gateway/README.md
+git commit -m "docs(gateway): slack-watcher digest setup and two-workspace model"
 ```
 
 ---
@@ -812,8 +819,8 @@ Push the branch and open a PR against `next` titled `feat(workflows): slack-watc
 
 This task is checklist-style, not TDD — it configures the live instance at `~/.octomux/`.
 
-- [ ] **Step 1: Slack app update.** Send the owner (Slack self-DM, per user rules) the link to api.slack.com/apps with instructions: apply the updated manifest to the existing *octomux conductor* app, reinstall, and hand back the `xoxp-` (new) token; confirm `xoxb-`/`xapp-` unchanged.
-- [ ] **Step 2: Env.** Add to the `.env` octomux boots from: `OCTOMUX_SLACK_USER_TOKEN`, and confirm `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`, `OCTOMUX_GATEWAY_SLACK_ALLOW=<owner member id>` are present. Restart octomux; verify `gateway: Slack gateway started` in `~/.octomux/logs/octomux.log`.
+- [ ] **Step 1: Conductor app in the personal workspace.** Only the Telegram gateway is live today. Send the owner (Slack self-DM, per user rules) the api.slack.com/apps link + the conductor manifest with instructions: create the app **in their personal workspace** from `server/gateway/slack-app-manifest.yaml`, enable Socket Mode, install, and hand back the `xoxb-` + `xapp-` tokens and their personal-workspace member id (profile → ⋯ → Copy member ID).
+- [ ] **Step 2: Env.** Add to the `.env` octomux boots from: `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`, `OCTOMUX_GATEWAY_SLACK_ALLOW=<personal-workspace member id>`. Restart octomux; verify `gateway: Slack gateway started` in `~/.octomux/logs/octomux.log`. No watcher-specific env vars — inbox reads use the claude.ai Slack connector.
 - [ ] **Step 3: Stop hook.** Verify the no-op Stop hook exists in `~/.claude/settings.json` (known requirement: without it, gateway replies buffer forever).
-- [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<owner member id>" }`.
-- [ ] **Step 5: Smoke test.** `POST /api/schedules/:id/run` → watch the run on the /runs feed → digest DM arrives (or a clean `digestSent: false` result on a quiet window) → reply to the digest DM and confirm the gateway conductor responds → check `grep slack-watcher ~/.octomux/logs/octomux.log` for a clean run. Record the result in the README smoke-test table.
+- [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<watched-workspace member id>", "digestUserId": "<personal-workspace member id>" }`.
+- [ ] **Step 5: Smoke test.** `POST /api/schedules/:id/run` → watch the run on the /runs feed. This first run doubles as the **MCP-in-headless check**: a `blocked` result naming missing Slack tools means the claude.ai connector isn't reachable headless, and the v1.1 reader app becomes the unblocker. Otherwise: digest DM arrives (or a clean `digestSent: false` result on a quiet window) → reply to the digest DM and confirm the gateway conductor responds → check `grep slack-watcher ~/.octomux/logs/octomux.log` for a clean run. Record the result in the README smoke-test table.

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -132,7 +132,8 @@ export const SLACK_WATCHER_CONFIG_SCHEMA = {
     telegramChatId: {
       type: 'string',
       title: 'Telegram chat id',
-      description: "Numeric Telegram chat id (the gateway allowlist id). Required for the 'telegram' target.",
+      description:
+        "Numeric Telegram chat id (the gateway allowlist id). Required for the 'telegram' target.",
       default: '',
     },
     digestUserId: {
@@ -537,7 +538,6 @@ missing or the exact error string in `summary`, and stop.
 
    **Suggested replies must sound like the owner dashed them off, not like an
    assistant wrote them.** Rules:
-
    - Before writing a reply, look at the owner's own messages in that thread or
      channel (they're in the context you already fetched) and mirror how they write
      there: formality, capitalization, emoji or none, greeting or none.
@@ -557,7 +557,6 @@ missing or the exact error string in `summary`, and stop.
 
 5. **Send it** — only if at least one item survived filtering, and only to the
    `{{digestTarget}}` destination:
-
    - `telegram`: one
      `curl -s -X POST "https://api.telegram.org/bot$OCTOMUX_GATEWAY_TELEGRAM_TOKEN/sendMessage" -d "chat_id={{telegramChatId}}" --data-urlencode "text=<digest>"`
      (plain text — drop the `*bold*` markers for Telegram).
@@ -904,7 +903,7 @@ Push the branch and open a PR against `next` titled `feat(workflows): slack-watc
 
 This task is checklist-style, not TDD — it configures the live instance at `~/.octomux/`.
 
-- [ ] **Step 1: Conductor app in the personal workspace** *(optional if going Telegram-first — deferrable until a Slack digest target is wanted)*. Only the Telegram gateway is live today. Send the owner (Slack self-DM, per user rules) the api.slack.com/apps link + the conductor manifest with instructions: create the app **in their personal workspace** from `server/gateway/slack-app-manifest.yaml`, enable Socket Mode, install, and hand back the `xoxb-` + `xapp-` tokens and their personal-workspace member id (profile → ⋯ → Copy member ID).
+- [ ] **Step 1: Conductor app in the personal workspace** _(optional if going Telegram-first — deferrable until a Slack digest target is wanted)_. Only the Telegram gateway is live today. Send the owner (Slack self-DM, per user rules) the api.slack.com/apps link + the conductor manifest with instructions: create the app **in their personal workspace** from `server/gateway/slack-app-manifest.yaml`, enable Socket Mode, install, and hand back the `xoxb-` + `xapp-` tokens and their personal-workspace member id (profile → ⋯ → Copy member ID).
 - [ ] **Step 2: Env.** Add to the `.env` octomux boots from: `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`, `OCTOMUX_GATEWAY_SLACK_ALLOW=<personal-workspace member id>`. Restart octomux; verify `gateway: Slack gateway started` in `~/.octomux/logs/octomux.log`. No watcher-specific env vars — inbox reads use the claude.ai Slack connector.
 - [ ] **Step 3: Stop hook.** Verify the no-op Stop hook exists in `~/.claude/settings.json` (known requirement: without it, gateway replies buffer forever).
 - [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<watched-workspace member id>", "digestTarget": "telegram", "telegramChatId": "<numeric id from the Telegram allowlist>" }` — the Telegram gateway is already live, so this works before Steps 1–2; switch `digestTarget` to `slack` with `digestUserId`/`digestChannel` in the UI once the conductor app exists.

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -1,0 +1,819 @@
+# Slack Watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A cron-scheduled headless workflow (`slack-watcher`) that reads the owner's Slack inbox with a read-only user token and has the gateway bot DM a concise digest with suggested replies — only when something needs the owner.
+
+**Architecture:** New workflow kind modeled exactly on `overnight-log-summary`: `schema.ts` (config + output JSON Schemas), `run.ts` (skill-body interpolation + `runSessionVertical`), `index.ts` (registry entry), shipped skill at `plugin/skills/slack-watcher/SKILL.md` seeded into the `schedule_skills` DB table on first read. The skill drives the Slack Web API via `curl` using tokens inherited from the server's env. Spec: `spec/slack-watcher.md`.
+
+**Tech Stack:** TypeScript (Express 5 server), vitest, better-sqlite3 test DB via `createTestDb()`, Ajv for schema tests, Slack Web API over curl (no new npm deps).
+
+## Global Constraints
+
+- Conventional commits: `feat(scope): message`, kebab-case scope, header ≤ 100 chars.
+- Prettier: single quotes, trailing commas, 100 char width, semicolons. Run `bun run format` before committing if unsure.
+- Server files use `const logger = childLogger('<module>');` — never `console.*` in `server/`.
+- Tests: vitest, `NODE_ENV=test` is set by vitest.config.ts. Run a single file with `bun run vitest run <path>`.
+- Full gates before PR: `bun run test`, `bun run typecheck`, `bun run lint`.
+- The frontend /schedules form is schema-driven from the workflow `config` schema — **no UI changes are needed**.
+- The agent never sends Slack messages as the owner. Only the bot posts, and only the digest.
+
+---
+
+### Task 1: Config + output schemas
+
+**Files:**
+- Create: `server/workflows/slack-watcher/schema.ts`
+- Test: `server/workflows/slack-watcher/schema.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SLACK_WATCHER_CONFIG_SCHEMA` (object schema with `slackUserId: string` default `''`, `lookbackMinutes: number` default `40`, `digestChannel: string` default `''`) and `SLACK_WATCHER_SCHEMA` (submit_result payload: required `outcome`, `window`, `summary`, `digestSent`, `items`; optional `links`). Item shape: `{ channel, from, about, urgency: 'low'|'medium'|'high', suggestedReply?, permalink? }`.
+
+- [ ] **Step 1: Write the failing test**
+
+`server/workflows/slack-watcher/schema.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { SLACK_WATCHER_CONFIG_SCHEMA, SLACK_WATCHER_SCHEMA } from './schema.js';
+
+describe('SLACK_WATCHER_SCHEMA', () => {
+  it('requires the run-result envelope alongside kind-specific fields', () => {
+    const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_SCHEMA);
+
+    expect(validate({ window: '40m', summary: 'ok', digestSent: false, items: [] })).toBe(false);
+    expect(
+      validate({ outcome: 'done', window: '40m', summary: 'ok', digestSent: false, items: [] }),
+    ).toBe(true);
+  });
+
+  it('accepts a full digest item and rejects an unknown urgency', () => {
+    const validate = new Ajv().compile(SLACK_WATCHER_SCHEMA);
+    const base = { outcome: 'done', window: '40m', summary: '1 item', digestSent: true };
+
+    expect(
+      validate({
+        ...base,
+        items: [
+          {
+            channel: '#deploys',
+            from: 'Priya',
+            about: 'Blocked on the deploy config',
+            urgency: 'high',
+            suggestedReply: 'Use the staging override for now.',
+            permalink: 'https://slack.com/archives/C1/p1',
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      validate({
+        ...base,
+        items: [{ channel: '#x', from: 'a', about: 'b', urgency: 'urgent' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('applies config defaults for lookbackMinutes and digestChannel', () => {
+    const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_CONFIG_SCHEMA);
+    const cfg: Record<string, unknown> = { slackUserId: 'U01ABCDEF' };
+
+    expect(validate(cfg)).toBe(true);
+    expect(cfg.lookbackMinutes).toBe(40);
+    expect(cfg.digestChannel).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run vitest run server/workflows/slack-watcher/schema.test.ts`
+Expected: FAIL — cannot resolve `./schema.js`.
+
+- [ ] **Step 3: Write the schemas**
+
+`server/workflows/slack-watcher/schema.ts`:
+
+```typescript
+/** JSON Schemas for the slack-watcher vertical. Split out from index.ts so
+ * run.ts can import them without a circular dependency.
+ *
+ * `outcome` + `links` are the universal run-result envelope (see
+ * `RUN_RESULT_SCHEMA` in @octomux/types, spec/workflow-consolidation.md §5). */
+export const SLACK_WATCHER_CONFIG_SCHEMA = {
+  type: 'object',
+  properties: {
+    slackUserId: {
+      type: 'string',
+      title: 'Slack member id',
+      description: "The owner's Slack member id (e.g. U01ABCDEF) — whose inbox to watch.",
+      default: '',
+    },
+    lookbackMinutes: {
+      type: 'number',
+      title: 'Lookback minutes',
+      description: 'How far back each run scans — cron interval plus overlap so nothing is missed.',
+      default: 40,
+    },
+    digestChannel: {
+      type: 'string',
+      title: 'Digest channel id',
+      description: 'Channel for the digest. Empty = the bot opens a DM with the owner.',
+      default: '',
+    },
+  },
+  additionalProperties: false,
+};
+
+export const SLACK_WATCHER_SCHEMA = {
+  type: 'object',
+  properties: {
+    outcome: { type: 'string', enum: ['done', 'blocked', 'failed'] },
+    window: { type: 'string' },
+    summary: { type: 'string' },
+    digestSent: { type: 'boolean' },
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          channel: { type: 'string' },
+          from: { type: 'string' },
+          about: { type: 'string' },
+          urgency: { type: 'string', enum: ['low', 'medium', 'high'] },
+          suggestedReply: { type: 'string' },
+          permalink: { type: 'string' },
+        },
+        required: ['channel', 'from', 'about', 'urgency'],
+        additionalProperties: false,
+      },
+    },
+    links: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['label', 'url'],
+        properties: { label: { type: 'string' }, url: { type: 'string' } },
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['outcome', 'window', 'summary', 'digestSent', 'items'],
+  additionalProperties: false,
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run vitest run server/workflows/slack-watcher/schema.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/workflows/slack-watcher/schema.ts server/workflows/slack-watcher/schema.test.ts
+git commit -m "feat(workflows): slack-watcher config and output schemas"
+```
+
+---
+
+### Task 2: Run service with dedup memory
+
+**Files:**
+- Create: `server/workflows/slack-watcher/run.ts`
+- Modify: `server/schedule-prompt.ts:13-19` (add `'slack-watcher'` to `CRON_PROMPT_KINDS`)
+- Test: `server/workflows/slack-watcher/run.test.ts`
+
+**Interfaces:**
+- Consumes: `SLACK_WATCHER_SCHEMA` from Task 1; existing `resolveSchedulePrompt({ scheduleId, kind })`, `runSessionVertical(input)`, `listRunsForWorkflow(kind)`, `insertRun` / `finishRun` (tests only).
+- Produces: `runSlackWatcher(input: RunSlackWatcherInput): Promise<{ result: SlackWatcherResult }>` with `RunSlackWatcherInput = { repoPath: string; scheduleId?: string | null; slackUserId: string; lookbackMinutes: number; digestChannel: string; trigger?: 'cron' | 'manual' }`, plus exported `SlackWatcherResult` / `SlackWatcherItem` types and `previousItemsJson(): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+`server/workflows/slack-watcher/run.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestDb } from '../../test-helpers.js';
+import { insertRun, finishRun } from '../../repositories/runs.js';
+
+const mockGetSkill = vi.fn();
+const mockRunSessionVertical = vi.fn();
+
+vi.mock('../../skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+vi.mock('../../services/session-vertical-service.js', () => ({
+  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runSlackWatcher, previousItemsJson } from './run.js';
+import { SLACK_WATCHER_SCHEMA } from './schema.js';
+
+const SKILL_BODY =
+  'Watch {{slackUserId}} back {{lookbackMinutes}}m, post to "{{digestChannel}}", skip {{previousItems}}.';
+
+describe('runSlackWatcher', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockGetSkill.mockReset();
+    mockRunSessionVertical.mockReset();
+    mockGetSkill.mockResolvedValue({ name: 'slack-watcher', content: SKILL_BODY });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+  });
+
+  it('interpolates config placeholders and calls runSessionVertical', async () => {
+    const { result } = await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      scheduleId: 'sched-1',
+      slackUserId: 'U01ABCDEF',
+      lookbackMinutes: 40,
+      digestChannel: '',
+    });
+
+    expect(result).toEqual({ summary: 'ok' });
+    expect(mockGetSkill).toHaveBeenCalledWith('slack-watcher');
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.kind).toBe('slack-watcher');
+    expect(call.scheduleId).toBe('sched-1');
+    expect(call.workspaceDir).toBe('/repos/octomux');
+    expect(call.input).toBe('Watch U01ABCDEF back 40m, post to "", skip [].');
+    expect(call.outputSchema).toBe(SLACK_WATCHER_SCHEMA);
+  });
+
+  it('threads the previous done run’s items into {{previousItems}}', async () => {
+    const items = [{ channel: '#x', from: 'Priya', about: 'deploy', urgency: 'high' }];
+    const run = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
+    finishRun(run.id, {
+      status: 'done',
+      result: { outcome: 'done', window: '40m', summary: '1', digestSent: true, items },
+    });
+
+    expect(previousItemsJson()).toBe(JSON.stringify(items));
+
+    await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      slackUserId: 'U01ABCDEF',
+      lookbackMinutes: 40,
+      digestChannel: 'C123',
+    });
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.input).toContain(JSON.stringify(items));
+    expect(call.input).toContain('post to "C123"');
+  });
+
+  it('falls back to [] for missing, unfinished, or malformed previous runs', () => {
+    expect(previousItemsJson()).toBe('[]');
+
+    const running = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
+    expect(previousItemsJson()).toBe('[]'); // running run has no result yet
+
+    finishRun(running.id, { status: 'failed', error: 'boom' });
+    expect(previousItemsJson()).toBe('[]'); // failed run is not dedup memory
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run vitest run server/workflows/slack-watcher/run.test.ts`
+Expected: FAIL — cannot resolve `./run.js`.
+
+- [ ] **Step 3: Add the kind to CRON_PROMPT_KINDS**
+
+In `server/schedule-prompt.ts`, extend the array (order matches the existing list style):
+
+```typescript
+export const CRON_PROMPT_KINDS = [
+  'doc-drift',
+  'prod-log-triage',
+  'weekly-update',
+  'overnight-log-summary',
+  'daily-plan',
+  'slack-watcher',
+] as const;
+```
+
+`slack-watcher` is **not** added to `TASK_BACKED_KINDS` — it is a session vertical, not task-backed.
+
+- [ ] **Step 4: Write the run service**
+
+`server/workflows/slack-watcher/run.ts`:
+
+```typescript
+/**
+ * Service layer for the slack-watcher vertical: loads the skill body,
+ * interpolates schedule config plus the previous run's digested items (the
+ * dedup memory), and runs headless via `runSessionVertical`. Slack tokens
+ * reach the skill through the server's inherited environment — see
+ * spec/slack-watcher.md §Slack app tokens.
+ */
+import { resolveSchedulePrompt } from '../../schedule-prompt.js';
+import { listRunsForWorkflow } from '../../repositories/runs.js';
+import { runSessionVertical } from '../../services/session-vertical-service.js';
+import { SLACK_WATCHER_SCHEMA } from './schema.js';
+
+export interface RunSlackWatcherInput {
+  repoPath: string;
+  scheduleId?: string | null;
+  slackUserId: string;
+  lookbackMinutes: number;
+  digestChannel: string;
+  trigger?: 'cron' | 'manual';
+}
+
+export interface SlackWatcherItem {
+  channel: string;
+  from: string;
+  about: string;
+  urgency: 'low' | 'medium' | 'high';
+  suggestedReply?: string;
+  permalink?: string;
+}
+
+export interface SlackWatcherResult {
+  outcome: 'done' | 'blocked' | 'failed';
+  window: string;
+  summary: string;
+  digestSent: boolean;
+  items: SlackWatcherItem[];
+}
+
+/** Items from the most recent finished run — injected as the skill's dedup memory. */
+export function previousItemsJson(): string {
+  const last = listRunsForWorkflow('slack-watcher').find(
+    (r) => r.status === 'done' && r.result_json,
+  );
+  if (!last) return '[]';
+  try {
+    const result = JSON.parse(last.result_json!) as { items?: unknown };
+    return JSON.stringify(Array.isArray(result.items) ? result.items : []);
+  } catch {
+    return '[]';
+  }
+}
+
+export async function runSlackWatcher(
+  input: RunSlackWatcherInput,
+): Promise<{ result: SlackWatcherResult }> {
+  const skillContent = await resolveSchedulePrompt({
+    scheduleId: input.scheduleId,
+    kind: 'slack-watcher',
+  });
+  const prompt = skillContent
+    .replace(/\{\{slackUserId\}\}/g, input.slackUserId)
+    .replace(/\{\{lookbackMinutes\}\}/g, String(input.lookbackMinutes))
+    .replace(/\{\{digestChannel\}\}/g, input.digestChannel)
+    .replace(/\{\{previousItems\}\}/g, previousItemsJson());
+
+  return runSessionVertical<SlackWatcherResult>({
+    kind: 'slack-watcher',
+    scheduleId: input.scheduleId,
+    workspaceDir: input.repoPath,
+    input: prompt,
+    outputSchema: SLACK_WATCHER_SCHEMA,
+    trigger: input.trigger ?? 'cron',
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun run vitest run server/workflows/slack-watcher/run.test.ts server/schedule-prompt.test.ts`
+Expected: PASS (both files — schedule-prompt tests must not regress).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/workflows/slack-watcher/run.ts server/workflows/slack-watcher/run.test.ts server/schedule-prompt.ts
+git commit -m "feat(workflows): slack-watcher run service with previous-run dedup memory"
+```
+
+---
+
+### Task 3: Shipped skill prompt
+
+**Files:**
+- Create: `plugin/skills/slack-watcher/SKILL.md`
+
+**Interfaces:**
+- Consumes: placeholders `{{slackUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, `{{previousItems}}` (interpolated by Task 2) and env vars `OCTOMUX_SLACK_USER_TOKEN` / `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (inherited from the server process).
+- Produces: the prompt body that `getSkill('slack-watcher')` returns and `resolveScheduleSkillContent` seeds into the `schedule_skills` table. Its `submit_result` payload must match `SLACK_WATCHER_SCHEMA` from Task 1.
+
+- [ ] **Step 1: Write the skill**
+
+`plugin/skills/slack-watcher/SKILL.md` (this is prompt content — there is no unit test; Task 4's registration test plus the live smoke test in Task 6 cover it):
+
+````markdown
+---
+name: slack-watcher
+description: Use when running a scheduled slack-watcher session — scan the owner's Slack inbox for new messages that need them, DM a concise digest with suggested replies via the bot, and submit a structured result via submit_result
+---
+
+# Slack watcher
+
+Scan the owner's Slack inbox for the last {{lookbackMinutes}} minutes and, only if
+something needs them, send one concise digest DM through the octomux bot. This is a
+headless, unattended session — you do not edit files, commit, or open PRs. Your only
+side effects are Slack Web API reads, at most one `chat.postMessage`, and one
+`submit_result` call.
+
+The owner's Slack member id is `{{slackUserId}}`.
+
+## Tokens
+
+Two env vars, both inherited from the server:
+
+- `OCTOMUX_SLACK_USER_TOKEN` (xoxp-, read-only) — all inbox **reads**.
+- `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-) — **posting** the digest only.
+
+If either is missing or a Slack call returns `"ok": false` with an auth error, do not
+retry endlessly: call `submit_result` with `outcome: "blocked"` and the exact Slack
+error string in `summary`, then stop.
+
+## Steps
+
+1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)` —
+   only messages with `ts >= $SINCE` count.
+
+2. **Collect candidates** with the user token (add
+   `-H "Authorization: Bearer $OCTOMUX_SLACK_USER_TOKEN"` to every read):
+
+   - Mentions: `curl -s -G https://slack.com/api/search.messages --data-urlencode "query=<@{{slackUserId}}>" --data-urlencode "sort=timestamp" --data-urlencode "sort_dir=desc" --data-urlencode "count=50"`
+   - DMs to the owner: same endpoint with `--data-urlencode "query=is:dm"`.
+   - For each hit inside the window, pull thread context with
+     `conversations.replies` (params `channel`, `ts`) or nearby history with
+     `conversations.history` (params `channel`, `oldest=$SINCE`) so you understand
+     what is actually being asked.
+
+3. **Filter ruthlessly.** Drop: messages authored by `{{slackUserId}}`; bot and app
+   messages; joins/leaves and other channel noise; FYI-only chatter with no question
+   or request directed at the owner; and anything already covered by a previous
+   digest — the items below were already reported, so skip their threads unless a
+   **new** message arrived after the window they were reported in:
+
+   ```json
+   {{previousItems}}
+   ```
+
+4. **Compose the digest** — natural, human, concise. For each item (max 10, ordered
+   by urgency): who and where, what it's about in plain language, and a suggested
+   reply written in the owner's voice — short, direct, no corporate filler, ready to
+   paste as-is. Format:
+
+   ```
+   *Slack digest — <n> things need you*
+
+   1. *Priya · #deploys* — blocked on the staging deploy config, asking if she
+      should wait for your chart fix.
+      ↳ suggested: "Use the staging override for now — I'll land the chart fix
+      tomorrow morning."
+   ```
+
+   Never include token values, API keys, connection strings, or other secret shapes
+   in the digest — refer to them ("the staging token") without quoting them.
+
+5. **Send it** with the bot token — only if at least one item survived filtering.
+   Resolve the channel: use `{{digestChannel}}` if non-empty, otherwise
+   `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{slackUserId}}"`
+   and take `.channel.id`. Then one
+   `chat.postMessage` with the digest as `text`. **Zero items → send nothing.**
+   Silence is the correct output for a quiet window.
+
+6. **Call `submit_result` exactly once** with:
+
+   ```json
+   {
+     "outcome": "done",
+     "window": "<e.g. last 40 minutes>",
+     "summary": "<one line: '3 items need attention' or 'nothing needs attention'>",
+     "digestSent": true,
+     "items": [
+       {
+         "channel": "#deploys",
+         "from": "Priya",
+         "about": "Blocked on the staging deploy config",
+         "urgency": "high",
+         "suggestedReply": "Use the staging override for now — I'll land the chart fix tomorrow morning.",
+         "permalink": "https://…"
+       }
+     ]
+   }
+   ```
+
+   `items` must list everything you digested this run (it becomes the next run's
+   dedup memory), and be `[]` with `digestSent: false` on a quiet window.
+   `outcome`: `"done"` normally, `"blocked"` for token/auth problems, `"failed"`
+   only if composing/sending itself broke.
+
+## Notes
+
+- Be conservative — this runs unattended. When unsure whether something needs the
+  owner, prefer including it at `low` urgency over silently dropping it.
+- Never send any message other than the single digest, and never post as the owner —
+  the user token has no write scopes by design; do not look for workarounds.
+- Suggested replies are suggestions. The owner sends them; you never do.
+````
+
+- [ ] **Step 2: Verify the skill loads**
+
+Run: `bun run vitest run server/schedule-prompt.test.ts`
+Expected: PASS. Also sanity-check frontmatter parses: `head -5 plugin/skills/slack-watcher/SKILL.md` shows the `name: slack-watcher` block.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugin/skills/slack-watcher/SKILL.md
+git commit -m "feat(skills): slack-watcher digest skill"
+```
+
+---
+
+### Task 4: Workflow registration
+
+**Files:**
+- Create: `server/workflows/slack-watcher/index.ts`
+- Modify: `server/workflows/index.ts:1-9` (side-effect import, alphabetical)
+- Test: `server/workflows/slack-watcher/index.test.ts`
+
+**Interfaces:**
+- Consumes: `runSlackWatcher` (Task 2), both schemas (Task 1), `registerWorkflow` / `RunContext` / `WorkflowType`, `resolveWorkflowConfig` (tests).
+- Produces: registered kind `slack-watcher` (displayName `Slack Watcher`, `surfaces: ['artifact']`, cron trigger) — visible to the /schedules form and `listCronWorkflowKinds()`.
+
+- [ ] **Step 1: Write the failing test**
+
+`server/workflows/slack-watcher/index.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listWorkflows, listCronWorkflowKinds } from '../registry.js';
+import { resolveWorkflowConfig } from '../config.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockRunSlackWatcher = vi.fn().mockResolvedValue({ result: {} });
+
+vi.mock('./run.js', () => ({
+  runSlackWatcher: (...args: unknown[]) => mockRunSlackWatcher(...args),
+}));
+
+import './index.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'slack-watcher',
+    repo_path: '/repo',
+    cron: '*/30 3-18 * * *',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('slack-watcher workflow registration', () => {
+  beforeEach(() => {
+    mockRunSlackWatcher.mockClear();
+  });
+
+  it('registers the kind with an artifact surface, config, output schema, cron trigger', () => {
+    const wf = getWorkflow('slack-watcher');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Slack Watcher');
+    expect(wf?.surfaces).toEqual(['artifact']);
+    expect(wf?.config).toBeDefined();
+    expect(wf?.output).toBeDefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('appears in listWorkflows() and listCronWorkflowKinds()', () => {
+    expect(listWorkflows().some((w) => w.kind === 'slack-watcher')).toBe(true);
+    expect(listCronWorkflowKinds()).toContain('slack-watcher');
+  });
+
+  it('fires the run with schedule id and config defaults, without awaiting it', async () => {
+    mockRunSlackWatcher.mockReturnValue(new Promise(() => {}));
+
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({ id: 'sched-42', config_json: JSON.stringify({ slackUserId: 'U07X' }) });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    expect(mockRunSlackWatcher).toHaveBeenCalledTimes(1);
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.repoPath).toBe('/repo');
+    expect(call.scheduleId).toBe('sched-42');
+    expect(call.slackUserId).toBe('U07X');
+    expect(call.lookbackMinutes).toBe(40);
+    expect(call.digestChannel).toBe('');
+  });
+
+  it('passes through config overrides for lookback and digest channel', async () => {
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({
+      config_json: JSON.stringify({ slackUserId: 'U07X', lookbackMinutes: 20, digestChannel: 'C9' }),
+    });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.lookbackMinutes).toBe(20);
+    expect(call.digestChannel).toBe('C9');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run vitest run server/workflows/slack-watcher/index.test.ts`
+Expected: FAIL — cannot resolve `./index.js`.
+
+- [ ] **Step 3: Write the registration**
+
+`server/workflows/slack-watcher/index.ts`:
+
+```typescript
+import { registerWorkflow } from '../registry.js';
+import { childLogger } from '../../logger.js';
+import { runSlackWatcher } from './run.js';
+import { SLACK_WATCHER_CONFIG_SCHEMA, SLACK_WATCHER_SCHEMA } from './schema.js';
+import type { RunContext, WorkflowType } from '../types.js';
+
+const logger = childLogger('workflows/slack-watcher');
+
+export const slackWatcherWorkflow: WorkflowType = {
+  kind: 'slack-watcher',
+  displayName: 'Slack Watcher',
+  surfaces: ['artifact'],
+  config: SLACK_WATCHER_CONFIG_SCHEMA,
+  output: SLACK_WATCHER_SCHEMA,
+  trigger: { kind: 'cron' },
+  run: (ctx: RunContext) => {
+    logger.info(
+      { repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
+      'slack-watcher: schedule fired',
+    );
+    const cfg = ctx.config as {
+      slackUserId: string;
+      lookbackMinutes: number;
+      digestChannel: string;
+    };
+
+    // Fire-and-forget: runSessionVertical blocks for the full headless agent run.
+    void runSlackWatcher({
+      repoPath: ctx.repoPath,
+      scheduleId: ctx.scheduleId,
+      slackUserId: cfg.slackUserId,
+      lookbackMinutes: cfg.lookbackMinutes,
+      digestChannel: cfg.digestChannel,
+      trigger: ctx.trigger,
+    }).catch((err) => {
+      logger.error(
+        { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
+        'slack-watcher: run failed',
+      );
+    });
+    return Promise.resolve();
+  },
+};
+
+registerWorkflow(slackWatcherWorkflow);
+```
+
+In `server/workflows/index.ts`, add the side-effect import between `reviewer` and `weekly-update`:
+
+```typescript
+import './slack-watcher/index.js';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun run vitest run server/workflows/slack-watcher/ server/workflows/registry.test.ts`
+Expected: PASS (all slack-watcher files + registry untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/workflows/slack-watcher/index.ts server/workflows/slack-watcher/index.test.ts server/workflows/index.ts
+git commit -m "feat(workflows): register slack-watcher cron workflow kind"
+```
+
+---
+
+### Task 5: Slack app manifest user scopes + gateway README
+
+**Files:**
+- Modify: `server/gateway/slack-app-manifest.yaml:18-23`
+- Modify: `server/gateway/README.md` (Slack section + "Not in v1" footer)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the manifest the owner re-applies to mint the `xoxp-` user token; docs for `OCTOMUX_SLACK_USER_TOKEN`.
+
+- [ ] **Step 1: Add user scopes to the manifest**
+
+In `server/gateway/slack-app-manifest.yaml`, extend `oauth_config.scopes`:
+
+```yaml
+oauth_config:
+  scopes:
+    bot:
+      - chat:write # post the conductor's replies
+      - im:history # read the DMs sent to the bot
+      - channels:history # optional: read messages in channels the bot is in
+    user:
+      # Read-only inbox scopes for the slack-watcher workflow (spec/slack-watcher.md).
+      # Reinstalling the app after adding these mints an xoxp- user token.
+      - search:read # search the owner's messages (mentions, DMs)
+      - im:history # DM context
+      - mpim:history # group-DM context
+      - channels:history # public-channel thread context
+      - groups:history # private-channel thread context
+```
+
+- [ ] **Step 2: Document the watcher in the README**
+
+In `server/gateway/README.md`:
+
+a. After the Slack "§7 smoke test" section, add:
+
+```markdown
+## Slack watcher (proactive digest)
+
+The `slack-watcher` scheduled workflow (spec: [`spec/slack-watcher.md`](../../spec/slack-watcher.md))
+scans the **owner's** inbox on a cron and has this same bot DM a concise digest with
+suggested replies. It needs one extra token beyond the gateway's:
+
+```bash
+OCTOMUX_SLACK_USER_TOKEN=xoxp-your-user-token   # read-only user token; watcher inbox reads
+```
+
+The manifest above already includes the read-only **user** scopes (`search:read`,
+`im:history`, `mpim:history`, `channels:history`, `groups:history`). Reinstall the app
+after applying them (**Settings → Install App → Reinstall**) and copy the **User OAuth
+Token** (`xoxp-`) from the same page. The user token has no write scopes — the watcher
+reads with it and posts only via the bot token. Create the schedule at `/schedules`
+(kind **Slack Watcher**, cron e.g. `*/30 3-18 * * *` — cron is UTC) with your member id
+in the config.
+```
+
+b. In the final "## Not in v1" section, remove "proactive nudges (fast-follow)" and note it:
+
+```markdown
+The per-action approval button (v2) · full streaming/rich rendering (v1.1). Proactive
+nudges shipped as the `slack-watcher` scheduled workflow — see above.
+```
+
+- [ ] **Step 3: Verify YAML parses**
+
+Run: `bun -e "const y=require('yaml');const fs=require('fs');console.log(Object.keys(y.parse(fs.readFileSync('server/gateway/slack-app-manifest.yaml','utf8')).oauth_config.scopes))"`
+Expected: `[ "bot", "user" ]` (if the `yaml` package is unavailable, paste the manifest into api.slack.com's manifest validator during live setup instead).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/gateway/slack-app-manifest.yaml server/gateway/README.md
+git commit -m "docs(gateway): user-token scopes and setup for the slack-watcher digest"
+```
+
+---
+
+### Task 6: Full verification + PR
+
+**Files:**
+- No new files. Gates over the whole branch.
+
+- [ ] **Step 1: Run the full gates**
+
+```bash
+bun run typecheck && bun run lint && bun run test
+```
+Expected: all pass. Fix anything that fails before proceeding (prettier width on the new files is the usual culprit — `bun run format`).
+
+- [ ] **Step 2: Open the PR**
+
+Push the branch and open a PR against `next` titled `feat(workflows): slack-watcher proactive inbox digest`, body summarizing spec + plan links (`spec/slack-watcher.md`, `plans/2026-07-24-slack-watcher.md`), ending with the standard generated-with footer.
+
+---
+
+### Task 7: Live devbox setup (after merge — interactive, owner in the loop)
+
+**Files:** none (production config on this devbox).
+
+This task is checklist-style, not TDD — it configures the live instance at `~/.octomux/`.
+
+- [ ] **Step 1: Slack app update.** Send the owner (Slack self-DM, per user rules) the link to api.slack.com/apps with instructions: apply the updated manifest to the existing *octomux conductor* app, reinstall, and hand back the `xoxp-` (new) token; confirm `xoxb-`/`xapp-` unchanged.
+- [ ] **Step 2: Env.** Add to the `.env` octomux boots from: `OCTOMUX_SLACK_USER_TOKEN`, and confirm `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`, `OCTOMUX_GATEWAY_SLACK_ALLOW=<owner member id>` are present. Restart octomux; verify `gateway: Slack gateway started` in `~/.octomux/logs/octomux.log`.
+- [ ] **Step 3: Stop hook.** Verify the no-op Stop hook exists in `~/.claude/settings.json` (known requirement: without it, gateway replies buffer forever).
+- [ ] **Step 4: Create the schedule.** `POST /api/schedules` (or /schedules UI): kind `slack-watcher`, repo path = the octomux repo, cron `*/30 3-18 * * *`, config `{ "slackUserId": "<owner member id>" }`.
+- [ ] **Step 5: Smoke test.** `POST /api/schedules/:id/run` → watch the run on the /runs feed → digest DM arrives (or a clean `digestSent: false` result on a quiet window) → reply to the digest DM and confirm the gateway conductor responds → check `grep slack-watcher ~/.octomux/logs/octomux.log` for a clean run. Record the result in the README smoke-test table.

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -562,7 +562,8 @@ missing or the exact error string in `summary`, and stop.
      (plain text — drop the `*bold*` markers for Telegram).
    - `slack`: resolve the channel — `{{digestChannel}}` if non-empty, otherwise
      `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
-     and take `.channel.id` — then one `chat.postMessage` with the digest as `text`.
+     and take `.channel.id` — then one
+     `curl -s -X POST https://slack.com/api/chat.postMessage -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "channel=<channel id>" --data-urlencode "text=<digest>"`.
 
    **Zero items → send nothing.** Silence is the correct output for a quiet window.
 

--- a/plans/2026-07-24-slack-watcher.md
+++ b/plans/2026-07-24-slack-watcher.md
@@ -500,7 +500,8 @@ missing or the exact error string in `summary`, and stop.
 
 ## Steps
 
-1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)` —
+1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)`
+   (GNU date — on a macOS host use `date -v -{{lookbackMinutes}}M +%s` instead) —
    only messages with `ts >= $SINCE` count.
 
 2. **Collect candidates** with the Slack MCP tools (watched workspace):

--- a/plugin/skills/slack-watcher/SKILL.md
+++ b/plugin/skills/slack-watcher/SKILL.md
@@ -97,7 +97,8 @@ missing or the exact error string in `summary`, and stop.
      (plain text — drop the `*bold*` markers for Telegram).
    - `slack`: resolve the channel — `{{digestChannel}}` if non-empty, otherwise
      `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
-     and take `.channel.id` — then one `chat.postMessage` with the digest as `text`.
+     and take `.channel.id` — then one
+     `curl -s -X POST https://slack.com/api/chat.postMessage -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "channel=<channel id>" --data-urlencode "text=<digest>"`.
 
    **Zero items → send nothing.** Silence is the correct output for a quiet window.
 

--- a/plugin/skills/slack-watcher/SKILL.md
+++ b/plugin/skills/slack-watcher/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: slack-watcher
+description: Use when running a scheduled slack-watcher session — scan the owner's Slack inbox for new messages that need them, DM a concise digest with suggested replies via the bot, and submit a structured result via submit_result
+---
+
+# Slack watcher
+
+Scan the owner's Slack inbox for the last {{lookbackMinutes}} minutes and, only if
+something needs them, send one concise digest to the configured destination. This is a
+headless, unattended session — you do not edit files, commit, or open PRs. Your only
+side effects are Slack MCP reads, at most one outbound digest message, and one
+`submit_result` call.
+
+The owner's member id in the **watched** workspace is `{{slackUserId}}` (use it for all
+inbox searches). Their member id in the **bot's** workspace is `{{digestUserId}}` (use
+it only to open the digest DM) — the two workspaces may differ, so never mix the ids up.
+The digest destination is `{{digestTarget}}`.
+
+## Slack access
+
+Reads and writes use **different credentials in different workspaces** — never mix them:
+
+- **Inbox reads (watched workspace):** your Slack MCP connector tools —
+  `slack_search_public_and_private`, `slack_read_thread`, `slack_read_channel`,
+  `slack_search_users`. You must never call the connector's send/draft/canvas tools.
+- **Posting the digest:** via `curl`, using the env token for `{{digestTarget}}` —
+  `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` (xoxb-, bot's workspace) for `slack`,
+  `OCTOMUX_GATEWAY_TELEGRAM_TOKEN` for `telegram`. This is the only send you ever
+  perform.
+
+Before anything else, confirm the Slack MCP tools are available. If they are not, or the
+token for `{{digestTarget}}` is missing, or an API call fails with an auth error: do not
+retry endlessly — call `submit_result` with `outcome: "blocked"`, name exactly what was
+missing or the exact error string in `summary`, and stop.
+
+## Steps
+
+1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)` —
+   only messages with `ts >= $SINCE` count.
+
+2. **Collect candidates** with the Slack MCP tools (watched workspace):
+   - Mentions: `slack_search_public_and_private` with a query for `<@{{slackUserId}}>`,
+     newest first.
+   - DMs to the owner: the same search tool with an `is:dm` query (and `is:mpim` for
+     group DMs).
+   - Keep only hits inside the window, then pull thread context with
+     `slack_read_thread` (or nearby channel history with `slack_read_channel`) so you
+     understand what is actually being asked. Use `slack_search_users` to resolve
+     display names when a hit only gives you a user id.
+
+3. **Filter ruthlessly.** Drop: messages authored by `{{slackUserId}}`; bot and app
+   messages; joins/leaves and other channel noise; FYI-only chatter with no question
+   or request directed at the owner; and anything already covered by a previous
+   digest — the items below were already reported, so skip their threads unless a
+   **new** message arrived after the window they were reported in:
+
+   ```json
+   {{previousItems}}
+   ```
+
+4. **Compose the digest** — natural, human, concise. For each item (max 10, ordered
+   by urgency): who and where, what it's about in plain language, and a suggested
+   reply ready to paste as-is. Format:
+
+   ```
+   *Slack digest — <n> things need you*
+
+   1. *Priya · #deploys* — blocked on the staging deploy config, asking if she
+      should wait for your chart fix.
+      ↳ suggested: "use the staging override for now, I'll land the chart fix
+      tomorrow morning"
+   ```
+
+   **Suggested replies must sound like the owner dashed them off, not like an
+   assistant wrote them.** Rules:
+   - Before writing a reply, look at the owner's own messages in that thread or
+     channel (they're in the context you already fetched) and mirror how they write
+     there: formality, capitalization, emoji or none, greeting or none.
+   - 1–2 sentences. Contractions. Plain words. Answer the actual question; when
+     relevant, give a concrete next step or time ("I'll look after standup") instead
+     of vague reassurance.
+   - Banned: greetings and sign-offs the thread doesn't use, "I hope this helps",
+     "it's worth noting", "thanks for reaching out", "absolutely!", "great question",
+     "delve", "seamless", "robust", "leverage", "furthermore", and "it's not just X,
+     it's Y" constructions. If a reply reads like a support ticket response, rewrite
+     it shorter.
+   - Vary the shape between replies — identical sentence patterns across items is an
+     assistant tell.
+
+   Never include token values, API keys, connection strings, or other secret shapes
+   in the digest — refer to them ("the staging token") without quoting them.
+
+5. **Send it** — only if at least one item survived filtering, and only to the
+   `{{digestTarget}}` destination:
+   - `telegram`: one
+     `curl -s -X POST "https://api.telegram.org/bot$OCTOMUX_GATEWAY_TELEGRAM_TOKEN/sendMessage" -d "chat_id={{telegramChatId}}" --data-urlencode "text=<digest>"`
+     (plain text — drop the `*bold*` markers for Telegram).
+   - `slack`: resolve the channel — `{{digestChannel}}` if non-empty, otherwise
+     `curl -s -X POST https://slack.com/api/conversations.open -H "Authorization: Bearer $OCTOMUX_GATEWAY_SLACK_BOT_TOKEN" -d "users={{digestUserId}}"`
+     and take `.channel.id` — then one `chat.postMessage` with the digest as `text`.
+
+   **Zero items → send nothing.** Silence is the correct output for a quiet window.
+
+6. **Call `submit_result` exactly once** with:
+
+   ```json
+   {
+     "outcome": "done",
+     "window": "<e.g. last 40 minutes>",
+     "summary": "<one line: '3 items need attention' or 'nothing needs attention'>",
+     "digestSent": true,
+     "items": [
+       {
+         "channel": "#deploys",
+         "from": "Priya",
+         "about": "Blocked on the staging deploy config",
+         "urgency": "high",
+         "suggestedReply": "Use the staging override for now — I'll land the chart fix tomorrow morning.",
+         "permalink": "https://…"
+       }
+     ]
+   }
+   ```
+
+   `items` must list everything you digested this run (it becomes the next run's
+   dedup memory), and be `[]` with `digestSent: false` on a quiet window.
+   `outcome`: `"done"` normally, `"blocked"` for token/auth problems, `"failed"`
+   only if composing/sending itself broke.
+
+## Notes
+
+- Be conservative — this runs unattended. When unsure whether something needs the
+  owner, prefer including it at `low` urgency over silently dropping it.
+- Never send any message other than the single digest, and never post as the owner —
+  reads happen through the connector, but its send/draft tools are off-limits; the only
+  send you perform is the one gateway-token digest message. Do not look for workarounds.
+- Suggested replies are suggestions. The owner sends them; you never do.

--- a/plugin/skills/slack-watcher/SKILL.md
+++ b/plugin/skills/slack-watcher/SKILL.md
@@ -35,7 +35,8 @@ missing or the exact error string in `summary`, and stop.
 
 ## Steps
 
-1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)` —
+1. **Compute the window.** `SINCE=$(date -d "-{{lookbackMinutes}} minutes" +%s)`
+   (GNU date — on a macOS host use `date -v -{{lookbackMinutes}}M +%s` instead) —
    only messages with `ts >= $SINCE` count.
 
 2. **Collect candidates** with the Slack MCP tools (watched workspace):

--- a/server/gateway/README.md
+++ b/server/gateway/README.md
@@ -165,6 +165,34 @@ Record the result here once run:
 | ---- | -------------------- | --------------------------- | ----- |
 |      |                      |                             |       |
 
+## Slack watcher (proactive digest)
+
+The `slack-watcher` scheduled workflow (spec: [`spec/slack-watcher.md`](../../spec/slack-watcher.md))
+scans the **owner's** inbox on a cron and has this same bot DM a concise digest with
+suggested replies. Reads and writes are split across workspaces:
+
+- **Inbox reads** happen in the _watched_ workspace through the claude.ai Slack MCP
+  connector the headless session inherits — no app install in that workspace. If the
+  connector is unavailable in headless runs, watcher runs land as `blocked` on the
+  /runs feed naming the missing tools.
+- **Digest posting** goes to the destination picked in the schedule config
+  (`digestTarget`): the owner's **Telegram** chat via `OCTOMUX_GATEWAY_TELEGRAM_TOKEN`,
+  or a **Slack DM/channel** in the bot's own workspace via
+  `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` — no extra env vars either way. Telegram and
+  Slack-DM digests land in a gateway conversation, so replying to the digest reaches
+  the conductor.
+
+Create the schedule at `/schedules` (kind **Slack Watcher**, cron e.g.
+`*/30 3-18 * * *` — cron is UTC). All knobs are in the schedule form: `slackUserId`
+(watched workspace — whose inbox), `digestTarget` + `telegramChatId` or
+`digestUserId`/`digestChannel` (where the digest goes). The prompt itself is editable
+per kind in the UI (schedule skills — the shipped SKILL.md is only the seed).
+
+Hardening (v1.1, once the watched workspace allows an app install): a minimal
+user-scopes-only reader app (`search:read`, `im:history`, `mpim:history`,
+`channels:history`, `groups:history`) minting a read-only `xoxp-` token in
+`OCTOMUX_SLACK_USER_TOKEN` replaces the MCP dependency.
+
 ## (Optional) Read-only outward MCP servers
 
 To let the assistant **read** GitHub / Linear / etc., attach those MCP servers with **read-scoped
@@ -182,5 +210,5 @@ Keep write-capable tokens out of the gateway conductor's environment entirely.
 
 ## Not in v1
 
-The per-action approval button (v2) · proactive nudges (fast-follow) · full streaming/rich
-rendering (v1.1).
+The per-action approval button (v2) · full streaming/rich rendering (v1.1). Proactive
+nudges shipped as the `slack-watcher` scheduled workflow — see above.

--- a/server/schedule-prompt.ts
+++ b/server/schedule-prompt.ts
@@ -16,6 +16,7 @@ export const CRON_PROMPT_KINDS = [
   'weekly-update',
   'overnight-log-summary',
   'daily-plan',
+  'slack-watcher',
 ] as const;
 
 export type CronPromptKind = (typeof CRON_PROMPT_KINDS)[number];

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -6,6 +6,7 @@ import './overnight-log-summary/index.js';
 import './pr-extract/index.js';
 import './prod-log-triage/index.js';
 import './reviewer/index.js';
+import './slack-watcher/index.js';
 import './weekly-update/index.js';
 
 export { registerWorkflow, getWorkflow, listWorkflows, listCronWorkflowKinds } from './registry.js';

--- a/server/workflows/slack-watcher/index.test.ts
+++ b/server/workflows/slack-watcher/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listWorkflows, listCronWorkflowKinds } from '../registry.js';
+import { resolveWorkflowConfig } from '../config.js';
+import type { ScheduleRow } from '../../repositories/schedules.js';
+
+const mockRunSlackWatcher = vi.fn().mockResolvedValue({ result: {} });
+
+vi.mock('./run.js', () => ({
+  runSlackWatcher: (...args: unknown[]) => mockRunSlackWatcher(...args),
+}));
+
+import './index.js';
+
+function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    id: 'sched1',
+    kind: 'slack-watcher',
+    repo_path: '/repo',
+    cron: '*/30 3-18 * * *',
+    enabled: 1,
+    last_run_at: null,
+    config_json: null,
+    ...overrides,
+  };
+}
+
+describe('slack-watcher workflow registration', () => {
+  beforeEach(() => {
+    mockRunSlackWatcher.mockClear();
+  });
+
+  it('registers the kind with an artifact surface, config, output schema, cron trigger', () => {
+    const wf = getWorkflow('slack-watcher');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Slack Watcher');
+    expect(wf?.surfaces).toEqual(['artifact']);
+    expect(wf?.config).toBeDefined();
+    expect(wf?.output).toBeDefined();
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+  });
+
+  it('appears in listWorkflows() and listCronWorkflowKinds()', () => {
+    expect(listWorkflows().some((w) => w.kind === 'slack-watcher')).toBe(true);
+    expect(listCronWorkflowKinds()).toContain('slack-watcher');
+  });
+
+  it('fires the run with schedule id and config defaults, without awaiting it', async () => {
+    mockRunSlackWatcher.mockReturnValue(new Promise(() => {}));
+
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({ id: 'sched-42', config_json: JSON.stringify({ slackUserId: 'U07X' }) });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    expect(mockRunSlackWatcher).toHaveBeenCalledTimes(1);
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.repoPath).toBe('/repo');
+    expect(call.scheduleId).toBe('sched-42');
+    expect(call.slackUserId).toBe('U07X');
+    expect(call.digestTarget).toBe('slack');
+    expect(call.telegramChatId).toBe('');
+    expect(call.digestUserId).toBe('');
+    expect(call.lookbackMinutes).toBe(40);
+    expect(call.digestChannel).toBe('');
+  });
+
+  it('passes through config overrides for digest user, lookback, and digest channel', async () => {
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({
+      config_json: JSON.stringify({
+        slackUserId: 'U07X',
+        digestTarget: 'telegram',
+        telegramChatId: '555123',
+        digestUserId: 'U0PERSONAL',
+        lookbackMinutes: 20,
+        digestChannel: 'C9',
+      }),
+    });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.digestTarget).toBe('telegram');
+    expect(call.telegramChatId).toBe('555123');
+    expect(call.digestUserId).toBe('U0PERSONAL');
+    expect(call.lookbackMinutes).toBe(20);
+    expect(call.digestChannel).toBe('C9');
+  });
+});

--- a/server/workflows/slack-watcher/index.ts
+++ b/server/workflows/slack-watcher/index.ts
@@ -27,7 +27,7 @@ export const slackWatcherWorkflow: WorkflowType = {
       digestChannel: string;
     };
 
-    // Fire-and-forget: runSessionVertical blocks for the full headless agent run.
+    // Fire-and-forget: runSlackWatcher blocks for the full headless agent run.
     void runSlackWatcher({
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,

--- a/server/workflows/slack-watcher/index.ts
+++ b/server/workflows/slack-watcher/index.ts
@@ -1,0 +1,51 @@
+import { registerWorkflow } from '../registry.js';
+import { childLogger } from '../../logger.js';
+import { runSlackWatcher } from './run.js';
+import { SLACK_WATCHER_CONFIG_SCHEMA, SLACK_WATCHER_SCHEMA } from './schema.js';
+import type { RunContext, WorkflowType } from '../types.js';
+
+const logger = childLogger('workflows/slack-watcher');
+
+export const slackWatcherWorkflow: WorkflowType = {
+  kind: 'slack-watcher',
+  displayName: 'Slack Watcher',
+  surfaces: ['artifact'],
+  config: SLACK_WATCHER_CONFIG_SCHEMA,
+  output: SLACK_WATCHER_SCHEMA,
+  trigger: { kind: 'cron' },
+  run: (ctx: RunContext) => {
+    logger.info(
+      { repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
+      'slack-watcher: schedule fired',
+    );
+    const cfg = ctx.config as {
+      slackUserId: string;
+      digestTarget: string;
+      telegramChatId: string;
+      digestUserId: string;
+      lookbackMinutes: number;
+      digestChannel: string;
+    };
+
+    // Fire-and-forget: runSessionVertical blocks for the full headless agent run.
+    void runSlackWatcher({
+      repoPath: ctx.repoPath,
+      scheduleId: ctx.scheduleId,
+      slackUserId: cfg.slackUserId,
+      digestTarget: cfg.digestTarget,
+      telegramChatId: cfg.telegramChatId,
+      digestUserId: cfg.digestUserId,
+      lookbackMinutes: cfg.lookbackMinutes,
+      digestChannel: cfg.digestChannel,
+      trigger: ctx.trigger,
+    }).catch((err) => {
+      logger.error(
+        { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
+        'slack-watcher: run failed',
+      );
+    });
+    return Promise.resolve();
+  },
+};
+
+registerWorkflow(slackWatcherWorkflow);

--- a/server/workflows/slack-watcher/run.test.ts
+++ b/server/workflows/slack-watcher/run.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestDb } from '../../test-helpers.js';
+import { insertRun, finishRun } from '../../repositories/runs.js';
+
+const mockGetSkill = vi.fn();
+const mockRunSessionVertical = vi.fn();
+
+vi.mock('../../skills.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+vi.mock('../../services/session-vertical-service.js', () => ({
+  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+}));
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { runSlackWatcher, previousItemsJson } from './run.js';
+import { SLACK_WATCHER_SCHEMA } from './schema.js';
+
+const SKILL_BODY =
+  'Watch {{slackUserId}} back {{lookbackMinutes}}m, via {{digestTarget}} tg:{{telegramChatId}} DM {{digestUserId}} at "{{digestChannel}}", skip {{previousItems}}.';
+
+describe('runSlackWatcher', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockGetSkill.mockReset();
+    mockRunSessionVertical.mockReset();
+    mockGetSkill.mockResolvedValue({ name: 'slack-watcher', content: SKILL_BODY });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+  });
+
+  it('interpolates config placeholders and calls runSessionVertical', async () => {
+    const { result } = await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      scheduleId: 'sched-1',
+      slackUserId: 'U01ABCDEF',
+      digestTarget: 'slack',
+      telegramChatId: '',
+      digestUserId: 'U0PERSONAL',
+      lookbackMinutes: 40,
+      digestChannel: '',
+    });
+
+    expect(result).toEqual({ summary: 'ok' });
+    expect(mockGetSkill).toHaveBeenCalledWith('slack-watcher');
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.kind).toBe('slack-watcher');
+    expect(call.scheduleId).toBe('sched-1');
+    expect(call.workspaceDir).toBe('/repos/octomux');
+    expect(call.input).toBe(
+      'Watch U01ABCDEF back 40m, via slack tg: DM U0PERSONAL at "", skip [].',
+    );
+    expect(call.outputSchema).toBe(SLACK_WATCHER_SCHEMA);
+  });
+
+  it("threads the previous done run's items into {{previousItems}}", async () => {
+    const items = [{ channel: '#x', from: 'Priya', about: 'deploy', urgency: 'high' }];
+    const run = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
+    finishRun(run.id, {
+      status: 'done',
+      result: { outcome: 'done', window: '40m', summary: '1', digestSent: true, items },
+    });
+
+    expect(previousItemsJson()).toBe(JSON.stringify(items));
+
+    await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      slackUserId: 'U01ABCDEF',
+      digestTarget: 'telegram',
+      telegramChatId: '555123',
+      digestUserId: 'U0PERSONAL',
+      lookbackMinutes: 40,
+      digestChannel: 'C123',
+    });
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.input).toContain(JSON.stringify(items));
+    expect(call.input).toContain('via telegram tg:555123 DM U0PERSONAL at "C123"');
+  });
+
+  it('falls back to [] for missing, unfinished, or malformed previous runs', () => {
+    expect(previousItemsJson()).toBe('[]');
+
+    const running = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
+    expect(previousItemsJson()).toBe('[]'); // running run has no result yet
+
+    finishRun(running.id, { status: 'failed', error: 'boom' });
+    expect(previousItemsJson()).toBe('[]'); // failed run is not dedup memory
+  });
+});

--- a/server/workflows/slack-watcher/run.ts
+++ b/server/workflows/slack-watcher/run.ts
@@ -1,0 +1,84 @@
+/**
+ * Service layer for the slack-watcher vertical: loads the skill body,
+ * interpolates schedule config plus the previous run's digested items (the
+ * dedup memory), and runs headless via `runSessionVertical`. Slack tokens
+ * reach the skill through the server's inherited environment — see
+ * spec/slack-watcher.md §Slack app tokens.
+ */
+import { resolveSchedulePrompt } from '../../schedule-prompt.js';
+import { listRunsForWorkflow } from '../../repositories/runs.js';
+import { runSessionVertical } from '../../services/session-vertical-service.js';
+import { SLACK_WATCHER_SCHEMA } from './schema.js';
+
+export interface RunSlackWatcherInput {
+  repoPath: string;
+  scheduleId?: string | null;
+  /** Owner's member id in the watched workspace — whose inbox to search. */
+  slackUserId: string;
+  /** Digest destination: 'slack' (DM/channel via the bot) or 'telegram'. */
+  digestTarget: string;
+  /** Telegram numeric chat id — used when digestTarget is 'telegram'. */
+  telegramChatId: string;
+  /** Owner's member id in the bot's workspace — whom the bot DMs. */
+  digestUserId: string;
+  lookbackMinutes: number;
+  digestChannel: string;
+  trigger?: 'cron' | 'manual';
+}
+
+export interface SlackWatcherItem {
+  channel: string;
+  from: string;
+  about: string;
+  urgency: 'low' | 'medium' | 'high';
+  suggestedReply?: string;
+  permalink?: string;
+}
+
+export interface SlackWatcherResult {
+  outcome: 'done' | 'blocked' | 'failed';
+  window: string;
+  summary: string;
+  digestSent: boolean;
+  items: SlackWatcherItem[];
+}
+
+/** Items from the most recent finished run — injected as the skill's dedup memory. */
+export function previousItemsJson(): string {
+  const last = listRunsForWorkflow('slack-watcher').find(
+    (r) => r.status === 'done' && r.result_json,
+  );
+  if (!last) return '[]';
+  try {
+    const result = JSON.parse(last.result_json!) as { items?: unknown };
+    return JSON.stringify(Array.isArray(result.items) ? result.items : []);
+  } catch {
+    return '[]';
+  }
+}
+
+export async function runSlackWatcher(
+  input: RunSlackWatcherInput,
+): Promise<{ result: SlackWatcherResult }> {
+  const skillContent = await resolveSchedulePrompt({
+    scheduleId: input.scheduleId,
+    kind: 'slack-watcher',
+  });
+  const prompt = skillContent
+    .replace(/\{\{slackUserId\}\}/g, input.slackUserId)
+    .replace(/\{\{digestTarget\}\}/g, input.digestTarget)
+    .replace(/\{\{telegramChatId\}\}/g, input.telegramChatId)
+    .replace(/\{\{digestUserId\}\}/g, input.digestUserId)
+    .replace(/\{\{lookbackMinutes\}\}/g, String(input.lookbackMinutes))
+    .replace(/\{\{digestChannel\}\}/g, input.digestChannel)
+    .replace(/\{\{previousItems\}\}/g, previousItemsJson());
+
+  return runSessionVertical<SlackWatcherResult>({
+    kind: 'slack-watcher',
+    scheduleId: input.scheduleId,
+    workspaceDir: input.repoPath,
+    input: prompt,
+    outputSchema: SLACK_WATCHER_SCHEMA,
+    trigger: input.trigger ?? 'cron',
+  });
+}

--- a/server/workflows/slack-watcher/schema.test.ts
+++ b/server/workflows/slack-watcher/schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { SLACK_WATCHER_CONFIG_SCHEMA, SLACK_WATCHER_SCHEMA } from './schema.js';
+
+describe('SLACK_WATCHER_SCHEMA', () => {
+  it('requires the run-result envelope alongside kind-specific fields', () => {
+    const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_SCHEMA);
+
+    expect(validate({ window: '40m', summary: 'ok', digestSent: false, items: [] })).toBe(false);
+    expect(
+      validate({ outcome: 'done', window: '40m', summary: 'ok', digestSent: false, items: [] }),
+    ).toBe(true);
+  });
+
+  it('accepts a full digest item and rejects an unknown urgency', () => {
+    const validate = new Ajv().compile(SLACK_WATCHER_SCHEMA);
+    const base = { outcome: 'done', window: '40m', summary: '1 item', digestSent: true };
+
+    expect(
+      validate({
+        ...base,
+        items: [
+          {
+            channel: '#deploys',
+            from: 'Priya',
+            about: 'Blocked on the deploy config',
+            urgency: 'high',
+            suggestedReply: 'Use the staging override for now.',
+            permalink: 'https://slack.com/archives/C1/p1',
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      validate({
+        ...base,
+        items: [{ channel: '#x', from: 'a', about: 'b', urgency: 'urgent' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('applies config defaults for digestUserId, lookbackMinutes, and digestChannel', () => {
+    const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_CONFIG_SCHEMA);
+    const cfg: Record<string, unknown> = { slackUserId: 'U01ABCDEF' };
+
+    expect(validate(cfg)).toBe(true);
+    expect(cfg.digestUserId).toBe('');
+    expect(cfg.lookbackMinutes).toBe(40);
+    expect(cfg.digestChannel).toBe('');
+  });
+});

--- a/server/workflows/slack-watcher/schema.test.ts
+++ b/server/workflows/slack-watcher/schema.test.ts
@@ -39,13 +39,20 @@ describe('SLACK_WATCHER_SCHEMA', () => {
     ).toBe(false);
   });
 
-  it('applies config defaults for digestUserId, lookbackMinutes, and digestChannel', () => {
+  it('applies config defaults for digestTarget, telegramChatId, digestUserId, lookbackMinutes, and digestChannel', () => {
     const validate = new Ajv({ useDefaults: true }).compile(SLACK_WATCHER_CONFIG_SCHEMA);
     const cfg: Record<string, unknown> = { slackUserId: 'U01ABCDEF' };
 
     expect(validate(cfg)).toBe(true);
+    expect(cfg.digestTarget).toBe('slack');
+    expect(cfg.telegramChatId).toBe('');
     expect(cfg.digestUserId).toBe('');
     expect(cfg.lookbackMinutes).toBe(40);
     expect(cfg.digestChannel).toBe('');
+  });
+
+  it('rejects an unknown digestTarget', () => {
+    const validate = new Ajv().compile(SLACK_WATCHER_CONFIG_SCHEMA);
+    expect(validate({ slackUserId: 'U01ABCDEF', digestTarget: 'email' })).toBe(false);
   });
 });

--- a/server/workflows/slack-watcher/schema.ts
+++ b/server/workflows/slack-watcher/schema.ts
@@ -2,7 +2,12 @@
  * run.ts can import them without a circular dependency.
  *
  * `outcome` + `links` are the universal run-result envelope (see
- * `RUN_RESULT_SCHEMA` in @octomux/types, spec/workflow-consolidation.md §5). */
+ * `RUN_RESULT_SCHEMA` in @octomux/types, spec/workflow-consolidation.md §5).
+ *
+ * Cross-field requirements (telegram target → telegramChatId, slack target →
+ * digestUserId/digestChannel) are intentionally NOT schema-enforced: the skill
+ * validates at runtime and submits a `blocked` result, so the /schedules form
+ * stays simple. Don't add if/then deps here. */
 export const SLACK_WATCHER_CONFIG_SCHEMA = {
   type: 'object',
   properties: {

--- a/server/workflows/slack-watcher/schema.ts
+++ b/server/workflows/slack-watcher/schema.ts
@@ -1,0 +1,74 @@
+/** JSON Schemas for the slack-watcher vertical. Split out from index.ts so
+ * run.ts can import them without a circular dependency.
+ *
+ * `outcome` + `links` are the universal run-result envelope (see
+ * `RUN_RESULT_SCHEMA` in @octomux/types, spec/workflow-consolidation.md §5). */
+export const SLACK_WATCHER_CONFIG_SCHEMA = {
+  type: 'object',
+  properties: {
+    slackUserId: {
+      type: 'string',
+      title: 'Watched member id',
+      description:
+        "The owner's member id in the watched workspace (e.g. U01ABCDEF) — whose inbox to search.",
+      default: '',
+    },
+    digestUserId: {
+      type: 'string',
+      title: 'Digest member id',
+      description:
+        "The owner's member id in the bot's workspace — whom the bot DMs. Same as the watched id when both halves share a workspace.",
+      default: '',
+    },
+    lookbackMinutes: {
+      type: 'number',
+      title: 'Lookback minutes',
+      description: 'How far back each run scans — cron interval plus overlap so nothing is missed.',
+      default: 40,
+    },
+    digestChannel: {
+      type: 'string',
+      title: 'Digest channel id',
+      description: 'Channel for the digest. Empty = the bot opens a DM with the owner.',
+      default: '',
+    },
+  },
+  additionalProperties: false,
+};
+
+export const SLACK_WATCHER_SCHEMA = {
+  type: 'object',
+  properties: {
+    outcome: { type: 'string', enum: ['done', 'blocked', 'failed'] },
+    window: { type: 'string' },
+    summary: { type: 'string' },
+    digestSent: { type: 'boolean' },
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          channel: { type: 'string' },
+          from: { type: 'string' },
+          about: { type: 'string' },
+          urgency: { type: 'string', enum: ['low', 'medium', 'high'] },
+          suggestedReply: { type: 'string' },
+          permalink: { type: 'string' },
+        },
+        required: ['channel', 'from', 'about', 'urgency'],
+        additionalProperties: false,
+      },
+    },
+    links: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['label', 'url'],
+        properties: { label: { type: 'string' }, url: { type: 'string' } },
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['outcome', 'window', 'summary', 'digestSent', 'items'],
+  additionalProperties: false,
+};

--- a/server/workflows/slack-watcher/schema.ts
+++ b/server/workflows/slack-watcher/schema.ts
@@ -13,6 +13,20 @@ export const SLACK_WATCHER_CONFIG_SCHEMA = {
         "The owner's member id in the watched workspace (e.g. U01ABCDEF) — whose inbox to search.",
       default: '',
     },
+    digestTarget: {
+      type: 'string',
+      enum: ['slack', 'telegram'],
+      title: 'Digest destination',
+      description: 'Where the digest goes: a Slack DM/channel via the bot, or Telegram.',
+      default: 'slack',
+    },
+    telegramChatId: {
+      type: 'string',
+      title: 'Telegram chat id',
+      description:
+        "Numeric Telegram chat id (the gateway allowlist id). Required for the 'telegram' target.",
+      default: '',
+    },
     digestUserId: {
       type: 'string',
       title: 'Digest member id',

--- a/spec/slack-watcher.md
+++ b/spec/slack-watcher.md
@@ -31,7 +31,12 @@ built as a standard workflow kind rather than gateway-internal code.
 
 ## Architecture
 
-Two halves sharing one Slack app:
+Two halves. Slack credentials are **workspace-scoped**, and the watched workspace (the
+company workspace where the owner's inbox lives) differs from the workspace the gateway
+bot lives in (the owner's personal workspace). Installing a reader app on the company
+workspace is not currently possible (admin approval), so v1 reads through the
+**claude.ai Slack MCP connector**, which is already authorized on the watched workspace;
+the conductor bot app in the personal workspace handles posting and the gateway.
 
 1. **Proactive (new):** workflow kind `slack-watcher`, modeled on `overnight-log-summary`
    (headless session vertical, `surfaces: ['artifact']`, cron trigger, config + output
@@ -41,30 +46,30 @@ Two halves sharing one Slack app:
    owner's DM with the bot, which is exactly the conversation the gateway routes to the
    conductor.
 
-### Slack app tokens
+### Slack access
 
-| Token | Holder | Used for |
-| ----- | ------ | -------- |
-| `xoxb-` bot token (exists) | gateway + watcher | Posting the digest DM (`chat.postMessage`), opening the DM (`conversations.open`) |
-| `xapp-` app token (exists) | gateway | Socket Mode |
-| `xoxp-` user token (**new**) | watcher only | Reading the owner's inbox |
+| Credential | Workspace | Used for |
+| ---------- | --------- | -------- |
+| claude.ai Slack MCP connector (exists) | **watched** (company) | All inbox reads: `slack_search_public_and_private`, `slack_read_thread`, `slack_read_channel` |
+| `xoxb-` bot token (conductor app) | **digest** (personal) | Posting the digest DM (`chat.postMessage`), opening the DM (`conversations.open`) |
+| `xapp-` app token (conductor app) | digest (personal) | Socket Mode (gateway) |
 
-New **user** scopes added to `server/gateway/slack-app-manifest.yaml` under
-`oauth_config.scopes.user`: `search:read`, `im:history`, `mpim:history`,
-`channels:history`, `groups:history`. All read-only — the user token cannot post.
-Reinstalling the app mints the `xoxp-` token.
+**Known risk:** the claude.ai connector is interactively authenticated; its availability
+inside headless cron sessions on this host is unverified. The skill must check for the
+Slack MCP tools first and submit `outcome: 'blocked'` (with which tools were missing)
+when absent — a blocked run on the feed is the signal, never a silent no-digest.
 
-New env vars (loaded like the gateway's, documented in `server/gateway/README.md`):
+**Hardening path (v1.1, when installable):** a minimal reader app on the watched
+workspace with read-only user scopes (`search:read`, `im:history`, `mpim:history`,
+`channels:history`, `groups:history`) minting an `xoxp-` token in
+`OCTOMUX_SLACK_USER_TOKEN`; the skill then reads via `curl` instead of MCP. Nothing else
+in the design changes.
 
-```bash
-OCTOMUX_SLACK_USER_TOKEN=xoxp-...   # read-only user token; watcher inbox reads
-```
-
-The watcher reuses `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` for posting. The headless session
-inherits the octomux server's environment (`runSessionVertical` does no env plumbing), so
-both tokens are visible to the skill, which calls the Slack Web API with `curl`. If either
-token is missing, the run submits `outcome: 'blocked'` with a reason instead of failing
-silently.
+No new env vars in v1. The watcher reuses `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` for posting:
+the headless session inherits the octomux server's environment (`runSessionVertical`
+does no env plumbing), so the token is visible to the skill, which posts with `curl`.
+Missing bot token or missing Slack MCP tools → the run submits `outcome: 'blocked'` with
+a reason instead of failing silently.
 
 ## Components
 
@@ -79,10 +84,13 @@ Registers the kind. Shape mirrors `overnight-log-summary/index.ts`: `surfaces:
 
 ```
 SLACK_WATCHER_CONFIG_SCHEMA (drives the /schedules form):
-  slackUserId      string  — owner's member id (e.g. U0A798PTVD1); whose inbox to watch
+  slackUserId      string  — owner's member id in the WATCHED workspace; whose inbox to
+                             search (member ids differ per workspace)
+  digestUserId     string  — owner's member id in the DIGEST (bot's) workspace; whom the
+                             bot DMs. Same value as slackUserId in single-workspace setups
   lookbackMinutes  number  — default 40 (cron interval + overlap so gaps can't drop messages)
   digestChannel    string  — optional; channel id for the digest. Default '' = open a DM
-                             with slackUserId via conversations.open
+                             with digestUserId via conversations.open
 
 SLACK_WATCHER_SCHEMA (submit_result payload; envelope per spec/workflow-consolidation.md §5):
   outcome     'done' | 'blocked' | 'failed'
@@ -99,7 +107,8 @@ SLACK_WATCHER_SCHEMA (submit_result payload; envelope per spec/workflow-consolid
 Mirrors `overnight-log-summary/run.ts`:
 
 1. `resolveSchedulePrompt({ scheduleId, kind: 'slack-watcher' })` → DB skill body.
-2. Interpolates `{{slackUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, and
+2. Interpolates `{{slackUserId}}`, `{{digestUserId}}`, `{{lookbackMinutes}}`,
+   `{{digestChannel}}`, and
    `{{previousItems}}` — the `items` JSON from the most recent `done` run of this kind
    (via `listRunsForWorkflow('slack-watcher')`), `'[]'` when none. This is the dedup
    memory: the skill must not re-digest a thread already covered unless there are new
@@ -110,12 +119,14 @@ Mirrors `overnight-log-summary/run.ts`:
 
 ### `plugin/skills/slack-watcher/SKILL.md`
 
-Headless, unattended session; only side effects are Slack Web API reads and (at most) one
-`chat.postMessage`. Steps:
+Headless, unattended session; only side effects are Slack MCP reads and (at most) one
+bot-token `chat.postMessage`. Steps:
 
-1. **Collect** (user token): `search.messages` for `to:@{{slackUserId}}`-style DM search and
-   `@`-mention search within the last `{{lookbackMinutes}}` minutes; `conversations.history`
-   / `conversations.replies` for context on hits. Skip messages authored by the owner, bot
+1. **Collect** (Slack MCP, watched workspace): first verify the Slack MCP tools are
+   available — if not, submit `outcome: 'blocked'` naming the missing tools and stop.
+   Then `slack_search_public_and_private` for `@`-mentions of `{{slackUserId}}` and DMs
+   within the last `{{lookbackMinutes}}` minutes; `slack_read_thread` /
+   `slack_read_channel` for context on hits. Skip messages authored by the owner, bot
    noise, and joins/leaves.
 2. **Filter against `{{previousItems}}`** — drop threads already digested with no new
    messages since.
@@ -124,7 +135,7 @@ Headless, unattended session; only side effects are Slack Web API reads and (at 
    direct, no corporate filler. Order by urgency. Hard cap: digest ≤ 10 items, each ≤ 3
    lines + reply.
 4. **Send** (bot token): resolve the digest channel (`{{digestChannel}}` or
-   `conversations.open` with `{{slackUserId}}`), one `chat.postMessage` with the digest.
+   `conversations.open` with `{{digestUserId}}`), one `chat.postMessage` with the digest.
    **If no items survive filtering, send nothing.**
 5. **`submit_result`** matching `SLACK_WATCHER_SCHEMA`. Blocked tokens/API errors →
    `outcome: 'blocked'` with the reason in `summary`.
@@ -134,14 +145,17 @@ Headless, unattended session; only side effects are Slack Web API reads and (at 
 - `server/workflows/index.ts`: import `./slack-watcher/index.js`.
 - `server/schedule-prompt.ts`: add `'slack-watcher'` to `CRON_PROMPT_KINDS` (not
   task-backed).
-- `server/gateway/slack-app-manifest.yaml`: user scopes block.
-- `server/gateway/README.md`: user-token setup + `OCTOMUX_SLACK_USER_TOKEN`, and move
-  "proactive nudges" out of "Not in v1".
+- `server/gateway/README.md`: the two-workspace model (MCP reads on the watched
+  workspace, conductor bot posts on the personal one), the v1.1 reader-app hardening
+  path, and move "proactive nudges" out of "Not in v1". The conductor manifest is
+  untouched.
 
 ## Security
 
-- User token is **read-only by scope** — consistent with the gateway's "read-only by
-  credential, not code gate" model. No user-scoped `chat:write` anywhere.
+- Nothing in the watcher can write as the owner: reads go through the claude.ai Slack
+  connector, posting only through the bot token in the personal workspace — consistent
+  with the gateway's "read-only by credential, not code gate" model. The skill is
+  additionally instructed to never call the connector's send/draft tools.
 - The digest is posted by the skill itself (curl), so the gateway's server-side
   `redactSecrets` (`server/gateway/redact.ts`) cannot intercept it. The skill instead
   carries an explicit instruction: the digest must never contain token values, keys,
@@ -150,15 +164,20 @@ Headless, unattended session; only side effects are Slack Web API reads and (at 
 
 ## Live setup (this devbox, after merge)
 
-1. Update the Slack app from the amended manifest; reinstall → mints `xoxp-`, keeps
-   `xoxb-`/`xapp-`.
-2. Env: existing gateway vars + `OCTOMUX_GATEWAY_SLACK_ALLOW=<owner member id>` +
-   `OCTOMUX_SLACK_USER_TOKEN`.
-3. Verify the no-op Stop hook in `~/.claude/settings.json` (known gateway requirement —
+1. Create the conductor app in the owner's **personal** workspace from
+   `slack-app-manifest.yaml` per the gateway README → `xoxb-` + `xapp-` tokens (only the
+   Telegram gateway is live today).
+2. Env: `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`, `OCTOMUX_GATEWAY_SLACK_APP_TOKEN`,
+   `OCTOMUX_GATEWAY_SLACK_ALLOW=<owner member id in the personal workspace>`.
+3. Verify the claude.ai Slack connector (watched workspace) is reachable from a headless
+   session on this host — the first manual run doubles as this check; a `blocked` result
+   naming missing tools means it is not, and the v1.1 reader app becomes the unblocker.
+4. Verify the no-op Stop hook in `~/.claude/settings.json` (known gateway requirement —
    without it gateway replies buffer forever).
-4. Create the schedule: kind `slack-watcher`, repo path, cron `*/30 3-18 * * *` (UTC ≈
-   08:30–23:30 IST), config `{ slackUserId: <owner id> }`.
-5. Smoke: `POST /api/schedules/:id/run`, confirm digest DM arrives, reply to it, confirm the
+5. Create the schedule: kind `slack-watcher`, repo path, cron `*/30 3-18 * * *` (UTC ≈
+   08:30–23:30 IST), config `{ slackUserId: <watched-workspace id>, digestUserId:
+   <personal-workspace id> }`.
+6. Smoke: `POST /api/schedules/:id/run`, confirm digest DM arrives, reply to it, confirm the
    gateway conductor answers.
 
 ## Testing
@@ -167,8 +186,8 @@ Follow the per-workflow layout (`overnight-log-summary` as the template):
 
 - `schema.test.ts` — config defaults applied; output schema accepts a full and a minimal
   (`digestSent: false`) payload.
-- `run.test.ts` — mocks `runSessionVertical`: prompt interpolation (all four placeholders),
-  previous-run items threading, token env injection, blocked path when tokens missing.
+- `run.test.ts` — mocks `runSessionVertical`: prompt interpolation (all five placeholders)
+  and previous-run items threading.
 - `index.test.ts` — kind registered, cron-triggerable (`listCronWorkflowKinds` includes it).
 - `registry.test.ts` untouched; `schedule-prompt` seed test extended for the new kind.
 - Slack Web API is never called in tests; the skill's behavior is prompt-side and the

--- a/spec/slack-watcher.md
+++ b/spec/slack-watcher.md
@@ -1,0 +1,175 @@
+# Slack Watcher — proactive inbox digest over the gateway
+
+A cron-scheduled, headless workflow that reads the owner's Slack inbox (DMs, mentions,
+active threads), and — only when something needs them — has the gateway bot DM a concise,
+natural-language digest with ready-to-paste suggested replies. The digest lands in the same
+bot DM the Slack gateway (`server/gateway/`) already listens on, so the owner can reply
+conversationally ("expand #2", "draft a longer reply to Priya") and the conductor acts.
+
+This is the "proactive nudges" fast-follow named in `server/gateway/README.md` §"Not in v1",
+built as a standard workflow kind rather than gateway-internal code.
+
+## Goals
+
+- Every ~30 minutes during waking hours, surface new Slack messages that need the owner:
+  direct DMs, @-mentions, and replies in threads the owner participates in.
+- Digest is concise natural human language — what it's about, why it matters, and a
+  suggested reply the owner can paste as-is. No digest when nothing needs attention.
+- Suggested replies are text in the digest. The agent **never sends as the owner**
+  (same draft-only rule as `daily-plan`).
+- Reuse: schedules/cron poller, `runSessionVertical`, the workflow registry, the gateway
+  bot + DM channel, the schedule-skills DB prompt store.
+
+## Non-goals (v1)
+
+- Sending replies as the owner (no user-scoped `chat:write`; "reply-as-me with gateway
+  confirmation" is v2).
+- Multi-user / multi-workspace. One owner, one workspace — same as the gateway.
+- Real-time event push. 30-minute polling is the design point; the gateway remains the
+  real-time reactive surface.
+- Gmail/Calendar/Jira context — that stays in `daily-plan`.
+
+## Architecture
+
+Two halves sharing one Slack app:
+
+1. **Proactive (new):** workflow kind `slack-watcher`, modeled on `overnight-log-summary`
+   (headless session vertical, `surfaces: ['artifact']`, cron trigger, config + output
+   schemas). Skill prompt shipped at `plugin/skills/slack-watcher/SKILL.md`, seeded into the
+   `schedule_skills` table on first read like every other cron kind.
+2. **Reactive (exists):** the Slack gateway (Socket Mode). The digest is posted into the
+   owner's DM with the bot, which is exactly the conversation the gateway routes to the
+   conductor.
+
+### Slack app tokens
+
+| Token | Holder | Used for |
+| ----- | ------ | -------- |
+| `xoxb-` bot token (exists) | gateway + watcher | Posting the digest DM (`chat.postMessage`), opening the DM (`conversations.open`) |
+| `xapp-` app token (exists) | gateway | Socket Mode |
+| `xoxp-` user token (**new**) | watcher only | Reading the owner's inbox |
+
+New **user** scopes added to `server/gateway/slack-app-manifest.yaml` under
+`oauth_config.scopes.user`: `search:read`, `im:history`, `mpim:history`,
+`channels:history`, `groups:history`. All read-only — the user token cannot post.
+Reinstalling the app mints the `xoxp-` token.
+
+New env vars (loaded like the gateway's, documented in `server/gateway/README.md`):
+
+```bash
+OCTOMUX_SLACK_USER_TOKEN=xoxp-...   # read-only user token; watcher inbox reads
+```
+
+The watcher reuses `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` for posting. The headless session
+inherits the octomux server's environment (`runSessionVertical` does no env plumbing), so
+both tokens are visible to the skill, which calls the Slack Web API with `curl`. If either
+token is missing, the run submits `outcome: 'blocked'` with a reason instead of failing
+silently.
+
+## Components
+
+### `server/workflows/slack-watcher/index.ts`
+
+Registers the kind. Shape mirrors `overnight-log-summary/index.ts`: `surfaces:
+['artifact']`, `config: SLACK_WATCHER_CONFIG_SCHEMA`, `output: SLACK_WATCHER_SCHEMA`,
+`trigger: { kind: 'cron' }`, fire-and-forget `run` with error logging. Imported from
+`server/workflows/index.ts`.
+
+### `server/workflows/slack-watcher/schema.ts`
+
+```
+SLACK_WATCHER_CONFIG_SCHEMA (drives the /schedules form):
+  slackUserId      string  — owner's member id (e.g. U0A798PTVD1); whose inbox to watch
+  lookbackMinutes  number  — default 40 (cron interval + overlap so gaps can't drop messages)
+  digestChannel    string  — optional; channel id for the digest. Default '' = open a DM
+                             with slackUserId via conversations.open
+
+SLACK_WATCHER_SCHEMA (submit_result payload; envelope per spec/workflow-consolidation.md §5):
+  outcome     'done' | 'blocked' | 'failed'
+  window      string  — human description of the window scanned
+  summary     string  — one-line: "3 items need you" / "nothing needs attention"
+  digestSent  boolean — false when there was nothing to send
+  items[]     { channel, from, about, urgency: 'low'|'medium'|'high',
+                suggestedReply?, permalink? }
+  links[]     { label, url }
+```
+
+### `server/workflows/slack-watcher/run.ts`
+
+Mirrors `overnight-log-summary/run.ts`:
+
+1. `resolveSchedulePrompt({ scheduleId, kind: 'slack-watcher' })` → DB skill body.
+2. Interpolates `{{slackUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, and
+   `{{previousItems}}` — the `items` JSON from the most recent `done` run of this kind
+   (via `listRunsForWorkflow('slack-watcher')`), `'[]'` when none. This is the dedup
+   memory: the skill must not re-digest a thread already covered unless there are new
+   messages in it.
+3. `runSessionVertical({ kind: 'slack-watcher', scheduleId, workspaceDir: repoPath,
+   input: prompt, outputSchema: SLACK_WATCHER_SCHEMA, trigger })`. The Slack tokens reach
+   the skill via inherited server env (see §Slack app tokens).
+
+### `plugin/skills/slack-watcher/SKILL.md`
+
+Headless, unattended session; only side effects are Slack Web API reads and (at most) one
+`chat.postMessage`. Steps:
+
+1. **Collect** (user token): `search.messages` for `to:@{{slackUserId}}`-style DM search and
+   `@`-mention search within the last `{{lookbackMinutes}}` minutes; `conversations.history`
+   / `conversations.replies` for context on hits. Skip messages authored by the owner, bot
+   noise, and joins/leaves.
+2. **Filter against `{{previousItems}}`** — drop threads already digested with no new
+   messages since.
+3. **Compose** — for each remaining item: who, where, what it's about in plain language, why
+   it needs the owner, urgency, and a suggested reply written in the owner's voice: short,
+   direct, no corporate filler. Order by urgency. Hard cap: digest ≤ 10 items, each ≤ 3
+   lines + reply.
+4. **Send** (bot token): resolve the digest channel (`{{digestChannel}}` or
+   `conversations.open` with `{{slackUserId}}`), one `chat.postMessage` with the digest.
+   **If no items survive filtering, send nothing.**
+5. **`submit_result`** matching `SLACK_WATCHER_SCHEMA`. Blocked tokens/API errors →
+   `outcome: 'blocked'` with the reason in `summary`.
+
+### Registry / prompt-store touchpoints
+
+- `server/workflows/index.ts`: import `./slack-watcher/index.js`.
+- `server/schedule-prompt.ts`: add `'slack-watcher'` to `CRON_PROMPT_KINDS` (not
+  task-backed).
+- `server/gateway/slack-app-manifest.yaml`: user scopes block.
+- `server/gateway/README.md`: user-token setup + `OCTOMUX_SLACK_USER_TOKEN`, and move
+  "proactive nudges" out of "Not in v1".
+
+## Security
+
+- User token is **read-only by scope** — consistent with the gateway's "read-only by
+  credential, not code gate" model. No user-scoped `chat:write` anywhere.
+- The digest is posted by the skill itself (curl), so the gateway's server-side
+  `redactSecrets` (`server/gateway/redact.ts`) cannot intercept it. The skill instead
+  carries an explicit instruction: the digest must never contain token values, keys,
+  connection strings, or other secret shapes — quote around them, not through them.
+- Tokens live in env / `.env`, never in DB rows, config JSON, or `submit_result` payloads.
+
+## Live setup (this devbox, after merge)
+
+1. Update the Slack app from the amended manifest; reinstall → mints `xoxp-`, keeps
+   `xoxb-`/`xapp-`.
+2. Env: existing gateway vars + `OCTOMUX_GATEWAY_SLACK_ALLOW=<owner member id>` +
+   `OCTOMUX_SLACK_USER_TOKEN`.
+3. Verify the no-op Stop hook in `~/.claude/settings.json` (known gateway requirement —
+   without it gateway replies buffer forever).
+4. Create the schedule: kind `slack-watcher`, repo path, cron `*/30 3-18 * * *` (UTC ≈
+   08:30–23:30 IST), config `{ slackUserId: <owner id> }`.
+5. Smoke: `POST /api/schedules/:id/run`, confirm digest DM arrives, reply to it, confirm the
+   gateway conductor answers.
+
+## Testing
+
+Follow the per-workflow layout (`overnight-log-summary` as the template):
+
+- `schema.test.ts` — config defaults applied; output schema accepts a full and a minimal
+  (`digestSent: false`) payload.
+- `run.test.ts` — mocks `runSessionVertical`: prompt interpolation (all four placeholders),
+  previous-run items threading, token env injection, blocked path when tokens missing.
+- `index.test.ts` — kind registered, cron-triggerable (`listCronWorkflowKinds` includes it).
+- `registry.test.ts` untouched; `schedule-prompt` seed test extended for the new kind.
+- Slack Web API is never called in tests; the skill's behavior is prompt-side and the
+  live smoke test (§Live setup) covers the integration.

--- a/spec/slack-watcher.md
+++ b/spec/slack-watcher.md
@@ -42,17 +42,20 @@ the conductor bot app in the personal workspace handles posting and the gateway.
    (headless session vertical, `surfaces: ['artifact']`, cron trigger, config + output
    schemas). Skill prompt shipped at `plugin/skills/slack-watcher/SKILL.md`, seeded into the
    `schedule_skills` table on first read like every other cron kind.
-2. **Reactive (exists):** the Slack gateway (Socket Mode). The digest is posted into the
-   owner's DM with the bot, which is exactly the conversation the gateway routes to the
-   conductor.
+2. **Reactive (exists):** the gateways. The digest destination is configurable per
+   schedule (`digestTarget`): the owner's **Telegram** chat (gateway already live), a
+   **Slack DM** with the conductor bot, or a **Slack channel** in the bot's workspace.
+   Telegram and Slack-DM destinations land in a conversation a gateway routes to the
+   conductor, so replying to the digest just works; a channel destination is
+   broadcast-only unless the bot is subscribed to `message.channels` there.
 
 ### Slack access
 
-| Credential | Workspace | Used for |
-| ---------- | --------- | -------- |
+| Credential                             | Workspace             | Used for                                                                                      |
+| -------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------- |
 | claude.ai Slack MCP connector (exists) | **watched** (company) | All inbox reads: `slack_search_public_and_private`, `slack_read_thread`, `slack_read_channel` |
-| `xoxb-` bot token (conductor app) | **digest** (personal) | Posting the digest DM (`chat.postMessage`), opening the DM (`conversations.open`) |
-| `xapp-` app token (conductor app) | digest (personal) | Socket Mode (gateway) |
+| `xoxb-` bot token (conductor app)      | **digest** (personal) | Posting the digest DM (`chat.postMessage`), opening the DM (`conversations.open`)             |
+| `xapp-` app token (conductor app)      | digest (personal)     | Socket Mode (gateway)                                                                         |
 
 **Known risk:** the claude.ai connector is interactively authenticated; its availability
 inside headless cron sessions on this host is unverified. The skill must check for the
@@ -65,11 +68,12 @@ workspace with read-only user scopes (`search:read`, `im:history`, `mpim:history
 `OCTOMUX_SLACK_USER_TOKEN`; the skill then reads via `curl` instead of MCP. Nothing else
 in the design changes.
 
-No new env vars in v1. The watcher reuses `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` for posting:
-the headless session inherits the octomux server's environment (`runSessionVertical`
-does no env plumbing), so the token is visible to the skill, which posts with `curl`.
-Missing bot token or missing Slack MCP tools → the run submits `outcome: 'blocked'` with
-a reason instead of failing silently.
+No new env vars in v1. The watcher reuses the gateway tokens for posting —
+`OCTOMUX_GATEWAY_SLACK_BOT_TOKEN` for Slack destinations, `OCTOMUX_GATEWAY_TELEGRAM_TOKEN`
+for Telegram: the headless session inherits the octomux server's environment
+(`runSessionVertical` does no env plumbing), so the tokens are visible to the skill,
+which posts with `curl`. Missing token for the configured target or missing Slack MCP
+tools → the run submits `outcome: 'blocked'` with a reason instead of failing silently.
 
 ## Components
 
@@ -83,14 +87,19 @@ Registers the kind. Shape mirrors `overnight-log-summary/index.ts`: `surfaces:
 ### `server/workflows/slack-watcher/schema.ts`
 
 ```
-SLACK_WATCHER_CONFIG_SCHEMA (drives the /schedules form):
+SLACK_WATCHER_CONFIG_SCHEMA (drives the /schedules form — every field below is
+user-editable in the UI, like the prompt body is via schedule_skills):
   slackUserId      string  — owner's member id in the WATCHED workspace; whose inbox to
                              search (member ids differ per workspace)
+  digestTarget     enum    — 'telegram' | 'slack'; where the digest goes. Default 'slack'
+  telegramChatId   string  — Telegram numeric chat id (same id as the gateway allowlist);
+                             required when digestTarget = 'telegram'
   digestUserId     string  — owner's member id in the DIGEST (bot's) workspace; whom the
                              bot DMs. Same value as slackUserId in single-workspace setups
   lookbackMinutes  number  — default 40 (cron interval + overlap so gaps can't drop messages)
-  digestChannel    string  — optional; channel id for the digest. Default '' = open a DM
-                             with digestUserId via conversations.open
+  digestChannel    string  — optional; Slack channel id for the digest (bot must be in the
+                             channel). Default '' = open a DM with digestUserId via
+                             conversations.open
 
 SLACK_WATCHER_SCHEMA (submit_result payload; envelope per spec/workflow-consolidation.md §5):
   outcome     'done' | 'blocked' | 'failed'
@@ -107,14 +116,14 @@ SLACK_WATCHER_SCHEMA (submit_result payload; envelope per spec/workflow-consolid
 Mirrors `overnight-log-summary/run.ts`:
 
 1. `resolveSchedulePrompt({ scheduleId, kind: 'slack-watcher' })` → DB skill body.
-2. Interpolates `{{slackUserId}}`, `{{digestUserId}}`, `{{lookbackMinutes}}`,
-   `{{digestChannel}}`, and
+2. Interpolates `{{slackUserId}}`, `{{digestTarget}}`, `{{telegramChatId}}`,
+   `{{digestUserId}}`, `{{lookbackMinutes}}`, `{{digestChannel}}`, and
    `{{previousItems}}` — the `items` JSON from the most recent `done` run of this kind
    (via `listRunsForWorkflow('slack-watcher')`), `'[]'` when none. This is the dedup
    memory: the skill must not re-digest a thread already covered unless there are new
    messages in it.
 3. `runSessionVertical({ kind: 'slack-watcher', scheduleId, workspaceDir: repoPath,
-   input: prompt, outputSchema: SLACK_WATCHER_SCHEMA, trigger })`. The Slack tokens reach
+input: prompt, outputSchema: SLACK_WATCHER_SCHEMA, trigger })`. The Slack tokens reach
    the skill via inherited server env (see §Slack app tokens).
 
 ### `plugin/skills/slack-watcher/SKILL.md`
@@ -131,11 +140,17 @@ bot-token `chat.postMessage`. Steps:
 2. **Filter against `{{previousItems}}`** — drop threads already digested with no new
    messages since.
 3. **Compose** — for each remaining item: who, where, what it's about in plain language, why
-   it needs the owner, urgency, and a suggested reply written in the owner's voice: short,
-   direct, no corporate filler. Order by urgency. Hard cap: digest ≤ 10 items, each ≤ 3
-   lines + reply.
-4. **Send** (bot token): resolve the digest channel (`{{digestChannel}}` or
-   `conversations.open` with `{{digestUserId}}`), one `chat.postMessage` with the digest.
+   it needs the owner, urgency, and a suggested reply. Order by urgency. Hard cap: digest
+   ≤ 10 items, each ≤ 3 lines + reply. Replies must read like the owner dashed them off,
+   not like an assistant wrote them; the skill carries explicit style rules (mirror the
+   thread's tone and the owner's own voice in it, 1–2 sentences, contractions, plain
+   words, a concrete next step over vague reassurance, and a banned-phrase list of AI
+   tells — greetings/sign-offs, "it's worth noting", "I hope this helps", "delve",
+   "seamless", "not just X but Y", etc.).
+4. **Send** — switch on `{{digestTarget}}`. `telegram`: one Bot API `sendMessage` to
+   `{{telegramChatId}}` with `OCTOMUX_GATEWAY_TELEGRAM_TOKEN`. `slack`: resolve the
+   channel (`{{digestChannel}}` or `conversations.open` with `{{digestUserId}}`), one
+   `chat.postMessage` with `OCTOMUX_GATEWAY_SLACK_BOT_TOKEN`.
    **If no items survive filtering, send nothing.**
 5. **`submit_result`** matching `SLACK_WATCHER_SCHEMA`. Blocked tokens/API errors →
    `outcome: 'blocked'` with the reason in `summary`.
@@ -175,8 +190,10 @@ bot-token `chat.postMessage`. Steps:
 4. Verify the no-op Stop hook in `~/.claude/settings.json` (known gateway requirement —
    without it gateway replies buffer forever).
 5. Create the schedule: kind `slack-watcher`, repo path, cron `*/30 3-18 * * *` (UTC ≈
-   08:30–23:30 IST), config `{ slackUserId: <watched-workspace id>, digestUserId:
-   <personal-workspace id> }`.
+   08:30–23:30 IST), config `{ slackUserId: <watched-workspace id>, digestTarget:
+   'telegram', telegramChatId: <numeric id> }` — or `digestTarget: 'slack'` with
+   `digestUserId`/`digestChannel` once the conductor app exists. With the Telegram
+   target, steps 1–2 (the Slack conductor app) can be deferred entirely.
 6. Smoke: `POST /api/schedules/:id/run`, confirm digest DM arrives, reply to it, confirm the
    gateway conductor answers.
 
@@ -186,7 +203,7 @@ Follow the per-workflow layout (`overnight-log-summary` as the template):
 
 - `schema.test.ts` — config defaults applied; output schema accepts a full and a minimal
   (`digestSent: false`) payload.
-- `run.test.ts` — mocks `runSessionVertical`: prompt interpolation (all five placeholders)
+- `run.test.ts` — mocks `runSessionVertical`: prompt interpolation (all seven placeholders)
   and previous-run items threading.
 - `index.test.ts` — kind registered, cron-triggerable (`listCronWorkflowKinds` includes it).
 - `registry.test.ts` untouched; `schedule-prompt` seed test extended for the new kind.

--- a/spec/slack-watcher.md
+++ b/spec/slack-watcher.md
@@ -191,7 +191,7 @@ bot-token `chat.postMessage`. Steps:
    without it gateway replies buffer forever).
 5. Create the schedule: kind `slack-watcher`, repo path, cron `*/30 3-18 * * *` (UTC ≈
    08:30–23:30 IST), config `{ slackUserId: <watched-workspace id>, digestTarget:
-   'telegram', telegramChatId: <numeric id> }` — or `digestTarget: 'slack'` with
+'telegram', telegramChatId: <numeric id> }` — or `digestTarget: 'slack'` with
    `digestUserId`/`digestChannel` once the conductor app exists. With the Telegram
    target, steps 1–2 (the Slack conductor app) can be deferred entirely.
 6. Smoke: `POST /api/schedules/:id/run`, confirm digest DM arrives, reply to it, confirm the


### PR DESCRIPTION
## What

A new \`slack-watcher\` cron workflow kind: a headless scheduled agent that reads the owner's Slack inbox in the **watched** (company) workspace via the claude.ai Slack MCP connector and — only when something needs them — sends one concise digest with human-sounding suggested replies to a configurable destination (\`digestTarget\`): the owner's **Telegram** chat (gateway already live) or a **Slack DM/channel** via the conductor bot in the personal workspace. Replying to the digest lands in a gateway conversation, so the conductor picks it up.

- Spec: \`spec/slack-watcher.md\` · Plan: \`plans/2026-07-24-slack-watcher.md\`
- Modeled on the \`overnight-log-summary\` vertical: \`schema.ts\` + \`run.ts\` + \`index.ts\` under \`server/workflows/slack-watcher/\`, skill at \`plugin/skills/slack-watcher/SKILL.md\` (seeded into the editable \`schedule_skills\` table), registered in the workflow registry + \`CRON_PROMPT_KINDS\`.
- Dedup memory: each run interpolates the previous done run's \`items\` into the prompt so threads aren't re-digested.
- All config is editable from the /schedules form (schema-driven); the prompt is editable per kind in the UI.
- Security: reads via the connector only (send/draft tools banned in-prompt), the single outbound send uses the gateway token for the chosen target, never sends as the owner, no tokens in config/result/digest. No DB migration.

## Testing

- \`bun run typecheck\` clean · \`bun run lint\` 0 errors (60 pre-existing warnings) · \`prettier --check\` clean
- \`bun run test\`: 3939/3940 — the single failure (\`src/pages/HomePage.test.tsx\` composer hydration) is a waitFor flake under full-suite load; passes 6/6 in isolation and this branch touches no frontend files
- New: 19 tests across schema/run/registration + schedule-prompt regressions

## Not in this PR

Live setup (Telegram-first schedule on the devbox, optional Slack conductor app) follows after merge per plan Task 7. v1.1 hardening path (read-only \`xoxp-\` reader app on the watched workspace) documented in the spec/README.
