### PR TITLE
feat(schedules): make every schedule knob DB-backed and UI-editable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,11 +130,20 @@ the `agent_learnings` table and `server/routes/learnings.ts`.
 
 ## Schedules
 
-Cron-triggered runs replaced the old `octomux team` command (deleted in `90cf49e`). A `schedules`
-row is `(kind, repo_path)`-unique with a 5-field cron; `poller/schedule-cron.ts` calls
-`isCronDue()` (`server/schedules/cron.ts`, `croner`, evaluated in UTC) and hands due rows to
-`poller/execute-schedule-run.ts`. Managed from `/schedules` in the UI and
-`server/routes/schedules.ts` (`GET/POST /api/schedules`, `POST /api/schedules/:id/run`).
+Cron-triggered runs replaced the old `octomux team` command (deleted in `90cf49e`). Multiple
+schedules per `(kind, repo_path)` are allowed (the old UNIQUE constraint is gone). Each row
+carries a 5-field cron plus per-schedule `name`, `timezone` (IANA, NULL → UTC), `model`,
+`timeout_ms` (headless session timeout, NULL → 5 min), `config_json`, and `prompt` (per-schedule
+override of the kind's `schedule_skills` body — see spec/schedule-configurability.md).
+`poller/schedule-cron.ts` calls `isCronDue(expr, now, timezone)` (`server/schedules/cron.ts`,
+`croner`) with a same-minute refire guard, and hands due rows to
+`poller/execute-schedule-run.ts`, which threads model/timeout into the workflow's `RunContext`.
+Session-vertical prompts interpolate `{{configKey}}` placeholders generically
+(`server/prompt-interpolate.ts`, single-pass). The `custom` kind is a prompt-only session
+vertical (prompt + name required, generic outcome/summary/links envelope). Managed from
+`/schedules` in the UI and `server/routes/schedules.ts` (`GET/POST /api/schedules`,
+`PATCH /api/schedules/:id`, `POST /api/schedules/:id/run`,
+`GET /api/schedules/:id/effective-prompt`).
 
 ## Testing Patterns
 

--- a/plans/2026-07-24-schedule-configurability.md
+++ b/plans/2026-07-24-schedule-configurability.md
@@ -1,0 +1,239 @@
+# Schedule Configurability — Implementation Plan
+
+> Executes `spec/schedule-configurability.md` (FINAL, 5-persona reviewed). Parallel
+> sonnet work packages with **disjoint file sets**, two waves + an integration pass.
+> Every package agent reads the spec first; this plan pins the decomposition and the
+> cross-package interfaces so packages compose without coordination.
+
+**Goal:** every hardcoded schedule knob becomes DB-backed and UI-editable; add the
+generic `custom` cron kind.
+
+**Execution rules (all packages):**
+
+- Work directly in this worktree. Edit ONLY the files listed for your package.
+  Do NOT commit, do NOT run `git add`, do NOT run `tsc`/`bun run typecheck` (other
+  packages land concurrently; the integration pass owns repo-wide checks).
+- Run only your own test files: `bun run test -- <path>` (vitest).
+- Do not edit `server/test-helpers.ts` or `src/test-helpers.tsx`; keep new fixtures
+  local to your test files.
+- Follow repo conventions: pino `childLogger`, template-literal SQL with
+  `datetime('now')`, table-driven `it.each`, Prettier style.
+
+## Pinned cross-package interfaces
+
+```ts
+// server/repositories/schedules.ts (A1)
+interface ScheduleRow {
+  id: string; kind: string; repo_path: string;
+  name: string | null; cron: string; timezone: string | null;
+  enabled: number; model: string | null; timeout_ms: number | null;
+  last_run_at: string | null; config_json: string | null; prompt: string | null;
+}
+createSchedule(input: CreateScheduleInput): ScheduleRow   // pure insert; SELECT by id
+interface CreateScheduleInput { kind: string; repoPath: string; cron: string;
+  name?: string; timezone?: string; enabled?: boolean; model?: string;
+  timeoutMs?: number; config?: Record<string, unknown>; prompt?: string }
+updateSchedule(id, patch: UpdateScheduleInput): ScheduleRow | undefined
+interface UpdateScheduleInput { name?: string | null; repoPath?: string; cron?: string;
+  timezone?: string | null; enabled?: boolean; model?: string | null;
+  timeoutMs?: number | null; config?: Record<string, unknown>; prompt?: string | null }
+
+// server/schedules/cron.ts (A1)
+isCronDue(expr: string, now: Date, timezone?: string | null): boolean
+
+// server/workflows/types.ts (A1)
+WorkflowType.execution?: 'session' | 'task' | 'chat'
+RunContext.model?: string | null
+RunContext.timeoutMs?: number | null
+
+// server/prompt-interpolate.ts (A2, new file)
+interpolatePrompt(body: string, vars: Record<string, unknown>): string  // single pass
+
+// server/schedule-prompt.ts (A2)
+resolveSchedulePromptWithSource(input: { scheduleId?: string | null; kind: string }):
+  Promise<{ content: string; source: 'override' | 'kind_skill' }>
+// resolveSchedulePrompt stays, becomes a thin wrapper returning .content
+
+// server/services/session-vertical-service.ts (A3)
+RunSessionVerticalInput.timeoutMs?: number | null   // model already exists
+
+// server/chats.ts (A3)
+CreateChatOptions.model?: string | null
+
+// server/workflows/slack-watcher/run.ts (B2)
+previousItemsJson(scheduleId: string | null | undefined): string
+
+// Validation constants (B1 route-level; B3 embeds refname pattern in config schemas)
+MODEL:    /^[a-zA-Z0-9._:/-]{1,128}$/
+REFNAME:  /^[a-zA-Z0-9._/-]{1,80}$/        // JSON Schema "pattern" on baseBranch/branchPrefix
+TIMEOUT:  integer, 10_000 <= v <= 86_400_000
+
+// API shapes (B1 serves, A4 consumes — build from the spec, not from each other)
+GET /api/schedules/kinds → { kinds: [{ kind, displayName, configSchema,
+  execution, promptRequired, supportsTimeout }] }
+GET /api/schedules/:id/effective-prompt → { content: string, source: 'override' | 'kind_skill' }
+```
+
+---
+
+## Wave 1 — 4 parallel packages
+
+### A1 — Data layer, cron timezone, run-context threading
+
+**Files:** `server/db/schema.ts`, `server/db/migrations.ts`, `server/db.test.ts`,
+`server/repositories/schedules.ts` + `.test.ts`, `server/schedules/cron.ts` + `.test.ts`,
+`server/poller/schedule-cron.ts` + `.test.ts`, `server/poller/execute-schedule-run.ts`
+
+- `.test.ts`, `server/workflows/types.ts`, plus **one-line** `execution:` additions to
+  the workflow objects in `server/workflows/{slack-watcher,weekly-update,overnight-log-summary}/index.ts`
+  (`'session'`), `{doc-drift,prod-log-triage}/index.ts` (`'task'`), `daily-plan/index.ts`
+  (`'chat'`). Touch nothing else in those six files.
+
+Spec sections: §2 (SCHEMA constant + idempotent transaction-wrapped rebuild, delete
+`upsertSchedule`, `createSchedule` SELECT-by-id, full `updateSchedule`, extended
+`SCHEDULE_COLUMNS`), §3 (isCronDue timezone + compound cache key, pollSchedules passes
+`row.timezone`, same-minute refire guard on `last_run_at`), §5 items 1–2
+(`executeScheduleRun` populates `ctx.model`/`ctx.timeoutMs` from the row and logs run
+start with `prompt_source: row.prompt ? 'schedule_override' : 'kind_skill'`).
+
+Route `routes/schedules.ts` still calls `upsertSchedule` after this package — leave a
+temporary `export const upsertSchedule = createSchedule`-style alias ONLY if renaming
+breaks its import, and note it; B1 removes the alias. Prefer: keep exporting a
+`createSchedule` and change nothing in routes (B1 owns that file).
+
+Tests (extend existing files): migration idempotency + row survival + duplicate
+(kind, repo_path) inserts; cron tz cases incl. DST + compound cache key; same-minute
+guard; executeScheduleRun threading + run-start log line.
+
+### A2 — Prompt resolution + interpolation
+
+**Files:** `server/schedule-prompt.ts` + `.test.ts`, **new** `server/prompt-interpolate.ts`
+
+- **new** `server/prompt-interpolate.test.ts`.
+
+Spec §4: precedence rewrite of `resolveSchedulePrompt` (schedule override → kind skill)
+and `skillContentOverridesForScheduleId` (return `{ [kind]: schedule.prompt }` when
+non-empty); add `resolveSchedulePromptWithSource`; debug-log the branch taken.
+`interpolatePrompt`: single pass (split-on-token or one `String.replace` sweep with a
+callback — never loop until fixpoint), scalars via `String()`, objects via
+`JSON.stringify`, unknown `{{tokens}}` untouched.
+
+Note: `ScheduleRow.prompt` is added by A1 concurrently. If the field isn't on the type
+yet, code against it anyway (`schedule.prompt`) — vitest strips types, and the
+integration pass typechecks after both land. Do not edit `repositories/schedules.ts`.
+
+Tests: precedence table (override / skill / lazy-seed), overrides map honors
+`schedule.prompt`, interpolation table incl. single-pass case (`vars.a = '{{b}}'`
+stays literal), repeated keys, object stringification.
+
+### A3 — Harness quoting, session timeout, chat model
+
+**Files:** `server/harnesses/shared.ts` + `.test.ts`,
+`server/services/session-vertical-service.ts` + `.test.ts`, `server/chats.ts`.
+
+Spec §5: `applyModel` wraps the value with `shellQuoteSingle` (import from
+`server/shell-quote.ts`) — update existing `shared.test.ts` expectations accordingly
+and add a metacharacter case asserting the quoted output. `RunSessionVerticalInput`
+gains `timeoutMs?: number | null`, forwarded as `timeoutMs: i.timeoutMs ?? undefined`
+to `runAgentSession` (which already accepts it and defaults internally).
+`CreateChatOptions` gains `model?: string | null`; apply it to the launch flags the
+same way task launch does (find the flags assembly in `createChat` and pass through
+`applyModel(flags, opts.model)`).
+
+Tests: quoting cases; session-vertical passes timeoutMs through (mock
+`runAgentSession` per existing test patterns in `session-vertical-service.test.ts`).
+`chats.ts` has no dedicated test file — cover the model flag via a focused new
+assertion only if an existing api test file already exercises createChat; otherwise
+rely on the applyModel unit tests (do not create `server/chats.test.ts` — keep the
+package small).
+
+### A4 — Frontend
+
+**Files:** `src/lib/api/schedulesApi.ts`, **new** `src/lib/models.ts`,
+`src/pages/SchedulesPage.tsx` + `.test.tsx`,
+`src/components/schedules/SchemaConfigForm.tsx` + `.test.tsx`,
+**new** `src/components/schedules/TimezoneField.tsx` (+ **new** `.test.tsx`).
+
+Spec §9 in full, building against the pinned API shapes above (server lands in the
+same release): extended `ScheduleRow`/`ScheduleKindInfo`/`CreateScheduleInput`/
+`UpdateScheduleInput` (all new fields nullable/optional), `getEffectivePrompt(id)`
+API fn; create-panel field-visibility matrix (Advanced disclosure for name/model/
+timeout; custom ⇒ name + prompt required, submit disabled while empty); timezone
+searchable combobox with "Use browser timezone" and `Zone (UTC±H:MM)` labels;
+edit-card prompt override editor (lazy effective-prompt preview, Override copies
+default into textarea, Reset-to-default confirm → `prompt: null`); multi-instance
+card/delete-dialog disambiguation (cron shown when names collide); kind as
+non-interactive badge; `SchemaConfigForm` renders `format: 'single-line'` strings as
+`Input` (replace the hardcoded `verify`/`logCommand` name checks); `KNOWN_MODELS`
+datalist (`claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`,
+`claude-haiku-4-5-20251001`).
+
+Tests: mock `Intl.supportedValuesOf` (undefined in JSDOM); follow existing
+`SchedulesPage.test.tsx` + `src/test-helpers.tsx` patterns (`mockApi`).
+
+---
+
+## Wave 2 — 3 parallel packages (starts only after all of Wave 1 lands)
+
+### B1 — Routes
+
+**Files:** `server/routes/schedules.ts`, `server/api.schedules.test.ts`.
+
+Spec §8 + validation from §3/§5/§7: POST switches to `createSchedule` (201 always;
+remove any A1 compat alias); PATCH accepts `name/repoPath/cron/timezone/model/
+timeoutMs/config/prompt`; cron+timezone validated on both verbs via
+`new Cron(expr, { timezone, paused: true })` in try/catch → `badRequest` (import
+`Cron` from `croner`); model regex; timeout bounds; custom ⇒ non-empty `prompt` and
+`name` required when enabled; kinds endpoint adds `execution`, `promptRequired`
+(`kind === 'custom'`), `supportsTimeout` (`execution === 'session'`); new
+`GET /api/schedules/:id/effective-prompt` via `resolveSchedulePromptWithSource`.
+Config `pattern` violations (refname fields) already surface through the existing
+`validateWorkflowConfig` 400 path — add a test, not new code.
+
+### B2 — Session-vertical + chat workflows
+
+**Files:** `server/workflows/slack-watcher/{index,run}.ts` + both `.test.ts`,
+`server/workflows/weekly-update/{index,run}.ts` + tests,
+`server/workflows/overnight-log-summary/{index,run}.ts` + tests,
+`server/workflows/daily-plan/{index,run}.ts` + tests.
+
+Spec §4.2 + §5 items 3–4: thread `ctx.model`/`ctx.timeoutMs` through each input struct
+into `runSessionVertical`; daily-plan passes `model` to `createChat`. Replace the
+`.replace()` chains with `interpolatePrompt(skillContent, { ...config, ...extras })`
+(slack-watcher extras: `previousItems`). `previousItemsJson(scheduleId)` filters via
+`listRunsForSchedule` (import from `../../repositories/runs.js`), falling back to `[]`
+when `scheduleId` is null. Keep each workflow's `execution` field as set in Wave 1.
+
+### B3 — Task-backed config + custom kind
+
+**Files:** `server/workflows/doc-drift/{schema,index,run}.ts` + `index/run` tests,
+`server/workflows/prod-log-triage/{schema,index,run}.ts` + tests,
+**new** `server/workflows/custom/index.ts`, **new** `server/workflows/custom/run.ts`,
+**new** tests for both, `server/workflows/index.ts` (add `import './custom/index.js';`).
+
+Spec §6: `baseBranch` (default `'main'`) + `branchPrefix` (defaults `'doc-drift'` /
+`'triage'`) with `"format": "single-line"` and `"pattern": "^[a-zA-Z0-9._/-]{1,80}$"`;
+thread both through run.ts (branch = `` `${branchPrefix}/${short}-${dateStamp}` ``);
+thread `ctx.model` into the task insert (both `insertDocDriftTask`/`insertTriageTask`
+already write task rows — add `model` to the insert params and the tasks INSERT column
+list they use). Spec §7: custom kind — `execution: 'session'`, reads
+`getSchedule(ctx.scheduleId).prompt` directly (fail the run if empty), interpolates
+extras only, output schema = `RUN_RESULT_SCHEMA` (import from `@octomux/types`) with
+`additionalProperties: false` + required `['outcome','summary']`, owns its runs row
+(`insertRun` on entry, `finishRun('failed')` in catch; on success `runSessionVertical`'s
+existing run handling applies — mirror how weekly-update's run row lifecycle works and
+keep behavior consistent with it).
+
+---
+
+## Wave 3 — Integration (orchestrator, sequential)
+
+1. `bun run typecheck` — fix cross-package seams (expected: A2's `schedule.prompt`
+   before/after A1 types, route/type drift).
+2. `bun run test` full suite; `bun run lint:fix`; `bun run format`.
+3. Update `CLAUDE.md` Schedules section (multi-instance, timezone, custom kind,
+   per-schedule prompt) and `MEMORY` note about schedule-skills if behavior nuance
+   changed (it didn't — overrides layer on top).
+4. Conventional commits (no AI attribution), logically grouped (data layer / prompts /
+   workflows / routes / UI), or a single `feat(schedules)` commit if the tree bisects
+   poorly.

--- a/server/api.schedules.test.ts
+++ b/server/api.schedules.test.ts
@@ -2,16 +2,40 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from './app.js';
 import { createTestDb } from './test-helpers.js';
-import { upsertSchedule } from './repositories/schedules.js';
+import { createSchedule } from './repositories/schedules.js';
 import { insertRun } from './repositories/runs.js';
+import { upsertScheduleSkill } from './repositories/schedule-skills.js';
+import { registerWorkflow } from './workflows/registry.js';
+
+// Register a minimal 'custom' test workflow to exercise the custom-kind validation path.
+// B3 will register this in production; this inline registration keeps the tests self-contained
+// until that lands.
+function ensureCustomWorkflowRegistered() {
+  // Guard: if already registered (e.g. by B3 landing), skip.
+  try {
+    registerWorkflow({
+      kind: 'custom',
+      displayName: 'Custom Prompt',
+      surfaces: ['artifact'],
+      execution: 'session',
+      trigger: { kind: 'cron' },
+      run: async () => {},
+    });
+  } catch {
+    // registerWorkflow overwrites silently (Map.set), so no throw expected
+  }
+}
 
 describe('schedule routes', () => {
   let app: ReturnType<typeof createApp>;
 
   beforeEach(() => {
     createTestDb();
+    ensureCustomWorkflowRegistered();
     app = createApp();
   });
+
+  // ── GET /api/schedules/kinds ────────────────────────────────────────────────
 
   describe('GET /api/schedules/kinds', () => {
     it('lists registered schedule kinds', async () => {
@@ -23,12 +47,49 @@ describe('schedule routes', () => {
       expect(kinds).toContain('weekly-update');
       expect(kinds).toContain('daily-plan');
     });
+
+    it('includes execution, promptRequired, and supportsTimeout flags', async () => {
+      const res = await request(app).get('/api/schedules/kinds');
+      expect(res.status).toBe(200);
+
+      const byKind = Object.fromEntries(res.body.kinds.map((k: { kind: string }) => [k.kind, k]));
+
+      // session kind (weekly-update)
+      if (byKind['weekly-update']) {
+        expect(byKind['weekly-update'].execution).toBe('session');
+        expect(byKind['weekly-update'].supportsTimeout).toBe(true);
+        expect(byKind['weekly-update'].promptRequired).toBe(false);
+      }
+
+      // task kind (doc-drift)
+      if (byKind['doc-drift']) {
+        expect(byKind['doc-drift'].execution).toBe('task');
+        expect(byKind['doc-drift'].supportsTimeout).toBe(false);
+        expect(byKind['doc-drift'].promptRequired).toBe(false);
+      }
+
+      // chat kind (daily-plan)
+      if (byKind['daily-plan']) {
+        expect(byKind['daily-plan'].execution).toBe('chat');
+        expect(byKind['daily-plan'].supportsTimeout).toBe(false);
+        expect(byKind['daily-plan'].promptRequired).toBe(false);
+      }
+
+      // custom kind
+      if (byKind['custom']) {
+        expect(byKind['custom'].execution).toBe('session');
+        expect(byKind['custom'].supportsTimeout).toBe(true);
+        expect(byKind['custom'].promptRequired).toBe(true);
+      }
+    });
   });
+
+  // ── GET /api/schedules ─────────────────────────────────────────────────────
 
   describe('GET /api/schedules', () => {
     it('lists all schedules, enabled and disabled', async () => {
-      upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
-      upsertSchedule({
+      createSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
+      createSchedule({
         kind: 'prod-log-triage',
         repoPath: '/repo-b',
         cron: '0 8 * * *',
@@ -40,6 +101,8 @@ describe('schedule routes', () => {
       expect(res.body).toHaveLength(2);
     });
   });
+
+  // ── POST /api/schedules ────────────────────────────────────────────────────
 
   describe('POST /api/schedules', () => {
     it('creates a schedule and returns 201', async () => {
@@ -53,20 +116,67 @@ describe('schedule routes', () => {
       expect(res.body.enabled).toBe(1);
     });
 
-    it('accepts enabled=false and a config blob', async () => {
-      const res = await request(app)
+    it('always returns 201 (no upsert — two POSTs with same kind+repo produce two rows)', async () => {
+      const res1 = await request(app)
         .post('/api/schedules')
-        .send({
-          kind: 'prod-log-triage',
-          repoPath: '/repo',
-          cron: '0 7 * * *',
-          enabled: false,
-          config: { logCommand: 'flyctl logs -a my-app' },
-        });
+        .send({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+      const res2 = await request(app)
+        .post('/api/schedules')
+        .send({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 8 * * *' });
+
+      expect(res1.status).toBe(201);
+      expect(res2.status).toBe(201);
+      expect(res1.body.id).not.toBe(res2.body.id);
+
+      const list = await request(app).get('/api/schedules');
+      expect(list.body).toHaveLength(2);
+    });
+
+    it('accepts enabled=false', async () => {
+      const res = await request(app).post('/api/schedules').send({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        enabled: false,
+      });
 
       expect(res.status).toBe(201);
       expect(res.body.enabled).toBe(0);
-      expect(JSON.parse(res.body.config_json)).toEqual({ logCommand: 'flyctl logs -a my-app' });
+    });
+
+    it('accepts a config blob and stores it as config_json', async () => {
+      // Use slack-watcher whose schema has no format:'single-line' fields
+      const res = await request(app)
+        .post('/api/schedules')
+        .send({
+          kind: 'slack-watcher',
+          repoPath: '/repo',
+          cron: '0 7 * * *',
+          config: { slackUserId: 'U123', digestTarget: 'slack' },
+        });
+
+      expect(res.status).toBe(201);
+      expect(JSON.parse(res.body.config_json)).toMatchObject({ slackUserId: 'U123' });
+    });
+
+    it('accepts optional name, timezone, model, timeoutMs, prompt', async () => {
+      const res = await request(app).post('/api/schedules').send({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+        name: 'My Weekly',
+        timezone: 'America/New_York',
+        model: 'claude-opus-4-8',
+        timeoutMs: 600000,
+        prompt: 'do the thing',
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe('My Weekly');
+      expect(res.body.timezone).toBe('America/New_York');
+      expect(res.body.model).toBe('claude-opus-4-8');
+      expect(res.body.timeout_ms).toBe(600000);
+      expect(res.body.prompt).toBe('do the thing');
     });
 
     it('rejects an unknown kind with 400', async () => {
@@ -96,11 +206,100 @@ describe('schedule routes', () => {
         .send({ kind: 'prod-log-triage', repoPath: '/repo', cron: '   ' });
       expect(res.status).toBe(400);
     });
+
+    // ── Validation table ──────────────────────────────────────────────────────
+
+    it.each([
+      // [description, body patch, expected 400]
+      ['bad cron expression', { cron: 'not-a-cron' }, true],
+      ['bad cron with valid fields', { cron: '99 99 * * *' }, true],
+      ['bad timezone (valid cron)', { cron: '0 7 * * *', timezone: 'Invalid/Zone' }, true],
+      ['bad model (contains spaces)', { cron: '0 7 * * *', model: 'bad model name' }, true],
+      ['bad model (too long)', { cron: '0 7 * * *', model: 'a'.repeat(129) }, true],
+      ['bad model (has shell injection)', { cron: '0 7 * * *', model: 'model;rm -rf /' }, true],
+      ['timeoutMs too small (9999)', { cron: '0 7 * * *', timeoutMs: 9999 }, true],
+      ['timeoutMs too large (86_400_001)', { cron: '0 7 * * *', timeoutMs: 86_400_001 }, true],
+      ['timeoutMs non-integer (float)', { cron: '0 7 * * *', timeoutMs: 30000.5 }, true],
+      ['valid model passes', { cron: '0 7 * * *', model: 'claude-opus-4-8' }, false],
+      ['valid timeoutMs passes (boundary min)', { cron: '0 7 * * *', timeoutMs: 10_000 }, false],
+      [
+        'valid timeoutMs passes (boundary max)',
+        { cron: '0 7 * * *', timeoutMs: 86_400_000 },
+        false,
+      ],
+    ])(
+      'POST validation: %s',
+      async (_desc: string, bodyPatch: Record<string, unknown>, expectBad: boolean) => {
+        const body = {
+          kind: 'weekly-update',
+          repoPath: '/repo',
+          cron: '0 7 * * *',
+          ...bodyPatch,
+        };
+        const res = await request(app).post('/api/schedules').send(body);
+        if (expectBad) {
+          expect(res.status).toBe(400);
+        } else {
+          expect(res.status).toBe(201);
+        }
+      },
+    );
+
+    // ── custom kind validation ─────────────────────────────────────────────────
+
+    it('rejects enabled custom schedule without prompt (400)', async () => {
+      const res = await request(app)
+        .post('/api/schedules')
+        .send({ kind: 'custom', repoPath: '/repo', cron: '0 7 * * *', name: 'My Custom' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/prompt/i);
+    });
+
+    it('rejects enabled custom schedule without name (400)', async () => {
+      const res = await request(app).post('/api/schedules').send({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        prompt: 'do something',
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/name/i);
+    });
+
+    it('accepts valid custom schedule with name and prompt (201)', async () => {
+      const res = await request(app).post('/api/schedules').send({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        name: 'My Custom',
+        prompt: 'do something useful',
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe('My Custom');
+      expect(res.body.prompt).toBe('do something useful');
+    });
+
+    it('allows disabled custom schedule without prompt or name (201)', async () => {
+      const res = await request(app).post('/api/schedules').send({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        enabled: false,
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.enabled).toBe(0);
+    });
   });
+
+  // ── PATCH /api/schedules/:id ────────────────────────────────────────────────
 
   describe('PATCH /api/schedules/:id', () => {
     it('updates cron/enabled/config and returns 200', async () => {
-      const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+      const row = createSchedule({
+        kind: 'prod-log-triage',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
 
       const res = await request(app)
         .patch(`/api/schedules/${row.id}`)
@@ -111,6 +310,59 @@ describe('schedule routes', () => {
       expect(res.body.enabled).toBe(0);
     });
 
+    it('patches repoPath and new fields (name, timezone, model, timeoutMs, prompt)', async () => {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/old-repo',
+        cron: '0 7 * * 1',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({
+        repoPath: '/new-repo',
+        name: 'Renamed',
+        timezone: 'Europe/London',
+        model: 'claude-sonnet-4-6',
+        timeoutMs: 120000,
+        prompt: 'new override prompt',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.repo_path).toBe('/new-repo');
+      expect(res.body.name).toBe('Renamed');
+      expect(res.body.timezone).toBe('Europe/London');
+      expect(res.body.model).toBe('claude-sonnet-4-6');
+      expect(res.body.timeout_ms).toBe(120000);
+      expect(res.body.prompt).toBe('new override prompt');
+    });
+
+    it('clears prompt when patched with null', async () => {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+        prompt: 'existing override',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({ prompt: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.prompt).toBeNull();
+    });
+
+    it('clears name when patched with null', async () => {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+        name: 'Named',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({ name: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBeNull();
+    });
+
     it('returns 404 for an unknown id', async () => {
       const res = await request(app)
         .patch('/api/schedules/does-not-exist')
@@ -119,15 +371,112 @@ describe('schedule routes', () => {
     });
 
     it('rejects a blank cron with 400', async () => {
-      const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+      const row = createSchedule({
+        kind: 'prod-log-triage',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
       const res = await request(app).patch(`/api/schedules/${row.id}`).send({ cron: '  ' });
       expect(res.status).toBe(400);
     });
+
+    // ── PATCH validation table ─────────────────────────────────────────────────
+
+    it.each([
+      ['bad cron expression', { cron: 'not-a-cron' }, true],
+      ['bad timezone (valid cron)', { timezone: 'Invalid/Zone' }, true],
+      ['bad model (spaces)', { model: 'bad name' }, true],
+      ['timeoutMs too small', { timeoutMs: 5000 }, true],
+      ['timeoutMs too large', { timeoutMs: 90_000_000 }, true],
+      ['timeoutMs non-integer', { timeoutMs: 1234.5 }, true],
+      ['valid model', { model: 'claude-opus-4-8' }, false],
+      ['valid timezone', { timezone: 'America/Chicago' }, false],
+      ['valid timeoutMs', { timeoutMs: 30000 }, false],
+    ])(
+      'PATCH validation: %s',
+      async (_desc: string, bodyPatch: Record<string, unknown>, expectBad: boolean) => {
+        const row = createSchedule({
+          kind: 'weekly-update',
+          repoPath: '/repo',
+          cron: '0 7 * * 1',
+        });
+        const res = await request(app).patch(`/api/schedules/${row.id}`).send(bodyPatch);
+        if (expectBad) {
+          expect(res.status).toBe(400);
+        } else {
+          expect(res.status).toBe(200);
+        }
+      },
+    );
+
+    // ── custom kind PATCH validation ──────────────────────────────────────────
+
+    it('rejects enabling a custom schedule without prompt (400)', async () => {
+      const row = createSchedule({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        enabled: false,
+        name: 'My Custom',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({ enabled: true });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects enabling a custom schedule without name (400)', async () => {
+      const row = createSchedule({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        enabled: false,
+        prompt: 'do something',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({ enabled: true });
+      expect(res.status).toBe(400);
+    });
+
+    it('allows enabling a custom schedule with both name and prompt (200)', async () => {
+      const row = createSchedule({
+        kind: 'custom',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        enabled: false,
+        name: 'My Custom',
+        prompt: 'do something useful',
+      });
+
+      const res = await request(app).patch(`/api/schedules/${row.id}`).send({ enabled: true });
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(1);
+    });
+
+    it('validates cron+timezone pair with effective values (PATCH timezone changes effective tz)', async () => {
+      // Create with a valid cron (daily), then try to set invalid timezone
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+      });
+
+      const res = await request(app)
+        .patch(`/api/schedules/${row.id}`)
+        .send({ timezone: 'Not/A/Timezone' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/timezone/i);
+    });
   });
+
+  // ── DELETE /api/schedules/:id ────────────────────────────────────────────────
 
   describe('DELETE /api/schedules/:id', () => {
     it('deletes a schedule and returns 204', async () => {
-      const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+      const row = createSchedule({
+        kind: 'prod-log-triage',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
 
       const res = await request(app).delete(`/api/schedules/${row.id}`);
       expect(res.status).toBe(204);
@@ -142,9 +491,15 @@ describe('schedule routes', () => {
     });
   });
 
+  // ── GET /api/schedules/:id/runs ─────────────────────────────────────────────
+
   describe('GET /api/schedules/:id/runs', () => {
     it('returns runs stamped with this schedule id from the runs table', async () => {
-      const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+      const row = createSchedule({
+        kind: 'prod-log-triage',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
       insertRun({
         workflowKind: 'weekly-update',
         trigger: 'manual',
@@ -170,9 +525,11 @@ describe('schedule routes', () => {
     });
   });
 
+  // ── POST /api/schedules/:id/run ──────────────────────────────────────────────
+
   describe('POST /api/schedules/:id/run', () => {
     it('triggers a manual run via executeScheduleRun', async () => {
-      const row = upsertSchedule({
+      const row = createSchedule({
         kind: 'weekly-update',
         repoPath: '/repo',
         cron: '0 7 * * *',
@@ -187,6 +544,67 @@ describe('schedule routes', () => {
     it('returns 404 for an unknown schedule id', async () => {
       const res = await request(app).post('/api/schedules/does-not-exist/run');
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ── GET /api/schedules/:id/effective-prompt ──────────────────────────────────
+
+  describe('GET /api/schedules/:id/effective-prompt', () => {
+    it('returns 404 for an unknown schedule id', async () => {
+      const res = await request(app).get('/api/schedules/does-not-exist/effective-prompt');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns kind_skill source when no schedule prompt override exists', async () => {
+      // Pre-seed the schedule_skills DB so resolveScheduleSkillContent doesn't hit the filesystem
+      upsertScheduleSkill('weekly-update', 'The weekly update skill content');
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+      });
+
+      const res = await request(app).get(`/api/schedules/${row.id}/effective-prompt`);
+      expect(res.status).toBe(200);
+      expect(res.body.source).toBe('kind_skill');
+      expect(res.body.content).toBe('The weekly update skill content');
+    });
+
+    it('returns override source after PATCHing a prompt override', async () => {
+      upsertScheduleSkill('weekly-update', 'The weekly update skill content');
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+      });
+
+      // PATCH the prompt override
+      await request(app)
+        .patch(`/api/schedules/${row.id}`)
+        .send({ prompt: 'my custom override prompt' });
+
+      const res = await request(app).get(`/api/schedules/${row.id}/effective-prompt`);
+      expect(res.status).toBe(200);
+      expect(res.body.source).toBe('override');
+      expect(res.body.content).toBe('my custom override prompt');
+    });
+
+    it('falls back to kind_skill source after clearing prompt override (prompt: null)', async () => {
+      upsertScheduleSkill('weekly-update', 'The weekly update skill content');
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * 1',
+        prompt: 'my custom override',
+      });
+
+      // Clear the override
+      await request(app).patch(`/api/schedules/${row.id}`).send({ prompt: null });
+
+      const res = await request(app).get(`/api/schedules/${row.id}/effective-prompt`);
+      expect(res.status).toBe(200);
+      expect(res.body.source).toBe('kind_skill');
+      expect(res.body.content).toBe('The weekly update skill content');
     });
   });
 });

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -13,6 +13,7 @@ import {
   deleteAgentRow,
 } from './repositories/index.js';
 import { getHarness } from './harnesses/index.js';
+import { applyModel } from './harnesses/shared.js';
 import { hookBaseUrl } from './hook-base-url.js';
 import { resolveHarnessFlags } from './harness-flags.js';
 import { childLogger } from './logger.js';
@@ -47,6 +48,7 @@ export interface CreateChatOptions {
   agent?: string | null;
   prompt?: string | null;
   harnessId?: string | null;
+  model?: string | null;
 }
 
 /**
@@ -64,7 +66,7 @@ export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
   const harness = getHarness(opts.harnessId ?? null);
   const agentId = id; // for standalone chats, agent row id == chat id
   const hookToken = crypto.randomBytes(32).toString('hex');
-  const flags = await resolveHarnessFlags(harness);
+  const flags = applyModel(await resolveHarnessFlags(harness), opts.model);
 
   let sessionIdForDb: string | null;
   let sessionIdForLaunch: string;

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -699,3 +699,88 @@ describe('agents feature: agent_configs table + orchestrator_conversations.agent
     expect(agentIdCol!.notnull).toBe(0);
   });
 });
+
+describe('schedules configurability migration (2026-07-24)', () => {
+  it('fresh DB has schedules table with new columns and no UNIQUE(kind, repo_path)', () => {
+    const db = createTestDb();
+    const cols = (db.pragma('table_info(schedules)') as Array<{ name: string }>).map((c) => c.name);
+
+    for (const col of [
+      'id',
+      'kind',
+      'repo_path',
+      'name',
+      'cron',
+      'timezone',
+      'enabled',
+      'model',
+      'timeout_ms',
+      'last_run_at',
+      'config_json',
+      'prompt',
+      'created_at',
+      'updated_at',
+    ]) {
+      expect(cols).toContain(col);
+    }
+
+    // No UNIQUE(kind, repo_path) — two rows with same kind+repo_path must succeed
+    db.prepare(
+      `INSERT INTO schedules (id, kind, repo_path, cron) VALUES ('s1', 'watcher', '/repo', '0 7 * * *')`,
+    ).run();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO schedules (id, kind, repo_path, cron) VALUES ('s2', 'watcher', '/repo', '0 8 * * *')`,
+        )
+        .run(),
+    ).not.toThrow();
+  });
+
+  it('migration idempotent: calling initDb twice leaves schedules table intact', () => {
+    const db = createTestDb();
+    db.prepare(
+      `INSERT INTO schedules (id, kind, repo_path, cron) VALUES ('s1', 'watcher', '/repo', '0 7 * * *')`,
+    ).run();
+
+    // Second initDb (re-run migrations) — uses already-imported initDb
+    initDb(db);
+
+    const rows = db.prepare('SELECT id FROM schedules').all() as Array<{ id: string }>;
+    expect(rows.map((r) => r.id)).toContain('s1');
+    const cols = (db.pragma('table_info(schedules)') as Array<{ name: string }>).map((c) => c.name);
+    expect(cols).toContain('timezone');
+  });
+
+  it('pre-migration rows preserve id and last_run_at after rebuild', () => {
+    // Use an already-initialized DB (all migrations have run), then directly
+    // write a row as if it existed before the timezone migration (no name/timezone/
+    // model/timeout_ms set). Calling initDb again must preserve id + last_run_at.
+    const db = createTestDb();
+
+    // Insert a row with only the pre-migration columns populated
+    db.prepare(
+      `INSERT INTO schedules (id, kind, repo_path, cron, last_run_at)
+       VALUES ('existing-id', 'prod-log-triage', '/live-repo', '0 7 * * *', '2026-07-23 07:00:00')`,
+    ).run();
+
+    // Re-run migrations (idempotent — timezone column already present, rebuild skipped)
+    initDb(db);
+
+    const row = db.prepare('SELECT * FROM schedules WHERE id = ?').get('existing-id') as Record<
+      string,
+      unknown
+    >;
+
+    expect(row).toBeDefined();
+    expect(row.id).toBe('existing-id');
+    expect(row.last_run_at).toBe('2026-07-23 07:00:00');
+    expect(row.kind).toBe('prod-log-triage');
+    expect(row.repo_path).toBe('/live-repo');
+    // New columns were not set — they should be NULL
+    expect(row.name).toBeNull();
+    expect(row.timezone).toBeNull();
+    expect(row.model).toBeNull();
+    expect(row.timeout_ms).toBeNull();
+  });
+});

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -909,6 +909,45 @@ export function runMigrations(instance: Database.Database): void {
   addColumn(instance, 'schedules', 'config_json', 'config_json TEXT', scheduleCols);
   addColumn(instance, 'schedules', 'prompt', 'prompt TEXT', scheduleCols);
 
+  // ── Schedule configurability: name/timezone/model/timeout_ms + drop UNIQUE
+  // (2026-07-24) ─────────────────────────────────────────────────────────────
+  // Table rebuild: adds new columns, removes UNIQUE(kind, repo_path) constraint.
+  // Idempotency guard: only run when `timezone` column is missing.
+  // Transaction-wrapped so a crash mid-rebuild cannot lose the table.
+  if (!columnsOf(instance, 'schedules').has('timezone')) {
+    instance
+      .transaction(() => {
+        instance.exec(`
+          CREATE TABLE schedules_new (
+            id            TEXT PRIMARY KEY,
+            kind          TEXT NOT NULL,
+            repo_path     TEXT NOT NULL,
+            name          TEXT,
+            cron          TEXT NOT NULL,
+            timezone      TEXT,
+            enabled       INTEGER NOT NULL DEFAULT 1,
+            model         TEXT,
+            timeout_ms    INTEGER,
+            last_run_at   TEXT,
+            config_json   TEXT,
+            prompt        TEXT,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+          )
+        `);
+        instance.exec(`
+          INSERT INTO schedules_new
+            (id, kind, repo_path, cron, enabled, last_run_at, config_json, prompt, created_at, updated_at)
+          SELECT
+            id, kind, repo_path, cron, enabled, last_run_at, config_json, prompt, created_at, updated_at
+          FROM schedules
+        `);
+        instance.exec(`DROP TABLE schedules`);
+        instance.exec(`ALTER TABLE schedules_new RENAME TO schedules`);
+      })
+      .default();
+  }
+
   // ── Link scheduled runs back to their schedule (2026-07-18, P5) ──────────
   const taskColsForSchedule = columnsOf(instance, 'tasks');
   addColumn(instance, 'tasks', 'schedule_id', 'schedule_id TEXT', taskColsForSchedule);

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -169,14 +169,17 @@ CREATE TABLE IF NOT EXISTS schedules (
   id            TEXT PRIMARY KEY,
   kind          TEXT NOT NULL,
   repo_path     TEXT NOT NULL,
+  name          TEXT,
   cron          TEXT NOT NULL,
+  timezone      TEXT,
   enabled       INTEGER NOT NULL DEFAULT 1,
+  model         TEXT,
+  timeout_ms    INTEGER,
   last_run_at   TEXT,
   config_json   TEXT,
   prompt        TEXT,
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
-  UNIQUE(kind, repo_path)
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS schedule_skills (

--- a/server/harnesses/claude-code.test.ts
+++ b/server/harnesses/claude-code.test.ts
@@ -64,7 +64,7 @@ describe('claudeCodeHarness', () => {
 describe('buildLaunchCommand model override', () => {
   it('appends --model when model is set and flags has no --model', () => {
     expect(claudeCodeHarness.buildLaunchCommand({ sessionId: 's1', model: 'sonnet' })).toBe(
-      'claude --session-id s1 --model sonnet',
+      "claude --session-id s1 --model 'sonnet'",
     );
   });
 
@@ -75,7 +75,7 @@ describe('buildLaunchCommand model override', () => {
         flags: ' --model opus',
         model: 'sonnet',
       }),
-    ).toBe('claude --session-id s1 --model sonnet');
+    ).toBe("claude --session-id s1 --model 'sonnet'");
   });
 
   it('preserves non-model flags alongside per-task model', () => {
@@ -85,7 +85,7 @@ describe('buildLaunchCommand model override', () => {
         flags: ' --dangerously-skip-permissions --model opus',
         model: 'sonnet',
       }),
-    ).toBe('claude --session-id s1 --dangerously-skip-permissions --model sonnet');
+    ).toBe("claude --session-id s1 --dangerously-skip-permissions --model 'sonnet'");
   });
 
   it('leaves flags unchanged when no per-task model', () => {
@@ -103,7 +103,7 @@ describe('buildResumeCommand model override', () => {
         flags: ' --model opus',
         model: 'sonnet',
       }),
-    ).toBe('claude --resume s1 --model sonnet');
+    ).toBe("claude --resume s1 --model 'sonnet'");
   });
 });
 
@@ -115,7 +115,7 @@ describe('buildContinueCommand model override', () => {
         flags: ' --model opus',
         model: 'sonnet',
       }),
-    ).toBe('claude --continue --session-id s1 --model sonnet');
+    ).toBe("claude --continue --session-id s1 --model 'sonnet'");
   });
 });
 

--- a/server/harnesses/shared.test.ts
+++ b/server/harnesses/shared.test.ts
@@ -76,16 +76,48 @@ describe('formatHarnessFlags', () => {
 });
 
 describe('applyModel', () => {
-  it('appends model when absent from flags', () => {
-    expect(applyModel('', 'sonnet')).toBe(' --model sonnet');
+  it('appends model when absent from flags — value is single-quoted', () => {
+    expect(applyModel('', 'claude-opus-4-8')).toBe(" --model 'claude-opus-4-8'");
   });
 
-  it('replaces existing --model token', () => {
-    expect(applyModel(' --model opus', 'sonnet')).toBe(' --model sonnet');
+  it('replaces existing --model token — new value is single-quoted', () => {
+    expect(applyModel(' --model opus', 'sonnet')).toBe(" --model 'sonnet'");
   });
 
   it('returns flags unchanged when model is unset', () => {
     expect(applyModel(' --verbose', null)).toBe(' --verbose');
+  });
+
+  it('returns flags unchanged when model is undefined', () => {
+    expect(applyModel(' --verbose', undefined)).toBe(' --verbose');
+  });
+
+  it('returns flags unchanged when model is empty string', () => {
+    expect(applyModel(' --verbose', '')).toBe(' --verbose');
+  });
+
+  it('single-quotes model containing semicolon — metacharacter cannot escape', () => {
+    // ';rm -rf /' must not execute as a second shell command
+    const result = applyModel('', 'bad;rm -rf /');
+    expect(result).toBe(" --model 'bad;rm -rf /'");
+    // The semicolon is inside single quotes — it is not an unquoted shell metacharacter
+    expect(result).toContain("'bad;rm -rf /'");
+  });
+
+  it('single-quotes model containing spaces', () => {
+    expect(applyModel('', 'my model name')).toBe(" --model 'my model name'");
+  });
+
+  it('single-quotes model containing $(...) — command substitution cannot run', () => {
+    const result = applyModel('', '$(evil-cmd)');
+    expect(result).toBe(" --model '$(evil-cmd)'");
+    // The $( is wrapped in single quotes — it will not be interpolated by the shell.
+    // The raw (unquoted) sequence $( must not appear outside of single quotes.
+    expect(result).not.toMatch(/(?<!')\$\(/);
+  });
+
+  it('simple model id round-trips as single-quoted form', () => {
+    expect(applyModel('', 'claude-opus-4-8')).toBe(" --model 'claude-opus-4-8'");
   });
 });
 

--- a/server/harnesses/shared.ts
+++ b/server/harnesses/shared.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import type { HarnessLaunchOpts, HarnessResumeOpts } from './types.js';
 import { validateAgentName } from './types.js';
+import { shellQuoteSingle } from '../shell-quote.js';
 
 /** Canonical JSON settings/config serialization (trailing newline). */
 export function formatJsonConfig(obj: unknown): string {
@@ -25,7 +26,7 @@ export function formatHarnessFlags(parts: string[]): string {
 export function applyModel(flags: string, model: string | null | undefined): string {
   if (!model) return flags;
   const stripped = flags.replace(/\s*--model\s+\S+/g, '');
-  return `${stripped} --model ${model}`;
+  return `${stripped} --model ${shellQuoteSingle(model)}`;
 }
 
 export type SettingsFieldValidator = (value: unknown) => unknown;

--- a/server/poller/execute-schedule-run.test.ts
+++ b/server/poller/execute-schedule-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import pino from 'pino';
 import { createTestDb } from '../test-helpers.js';
-import { upsertSchedule } from '../repositories/schedules.js';
+import { createSchedule } from '../repositories/schedules.js';
 import { insertRun, listRunsForSchedule } from '../repositories/runs.js';
 
 const mockRun = vi.fn().mockResolvedValue(undefined);
@@ -18,6 +19,25 @@ vi.mock('../workflows/registry.js', async (importOriginal) => {
 
 import { executeScheduleRun } from './execute-schedule-run.js';
 
+/** Collect pino JSON log lines into memory for assertions. */
+function bufferStream() {
+  const chunks: string[] = [];
+  return {
+    stream: {
+      write(chunk: string) {
+        chunks.push(chunk);
+      },
+    },
+    lines(): Array<Record<string, unknown>> {
+      return chunks
+        .join('')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+    },
+  };
+}
+
 describe('executeScheduleRun', () => {
   beforeEach(() => {
     createTestDb();
@@ -25,7 +45,7 @@ describe('executeScheduleRun', () => {
   });
 
   it('calls wf.run with the same context shape as the cron poller', async () => {
-    const row = upsertSchedule({
+    const row = createSchedule({
       kind: 'weekly-update',
       repoPath: '/repo',
       cron: '0 7 * * *',
@@ -44,7 +64,7 @@ describe('executeScheduleRun', () => {
   });
 
   it('creates a runs row when the workflow handler inserts one', async () => {
-    const row = upsertSchedule({
+    const row = createSchedule({
       kind: 'weekly-update',
       repoPath: '/repo',
       cron: '0 7 * * *',
@@ -64,5 +84,123 @@ describe('executeScheduleRun', () => {
     expect(runs).toHaveLength(1);
     expect(runs[0].workflow_kind).toBe('weekly-update');
     expect(runs[0].trigger).toBe('manual');
+  });
+
+  // ── model/timeoutMs threading ───────────────────────────────────────────────
+
+  it('threads row.model and row.timeout_ms into RunContext', async () => {
+    const row = createSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      model: 'claude-opus-4-8',
+      timeoutMs: 600000,
+    });
+
+    await executeScheduleRun(row.id, { trigger: 'cron' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-4-8',
+        timeoutMs: 600000,
+      }),
+    );
+  });
+
+  it('passes null model/timeoutMs when not set on the row', async () => {
+    const row = createSchedule({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+    });
+
+    await executeScheduleRun(row.id, { trigger: 'cron' });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: null,
+        timeoutMs: null,
+      }),
+    );
+  });
+
+  // ── run-start info log ──────────────────────────────────────────────────────
+
+  it('logs run-start info with schedule_id, kind, trigger, model, timeout_ms, prompt_source', async () => {
+    const { getLogger, setLogger } = await import('../logger.js');
+    const original = getLogger();
+    const buf = bufferStream();
+    setLogger(pino({ level: 'trace' }, buf.stream));
+
+    try {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        model: 'claude-sonnet-4-6',
+        timeoutMs: 120000,
+      });
+
+      await executeScheduleRun(row.id, { trigger: 'cron' });
+
+      const startLog = buf.lines().find((l) => l.msg === 'schedule run started');
+      expect(startLog).toBeDefined();
+      expect(startLog!.schedule_id).toBe(row.id);
+      expect(startLog!.kind).toBe('weekly-update');
+      expect(startLog!.trigger).toBe('cron');
+      expect(startLog!.model).toBe('claude-sonnet-4-6');
+      expect(startLog!.timeout_ms).toBe(120000);
+      expect(startLog!.prompt_source).toBe('kind_skill');
+    } finally {
+      setLogger(original);
+    }
+  });
+
+  it('logs prompt_source as schedule_override when schedule has a prompt', async () => {
+    const { getLogger, setLogger } = await import('../logger.js');
+    const original = getLogger();
+    const buf = bufferStream();
+    setLogger(pino({ level: 'trace' }, buf.stream));
+
+    try {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+        prompt: 'custom prompt text',
+      });
+
+      await executeScheduleRun(row.id, { trigger: 'manual' });
+
+      const startLog = buf.lines().find((l) => l.msg === 'schedule run started');
+      expect(startLog).toBeDefined();
+      expect(startLog!.prompt_source).toBe('schedule_override');
+    } finally {
+      setLogger(original);
+    }
+  });
+
+  it('logs model as "default" and timeout_ms as 300000 when row has nulls', async () => {
+    const { getLogger, setLogger } = await import('../logger.js');
+    const original = getLogger();
+    const buf = bufferStream();
+    setLogger(pino({ level: 'trace' }, buf.stream));
+
+    try {
+      const row = createSchedule({
+        kind: 'weekly-update',
+        repoPath: '/repo',
+        cron: '0 7 * * *',
+      });
+
+      await executeScheduleRun(row.id, { trigger: 'cron' });
+
+      const startLog = buf.lines().find((l) => l.msg === 'schedule run started');
+      expect(startLog).toBeDefined();
+      expect(startLog!.model).toBe('default');
+      expect(startLog!.timeout_ms).toBe(300000);
+    } finally {
+      setLogger(original);
+    }
   });
 });

--- a/server/poller/execute-schedule-run.ts
+++ b/server/poller/execute-schedule-run.ts
@@ -29,6 +29,19 @@ export async function executeScheduleRun(
 
   const config = resolveWorkflowConfig(wf, row.config_json);
   const trigger = options?.trigger ?? 'cron';
+  const promptSource = row.prompt ? 'schedule_override' : 'kind_skill';
+
+  logger.info(
+    {
+      schedule_id: row.id,
+      kind: row.kind,
+      trigger,
+      model: row.model ?? 'default',
+      timeout_ms: row.timeout_ms ?? 300000,
+      prompt_source: promptSource,
+    },
+    'schedule run started',
+  );
 
   try {
     await wf.run({
@@ -36,6 +49,8 @@ export async function executeScheduleRun(
       config,
       scheduleId: row.id,
       trigger,
+      model: row.model ?? null,
+      timeoutMs: row.timeout_ms ?? null,
     });
   } catch (err) {
     logger.error({ err, schedule_id: row.id, kind: row.kind }, 'executeScheduleRun: run failed');

--- a/server/poller/schedule-cron.test.ts
+++ b/server/poller/schedule-cron.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb } from '../test-helpers.js';
-import { upsertSchedule, listEnabledSchedules } from '../repositories/schedules.js';
+import { createSchedule, listEnabledSchedules } from '../repositories/schedules.js';
 
 const mockRun = vi.fn().mockResolvedValue(undefined);
 
@@ -24,7 +24,7 @@ describe('pollSchedules', () => {
   });
 
   it('calls the matching run handler and touches last_run_at when a schedule is due now', async () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     const now = new Date('2026-07-18T07:00:00Z');
 
     await pollSchedules(now);
@@ -39,7 +39,7 @@ describe('pollSchedules', () => {
   });
 
   it('does not call the run handler when the schedule is not due', async () => {
-    upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     const now = new Date('2026-07-18T08:00:00Z');
 
     await pollSchedules(now);
@@ -51,12 +51,83 @@ describe('pollSchedules', () => {
 
   it('does not throw when a run handler rejects, and still touches last_run_at', async () => {
     mockRun.mockRejectedValueOnce(new Error('boom'));
-    upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     const now = new Date('2026-07-18T07:00:00Z');
 
     await expect(pollSchedules(now)).resolves.toBeUndefined();
 
     const [updated] = listEnabledSchedules();
     expect(updated.last_run_at).not.toBeNull();
+  });
+
+  it('passes row.timezone to isCronDue (schedule with timezone fires at local hour)', async () => {
+    // "0 7 * * *" in America/New_York (EDT = UTC-4) fires at 11:00 UTC
+    createSchedule({
+      kind: 'prod-log-triage',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      timezone: 'America/New_York',
+    });
+    const now = new Date('2026-07-18T11:00:00Z'); // 7am EDT
+
+    await pollSchedules(now);
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when tz schedule is not due at UTC equivalent', async () => {
+    createSchedule({
+      kind: 'prod-log-triage',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      timezone: 'America/New_York',
+    });
+    const now = new Date('2026-07-18T07:00:00Z'); // 3am EDT, not 7am
+
+    await pollSchedules(now);
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  // ── Same-minute refire guard ─────────────────────────────────────────────────
+
+  it('skips a schedule whose last_run_at is in the same UTC minute as now', async () => {
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    // Simulate the schedule already having fired this minute.
+    // last_run_at uses SQLite datetime('now') format: 'YYYY-MM-DD HH:MM:SS'
+    const { getDb } = await import('../db.js');
+    getDb()
+      .prepare(`UPDATE schedules SET last_run_at = ? WHERE id = ?`)
+      .run('2026-07-18 07:00:30', row.id); // same minute as now (07:00Z)
+
+    const now = new Date('2026-07-18T07:00:55Z'); // still same minute
+
+    await pollSchedules(now);
+
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it('fires a schedule whose last_run_at is in a different UTC minute', async () => {
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '* * * * *' });
+    // last_run_at is one minute earlier — should still fire
+    const { getDb } = await import('../db.js');
+    getDb()
+      .prepare(`UPDATE schedules SET last_run_at = ? WHERE id = ?`)
+      .run('2026-07-18 06:59:30', row.id);
+
+    const now = new Date('2026-07-18T07:00:00Z');
+
+    await pollSchedules(now);
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires a schedule with null last_run_at (never run before)', async () => {
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const now = new Date('2026-07-18T07:00:00Z');
+
+    await pollSchedules(now);
+
+    expect(mockRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/poller/schedule-cron.ts
+++ b/server/poller/schedule-cron.ts
@@ -2,10 +2,26 @@ import { listEnabledSchedules } from '../repositories/schedules.js';
 import { isCronDue } from '../schedules/cron.js';
 import { executeScheduleRun } from './execute-schedule-run.js';
 
+/**
+ * Same-minute refire guard: returns true when `last_run_at` falls in the same
+ * UTC minute as `now`. This prevents double-fires from poller-tick jitter and
+ * DST fall-back (one UTC minute matching twice in a DST overlap).
+ *
+ * `last_run_at` is stored in SQLite `datetime('now')` format: 'YYYY-MM-DD HH:MM:SS' UTC.
+ */
+function isSameUtcMinute(last_run_at: string | null, now: Date): boolean {
+  if (!last_run_at) return false;
+  // Convert 'YYYY-MM-DD HH:MM:SS' → 'YYYY-MM-DDTHH:MM' for comparison
+  const lastMinute = last_run_at.slice(0, 16).replace(' ', 'T');
+  const nowMinute = now.toISOString().slice(0, 16);
+  return lastMinute === nowMinute;
+}
+
 /** Generic cron trigger: fires the registered kind's `run` for every enabled, due schedule row. */
 export async function pollSchedules(now: Date = new Date()): Promise<void> {
   for (const row of listEnabledSchedules()) {
-    if (!isCronDue(row.cron, now)) continue;
+    if (!isCronDue(row.cron, now, row.timezone)) continue;
+    if (isSameUtcMinute(row.last_run_at, now)) continue;
     await executeScheduleRun(row.id, { trigger: 'cron' });
   }
 }

--- a/server/prompt-interpolate.test.ts
+++ b/server/prompt-interpolate.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { interpolatePrompt } from './prompt-interpolate.js';
+
+describe('interpolatePrompt', () => {
+  it.each([
+    // [description, body, vars, expected]
+    ['replaces a string scalar', 'Hello, {{name}}!', { name: 'World' }, 'Hello, World!'],
+    ['replaces a number', 'Count: {{count}}', { count: 42 }, 'Count: 42'],
+    ['replaces a boolean true', 'Flag: {{ok}}', { ok: true }, 'Flag: true'],
+    ['replaces a boolean false', 'Flag: {{ok}}', { ok: false }, 'Flag: false'],
+    ['stringifies null', 'Value: {{v}}', { v: null as unknown as string }, 'Value: null'],
+    [
+      'stringifies an object via JSON.stringify',
+      'Config: {{cfg}}',
+      { cfg: { a: 1 } },
+      'Config: {"a":1}',
+    ],
+    [
+      'stringifies an array via JSON.stringify',
+      'Items: {{list}}',
+      { list: [1, 2, 3] },
+      'Items: [1,2,3]',
+    ],
+    [
+      'leaves unknown placeholder intact',
+      'Hello, {{name}} and {{unknown}}!',
+      { name: 'World' },
+      'Hello, World and {{unknown}}!',
+    ],
+    [
+      'replaces repeated occurrences of the same key',
+      '{{x}} + {{x}} = two {{x}}',
+      { x: 'foo' },
+      'foo + foo = two foo',
+    ],
+    ['empty vars — all placeholders remain', 'Hello {{a}} and {{b}}', {}, 'Hello {{a}} and {{b}}'],
+    [
+      'no placeholders — body unchanged',
+      'Plain text, no interpolation',
+      { a: 'ignored' },
+      'Plain text, no interpolation',
+    ],
+    [
+      'single pass — var containing a placeholder stays literal',
+      '{{a}}',
+      { a: '{{b}}', b: 'X' },
+      '{{b}}',
+    ],
+    [
+      'single pass — nested reference in output not expanded',
+      'start {{a}} end',
+      { a: '{{b}}', b: 'SHOULD_NOT_APPEAR' },
+      'start {{b}} end',
+    ],
+    [
+      'key with underscores and digits is matched',
+      '{{repo_path_1}}',
+      { repo_path_1: '/home/repo' },
+      '/home/repo',
+    ],
+  ] as const)(
+    '%s',
+    (_desc: string, body: string, vars: Record<string, unknown>, expected: string) => {
+      expect(interpolatePrompt(body, vars)).toBe(expected);
+    },
+  );
+});

--- a/server/prompt-interpolate.ts
+++ b/server/prompt-interpolate.ts
@@ -1,0 +1,18 @@
+/**
+ * Generic single-pass `{{key}}` interpolation for schedule prompts.
+ *
+ * Rules:
+ * - Exactly one sweep — the output is never re-scanned. A var value that contains
+ *   `{{otherKey}}` stays literal in the output (no fixpoint expansion).
+ * - Scalars (string, number, boolean, null, undefined) are stringified via `String()`.
+ * - Objects and arrays are stringified via `JSON.stringify`.
+ * - Unknown placeholders (key not present in `vars`) are left intact.
+ */
+export function interpolatePrompt(body: string, vars: Record<string, unknown>): string {
+  return body.replace(/\{\{([a-zA-Z0-9_]+)\}\}/g, (_match, key: string) => {
+    if (!(key in vars)) return _match;
+    const v = vars[key];
+    if (v !== null && typeof v === 'object') return JSON.stringify(v);
+    return String(v);
+  });
+}

--- a/server/repositories/schedules.test.ts
+++ b/server/repositories/schedules.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { createTestDb } from '../test-helpers.js';
 import {
   listEnabledSchedules,
-  upsertSchedule,
+  createSchedule,
   touchScheduleLastRun,
   listSchedules,
   getSchedule,
@@ -15,8 +15,8 @@ describe('schedules repo', () => {
     createTestDb();
   });
 
-  it('upsertSchedule inserts a new row', () => {
-    const row = upsertSchedule({
+  it('createSchedule inserts a new row', () => {
+    const row = createSchedule({
       kind: 'prod-log-triage',
       repoPath: '/repo',
       cron: '0 7 * * *',
@@ -27,25 +27,50 @@ describe('schedules repo', () => {
     expect(row.cron).toBe('0 7 * * *');
     expect(row.enabled).toBe(1);
     expect(row.last_run_at).toBeNull();
+    expect(row.name).toBeNull();
+    expect(row.timezone).toBeNull();
+    expect(row.model).toBeNull();
+    expect(row.timeout_ms).toBeNull();
+    expect(row.prompt).toBeNull();
   });
 
-  it('upsertSchedule updates on conflict (kind, repo_path)', () => {
-    const first = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
-    const second = upsertSchedule({
+  it('createSchedule stores all optional fields', () => {
+    const row = createSchedule({
+      kind: 'slack-watcher',
+      repoPath: '/repo',
+      cron: '0 8 * * *',
+      name: 'My Watcher',
+      timezone: 'America/New_York',
+      model: 'claude-opus-4-8',
+      timeoutMs: 600000,
+      prompt: 'custom prompt',
+      config: { slackUserId: 'U123' },
+    });
+
+    expect(row.name).toBe('My Watcher');
+    expect(row.timezone).toBe('America/New_York');
+    expect(row.model).toBe('claude-opus-4-8');
+    expect(row.timeout_ms).toBe(600000);
+    expect(row.prompt).toBe('custom prompt');
+    expect(row.config_json).not.toBeNull();
+    expect(JSON.parse(row.config_json as string)).toEqual({ slackUserId: 'U123' });
+  });
+
+  it('two createSchedule calls for the same (kind, repo_path) both succeed (no UNIQUE constraint)', () => {
+    const first = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const second = createSchedule({
       kind: 'prod-log-triage',
       repoPath: '/repo',
       cron: '0 8 * * *',
-      enabled: false,
     });
 
-    expect(second.id).toBe(first.id);
-    expect(second.cron).toBe('0 8 * * *');
-    expect(second.enabled).toBe(0);
+    expect(first.id).not.toBe(second.id);
+    expect(listSchedules()).toHaveLength(2);
   });
 
   it('listEnabledSchedules returns only enabled rows', () => {
-    upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
-    upsertSchedule({
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
+    createSchedule({
       kind: 'prod-log-triage',
       repoPath: '/repo-b',
       cron: '0 7 * * *',
@@ -57,8 +82,8 @@ describe('schedules repo', () => {
     expect(rows[0].repo_path).toBe('/repo-a');
   });
 
-  it('upsertSchedule stores config_json, round-trips through listEnabledSchedules', () => {
-    upsertSchedule({
+  it('createSchedule stores config_json, round-trips through listEnabledSchedules', () => {
+    createSchedule({
       kind: 'prod-log-triage',
       repoPath: '/repo',
       cron: '0 7 * * *',
@@ -73,13 +98,13 @@ describe('schedules repo', () => {
     });
   });
 
-  it('upsertSchedule without config leaves config_json null', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+  it('createSchedule without config leaves config_json null', () => {
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     expect(row.config_json).toBeNull();
   });
 
   it('touchScheduleLastRun sets last_run_at', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     expect(row.last_run_at).toBeNull();
 
     touchScheduleLastRun(row.id);
@@ -89,8 +114,8 @@ describe('schedules repo', () => {
   });
 
   it('listSchedules returns all rows, enabled and disabled', () => {
-    upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
-    upsertSchedule({
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo-a', cron: '0 7 * * *' });
+    createSchedule({
       kind: 'prod-log-triage',
       repoPath: '/repo-b',
       cron: '0 7 * * *',
@@ -102,7 +127,7 @@ describe('schedules repo', () => {
   });
 
   it('getSchedule returns a row by id', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     expect(getSchedule(row.id)).toEqual(row);
   });
 
@@ -111,7 +136,7 @@ describe('schedules repo', () => {
   });
 
   it('updateSchedule partially updates cron/enabled/config', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
 
     const updated = updateSchedule(row.id, { cron: '0 8 * * *', enabled: false });
 
@@ -121,11 +146,58 @@ describe('schedules repo', () => {
   });
 
   it('updateSchedule serializes config to config_json', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
 
     const updated = updateSchedule(row.id, { config: { maxIterations: 7 } });
 
     expect(JSON.parse(updated?.config_json as string)).toEqual({ maxIterations: 7 });
+  });
+
+  it('updateSchedule patches new fields: repoPath/name/timezone/model/timeoutMs/prompt', () => {
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+
+    const updated = updateSchedule(row.id, {
+      repoPath: '/new-repo',
+      name: 'My Schedule',
+      timezone: 'Europe/London',
+      model: 'claude-sonnet-4-6',
+      timeoutMs: 120000,
+      prompt: 'override prompt',
+    });
+
+    expect(updated?.repo_path).toBe('/new-repo');
+    expect(updated?.name).toBe('My Schedule');
+    expect(updated?.timezone).toBe('Europe/London');
+    expect(updated?.model).toBe('claude-sonnet-4-6');
+    expect(updated?.timeout_ms).toBe(120000);
+    expect(updated?.prompt).toBe('override prompt');
+  });
+
+  it('updateSchedule clears nullable fields when set to null', () => {
+    const row = createSchedule({
+      kind: 'slack-watcher',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      name: 'Named',
+      timezone: 'US/Pacific',
+      model: 'claude-opus-4-8',
+      timeoutMs: 60000,
+      prompt: 'some prompt',
+    });
+
+    const updated = updateSchedule(row.id, {
+      name: null,
+      timezone: null,
+      model: null,
+      timeoutMs: null,
+      prompt: null,
+    });
+
+    expect(updated?.name).toBeNull();
+    expect(updated?.timezone).toBeNull();
+    expect(updated?.model).toBeNull();
+    expect(updated?.timeout_ms).toBeNull();
+    expect(updated?.prompt).toBeNull();
   });
 
   it('updateSchedule returns undefined for an unknown id', () => {
@@ -133,7 +205,7 @@ describe('schedules repo', () => {
   });
 
   it('deleteSchedule removes the row', () => {
-    const row = upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
 
     deleteSchedule(row.id);
 

--- a/server/repositories/schedules.ts
+++ b/server/repositories/schedules.ts
@@ -13,45 +13,75 @@ export interface ScheduleRow {
   id: string;
   kind: string;
   repo_path: string;
+  name: string | null;
   cron: string;
+  timezone: string | null;
   enabled: number;
+  model: string | null;
+  timeout_ms: number | null;
   last_run_at: string | null;
   config_json: string | null;
+  prompt: string | null;
 }
 
-export interface UpsertScheduleInput {
+export interface CreateScheduleInput {
   kind: string;
   repoPath: string;
   cron: string;
+  name?: string;
+  timezone?: string;
   enabled?: boolean;
+  model?: string;
+  timeoutMs?: number;
   config?: Record<string, unknown>;
+  prompt?: string;
 }
 
-const SCHEDULE_COLUMNS = 'id, kind, repo_path, cron, enabled, last_run_at, config_json';
+export interface UpdateScheduleInput {
+  name?: string | null;
+  repoPath?: string;
+  cron?: string;
+  timezone?: string | null;
+  enabled?: boolean;
+  model?: string | null;
+  timeoutMs?: number | null;
+  config?: Record<string, unknown>;
+  prompt?: string | null;
+}
 
-/** Insert a schedule, or update cron/enabled/config on conflict for (kind, repo_path). */
-export function upsertSchedule(input: UpsertScheduleInput): ScheduleRow {
+const SCHEDULE_COLUMNS =
+  'id, kind, repo_path, name, cron, timezone, enabled, model, timeout_ms, last_run_at, config_json, prompt';
+
+/** Insert a new schedule row (pure insert — no upsert semantics). Returns the freshly inserted row. */
+export function createSchedule(input: CreateScheduleInput): ScheduleRow {
   const id = nanoid(12);
   const enabled = input.enabled === false ? 0 : 1;
   const configJson = input.config ? JSON.stringify(input.config) : null;
 
   getDb()
     .prepare(
-      `INSERT INTO schedules (id, kind, repo_path, cron, enabled, config_json)
-       VALUES (?, ?, ?, ?, ?, ?)
-       ON CONFLICT(kind, repo_path) DO UPDATE SET
-         cron = excluded.cron,
-         enabled = excluded.enabled,
-         config_json = excluded.config_json,
-         updated_at = datetime('now')`,
+      `INSERT INTO schedules (id, kind, repo_path, name, cron, timezone, enabled, model, timeout_ms, config_json, prompt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
-    .run(id, input.kind, input.repoPath, input.cron, enabled, configJson);
+    .run(
+      id,
+      input.kind,
+      input.repoPath,
+      input.name ?? null,
+      input.cron,
+      input.timezone ?? null,
+      enabled,
+      input.model ?? null,
+      input.timeoutMs ?? null,
+      configJson,
+      input.prompt ?? null,
+    );
 
   const row = getDb()
-    .prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules WHERE kind = ? AND repo_path = ?`)
-    .get(input.kind, input.repoPath) as ScheduleRow;
+    .prepare(`SELECT ${SCHEDULE_COLUMNS} FROM schedules WHERE id = ?`)
+    .get(id) as ScheduleRow;
 
-  logger.info({ schedule_id: row.id, kind: input.kind }, 'schedule upserted');
+  logger.info({ schedule_id: row.id, kind: input.kind }, 'schedule created');
   return row;
 }
 
@@ -83,27 +113,32 @@ export function getSchedule(id: string): ScheduleRow | undefined {
     | undefined;
 }
 
-export interface UpdateScheduleInput {
-  cron?: string;
-  enabled?: boolean;
-  config?: Record<string, unknown>;
-}
-
-/** Partially update a schedule's cron/enabled/config. Returns undefined if not found. */
+/** Partially update a schedule's fields. Returns undefined if not found. */
 export function updateSchedule(id: string, patch: UpdateScheduleInput): ScheduleRow | undefined {
   const existing = getSchedule(id);
   if (!existing) return undefined;
 
   const cron = patch.cron ?? existing.cron;
+  const repoPath = patch.repoPath ?? existing.repo_path;
   const enabled = patch.enabled === undefined ? existing.enabled : patch.enabled ? 1 : 0;
   const configJson =
     patch.config !== undefined ? JSON.stringify(patch.config) : existing.config_json;
+  // null in patch means "clear it"; undefined means "keep existing"
+  const name = 'name' in patch ? (patch.name ?? null) : existing.name;
+  const timezone = 'timezone' in patch ? (patch.timezone ?? null) : existing.timezone;
+  const model = 'model' in patch ? (patch.model ?? null) : existing.model;
+  const timeoutMs = 'timeoutMs' in patch ? (patch.timeoutMs ?? null) : existing.timeout_ms;
+  const prompt = 'prompt' in patch ? (patch.prompt ?? null) : existing.prompt;
 
   getDb()
     .prepare(
-      `UPDATE schedules SET cron = ?, enabled = ?, config_json = ?, updated_at = datetime('now') WHERE id = ?`,
+      `UPDATE schedules
+       SET cron = ?, repo_path = ?, enabled = ?, config_json = ?, name = ?,
+           timezone = ?, model = ?, timeout_ms = ?, prompt = ?,
+           updated_at = datetime('now')
+       WHERE id = ?`,
     )
-    .run(cron, enabled, configJson, id);
+    .run(cron, repoPath, enabled, configJson, name, timezone, model, timeoutMs, prompt, id);
 
   logger.info({ schedule_id: id }, 'schedule updated');
   return getSchedule(id);

--- a/server/routes/schedules.ts
+++ b/server/routes/schedules.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import type { Request, Response } from 'express';
+import { Cron } from 'croner';
 import { childLogger } from '../logger.js';
 import {
   listSchedules,
   getSchedule,
-  upsertSchedule,
+  createSchedule,
   updateSchedule,
   deleteSchedule,
 } from '../repositories/schedules.js';
@@ -12,11 +13,16 @@ import { listRunsForSchedule } from '../repositories/runs.js';
 import { getWorkflow, listCronWorkflowKinds } from '../workflows/registry.js';
 import { validateWorkflowConfig } from '../workflows/config.js';
 import { executeScheduleRun } from '../poller/execute-schedule-run.js';
+import { resolveSchedulePromptWithSource } from '../schedule-prompt.js';
 import { badRequest, notFound, ServiceError } from '../services/errors.js';
 
 const logger = childLogger('routes/schedules');
 
 export const router = express.Router();
+
+const MODEL_REGEX = /^[a-zA-Z0-9._:/-]{1,128}$/;
+const TIMEOUT_MIN = 10_000;
+const TIMEOUT_MAX = 86_400_000;
 
 function assertCronKind(kind: string): void {
   if (!listCronWorkflowKinds().includes(kind)) {
@@ -37,6 +43,60 @@ function validateScheduleConfig(kind: string, config: unknown): void {
   }
 }
 
+/**
+ * Validate a cron expression against a timezone.
+ * Throws a 400 badRequest distinguishing expression vs. timezone errors.
+ *
+ * croner does not throw at construction time for invalid timezones — it only
+ * throws on .match(). We probe with a .match() call to trigger validation.
+ * To distinguish expression errors from timezone errors, we first try with UTC:
+ * if UTC also throws, the expression is bad; otherwise the timezone is bad.
+ */
+function validateCronWithTimezone(expr: string, timezone?: string | null): void {
+  const tz = timezone ?? 'UTC';
+  try {
+    const job = new Cron(expr, { timezone: tz, paused: true });
+    // Probe to trigger timezone validation (croner validates timezone lazily on match)
+    job.match(new Date());
+  } catch (err) {
+    if (err instanceof ServiceError) throw err;
+    // Distinguish: try with UTC — if it also throws, the expression is bad;
+    // if UTC works, the timezone is the problem.
+    if (tz !== 'UTC') {
+      try {
+        const utcJob = new Cron(expr, { timezone: 'UTC', paused: true });
+        utcJob.match(new Date());
+        // Expression valid with UTC → timezone is the problem
+        throw badRequest(`invalid timezone: ${tz}`);
+      } catch (innerErr) {
+        if (innerErr instanceof ServiceError) throw innerErr;
+        // Also fails with UTC → expression is the problem
+        throw badRequest(`invalid cron expression: ${expr}`);
+      }
+    }
+    throw badRequest(`invalid cron expression: ${expr}`);
+  }
+}
+
+function validateModel(model: unknown): void {
+  if (model === null || model === undefined) return;
+  if (typeof model !== 'string' || !MODEL_REGEX.test(model)) {
+    throw badRequest('model must match ^[a-zA-Z0-9._:/-]{1,128}$');
+  }
+}
+
+function validateTimeoutMs(timeoutMs: unknown): void {
+  if (timeoutMs === null || timeoutMs === undefined) return;
+  if (
+    typeof timeoutMs !== 'number' ||
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < TIMEOUT_MIN ||
+    timeoutMs > TIMEOUT_MAX
+  ) {
+    throw badRequest(`timeoutMs must be an integer between ${TIMEOUT_MIN} and ${TIMEOUT_MAX}`);
+  }
+}
+
 // NOTE: registered before '/api/schedules/:id' — Express matches routes in
 // declaration order, so the literal 'kinds' segment must win over the :id param.
 router.get('/api/schedules/kinds', (_req: Request, res: Response) => {
@@ -47,9 +107,25 @@ router.get('/api/schedules/kinds', (_req: Request, res: Response) => {
         kind: wf.kind,
         displayName: wf.displayName,
         configSchema: wf.config ?? null,
+        execution: wf.execution ?? null,
+        promptRequired: wf.kind === 'custom',
+        supportsTimeout: wf.execution === 'session',
       };
     }),
   });
+});
+
+// NOTE: registered before '/api/schedules/:id' to avoid :id capturing 'effective-prompt'
+// is NOT needed here because Express matches the literal 'kinds' before :id only when
+// the route is registered first. effective-prompt is on /:id/effective-prompt so the
+// sub-path is distinct — but we register it early to be explicit.
+router.get('/api/schedules/:id/effective-prompt', async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const existing = getSchedule(id);
+  if (!existing) throw notFound('Schedule not found');
+
+  const result = await resolveSchedulePromptWithSource({ scheduleId: id, kind: existing.kind });
+  res.json(result);
 });
 
 router.get('/api/schedules', (_req: Request, res: Response) => {
@@ -63,6 +139,11 @@ router.post('/api/schedules', (req: Request, res: Response) => {
     cron?: unknown;
     enabled?: unknown;
     config?: unknown;
+    name?: unknown;
+    timezone?: unknown;
+    model?: unknown;
+    timeoutMs?: unknown;
+    prompt?: unknown;
   };
 
   if (typeof body.kind !== 'string') {
@@ -75,26 +156,63 @@ router.post('/api/schedules', (req: Request, res: Response) => {
   if (typeof body.cron !== 'string' || !body.cron.trim()) {
     throw badRequest('cron is required');
   }
+
+  const timezone = body.timezone !== undefined ? (body.timezone as string | null) : undefined;
+
+  // Validate cron + timezone together
+  validateCronWithTimezone(body.cron, typeof timezone === 'string' ? timezone : null);
+
+  // Validate model
+  validateModel(body.model);
+
+  // Validate timeoutMs
+  validateTimeoutMs(body.timeoutMs);
+
   validateScheduleConfig(body.kind, body.config);
 
-  const row = upsertSchedule({
+  // Determine effective enabled state
+  const enabledBool =
+    typeof body.enabled === 'boolean' ? body.enabled : body.enabled === undefined ? true : true;
+
+  // custom kind: when enabled, require non-empty prompt and non-empty name
+  if (body.kind === 'custom' && enabledBool) {
+    if (typeof body.prompt !== 'string' || !body.prompt.trim()) {
+      throw badRequest('custom schedules require a non-empty prompt');
+    }
+    if (typeof body.name !== 'string' || !body.name.trim()) {
+      throw badRequest('custom schedules require a non-empty name');
+    }
+  }
+
+  const row = createSchedule({
     kind: body.kind,
     repoPath: body.repoPath,
     cron: body.cron,
     enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
     config: body.config as Record<string, unknown> | undefined,
+    name: typeof body.name === 'string' ? body.name : undefined,
+    timezone: typeof timezone === 'string' ? timezone : undefined,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    timeoutMs: typeof body.timeoutMs === 'number' ? body.timeoutMs : undefined,
+    prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
   });
 
   logger.info({ schedule_id: row.id, kind: row.kind }, 'schedule: created via API');
   res.status(201).json(row);
 });
 
-router.patch('/api/schedules/:id', (req: Request, res: Response) => {
+router.patch('/api/schedules/:id', async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   const body = req.body as {
     cron?: unknown;
     enabled?: unknown;
     config?: unknown;
+    name?: unknown;
+    repoPath?: unknown;
+    timezone?: unknown;
+    model?: unknown;
+    timeoutMs?: unknown;
+    prompt?: unknown;
   };
 
   if (body.cron !== undefined && (typeof body.cron !== 'string' || !body.cron.trim())) {
@@ -106,15 +224,69 @@ router.patch('/api/schedules/:id', (req: Request, res: Response) => {
 
   const existing = getSchedule(id);
   if (!existing) throw notFound('Schedule not found');
+
+  // Validate cron + timezone pair (using effective values after patch)
+  const effectiveCron = typeof body.cron === 'string' ? body.cron : existing.cron;
+  const effectiveTimezone =
+    'timezone' in body ? (body.timezone as string | null | undefined) : existing.timezone;
+  validateCronWithTimezone(effectiveCron, effectiveTimezone ?? null);
+
+  // Validate model
+  validateModel(body.model);
+
+  // Validate timeoutMs
+  validateTimeoutMs(body.timeoutMs);
+
   if (body.config !== undefined) {
     validateScheduleConfig(existing.kind, body.config);
   }
 
-  const updated = updateSchedule(id, {
-    cron: body.cron as string | undefined,
-    enabled: body.enabled as boolean | undefined,
+  // custom kind: when the resulting row would be enabled, require non-empty prompt and name
+  if (existing.kind === 'custom') {
+    const effectiveEnabled =
+      typeof body.enabled === 'boolean' ? body.enabled : Boolean(existing.enabled);
+
+    if (effectiveEnabled) {
+      const effectivePrompt =
+        'prompt' in body ? (body.prompt as string | null | undefined) : existing.prompt;
+      const effectiveName =
+        'name' in body ? (body.name as string | null | undefined) : existing.name;
+
+      if (!effectivePrompt || !effectivePrompt.trim()) {
+        throw badRequest('custom schedules require a non-empty prompt');
+      }
+      if (!effectiveName || !effectiveName.trim()) {
+        throw badRequest('custom schedules require a non-empty name');
+      }
+    }
+  }
+
+  const patch: Parameters<typeof updateSchedule>[1] = {
+    cron: typeof body.cron === 'string' ? body.cron : undefined,
+    enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
     config: body.config as Record<string, unknown> | undefined,
-  });
+  };
+
+  if ('name' in body) {
+    patch.name = (body.name as string | null | undefined) ?? null;
+  }
+  if ('repoPath' in body) {
+    patch.repoPath = body.repoPath as string;
+  }
+  if ('timezone' in body) {
+    patch.timezone = (body.timezone as string | null | undefined) ?? null;
+  }
+  if ('model' in body) {
+    patch.model = (body.model as string | null | undefined) ?? null;
+  }
+  if ('timeoutMs' in body) {
+    patch.timeoutMs = (body.timeoutMs as number | null | undefined) ?? null;
+  }
+  if ('prompt' in body) {
+    patch.prompt = (body.prompt as string | null | undefined) ?? null;
+  }
+
+  const updated = updateSchedule(id, patch);
   if (!updated) throw notFound('Schedule not found');
 
   res.json(updated);

--- a/server/schedule-prompt.test.ts
+++ b/server/schedule-prompt.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb } from './test-helpers.js';
-import { upsertSchedule } from './repositories/schedules.js';
+import { createSchedule } from './repositories/schedules.js';
+import { getDb } from './db.js';
 import { getScheduleSkillRow, upsertScheduleSkill } from './repositories/schedule-skills.js';
+import { nanoid } from 'nanoid';
 
 const mockGetSkill = vi.fn();
 
@@ -11,10 +13,28 @@ vi.mock('./skills.js', () => ({
 
 import {
   resolveSchedulePrompt,
+  resolveSchedulePromptWithSource,
   resolveScheduleSkillContent,
   getDefaultPromptForKind,
   skillContentOverridesForScheduleId,
 } from './schedule-prompt.js';
+
+/** Insert a schedule row with a prompt field directly via SQL (A1 may not have landed). */
+function insertScheduleWithPrompt(opts: {
+  kind: string;
+  repoPath: string;
+  cron: string;
+  prompt: string | null;
+}): { id: string } {
+  const id = nanoid(12);
+  getDb()
+    .prepare(
+      `INSERT INTO schedules (id, kind, repo_path, cron, enabled, prompt)
+       VALUES (?, ?, ?, ?, 1, ?)`,
+    )
+    .run(id, opts.kind, opts.repoPath, opts.cron, opts.prompt);
+  return { id };
+}
 
 describe('schedule-prompt', () => {
   beforeEach(() => {
@@ -22,6 +42,8 @@ describe('schedule-prompt', () => {
     mockGetSkill.mockReset();
     mockGetSkill.mockResolvedValue({ name: 'weekly-update', content: 'Shipped SKILL body' });
   });
+
+  // ── Existing behaviour ──────────────────────────────────────────────────────
 
   it('getDefaultPromptForKind loads the shipped skill (no repo override)', async () => {
     const content = await getDefaultPromptForKind('weekly-update');
@@ -45,8 +67,17 @@ describe('schedule-prompt', () => {
     expect(mockGetSkill).not.toHaveBeenCalled();
   });
 
-  it('resolveSchedulePrompt returns the DB body and ignores the per-schedule prompt', async () => {
-    const row = upsertSchedule({ kind: 'weekly-update', repoPath: '/repo', cron: '0 7 * * *' });
+  it('editing the DB row changes the resolved prompt', async () => {
+    await resolveScheduleSkillContent('weekly-update'); // seed
+    upsertScheduleSkill('weekly-update', 'Newly edited body');
+
+    expect(await resolveSchedulePrompt({ kind: 'weekly-update' })).toBe('Newly edited body');
+  });
+
+  // ── resolveSchedulePrompt / resolveSchedulePromptWithSource precedence ──────
+
+  it('resolveSchedulePrompt returns kind skill when schedule has no prompt override', async () => {
+    const row = createSchedule({ kind: 'weekly-update', repoPath: '/repo', cron: '0 7 * * *' });
     upsertScheduleSkill('weekly-update', 'Edited DB body');
 
     const content = await resolveSchedulePrompt({
@@ -59,15 +90,94 @@ describe('schedule-prompt', () => {
     expect(mockGetSkill).not.toHaveBeenCalled();
   });
 
-  it('editing the DB row changes the resolved prompt', async () => {
-    await resolveScheduleSkillContent('weekly-update'); // seed
-    upsertScheduleSkill('weekly-update', 'Newly edited body');
+  it('resolveSchedulePromptWithSource returns kind_skill when no per-schedule override', async () => {
+    const row = createSchedule({ kind: 'weekly-update', repoPath: '/repo', cron: '0 7 * * *' });
+    upsertScheduleSkill('weekly-update', 'Kind skill body');
 
-    expect(await resolveSchedulePrompt({ kind: 'weekly-update' })).toBe('Newly edited body');
+    const result = await resolveSchedulePromptWithSource({
+      scheduleId: row.id,
+      kind: 'weekly-update',
+    });
+
+    expect(result).toEqual({ content: 'Kind skill body', source: 'kind_skill' });
   });
 
-  it('skillContentOverridesForScheduleId always injects the DB body for task-backed kinds', async () => {
-    const row = upsertSchedule({ kind: 'doc-drift', repoPath: '/repo', cron: '0 7 * * *' });
+  it('resolveSchedulePromptWithSource returns override when schedule.prompt is non-empty', async () => {
+    const { id } = insertScheduleWithPrompt({
+      kind: 'weekly-update',
+      repoPath: '/repo',
+      cron: '0 7 * * *',
+      prompt: 'My custom override prompt',
+    });
+    upsertScheduleSkill('weekly-update', 'Should not be used');
+
+    const result = await resolveSchedulePromptWithSource({
+      scheduleId: id,
+      kind: 'weekly-update',
+    });
+
+    expect(result).toEqual({ content: 'My custom override prompt', source: 'override' });
+    expect(mockGetSkill).not.toHaveBeenCalled();
+  });
+
+  it('resolveSchedulePrompt honors non-empty schedule.prompt over kind skill', async () => {
+    const { id } = insertScheduleWithPrompt({
+      kind: 'weekly-update',
+      repoPath: '/repo2',
+      cron: '0 8 * * *',
+      prompt: 'Override wins',
+    });
+    upsertScheduleSkill('weekly-update', 'Kind skill body');
+
+    const content = await resolveSchedulePrompt({
+      scheduleId: id,
+      kind: 'weekly-update',
+    });
+
+    expect(content).toBe('Override wins');
+  });
+
+  it('resolveSchedulePromptWithSource returns kind_skill when schedule.prompt is null', async () => {
+    const { id } = insertScheduleWithPrompt({
+      kind: 'weekly-update',
+      repoPath: '/repo3',
+      cron: '0 9 * * *',
+      prompt: null,
+    });
+    upsertScheduleSkill('weekly-update', 'Kind skill fallback');
+
+    const result = await resolveSchedulePromptWithSource({
+      scheduleId: id,
+      kind: 'weekly-update',
+    });
+
+    expect(result).toEqual({ content: 'Kind skill fallback', source: 'kind_skill' });
+  });
+
+  it('resolveSchedulePromptWithSource falls through to kind skill when scheduleId is absent', async () => {
+    upsertScheduleSkill('slack-watcher', 'Slack watcher skill');
+    mockGetSkill.mockResolvedValue({ name: 'slack-watcher', content: 'Slack watcher skill' });
+
+    const result = await resolveSchedulePromptWithSource({ kind: 'slack-watcher' });
+
+    expect(result.source).toBe('kind_skill');
+    expect(result.content).toBe('Slack watcher skill');
+  });
+
+  it('resolveSchedulePromptWithSource lazily seeds the kind skill from SKILL.md', async () => {
+    mockGetSkill.mockResolvedValue({ name: 'daily-plan', content: 'Daily plan shipped body' });
+
+    const result = await resolveSchedulePromptWithSource({ kind: 'daily-plan' });
+
+    expect(result.source).toBe('kind_skill');
+    expect(result.content).toBe('Daily plan shipped body');
+    expect(getScheduleSkillRow('daily-plan')?.content).toBe('Daily plan shipped body');
+  });
+
+  // ── skillContentOverridesForScheduleId ─────────────────────────────────────
+
+  it('skillContentOverridesForScheduleId injects DB body for task-backed kinds (no override)', async () => {
+    const row = createSchedule({ kind: 'doc-drift', repoPath: '/repo', cron: '0 7 * * *' });
     mockGetSkill.mockResolvedValue({ name: 'doc-drift', content: 'Doc drift body' });
 
     expect(await skillContentOverridesForScheduleId(row.id)).toEqual({
@@ -75,8 +185,36 @@ describe('schedule-prompt', () => {
     });
   });
 
+  it('skillContentOverridesForScheduleId uses schedule.prompt override for doc-drift', async () => {
+    const { id } = insertScheduleWithPrompt({
+      kind: 'doc-drift',
+      repoPath: '/override-repo',
+      cron: '0 7 * * *',
+      prompt: 'My doc-drift override',
+    });
+
+    const result = await skillContentOverridesForScheduleId(id);
+
+    expect(result).toEqual({ 'doc-drift': 'My doc-drift override' });
+    expect(mockGetSkill).not.toHaveBeenCalled();
+  });
+
+  it('skillContentOverridesForScheduleId uses schedule.prompt override for prod-log-triage', async () => {
+    const { id } = insertScheduleWithPrompt({
+      kind: 'prod-log-triage',
+      repoPath: '/triage-repo',
+      cron: '0 7 * * *',
+      prompt: 'My triage override',
+    });
+
+    const result = await skillContentOverridesForScheduleId(id);
+
+    expect(result).toEqual({ 'prod-log-triage': 'My triage override' });
+    expect(mockGetSkill).not.toHaveBeenCalled();
+  });
+
   it('skillContentOverridesForScheduleId returns undefined for non-task-backed kinds', async () => {
-    const row = upsertSchedule({ kind: 'weekly-update', repoPath: '/repo', cron: '0 7 * * *' });
+    const row = createSchedule({ kind: 'weekly-update', repoPath: '/repo', cron: '0 7 * * *' });
     expect(await skillContentOverridesForScheduleId(row.id)).toBeUndefined();
   });
 
@@ -84,4 +222,24 @@ describe('schedule-prompt', () => {
     expect(await skillContentOverridesForScheduleId(null)).toBeUndefined();
     expect(await skillContentOverridesForScheduleId('nope')).toBeUndefined();
   });
+
+  it.each([
+    ['null prompt', null, 'kind_skill'],
+    ['empty-string prompt is treated as falsy', '', 'kind_skill'],
+  ] as const)(
+    'skillContentOverridesForScheduleId falls back to kind skill when prompt is %s',
+    async (_label, promptValue, _expectedSource) => {
+      mockGetSkill.mockResolvedValue({ name: 'doc-drift', content: 'Doc drift skill body' });
+      const { id } = insertScheduleWithPrompt({
+        kind: 'doc-drift',
+        repoPath: `/repo-${nanoid(4)}`,
+        cron: '0 7 * * *',
+        prompt: promptValue,
+      });
+
+      const result = await skillContentOverridesForScheduleId(id);
+
+      expect(result).toEqual({ 'doc-drift': 'Doc drift skill body' });
+    },
+  );
 });

--- a/server/schedule-prompt.ts
+++ b/server/schedule-prompt.ts
@@ -1,14 +1,21 @@
 /**
  * Resolve workflow prompts for cron schedules. The DB `schedule_skills` table
  * is the single source of truth: one editable body per cron kind, lazily
- * seeded once from the shipped SKILL.md the first time a kind is read. There is
- * no per-schedule override and no SKILL.md runtime fallback. Task-backed kinds
- * pass the DB body into harness plugin flags via an ephemeral overlay plugin
- * at launch (`appendOctomuxPluginFlags`).
+ * seeded once from the shipped SKILL.md the first time a kind is read.
+ *
+ * Resolution precedence (§4.1):
+ *   1. `schedules.prompt` for the given `scheduleId` — if non-empty, use it.
+ *   2. `schedule_skills[kind]` — lazily seeded from shipped SKILL.md (unchanged).
+ *
+ * Task-backed kinds pass the resolved body into harness plugin flags via an
+ * ephemeral overlay plugin at launch (`appendOctomuxPluginFlags`).
  */
 import { getSkill } from './skills.js';
 import { getSchedule } from './repositories/schedules.js';
 import { getScheduleSkillRow, upsertScheduleSkill } from './repositories/schedule-skills.js';
+import { childLogger } from './logger.js';
+
+const logger = childLogger('schedule-prompt');
 
 export const CRON_PROMPT_KINDS = [
   'doc-drift',
@@ -48,13 +55,45 @@ export async function resolveScheduleSkillContent(kind: string): Promise<string>
   return seed;
 }
 
-/** The workflow prompt for a scheduled run — always the DB body for the kind. */
+/**
+ * Resolve the workflow prompt for a scheduled run, returning both the content
+ * and its source so callers can log or expose the resolution path.
+ *
+ * Precedence:
+ *   1. schedules.prompt (non-empty) → source: 'override'
+ *   2. schedule_skills[kind] (lazy-seeded from SKILL.md) → source: 'kind_skill'
+ */
+export async function resolveSchedulePromptWithSource(input: {
+  scheduleId?: string | null;
+  kind: string;
+}): Promise<{ content: string; source: 'override' | 'kind_skill' }> {
+  if (input.scheduleId) {
+    const schedule = getSchedule(input.scheduleId);
+    if (schedule && schedule.prompt) {
+      logger.debug(
+        { schedule_id: input.scheduleId, kind: input.kind, prompt_source: 'override' },
+        'resolved schedule prompt',
+      );
+      return { content: schedule.prompt, source: 'override' };
+    }
+  }
+
+  const content = await resolveScheduleSkillContent(input.kind);
+  logger.debug(
+    { schedule_id: input.scheduleId ?? null, kind: input.kind, prompt_source: 'kind_skill' },
+    'resolved schedule prompt',
+  );
+  return { content, source: 'kind_skill' };
+}
+
+/** The workflow prompt for a scheduled run — respects per-schedule override. */
 export async function resolveSchedulePrompt(input: {
   scheduleId?: string | null;
   kind: string;
   repoPath?: string;
 }): Promise<string> {
-  return resolveScheduleSkillContent(input.kind);
+  const { content } = await resolveSchedulePromptWithSource(input);
+  return content;
 }
 
 /**
@@ -62,6 +101,9 @@ export async function resolveSchedulePrompt(input: {
  * the agent reads the DB skill body via an ephemeral overlay plugin. Always
  * injects the DB body for doc-drift / prod-log-triage; undefined for every
  * other kind.
+ *
+ * When `schedule.prompt` is non-empty the override wins; otherwise falls back
+ * to the kind skill body as today.
  */
 export async function skillContentOverridesForScheduleId(
   scheduleId: string | null | undefined,
@@ -69,5 +111,22 @@ export async function skillContentOverridesForScheduleId(
   if (!scheduleId) return undefined;
   const schedule = getSchedule(scheduleId);
   if (!schedule || !TASK_BACKED_KINDS.has(schedule.kind)) return undefined;
+
+  if (schedule.prompt) {
+    logger.debug(
+      {
+        schedule_id: scheduleId,
+        kind: schedule.kind,
+        prompt_source: 'schedule_override',
+      },
+      'skillContentOverrides: using schedule prompt override',
+    );
+    return { [schedule.kind]: schedule.prompt };
+  }
+
+  logger.debug(
+    { schedule_id: scheduleId, kind: schedule.kind, prompt_source: 'kind_skill' },
+    'skillContentOverrides: using kind skill body',
+  );
   return { [schedule.kind]: await resolveScheduleSkillContent(schedule.kind) };
 }

--- a/server/schedules/cron.test.ts
+++ b/server/schedules/cron.test.ts
@@ -2,17 +2,91 @@ import { describe, it, expect } from 'vitest';
 import { isCronDue } from './cron.js';
 
 describe('isCronDue', () => {
+  // ── Original UTC cases ──────────────────────────────────────────────────────
+
   it.each([
-    ['* * * * *', new Date('2026-07-18T07:00:00Z'), true],
-    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), true],
-    ['0 7 * * *', new Date('2026-07-18T07:01:00Z'), false],
-    ['0 7 * * 1-5', new Date('2026-07-20T07:00:00Z'), true], // Mon
-    ['0 7 * * 1-5', new Date('2026-07-18T07:00:00Z'), false], // Sat
-    ['not a cron', new Date('2026-07-18T07:00:00Z'), false],
-    // Regression: the poller passes wall-clock `now` with non-zero seconds.
-    // A due schedule must fire anywhere within its minute, not only at :00.
-    ['* * * * *', new Date('2026-07-18T07:00:37Z'), true],
-    ['0 7 * * *', new Date('2026-07-18T07:00:45.912Z'), true],
-    ['0 7 * * *', new Date('2026-07-18T07:01:30Z'), false],
-  ])('%s @ %s → %s', (e, n, d) => expect(isCronDue(e, n)).toBe(d));
+    ['* * * * *', new Date('2026-07-18T07:00:00Z'), undefined, true],
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), undefined, true],
+    ['0 7 * * *', new Date('2026-07-18T07:01:00Z'), undefined, false],
+    ['0 7 * * 1-5', new Date('2026-07-20T07:00:00Z'), undefined, true], // Mon
+    ['0 7 * * 1-5', new Date('2026-07-18T07:00:00Z'), undefined, false], // Sat
+    ['not a cron', new Date('2026-07-18T07:00:00Z'), undefined, false],
+    // Regression: non-zero seconds within the due minute must still match
+    ['* * * * *', new Date('2026-07-18T07:00:37Z'), undefined, true],
+    ['0 7 * * *', new Date('2026-07-18T07:00:45.912Z'), undefined, true],
+    ['0 7 * * *', new Date('2026-07-18T07:01:30Z'), undefined, false],
+  ])('%s @ %s (tz=%s) → %s', (e, n, tz, d) => expect(isCronDue(e, n, tz)).toBe(d));
+
+  // ── Explicit UTC still works ────────────────────────────────────────────────
+
+  it.each([
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), 'UTC', true],
+    ['0 7 * * *', new Date('2026-07-18T07:01:00Z'), 'UTC', false],
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), null, true],
+  ])('%s @ %s tz=%s → %s', (e, n, tz, d) => expect(isCronDue(e, n, tz)).toBe(d));
+
+  // ── Offset timezone: America/New_York (UTC-4 in summer / EDT) ──────────────
+  // "0 7 * * *" in America/New_York fires at 11:00 UTC in summer (EDT = UTC-4)
+
+  it.each([
+    // Due: 07:00 EDT = 11:00 UTC
+    ['0 7 * * *', new Date('2026-07-18T11:00:00Z'), 'America/New_York', true],
+    // Not due: 07:00 UTC (= 03:00 EDT, not 07:00 EDT)
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), 'America/New_York', false],
+    // Non-zero seconds within due minute still match
+    ['0 7 * * *', new Date('2026-07-18T11:00:45Z'), 'America/New_York', true],
+  ])('%s @ %s in America/New_York → %s', (e, n, tz, d) => expect(isCronDue(e, n, tz)).toBe(d));
+
+  // ── DST spring-forward: America/New_York 2026-03-08 (clocks forward at 02:00) ──
+  // At 02:00 EST clocks jump to 03:00 EDT.
+  // EDT = UTC-4, so 3am EDT = 07:00Z.
+  // "0 3 * * *" in America/New_York fires at 07:00Z on spring-forward day.
+
+  it('DST spring-forward: 0 3 * * * in America/New_York fires at 07:00Z (3am EDT)', () => {
+    const springForwardDay = new Date('2026-03-08T07:00:00Z'); // 3am EDT = 07:00Z
+    expect(isCronDue('0 3 * * *', springForwardDay, 'America/New_York')).toBe(true);
+  });
+
+  it('DST spring-forward: does not match 08:00Z (different hour)', () => {
+    const wrongHour = new Date('2026-03-08T08:00:00Z'); // 4am EDT
+    expect(isCronDue('0 3 * * *', wrongHour, 'America/New_York')).toBe(false);
+  });
+
+  // ── DST fall-back: America/New_York 2026-11-01 (clocks back at 02:00) ──────
+  // At 02:00 EDT clocks fall back to 01:00 EST; 01:00 local appears twice.
+  // "0 1 * * *" in America/New_York: first occurrence is at 05:00Z (1am EDT),
+  // second occurrence at 06:00Z (1am EST). The same-minute guard in the poller
+  // handles double-fire; isCronDue itself may match both.
+  // We verify it matches at the first occurrence UTC instant.
+
+  it('DST fall-back: 0 1 * * * in America/New_York matches first occurrence (05:00Z)', () => {
+    const firstOccurrence = new Date('2026-11-01T05:00:00Z'); // 1am EDT
+    expect(isCronDue('0 1 * * *', firstOccurrence, 'America/New_York')).toBe(true);
+  });
+
+  // ── Invalid timezone → false (never crash) ──────────────────────────────────
+
+  it.each([
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), 'Not/AZone'],
+    ['0 7 * * *', new Date('2026-07-18T07:00:00Z'), 'Mars/Olympus'],
+  ])('%s in invalid tz %s → false', (e, n, tz) => {
+    expect(isCronDue(e, n, tz)).toBe(false);
+  });
+
+  // ── Compound cache key: same expr, different timezones cached independently ──
+  // "0 12 * * *" at noon UTC fires at:
+  //   UTC       → 12:00Z
+  //   Asia/Tokyo (UTC+9) → 03:00Z
+
+  it('same expr in UTC and Asia/Tokyo are cached independently', () => {
+    const utcNoon = new Date('2026-07-18T12:00:00Z');
+    const tokyoNoon = new Date('2026-07-18T03:00:00Z'); // 12:00 JST = 03:00 UTC
+
+    expect(isCronDue('0 12 * * *', utcNoon, 'UTC')).toBe(true);
+    expect(isCronDue('0 12 * * *', tokyoNoon, 'Asia/Tokyo')).toBe(true);
+
+    // And they don't cross-contaminate:
+    expect(isCronDue('0 12 * * *', tokyoNoon, 'UTC')).toBe(false);
+    expect(isCronDue('0 12 * * *', utcNoon, 'Asia/Tokyo')).toBe(false);
+  });
 });

--- a/server/schedules/cron.ts
+++ b/server/schedules/cron.ts
@@ -3,21 +3,27 @@ import { Cron } from 'croner';
 const cache = new Map<string, Cron>();
 
 /**
- * Returns true when 5-field `expr` is due during the minute containing `now` (UTC).
- * Invalid expressions never match.
+ * Returns true when 5-field `expr` is due during the minute containing `now`,
+ * evaluated in the given `timezone` (IANA zone; defaults to 'UTC').
+ * Invalid expressions or unknown timezones never match.
+ *
+ * Cache key: `${timezone ?? 'UTC'}\n${expr}` — \n cannot appear in a valid
+ * cron expression (croner rejects it), so this is collision-free.
  *
  * NOTE: croner's `.match()` is second-exact, but the poller passes wall-clock
  * `new Date()` (arbitrary seconds), so matching `now` directly would only ever
  * fire on the rare tick that lands on `:00`. We normalize to the start of the
  * minute so a schedule fires anywhere within its due minute.
  */
-export function isCronDue(expr: string, now: Date): boolean {
+export function isCronDue(expr: string, now: Date, timezone?: string | null): boolean {
   try {
-    let job = cache.get(expr);
+    const tz = timezone ?? 'UTC';
+    const cacheKey = `${tz}\n${expr}`;
+    let job = cache.get(cacheKey);
     // paused:true is REQUIRED — croner won't arm a timer for a callback-less job
     if (!job) {
-      job = new Cron(expr, { timezone: 'UTC', paused: true });
-      cache.set(expr, job);
+      job = new Cron(expr, { timezone: tz, paused: true });
+      cache.set(cacheKey, job);
     }
     const atMinute = new Date(now);
     atMinute.setUTCSeconds(0, 0);

--- a/server/services/output-contract.ts
+++ b/server/services/output-contract.ts
@@ -11,6 +11,9 @@ export interface ValidationResult {
 }
 
 const ajv = new Ajv({ allErrors: true, strict: true });
+// 'single-line' is a UI rendering hint on workflow config schemas, not a
+// validation format — register it as always-valid so strict mode accepts it.
+ajv.addFormat('single-line', true);
 const compiled = new Map<string, ValidateFunction>();
 
 /**

--- a/server/services/session-vertical-service.test.ts
+++ b/server/services/session-vertical-service.test.ts
@@ -70,4 +70,53 @@ describe('runSessionVertical', () => {
     expect(call.model).toBeNull();
     expect(call.run.scheduleId).toBeUndefined();
   });
+
+  it('passes timeoutMs through to runAgentSession when provided', async () => {
+    mockGetHarness.mockReturnValue({ id: 'claude-code' });
+    mockRunAgentSession.mockResolvedValue({ result: {} });
+
+    await runSessionVertical({
+      kind: 'weekly-update',
+      workspaceDir: '/repo',
+      input: 'do the weekly update',
+      outputSchema: {},
+      model: 'claude-sonnet-4-6',
+      timeoutMs: 600_000,
+    });
+
+    const call = mockRunAgentSession.mock.calls[0][0];
+    expect(call.timeoutMs).toBe(600_000);
+    expect(call.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('passes undefined for timeoutMs when omitted', async () => {
+    mockGetHarness.mockReturnValue({ id: 'claude-code' });
+    mockRunAgentSession.mockResolvedValue({ result: {} });
+
+    await runSessionVertical({
+      kind: 'weekly-update',
+      workspaceDir: '/repo',
+      input: 'x',
+      outputSchema: {},
+    });
+
+    const call = mockRunAgentSession.mock.calls[0][0];
+    expect(call.timeoutMs).toBeUndefined();
+  });
+
+  it('passes undefined for timeoutMs when explicitly null', async () => {
+    mockGetHarness.mockReturnValue({ id: 'claude-code' });
+    mockRunAgentSession.mockResolvedValue({ result: {} });
+
+    await runSessionVertical({
+      kind: 'weekly-update',
+      workspaceDir: '/repo',
+      input: 'x',
+      outputSchema: {},
+      timeoutMs: null,
+    });
+
+    const call = mockRunAgentSession.mock.calls[0][0];
+    expect(call.timeoutMs).toBeUndefined();
+  });
 });

--- a/server/services/session-vertical-service.ts
+++ b/server/services/session-vertical-service.ts
@@ -17,6 +17,7 @@ export interface RunSessionVerticalInput {
   input: string;
   outputSchema: object;
   model?: string | null;
+  timeoutMs?: number | null;
   trigger?: 'cron' | 'manual';
 }
 
@@ -30,6 +31,7 @@ export async function runSessionVertical<T = unknown>(
     substrate: ptySubstrate,
     outputSchema: i.outputSchema,
     model: i.model ?? null,
+    timeoutMs: i.timeoutMs ?? undefined,
     run: {
       workflowKind: i.kind,
       trigger: i.trigger ?? 'cron',

--- a/server/task-engine.test.ts
+++ b/server/task-engine.test.ts
@@ -295,7 +295,9 @@ describe('startTask', () => {
     insertTask(db);
     await startTask({ ...DEFAULTS.task, model: 'claude-sonnet-4-6' } as any);
 
-    expect(findLaunchCmd()).toContain('--model claude-sonnet-4-6');
+    // the launch cmd is itself single-quoted into `zsh -ic '...'`, so the quoted
+    // model value appears in its shell-escaped '\\'' form
+    expect(findLaunchCmd()).toContain("--model '\\''claude-sonnet-4-6'\\''");
   });
 
   // ─── Worker MCP config for orchestrator-managed tasks (SHR-160) ────────

--- a/server/workflows/config.ts
+++ b/server/workflows/config.ts
@@ -4,6 +4,9 @@ import { validateAgainstSchema } from '../services/output-contract.js';
 import type { WorkflowType } from './types.js';
 
 const ajv = new Ajv({ allErrors: true, strict: true, useDefaults: true });
+// 'single-line' is a UI rendering hint (SchemaConfigForm renders Input vs Textarea),
+// not a validation format — register it as always-valid so strict mode accepts it.
+ajv.addFormat('single-line', true);
 
 export function validateWorkflowConfig(
   wf: WorkflowType,

--- a/server/workflows/custom/index.test.ts
+++ b/server/workflows/custom/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getWorkflow, listCronWorkflowKinds } from '../registry.js';
+
+const mockRunCustom = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./run.js', () => ({
+  runCustom: (...args: unknown[]) => mockRunCustom(...args),
+}));
+
+import './index.js';
+
+describe('custom workflow registration', () => {
+  beforeEach(() => {
+    mockRunCustom.mockClear();
+  });
+
+  it('registers the custom kind in the workflow registry', () => {
+    const wf = getWorkflow('custom');
+    expect(wf).toBeDefined();
+    expect(wf?.displayName).toBe('Custom Prompt');
+    expect(wf?.surfaces).toEqual(['artifact']);
+    expect(wf?.execution).toBe('session');
+    expect(wf?.trigger).toEqual({ kind: 'cron' });
+    expect(wf?.run).toBeTypeOf('function');
+  });
+
+  it('appears in listCronWorkflowKinds()', () => {
+    const kinds = listCronWorkflowKinds();
+    expect(kinds).toContain('custom');
+  });
+
+  it('has no config schema (custom kind has no structured config in v1)', () => {
+    const wf = getWorkflow('custom')!;
+    expect(wf.config).toBeUndefined();
+  });
+
+  it('calls runCustom with the context fields and returns immediately (fire-and-forget)', async () => {
+    const wf = getWorkflow('custom')!;
+    const result = wf.run!({
+      repoPath: '/repo',
+      config: {},
+      scheduleId: 'sched-123',
+      model: 'claude-opus-4-8',
+      timeoutMs: 60000,
+      trigger: 'manual',
+    });
+
+    // The run() function returns Promise.resolve() immediately without awaiting runCustom
+    await result;
+
+    // Allow the void promise chain to flush
+    await Promise.resolve();
+
+    expect(mockRunCustom).toHaveBeenCalledTimes(1);
+    expect(mockRunCustom).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      scheduleId: 'sched-123',
+      model: 'claude-opus-4-8',
+      timeoutMs: 60000,
+      trigger: 'manual',
+    });
+  });
+
+  it('passes empty string scheduleId when ctx.scheduleId is undefined', async () => {
+    const wf = getWorkflow('custom')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: {},
+    });
+    await Promise.resolve();
+
+    expect(mockRunCustom).toHaveBeenCalledWith(expect.objectContaining({ scheduleId: '' }));
+  });
+});

--- a/server/workflows/custom/index.ts
+++ b/server/workflows/custom/index.ts
@@ -1,0 +1,33 @@
+import { registerWorkflow } from '../registry.js';
+import { childLogger } from '../../logger.js';
+import { runCustom } from './run.js';
+import type { RunContext, WorkflowType } from '../types.js';
+
+const logger = childLogger('workflows/custom');
+
+export const customWorkflow: WorkflowType = {
+  kind: 'custom',
+  displayName: 'Custom Prompt',
+  surfaces: ['artifact'],
+  execution: 'session',
+  trigger: { kind: 'cron' },
+  run: (ctx: RunContext) => {
+    logger.info({ repo_path: ctx.repoPath, schedule_id: ctx.scheduleId }, 'custom: schedule fired');
+
+    void runCustom({
+      repoPath: ctx.repoPath,
+      scheduleId: ctx.scheduleId ?? '',
+      model: ctx.model,
+      timeoutMs: ctx.timeoutMs,
+      trigger: ctx.trigger,
+    }).catch((err) => {
+      logger.error(
+        { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
+        'custom: run failed',
+      );
+    });
+    return Promise.resolve();
+  },
+};
+
+registerWorkflow(customWorkflow);

--- a/server/workflows/custom/run.test.ts
+++ b/server/workflows/custom/run.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestDb } from '../../test-helpers.js';
+import { createSchedule } from '../../repositories/schedules.js';
+import { listRunsForSchedule } from '../../repositories/runs.js';
+
+// ─── Mock runSessionVertical ─────────────────────────────────────────────────
+
+const mockRunSessionVertical = vi
+  .fn()
+  .mockResolvedValue({ result: { outcome: 'done', summary: 'ok' } });
+
+vi.mock('../../services/session-vertical-service.js', () => ({
+  runSessionVertical: (...args: unknown[]) => mockRunSessionVertical(...args),
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+import { runCustom } from './run.js';
+
+describe('runCustom', () => {
+  beforeEach(() => {
+    createTestDb();
+    mockRunSessionVertical.mockClear();
+    mockRunSessionVertical.mockResolvedValue({ result: { outcome: 'done', summary: 'ok' } });
+  });
+
+  it('inserts a failed run row and returns when the schedule has no prompt', async () => {
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      // no prompt
+    });
+
+    await runCustom({
+      repoPath: '/repo',
+      scheduleId: schedule.id,
+      trigger: 'manual',
+    });
+
+    expect(mockRunSessionVertical).not.toHaveBeenCalled();
+
+    const runs = listRunsForSchedule(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].workflow_kind).toBe('custom');
+    expect(runs[0].status).toBe('failed');
+    expect(runs[0].ended_at).not.toBeNull();
+
+    const result = JSON.parse(runs[0].result_json!);
+    expect(result.outcome).toBe('failed');
+    expect(result.summary).toBe('Custom schedule has no prompt.');
+  });
+
+  it('inserts a failed run row and returns when the schedule prompt is empty string', async () => {
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      prompt: '',
+    });
+
+    await runCustom({
+      repoPath: '/repo',
+      scheduleId: schedule.id,
+      trigger: 'cron',
+    });
+
+    expect(mockRunSessionVertical).not.toHaveBeenCalled();
+
+    const runs = listRunsForSchedule(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('failed');
+  });
+
+  it('inserts a failed run row when the schedule does not exist', async () => {
+    await runCustom({
+      repoPath: '/repo',
+      scheduleId: 'nonexistent-id',
+      trigger: 'cron',
+    });
+
+    expect(mockRunSessionVertical).not.toHaveBeenCalled();
+  });
+
+  it('happy path: calls runSessionVertical with prompt, model, timeoutMs, and trigger', async () => {
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      prompt: 'Generate a weekly summary for {{repo}}.',
+    });
+
+    await runCustom({
+      repoPath: '/repo',
+      scheduleId: schedule.id,
+      model: 'claude-opus-4-8',
+      timeoutMs: 120000,
+      trigger: 'manual',
+    });
+
+    expect(mockRunSessionVertical).toHaveBeenCalledTimes(1);
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.kind).toBe('custom');
+    expect(call.scheduleId).toBe(schedule.id);
+    expect(call.workspaceDir).toBe('/repo');
+    // Prompt passed through (unknown placeholders left intact by interpolatePrompt)
+    expect(call.input).toBe('Generate a weekly summary for {{repo}}.');
+    expect(call.model).toBe('claude-opus-4-8');
+    expect(call.timeoutMs).toBe(120000);
+    expect(call.trigger).toBe('manual');
+  });
+
+  it('happy path: outputSchema has additionalProperties: false and required outcome+summary', async () => {
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      prompt: 'Run my custom check.',
+    });
+
+    await runCustom({
+      repoPath: '/repo',
+      scheduleId: schedule.id,
+      trigger: 'cron',
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.outputSchema).toMatchObject({
+      type: 'object',
+      required: ['outcome', 'summary'],
+      additionalProperties: false,
+    });
+    expect(call.outputSchema.properties).toHaveProperty('outcome');
+    expect(call.outputSchema.properties).toHaveProperty('summary');
+  });
+
+  it('happy path: defaults trigger to cron when not provided', async () => {
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      prompt: 'Hello.',
+    });
+
+    await runCustom({ repoPath: '/repo', scheduleId: schedule.id });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.trigger).toBe('cron');
+  });
+
+  it('does not double-insert a run row on the happy path (runSessionVertical owns it)', async () => {
+    // runSessionVertical is mocked and handles its own run row internally.
+    // We verify runCustom does NOT call insertRun before handing off to runSessionVertical.
+    // The only way to detect a double-insert is to check that listRunsForSchedule returns
+    // exactly 0 rows (since the mock doesn't actually insert). If runCustom inserted its
+    // own row, we'd see 1.
+    const schedule = createSchedule({
+      kind: 'custom',
+      repoPath: '/repo',
+      cron: '0 9 * * *',
+      prompt: 'Do something.',
+    });
+
+    await runCustom({ repoPath: '/repo', scheduleId: schedule.id, trigger: 'cron' });
+
+    // Mock doesn't actually insert a runs row — if runCustom did, we'd see 1.
+    const runs = listRunsForSchedule(schedule.id);
+    expect(runs).toHaveLength(0);
+  });
+});

--- a/server/workflows/custom/run.ts
+++ b/server/workflows/custom/run.ts
@@ -1,0 +1,78 @@
+/**
+ * Service layer for the custom workflow kind — runs a schedule's prompt body
+ * as a headless session vertical with the universal RunResult envelope.
+ *
+ * Run-row lifecycle:
+ *   - Happy path: runSessionVertical passes `run:` to runAgentSession, which
+ *     calls insertRun on entry and finishRun on settle (done or failed). This
+ *     wrapper does NOT touch the runs row on the happy path — doing so would
+ *     double-insert, mirroring the weekly-update pattern exactly.
+ *   - Empty-prompt path: we detect the missing prompt before calling
+ *     runSessionVertical, so runAgentSession never runs and never inserts a
+ *     runs row. We own the row here: insertRun + finishRun('failed') to
+ *     prevent a row stuck at 'running'. We then return without calling
+ *     runSessionVertical.
+ */
+
+import { getSchedule } from '../../repositories/schedules.js';
+import { insertRun, finishRun } from '../../repositories/runs.js';
+import { runSessionVertical } from '../../services/session-vertical-service.js';
+import { interpolatePrompt } from '../../prompt-interpolate.js';
+import { childLogger } from '../../logger.js';
+import { RUN_RESULT_SCHEMA } from '@octomux/types';
+import type { RunResult } from '../../types.js';
+
+const logger = childLogger('workflows/custom');
+
+/** Output schema: RUN_RESULT_SCHEMA plus additionalProperties: false. */
+const CUSTOM_SCHEMA = {
+  ...RUN_RESULT_SCHEMA,
+  additionalProperties: false,
+};
+
+export interface RunCustomInput {
+  repoPath: string;
+  scheduleId: string;
+  model?: string | null;
+  timeoutMs?: number | null;
+  trigger?: 'cron' | 'manual';
+}
+
+export async function runCustom(input: RunCustomInput): Promise<void> {
+  const schedule = getSchedule(input.scheduleId);
+  const rawPrompt = schedule?.prompt;
+
+  if (!rawPrompt) {
+    logger.warn(
+      { schedule_id: input.scheduleId },
+      'custom: schedule has no prompt — failing run immediately',
+    );
+    const run = insertRun({
+      workflowKind: 'custom',
+      trigger: input.trigger ?? 'cron',
+      scheduleId: input.scheduleId,
+    });
+    finishRun(run.id, {
+      status: 'failed',
+      result: {
+        outcome: 'failed',
+        summary: 'Custom schedule has no prompt.',
+      } satisfies RunResult,
+    });
+    return;
+  }
+
+  // Interpolate extras only (no config on custom kind in v1).
+  const prompt = interpolatePrompt(rawPrompt, {});
+
+  await runSessionVertical({
+    kind: 'custom',
+    scheduleId: input.scheduleId,
+    workspaceDir: input.repoPath,
+    input: prompt,
+    outputSchema: CUSTOM_SCHEMA,
+    model: input.model,
+    timeoutMs: input.timeoutMs,
+    trigger: input.trigger ?? 'cron',
+  });
+}

--- a/server/workflows/daily-plan/index.test.ts
+++ b/server/workflows/daily-plan/index.test.ts
@@ -38,6 +38,33 @@ describe('daily-plan workflow registration', () => {
     });
 
     expect(mockRunDailyPlanFromSchedule).toHaveBeenCalledTimes(1);
-    expect(mockRunDailyPlanFromSchedule).toHaveBeenCalledWith({ scheduleId: 'sched-42' });
+    const call = mockRunDailyPlanFromSchedule.mock.calls[0][0];
+    expect(call.scheduleId).toBe('sched-42');
+  });
+
+  it('threads ctx.model into runDailyPlanFromSchedule', async () => {
+    const wf = getWorkflow('daily-plan')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: {},
+      scheduleId: 'sched-99',
+      model: 'claude-opus-4-8',
+    });
+
+    const call = mockRunDailyPlanFromSchedule.mock.calls[0][0];
+    expect(call.scheduleId).toBe('sched-99');
+    expect(call.model).toBe('claude-opus-4-8');
+  });
+
+  it('passes undefined model when ctx has none', async () => {
+    const wf = getWorkflow('daily-plan')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: {},
+      scheduleId: 'sched-100',
+    });
+
+    const call = mockRunDailyPlanFromSchedule.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
   });
 });

--- a/server/workflows/daily-plan/index.ts
+++ b/server/workflows/daily-plan/index.ts
@@ -6,9 +6,14 @@ export const dailyPlanWorkflow: WorkflowType = {
   kind: 'daily-plan',
   displayName: 'Daily Plan',
   surfaces: ['session'],
+  execution: 'chat',
   trigger: { kind: 'cron' },
   run: (ctx: RunContext) =>
-    runDailyPlanFromSchedule({ scheduleId: ctx.scheduleId!, trigger: ctx.trigger }),
+    runDailyPlanFromSchedule({
+      scheduleId: ctx.scheduleId!,
+      trigger: ctx.trigger,
+      model: ctx.model,
+    }),
 };
 
 registerWorkflow(dailyPlanWorkflow);

--- a/server/workflows/daily-plan/run.test.ts
+++ b/server/workflows/daily-plan/run.test.ts
@@ -35,7 +35,7 @@ describe('runDailyPlanFromSchedule', () => {
       scheduleId: 'sched-1',
       kind: 'daily-plan',
     });
-    expect(mockCreateChat).toHaveBeenCalledWith({ prompt: 'Prep the day.' });
+    expect(mockCreateChat).toHaveBeenCalledWith({ prompt: 'Prep the day.', model: undefined });
 
     const rows = getDb()
       .prepare(`SELECT * FROM runs WHERE workflow_kind = 'daily-plan'`)
@@ -44,6 +44,38 @@ describe('runDailyPlanFromSchedule', () => {
     expect(rows[0].chat_id).toBe('chat-1');
     expect(rows[0].schedule_id).toBe('sched-1');
     expect(rows[0].trigger).toBe('manual');
+  });
+
+  it('passes model to createChat when provided', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Prep the day.');
+    mockCreateChat.mockResolvedValue({ id: 'chat-2' });
+
+    await runDailyPlanFromSchedule({
+      scheduleId: 'sched-2',
+      trigger: 'cron',
+      model: 'claude-haiku-4-5-20251001',
+    });
+
+    expect(mockCreateChat).toHaveBeenCalledWith({
+      prompt: 'Prep the day.',
+      model: 'claude-haiku-4-5-20251001',
+    });
+  });
+
+  it('passes null model to createChat when model is null', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Prep the day.');
+    mockCreateChat.mockResolvedValue({ id: 'chat-3' });
+
+    await runDailyPlanFromSchedule({
+      scheduleId: 'sched-3',
+      trigger: 'cron',
+      model: null,
+    });
+
+    expect(mockCreateChat).toHaveBeenCalledWith({
+      prompt: 'Prep the day.',
+      model: null,
+    });
   });
 });
 

--- a/server/workflows/daily-plan/run.ts
+++ b/server/workflows/daily-plan/run.ts
@@ -14,6 +14,7 @@ const logger = childLogger('workflows/daily-plan');
 export interface RunDailyPlanFromScheduleInput {
   scheduleId: string;
   trigger?: 'cron' | 'manual';
+  model?: string | null;
 }
 
 export async function runDailyPlanFromSchedule(
@@ -23,7 +24,7 @@ export async function runDailyPlanFromSchedule(
     scheduleId: input.scheduleId,
     kind: 'daily-plan',
   });
-  const agent = await createChat({ prompt });
+  const agent = await createChat({ prompt, model: input.model });
   const trigger = input.trigger ?? 'cron';
 
   insertRun({

--- a/server/workflows/doc-drift.e2e.test.ts
+++ b/server/workflows/doc-drift.e2e.test.ts
@@ -19,7 +19,7 @@ vi.mock('../events.js', () => ({
 
 // ─── Import after mocks — side-effect registers the workflow + schedule handler ──
 
-import { upsertSchedule } from '../repositories/schedules.js';
+import { createSchedule } from '../repositories/schedules.js';
 import { pollSchedules } from '../poller/schedule-cron.js';
 import './doc-drift/index.js';
 
@@ -46,7 +46,7 @@ describe('cron -> doc-drift e2e', () => {
   });
 
   it('fires a due schedule through the full cron -> service -> loop path', async () => {
-    upsertSchedule({ kind: 'doc-drift', repoPath: '/repo', cron: '0 7 * * *' });
+    createSchedule({ kind: 'doc-drift', repoPath: '/repo', cron: '0 7 * * *' });
     const now = new Date('2026-07-18T07:00:00Z');
 
     await pollSchedules(now);

--- a/server/workflows/doc-drift/doc-drift-tasks.ts
+++ b/server/workflows/doc-drift/doc-drift-tasks.ts
@@ -32,6 +32,8 @@ export interface InsertDocDriftTaskParams {
   initialPrompt: string;
   /** Set when this task was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
+  /** Per-schedule model override — stamps tasks.model. */
+  model?: string | null;
 }
 
 /**
@@ -63,6 +65,7 @@ export function insertDocDriftTask(params: InsertDocDriftTaskParams): string {
     source: 'doc_drift',
     worktree_id: worktreeId,
     schedule_id: params.scheduleId ?? null,
+    model: params.model ?? null,
   });
 
   return id;

--- a/server/workflows/doc-drift/index.test.ts
+++ b/server/workflows/doc-drift/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getWorkflow } from '../registry.js';
-import { resolveWorkflowConfig } from '../config.js';
-import type { ScheduleRow } from '../../repositories/schedules.js';
+import { DOC_DRIFT_CONFIG_SCHEMA } from './schema.js';
 
 const mockCreateDocDriftTaskFromSchedule = vi.fn().mockResolvedValue({ id: 'task1' });
 
@@ -12,17 +11,14 @@ vi.mock('./run.js', () => ({
 
 import './index.js';
 
-function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
-  return {
-    id: 'sched1',
-    kind: 'doc-drift',
-    repo_path: '/repo',
-    cron: '0 7 * * *',
-    enabled: 1,
-    last_run_at: null,
-    config_json: null,
-    ...overrides,
-  };
+/** Build a resolved config with schema defaults applied without going through AJV. */
+function defaultConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {};
+  const props = DOC_DRIFT_CONFIG_SCHEMA.properties as Record<string, { default?: unknown }>;
+  for (const [key, prop] of Object.entries(props)) {
+    if ('default' in prop) defaults[key] = prop.default;
+  }
+  return { ...defaults, ...overrides };
 }
 
 describe('doc-drift workflow registration', () => {
@@ -41,13 +37,24 @@ describe('doc-drift workflow registration', () => {
     expect(wf?.run).toBeTypeOf('function');
   });
 
+  it('schema includes baseBranch and branchPrefix with format and pattern constraints', () => {
+    const props = DOC_DRIFT_CONFIG_SCHEMA.properties as Record<string, Record<string, unknown>>;
+    expect(props.baseBranch).toBeDefined();
+    expect(props.baseBranch.default).toBe('main');
+    expect(props.baseBranch.format).toBe('single-line');
+    expect(props.baseBranch.pattern).toBe('^[a-zA-Z0-9._/-]{1,80}$');
+    expect(props.branchPrefix).toBeDefined();
+    expect(props.branchPrefix.default).toBe('doc-drift');
+    expect(props.branchPrefix.format).toBe('single-line');
+    expect(props.branchPrefix.pattern).toBe('^[a-zA-Z0-9._/-]{1,80}$');
+  });
+
   it('default verify is scoped to the task branch (--head), not repo-wide', async () => {
     const wf = getWorkflow('doc-drift')!;
-    const row = makeRow();
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
     });
 
     expect(mockCreateDocDriftTaskFromSchedule).toHaveBeenCalledTimes(1);
@@ -58,46 +65,79 @@ describe('doc-drift workflow registration', () => {
 
   it('passes the schedule id through as scheduleId', async () => {
     const wf = getWorkflow('doc-drift')!;
-    const row = makeRow({ id: 'sched-42' });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched-42',
     });
 
     const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
     expect(call.scheduleId).toBe('sched-42');
   });
 
-  it('applies schema defaults when the row has no config_json', async () => {
+  it('applies schema defaults: maxIterations=4, baseBranch=main, branchPrefix=doc-drift', async () => {
     const wf = getWorkflow('doc-drift')!;
-    const row = makeRow({ config_json: null });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
     });
 
     const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
     expect(call.maxIterations).toBe(4);
     expect(call.verify).toContain('origin/HEAD');
+    expect(call.baseBranch).toBe('main');
+    expect(call.branchPrefix).toBe('doc-drift');
   });
 
-  it('passes through config_json overrides for verify/maxIterations', async () => {
+  it('passes through config overrides for verify/maxIterations', async () => {
     const wf = getWorkflow('doc-drift')!;
-    const config = {
-      verify: 'bun run test',
-      maxIterations: 2,
-    };
-    const row = makeRow({ config_json: JSON.stringify(config) });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig({ verify: 'bun run test', maxIterations: 2 }),
+      scheduleId: 'sched1',
     });
 
     const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
     expect(call.verify).toBe('bun run test');
     expect(call.maxIterations).toBe(2);
+  });
+
+  it('passes through config overrides for baseBranch and branchPrefix', async () => {
+    const wf = getWorkflow('doc-drift')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig({ baseBranch: 'develop', branchPrefix: 'docs/fix' }),
+      scheduleId: 'sched1',
+    });
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.baseBranch).toBe('develop');
+    expect(call.branchPrefix).toBe('docs/fix');
+  });
+
+  it('threads ctx.model through to the service call', async () => {
+    const wf = getWorkflow('doc-drift')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
+      model: 'claude-opus-4-8',
+    });
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.model).toBe('claude-opus-4-8');
+  });
+
+  it('passes null model when ctx.model is not set', async () => {
+    const wf = getWorkflow('doc-drift')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
+    });
+
+    const call = mockCreateDocDriftTaskFromSchedule.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
   });
 });

--- a/server/workflows/doc-drift/index.ts
+++ b/server/workflows/doc-drift/index.ts
@@ -11,6 +11,7 @@ export const docDriftWorkflow: WorkflowType = {
   kind: 'doc-drift',
   displayName: 'Doc Drift',
   surfaces: ['feed', 'artifact'],
+  execution: 'task',
   config: DOC_DRIFT_CONFIG_SCHEMA,
   trigger: { kind: 'cron' },
   run: async (ctx: RunContext) => {
@@ -18,11 +19,19 @@ export const docDriftWorkflow: WorkflowType = {
       { repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
       'doc-drift: schedule fired',
     );
-    const cfg = ctx.config as { verify: string; maxIterations: number };
+    const cfg = ctx.config as {
+      verify: string;
+      maxIterations: number;
+      baseBranch: string;
+      branchPrefix: string;
+    };
     await createDocDriftTaskFromSchedule({
       repoPath: ctx.repoPath,
       verify: cfg.verify,
       maxIterations: cfg.maxIterations,
+      baseBranch: cfg.baseBranch,
+      branchPrefix: cfg.branchPrefix,
+      model: ctx.model,
       scheduleId: ctx.scheduleId,
       trigger: ctx.trigger,
     });

--- a/server/workflows/doc-drift/run.test.ts
+++ b/server/workflows/doc-drift/run.test.ts
@@ -33,6 +33,14 @@ function insertActiveAgent(taskId: string): void {
     .run(`${taskId}-agent`, taskId);
 }
 
+const DEFAULT_INPUT = {
+  repoPath: '/repo',
+  verify: 'test -n "$(git diff --name-only origin/HEAD... -- \'*.md\')" && bun run build',
+  maxIterations: 4,
+  baseBranch: 'main',
+  branchPrefix: 'doc-drift',
+};
+
 describe('createDocDriftTaskFromSchedule', () => {
   beforeEach(() => {
     createTestDb();
@@ -49,11 +57,7 @@ describe('createDocDriftTaskFromSchedule', () => {
       insertActiveAgent(task.id);
     });
 
-    const result = await createDocDriftTaskFromSchedule({
-      repoPath: '/repo',
-      verify: 'test -n "$(git diff --name-only origin/HEAD... -- \'*.md\')" && bun run build',
-      maxIterations: 4,
-    });
+    const result = await createDocDriftTaskFromSchedule(DEFAULT_INPUT);
 
     expect(result.task.source).toBe('doc_drift');
     expect(mockStartTask).toHaveBeenCalledTimes(1);
@@ -76,9 +80,7 @@ describe('createDocDriftTaskFromSchedule', () => {
     });
 
     const result = await createDocDriftTaskFromSchedule({
-      repoPath: '/repo',
-      verify: 'bun run build',
-      maxIterations: 4,
+      ...DEFAULT_INPUT,
       scheduleId: 'sched-1',
     });
 
@@ -92,9 +94,7 @@ describe('createDocDriftTaskFromSchedule', () => {
     });
 
     const result = await createDocDriftTaskFromSchedule({
-      repoPath: '/repo',
-      verify: 'bun run build',
-      maxIterations: 4,
+      ...DEFAULT_INPUT,
       scheduleId: 'sched-1',
     });
 
@@ -106,16 +106,61 @@ describe('createDocDriftTaskFromSchedule', () => {
     expect(rows[0].loop_run_id).toEqual(expect.any(String));
   });
 
+  it('branch name uses branchPrefix and baseBranch from input', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      ...DEFAULT_INPUT,
+      branchPrefix: 'docs/fix',
+      baseBranch: 'develop',
+    });
+
+    const row = getDb()
+      .prepare(
+        'SELECT wt.branch, wt.base_branch FROM tasks t JOIN worktrees wt ON wt.id = t.worktree_id WHERE t.id = ?',
+      )
+      .get(result.id) as { branch: string; base_branch: string };
+    expect(row.branch).toMatch(/^docs\/fix\//);
+    expect(row.base_branch).toBe('develop');
+  });
+
+  it('stamps model on the task row when model is provided', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule({
+      ...DEFAULT_INPUT,
+      model: 'claude-opus-4-8',
+    });
+
+    const row = getDb().prepare('SELECT model FROM tasks WHERE id = ?').get(result.id) as {
+      model: string | null;
+    };
+    expect(row.model).toBe('claude-opus-4-8');
+  });
+
+  it('leaves model null when no model is provided', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createDocDriftTaskFromSchedule(DEFAULT_INPUT);
+
+    const row = getDb().prepare('SELECT model FROM tasks WHERE id = ?').get(result.id) as {
+      model: string | null;
+    };
+    expect(row.model).toBeNull();
+  });
+
   it('does NOT call startLoop when startTask leaves the task in runtime_state=error, and finishes the run as failed', async () => {
     mockStartTask.mockImplementation(async (task: { id: string }) => {
       setRuntimeState(task.id, 'error', 'setup failed');
     });
 
-    const result = await createDocDriftTaskFromSchedule({
-      repoPath: '/repo',
-      verify: 'bun run build',
-      maxIterations: 4,
-    });
+    const result = await createDocDriftTaskFromSchedule(DEFAULT_INPUT);
 
     expect(mockStartTask).toHaveBeenCalledTimes(1);
     expect(mockStartLoop).not.toHaveBeenCalled();
@@ -132,11 +177,7 @@ describe('createDocDriftTaskFromSchedule', () => {
   it('does NOT call startLoop when startTask resolves but no active agent exists, and finishes the run as failed', async () => {
     mockStartTask.mockResolvedValue(undefined); // resolves, no agent row inserted, no error state
 
-    const result = await createDocDriftTaskFromSchedule({
-      repoPath: '/repo',
-      verify: 'bun run build',
-      maxIterations: 4,
-    });
+    const result = await createDocDriftTaskFromSchedule(DEFAULT_INPUT);
 
     expect(mockStartTask).toHaveBeenCalledTimes(1);
     expect(mockStartLoop).not.toHaveBeenCalled();

--- a/server/workflows/doc-drift/run.ts
+++ b/server/workflows/doc-drift/run.ts
@@ -22,6 +22,12 @@ export interface CreateDocDriftTaskFromScheduleInput {
   repoPath: string;
   verify: string;
   maxIterations: number;
+  /** Override the base branch that the worktree branches off of. Defaults to 'main'. */
+  baseBranch: string;
+  /** Prefix for the feature branch name. Defaults to 'doc-drift'. */
+  branchPrefix: string;
+  /** Per-schedule model override; null/undefined means harness default. */
+  model?: string | null;
   /** Set when this run was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
   trigger?: 'cron' | 'manual';
@@ -38,7 +44,7 @@ export async function createDocDriftTaskFromSchedule(
   const id = nanoid(12);
   const short = repoShortName(input.repoPath);
   const dateStamp = new Date().toISOString().slice(0, 10);
-  const branch = `doc-drift/${short}-${dateStamp}`;
+  const branch = `${input.branchPrefix}/${short}-${dateStamp}`;
 
   const initialPrompt = buildDocDriftPrompt({
     docDriftTaskId: id,
@@ -49,11 +55,12 @@ export async function createDocDriftTaskFromSchedule(
     id,
     repoPath: input.repoPath,
     branch,
-    baseBranch: 'main',
+    baseBranch: input.baseBranch,
     title: `Doc drift: ${short} (${dateStamp})`,
     description: `Scheduled doc-drift run for ${short}`,
     initialPrompt,
     scheduleId: input.scheduleId,
+    model: input.model,
   });
 
   broadcast({ type: 'task:created', payload: { taskId: id } });

--- a/server/workflows/doc-drift/schema.ts
+++ b/server/workflows/doc-drift/schema.ts
@@ -16,6 +16,20 @@ export const DOC_DRIFT_CONFIG_SCHEMA = {
       minimum: 1,
       default: 4,
     },
+    baseBranch: {
+      type: 'string',
+      title: 'Base branch',
+      default: 'main',
+      format: 'single-line',
+      pattern: '^[a-zA-Z0-9._/-]{1,80}$',
+    },
+    branchPrefix: {
+      type: 'string',
+      title: 'Branch prefix',
+      default: 'doc-drift',
+      format: 'single-line',
+      pattern: '^[a-zA-Z0-9._/-]{1,80}$',
+    },
   },
   additionalProperties: false,
 };

--- a/server/workflows/index.ts
+++ b/server/workflows/index.ts
@@ -1,4 +1,5 @@
 // Side-effect imports register all known workflow kinds.
+import './custom/index.js';
 import './daily-plan/index.js';
 import './doc-drift/index.js';
 import './loops/index.js';

--- a/server/workflows/overnight-log-summary/index.test.ts
+++ b/server/workflows/overnight-log-summary/index.test.ts
@@ -16,10 +16,15 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     id: 'sched1',
     kind: 'overnight-log-summary',
     repo_path: '/repo',
+    name: null,
     cron: '0 6 * * *',
+    timezone: null,
     enabled: 1,
+    model: null,
+    timeout_ms: null,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }
@@ -73,5 +78,35 @@ describe('overnight-log-summary workflow registration', () => {
 
     const call = mockRunOvernightLogSummary.mock.calls[0][0];
     expect(call.logCommand).toBe('flyctl logs -a my-app');
+  });
+
+  it('threads ctx.model and ctx.timeoutMs into runOvernightLogSummary', async () => {
+    const wf = getWorkflow('overnight-log-summary')!;
+    const row = makeRow({ id: 'sched-99' });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+      model: 'claude-sonnet-4-6',
+      timeoutMs: 450000,
+    });
+
+    const call = mockRunOvernightLogSummary.mock.calls[0][0];
+    expect(call.model).toBe('claude-sonnet-4-6');
+    expect(call.timeoutMs).toBe(450000);
+  });
+
+  it('passes undefined model/timeoutMs when ctx has none', async () => {
+    const wf = getWorkflow('overnight-log-summary')!;
+    const row = makeRow({ id: 'sched-100' });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    const call = mockRunOvernightLogSummary.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
   });
 });

--- a/server/workflows/overnight-log-summary/index.ts
+++ b/server/workflows/overnight-log-summary/index.ts
@@ -10,6 +10,7 @@ export const overnightLogSummaryWorkflow: WorkflowType = {
   kind: 'overnight-log-summary',
   displayName: 'Overnight Log Summary',
   surfaces: ['artifact'],
+  execution: 'session',
   config: OVERNIGHT_LOG_SUMMARY_CONFIG_SCHEMA,
   output: OVERNIGHT_LOG_SUMMARY_SCHEMA,
   trigger: { kind: 'cron' },
@@ -26,6 +27,8 @@ export const overnightLogSummaryWorkflow: WorkflowType = {
       scheduleId: ctx.scheduleId,
       logCommand: cfg.logCommand,
       trigger: ctx.trigger,
+      model: ctx.model,
+      timeoutMs: ctx.timeoutMs,
     }).catch((err) => {
       logger.error(
         { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },

--- a/server/workflows/overnight-log-summary/run.test.ts
+++ b/server/workflows/overnight-log-summary/run.test.ts
@@ -48,4 +48,59 @@ describe('runOvernightLogSummary', () => {
     expect(call.input).toBe('Run gh run list --limit 30 for my-app.');
     expect(call.outputSchema).toBe(OVERNIGHT_LOG_SUMMARY_SCHEMA);
   });
+
+  it('leaves unknown {{tokens}} intact in the interpolated prompt', async () => {
+    mockGetSkill.mockResolvedValue({
+      name: 'overnight-log-summary',
+      content: 'Run {{logCommand}} {{unknownToken}} for {{repoShort}}.',
+    });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+
+    await runOvernightLogSummary({
+      repoPath: '/repos/My App',
+      scheduleId: 'sched-2',
+      logCommand: 'gh run list',
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.input).toBe('Run gh run list {{unknownToken}} for my-app.');
+  });
+
+  it('passes model and timeoutMs through to runSessionVertical', async () => {
+    mockGetSkill.mockResolvedValue({
+      name: 'overnight-log-summary',
+      content: 'Run {{logCommand}} for {{repoShort}}.',
+    });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+
+    await runOvernightLogSummary({
+      repoPath: '/repos/My App',
+      scheduleId: 'sched-3',
+      logCommand: 'gh run list --limit 30',
+      model: 'claude-haiku-4-5-20251001',
+      timeoutMs: 600000,
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.model).toBe('claude-haiku-4-5-20251001');
+    expect(call.timeoutMs).toBe(600000);
+  });
+
+  it('passes undefined model/timeoutMs when not specified', async () => {
+    mockGetSkill.mockResolvedValue({
+      name: 'overnight-log-summary',
+      content: 'Run {{logCommand}} for {{repoShort}}.',
+    });
+    mockRunSessionVertical.mockResolvedValue({ result: { summary: 'ok' } });
+
+    await runOvernightLogSummary({
+      repoPath: '/repos/My App',
+      scheduleId: 'sched-4',
+      logCommand: 'gh run list --limit 30',
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
+  });
 });

--- a/server/workflows/overnight-log-summary/run.ts
+++ b/server/workflows/overnight-log-summary/run.ts
@@ -6,6 +6,7 @@
 import { resolveSchedulePrompt } from '../../schedule-prompt.js';
 import { repoShortName } from '../../review-tasks.js';
 import { runSessionVertical } from '../../services/session-vertical-service.js';
+import { interpolatePrompt } from '../../prompt-interpolate.js';
 import { OVERNIGHT_LOG_SUMMARY_SCHEMA } from './schema.js';
 
 export interface RunOvernightLogSummaryInput {
@@ -13,6 +14,8 @@ export interface RunOvernightLogSummaryInput {
   scheduleId?: string | null;
   logCommand: string;
   trigger?: 'cron' | 'manual';
+  model?: string | null;
+  timeoutMs?: number | null;
 }
 
 export interface OvernightLogSummaryResult {
@@ -30,9 +33,10 @@ export async function runOvernightLogSummary(
     kind: 'overnight-log-summary',
     repoPath: input.repoPath,
   });
-  const prompt = skillContent
-    .replace(/\{\{logCommand\}\}/g, input.logCommand)
-    .replace(/\{\{repoShort\}\}/g, repoShortName(input.repoPath));
+  const prompt = interpolatePrompt(skillContent, {
+    logCommand: input.logCommand,
+    repoShort: repoShortName(input.repoPath),
+  });
 
   return runSessionVertical<OvernightLogSummaryResult>({
     kind: 'overnight-log-summary',
@@ -41,5 +45,7 @@ export async function runOvernightLogSummary(
     input: prompt,
     outputSchema: OVERNIGHT_LOG_SUMMARY_SCHEMA,
     trigger: input.trigger ?? 'cron',
+    model: input.model,
+    timeoutMs: input.timeoutMs,
   });
 }

--- a/server/workflows/prod-log-triage.e2e.test.ts
+++ b/server/workflows/prod-log-triage.e2e.test.ts
@@ -19,7 +19,7 @@ vi.mock('../events.js', () => ({
 
 // ─── Import after mocks — side-effect registers the workflow + schedule handler ──
 
-import { upsertSchedule } from '../repositories/schedules.js';
+import { createSchedule } from '../repositories/schedules.js';
 import { pollSchedules } from '../poller/schedule-cron.js';
 import './prod-log-triage/index.js';
 
@@ -46,7 +46,7 @@ describe('cron -> prod-log-triage e2e', () => {
   });
 
   it('fires a due schedule through the full cron -> service -> loop path', async () => {
-    upsertSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
+    createSchedule({ kind: 'prod-log-triage', repoPath: '/repo', cron: '0 7 * * *' });
     const now = new Date('2026-07-18T07:00:00Z');
 
     await pollSchedules(now);

--- a/server/workflows/prod-log-triage/index.test.ts
+++ b/server/workflows/prod-log-triage/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getWorkflow } from '../registry.js';
-import { resolveWorkflowConfig } from '../config.js';
-import type { ScheduleRow } from '../../repositories/schedules.js';
+import { PROD_LOG_TRIAGE_CONFIG_SCHEMA } from './schema.js';
 
 const mockCreateTriageTaskFromSchedule = vi.fn().mockResolvedValue({ id: 'task1' });
 
@@ -11,17 +10,14 @@ vi.mock('./run.js', () => ({
 
 import './index.js';
 
-function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
-  return {
-    id: 'sched1',
-    kind: 'prod-log-triage',
-    repo_path: '/repo',
-    cron: '0 7 * * *',
-    enabled: 1,
-    last_run_at: null,
-    config_json: null,
-    ...overrides,
-  };
+/** Build a resolved config with schema defaults applied without going through AJV. */
+function defaultConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {};
+  const props = PROD_LOG_TRIAGE_CONFIG_SCHEMA.properties as Record<string, { default?: unknown }>;
+  for (const [key, prop] of Object.entries(props)) {
+    if ('default' in prop) defaults[key] = prop.default;
+  }
+  return { ...defaults, ...overrides };
 }
 
 describe('prod-log-triage workflow registration', () => {
@@ -40,13 +36,27 @@ describe('prod-log-triage workflow registration', () => {
     expect(wf?.run).toBeTypeOf('function');
   });
 
+  it('schema includes baseBranch and branchPrefix with format and pattern constraints', () => {
+    const props = PROD_LOG_TRIAGE_CONFIG_SCHEMA.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.baseBranch).toBeDefined();
+    expect(props.baseBranch.default).toBe('main');
+    expect(props.baseBranch.format).toBe('single-line');
+    expect(props.baseBranch.pattern).toBe('^[a-zA-Z0-9._/-]{1,80}$');
+    expect(props.branchPrefix).toBeDefined();
+    expect(props.branchPrefix.default).toBe('triage');
+    expect(props.branchPrefix.format).toBe('single-line');
+    expect(props.branchPrefix.pattern).toBe('^[a-zA-Z0-9._/-]{1,80}$');
+  });
+
   it('default verify is scoped to the task branch (--head), not repo-wide (--search)', async () => {
     const wf = getWorkflow('prod-log-triage')!;
-    const row = makeRow();
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
     });
 
     expect(mockCreateTriageTaskFromSchedule).toHaveBeenCalledTimes(1);
@@ -57,48 +67,84 @@ describe('prod-log-triage workflow registration', () => {
 
   it('passes the schedule id through as scheduleId', async () => {
     const wf = getWorkflow('prod-log-triage')!;
-    const row = makeRow({ id: 'sched-42' });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched-42',
     });
 
     const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
     expect(call.scheduleId).toBe('sched-42');
   });
 
-  it('applies schema defaults when the row has no config_json', async () => {
+  it('applies schema defaults: logCommand, maxIterations=5, baseBranch=main, branchPrefix=triage', async () => {
     const wf = getWorkflow('prod-log-triage')!;
-    const row = makeRow({ config_json: null });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
     });
 
     const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
     expect(call.logCommand).toBe('gh run list --limit 20 --json databaseId,conclusion,name,url');
     expect(call.maxIterations).toBe(5);
+    expect(call.baseBranch).toBe('main');
+    expect(call.branchPrefix).toBe('triage');
   });
 
-  it('passes through config_json overrides for logCommand/verify/maxIterations', async () => {
+  it('passes through config overrides for logCommand/verify/maxIterations', async () => {
     const wf = getWorkflow('prod-log-triage')!;
-    const config = {
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'bun run test',
-      maxIterations: 3,
-    };
-    const row = makeRow({ config_json: JSON.stringify(config) });
     await wf.run!({
-      repoPath: row.repo_path,
-      config: resolveWorkflowConfig(wf, row.config_json),
-      scheduleId: row.id,
+      repoPath: '/repo',
+      config: defaultConfig({
+        logCommand: 'flyctl logs -a my-app',
+        verify: 'bun run test',
+        maxIterations: 3,
+      }),
+      scheduleId: 'sched1',
     });
 
     const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
     expect(call.logCommand).toBe('flyctl logs -a my-app');
     expect(call.verify).toBe('bun run test');
     expect(call.maxIterations).toBe(3);
+  });
+
+  it('passes through config overrides for baseBranch and branchPrefix', async () => {
+    const wf = getWorkflow('prod-log-triage')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig({ baseBranch: 'release', branchPrefix: 'ops/triage' }),
+      scheduleId: 'sched1',
+    });
+
+    const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
+    expect(call.baseBranch).toBe('release');
+    expect(call.branchPrefix).toBe('ops/triage');
+  });
+
+  it('threads ctx.model through to the service call', async () => {
+    const wf = getWorkflow('prod-log-triage')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
+      model: 'claude-sonnet-4-6',
+    });
+
+    const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
+    expect(call.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('passes undefined model when ctx.model is not set', async () => {
+    const wf = getWorkflow('prod-log-triage')!;
+    await wf.run!({
+      repoPath: '/repo',
+      config: defaultConfig(),
+      scheduleId: 'sched1',
+    });
+
+    const call = mockCreateTriageTaskFromSchedule.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
   });
 });

--- a/server/workflows/prod-log-triage/index.ts
+++ b/server/workflows/prod-log-triage/index.ts
@@ -10,6 +10,7 @@ export const prodLogTriageWorkflow: WorkflowType = {
   kind: 'prod-log-triage',
   displayName: 'Prod Log Triage',
   surfaces: ['feed', 'artifact'],
+  execution: 'task',
   config: PROD_LOG_TRIAGE_CONFIG_SCHEMA,
   trigger: { kind: 'cron' },
   run: async (ctx: RunContext) => {
@@ -17,12 +18,21 @@ export const prodLogTriageWorkflow: WorkflowType = {
       { repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },
       'prod-log-triage: schedule fired',
     );
-    const cfg = ctx.config as { logCommand: string; verify: string; maxIterations: number };
+    const cfg = ctx.config as {
+      logCommand: string;
+      verify: string;
+      maxIterations: number;
+      baseBranch: string;
+      branchPrefix: string;
+    };
     await createTriageTaskFromSchedule({
       repoPath: ctx.repoPath,
       logCommand: cfg.logCommand,
       verify: cfg.verify,
       maxIterations: cfg.maxIterations,
+      baseBranch: cfg.baseBranch,
+      branchPrefix: cfg.branchPrefix,
+      model: ctx.model,
       scheduleId: ctx.scheduleId,
       trigger: ctx.trigger,
     });

--- a/server/workflows/prod-log-triage/prod-log-triage-tasks.ts
+++ b/server/workflows/prod-log-triage/prod-log-triage-tasks.ts
@@ -32,6 +32,8 @@ export interface InsertTriageTaskParams {
   initialPrompt: string;
   /** Set when this task was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
+  /** Per-schedule model override — stamps tasks.model. */
+  model?: string | null;
 }
 
 /**
@@ -63,6 +65,7 @@ export function insertTriageTask(params: InsertTriageTaskParams): string {
     source: 'prod_log_triage',
     worktree_id: worktreeId,
     schedule_id: params.scheduleId ?? null,
+    model: params.model ?? null,
   });
 
   return id;

--- a/server/workflows/prod-log-triage/run.test.ts
+++ b/server/workflows/prod-log-triage/run.test.ts
@@ -33,6 +33,15 @@ function insertActiveAgent(taskId: string): void {
     .run(`${taskId}-agent`, taskId);
 }
 
+const DEFAULT_INPUT = {
+  repoPath: '/repo',
+  logCommand: 'flyctl logs -a my-app',
+  verify: 'test -f desk/incidents/*.md && bun run build',
+  maxIterations: 5,
+  baseBranch: 'main',
+  branchPrefix: 'triage',
+};
+
 describe('createTriageTaskFromSchedule', () => {
   beforeEach(() => {
     createTestDb();
@@ -49,12 +58,7 @@ describe('createTriageTaskFromSchedule', () => {
       insertActiveAgent(task.id);
     });
 
-    const result = await createTriageTaskFromSchedule({
-      repoPath: '/repo',
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'test -f desk/incidents/*.md && bun run build',
-      maxIterations: 5,
-    });
+    const result = await createTriageTaskFromSchedule(DEFAULT_INPUT);
 
     expect(result.task.source).toBe('prod_log_triage');
     expect(mockStartTask).toHaveBeenCalledTimes(1);
@@ -77,10 +81,7 @@ describe('createTriageTaskFromSchedule', () => {
     });
 
     const result = await createTriageTaskFromSchedule({
-      repoPath: '/repo',
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'bun run build',
-      maxIterations: 5,
+      ...DEFAULT_INPUT,
       scheduleId: 'sched-1',
     });
 
@@ -94,10 +95,7 @@ describe('createTriageTaskFromSchedule', () => {
     });
 
     const result = await createTriageTaskFromSchedule({
-      repoPath: '/repo',
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'bun run build',
-      maxIterations: 5,
+      ...DEFAULT_INPUT,
       scheduleId: 'sched-1',
     });
 
@@ -109,17 +107,61 @@ describe('createTriageTaskFromSchedule', () => {
     expect(rows[0].loop_run_id).toEqual(expect.any(String));
   });
 
+  it('branch name uses branchPrefix and baseBranch from input', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createTriageTaskFromSchedule({
+      ...DEFAULT_INPUT,
+      branchPrefix: 'ops/triage',
+      baseBranch: 'release',
+    });
+
+    const row = getDb()
+      .prepare(
+        'SELECT wt.branch, wt.base_branch FROM tasks t JOIN worktrees wt ON wt.id = t.worktree_id WHERE t.id = ?',
+      )
+      .get(result.id) as { branch: string; base_branch: string };
+    expect(row.branch).toMatch(/^ops\/triage\//);
+    expect(row.base_branch).toBe('release');
+  });
+
+  it('stamps model on the task row when model is provided', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createTriageTaskFromSchedule({
+      ...DEFAULT_INPUT,
+      model: 'claude-sonnet-4-6',
+    });
+
+    const row = getDb().prepare('SELECT model FROM tasks WHERE id = ?').get(result.id) as {
+      model: string | null;
+    };
+    expect(row.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('leaves model null when no model is provided', async () => {
+    mockStartTask.mockImplementation(async (task: { id: string }) => {
+      insertActiveAgent(task.id);
+    });
+
+    const result = await createTriageTaskFromSchedule(DEFAULT_INPUT);
+
+    const row = getDb().prepare('SELECT model FROM tasks WHERE id = ?').get(result.id) as {
+      model: string | null;
+    };
+    expect(row.model).toBeNull();
+  });
+
   it('does NOT call startLoop when startTask leaves the task in runtime_state=error, and finishes the run as failed', async () => {
     mockStartTask.mockImplementation(async (task: { id: string }) => {
       setRuntimeState(task.id, 'error', 'setup failed');
     });
 
-    const result = await createTriageTaskFromSchedule({
-      repoPath: '/repo',
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'bun run build',
-      maxIterations: 3,
-    });
+    const result = await createTriageTaskFromSchedule(DEFAULT_INPUT);
 
     expect(mockStartTask).toHaveBeenCalledTimes(1);
     expect(mockStartLoop).not.toHaveBeenCalled();
@@ -136,12 +178,7 @@ describe('createTriageTaskFromSchedule', () => {
   it('does NOT call startLoop when startTask resolves but no active agent exists, and finishes the run as failed', async () => {
     mockStartTask.mockResolvedValue(undefined); // resolves, no agent row inserted, no error state
 
-    const result = await createTriageTaskFromSchedule({
-      repoPath: '/repo',
-      logCommand: 'flyctl logs -a my-app',
-      verify: 'bun run build',
-      maxIterations: 3,
-    });
+    const result = await createTriageTaskFromSchedule(DEFAULT_INPUT);
 
     expect(mockStartTask).toHaveBeenCalledTimes(1);
     expect(mockStartLoop).not.toHaveBeenCalled();

--- a/server/workflows/prod-log-triage/run.ts
+++ b/server/workflows/prod-log-triage/run.ts
@@ -23,6 +23,12 @@ export interface CreateTriageTaskFromScheduleInput {
   logCommand: string;
   verify: string;
   maxIterations: number;
+  /** Override the base branch that the worktree branches off of. Defaults to 'main'. */
+  baseBranch: string;
+  /** Prefix for the feature branch name. Defaults to 'triage'. */
+  branchPrefix: string;
+  /** Per-schedule model override; null/undefined means harness default. */
+  model?: string | null;
   /** Set when this run was fired by a schedule — stamps tasks.schedule_id. */
   scheduleId?: string;
   trigger?: 'cron' | 'manual';
@@ -39,7 +45,7 @@ export async function createTriageTaskFromSchedule(
   const id = nanoid(12);
   const short = repoShortName(input.repoPath);
   const dateStamp = new Date().toISOString().slice(0, 10);
-  const branch = `triage/${short}-${dateStamp}`;
+  const branch = `${input.branchPrefix}/${short}-${dateStamp}`;
 
   const initialPrompt = buildTriagePrompt({
     triageTaskId: id,
@@ -51,11 +57,12 @@ export async function createTriageTaskFromSchedule(
     id,
     repoPath: input.repoPath,
     branch,
-    baseBranch: 'main',
+    baseBranch: input.baseBranch,
     title: `Prod log triage: ${short} (${dateStamp})`,
     description: `Scheduled prod-log-triage run for ${short}`,
     initialPrompt,
     scheduleId: input.scheduleId,
+    model: input.model,
   });
 
   broadcast({ type: 'task:created', payload: { taskId: id } });

--- a/server/workflows/prod-log-triage/schema.ts
+++ b/server/workflows/prod-log-triage/schema.ts
@@ -22,6 +22,20 @@ export const PROD_LOG_TRIAGE_CONFIG_SCHEMA = {
       minimum: 1,
       default: 5,
     },
+    baseBranch: {
+      type: 'string',
+      title: 'Base branch',
+      default: 'main',
+      format: 'single-line',
+      pattern: '^[a-zA-Z0-9._/-]{1,80}$',
+    },
+    branchPrefix: {
+      type: 'string',
+      title: 'Branch prefix',
+      default: 'triage',
+      format: 'single-line',
+      pattern: '^[a-zA-Z0-9._/-]{1,80}$',
+    },
   },
   additionalProperties: false,
 };

--- a/server/workflows/slack-watcher/index.test.ts
+++ b/server/workflows/slack-watcher/index.test.ts
@@ -16,10 +16,15 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     id: 'sched1',
     kind: 'slack-watcher',
     repo_path: '/repo',
+    name: null,
     cron: '*/30 3-18 * * *',
+    timezone: null,
     enabled: 1,
+    model: null,
+    timeout_ms: null,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }
@@ -91,5 +96,35 @@ describe('slack-watcher workflow registration', () => {
     expect(call.digestUserId).toBe('U0PERSONAL');
     expect(call.lookbackMinutes).toBe(20);
     expect(call.digestChannel).toBe('C9');
+  });
+
+  it('threads ctx.model and ctx.timeoutMs into runSlackWatcher', async () => {
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({ config_json: JSON.stringify({ slackUserId: 'U07X' }) });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+      model: 'claude-haiku-4-5-20251001',
+      timeoutMs: 60000,
+    });
+
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.model).toBe('claude-haiku-4-5-20251001');
+    expect(call.timeoutMs).toBe(60000);
+  });
+
+  it('passes null model/timeoutMs through when ctx has none', async () => {
+    const wf = getWorkflow('slack-watcher')!;
+    const row = makeRow({ config_json: JSON.stringify({ slackUserId: 'U07X' }) });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: resolveWorkflowConfig(wf, row.config_json),
+      scheduleId: row.id,
+    });
+
+    const call = mockRunSlackWatcher.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
   });
 });

--- a/server/workflows/slack-watcher/index.ts
+++ b/server/workflows/slack-watcher/index.ts
@@ -10,6 +10,7 @@ export const slackWatcherWorkflow: WorkflowType = {
   kind: 'slack-watcher',
   displayName: 'Slack Watcher',
   surfaces: ['artifact'],
+  execution: 'session',
   config: SLACK_WATCHER_CONFIG_SCHEMA,
   output: SLACK_WATCHER_SCHEMA,
   trigger: { kind: 'cron' },
@@ -38,6 +39,8 @@ export const slackWatcherWorkflow: WorkflowType = {
       lookbackMinutes: cfg.lookbackMinutes,
       digestChannel: cfg.digestChannel,
       trigger: ctx.trigger,
+      model: ctx.model,
+      timeoutMs: ctx.timeoutMs,
     }).catch((err) => {
       logger.error(
         { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },

--- a/server/workflows/slack-watcher/run.test.ts
+++ b/server/workflows/slack-watcher/run.test.ts
@@ -53,18 +53,58 @@ describe('runSlackWatcher', () => {
     expect(call.outputSchema).toBe(SLACK_WATCHER_SCHEMA);
   });
 
+  it('passes model and timeoutMs through to runSessionVertical', async () => {
+    await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      scheduleId: 'sched-1',
+      slackUserId: 'U01',
+      digestTarget: 'slack',
+      telegramChatId: '',
+      digestUserId: 'U0P',
+      lookbackMinutes: 40,
+      digestChannel: '',
+      model: 'claude-haiku-4-5-20251001',
+      timeoutMs: 120000,
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.model).toBe('claude-haiku-4-5-20251001');
+    expect(call.timeoutMs).toBe(120000);
+  });
+
+  it('passes null model and timeoutMs through to runSessionVertical when omitted', async () => {
+    await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      slackUserId: 'U01',
+      digestTarget: 'slack',
+      telegramChatId: '',
+      digestUserId: 'U0P',
+      lookbackMinutes: 40,
+      digestChannel: '',
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
+  });
+
   it("threads the previous done run's items into {{previousItems}}", async () => {
     const items = [{ channel: '#x', from: 'Priya', about: 'deploy', urgency: 'high' }];
-    const run = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
+    const run = insertRun({
+      workflowKind: 'slack-watcher',
+      trigger: 'cron',
+      scheduleId: 'sched-x',
+    });
     finishRun(run.id, {
       status: 'done',
       result: { outcome: 'done', window: '40m', summary: '1', digestSent: true, items },
     });
 
-    expect(previousItemsJson()).toBe(JSON.stringify(items));
+    expect(previousItemsJson('sched-x')).toBe(JSON.stringify(items));
 
     await runSlackWatcher({
       repoPath: '/repos/octomux',
+      scheduleId: 'sched-x',
       slackUserId: 'U01ABCDEF',
       digestTarget: 'telegram',
       telegramChatId: '555123',
@@ -78,12 +118,88 @@ describe('runSlackWatcher', () => {
   });
 
   it('falls back to [] for missing, unfinished, or malformed previous runs', () => {
-    expect(previousItemsJson()).toBe('[]');
+    expect(previousItemsJson('sched-empty')).toBe('[]');
 
-    const running = insertRun({ workflowKind: 'slack-watcher', trigger: 'cron' });
-    expect(previousItemsJson()).toBe('[]'); // running run has no result yet
+    const running = insertRun({
+      workflowKind: 'slack-watcher',
+      trigger: 'cron',
+      scheduleId: 'sched-empty',
+    });
+    expect(previousItemsJson('sched-empty')).toBe('[]'); // running run has no result yet
 
     finishRun(running.id, { status: 'failed', error: 'boom' });
-    expect(previousItemsJson()).toBe('[]'); // failed run is not dedup memory
+    expect(previousItemsJson('sched-empty')).toBe('[]'); // failed run is not dedup memory
+  });
+
+  it('falls back to [] when scheduleId is null/undefined', () => {
+    expect(previousItemsJson(null)).toBe('[]');
+    expect(previousItemsJson(undefined)).toBe('[]');
+    expect(previousItemsJson()).toBe('[]');
+  });
+
+  it('previousItems is passed as a string scalar — a value containing {{tokens}} stays literal', async () => {
+    // Insert a run whose items JSON happens to contain curly-brace text
+    const items = [{ channel: '#x', from: 'bot', about: '{{slackUserId}}', urgency: 'low' }];
+    const run = insertRun({
+      workflowKind: 'slack-watcher',
+      trigger: 'cron',
+      scheduleId: 'sched-lit',
+    });
+    finishRun(run.id, {
+      status: 'done',
+      result: { outcome: 'done', window: '40m', summary: '1', digestSent: false, items },
+    });
+
+    await runSlackWatcher({
+      repoPath: '/repos/octomux',
+      scheduleId: 'sched-lit',
+      slackUserId: 'REAL_USER',
+      digestTarget: 'slack',
+      telegramChatId: '',
+      digestUserId: 'U0P',
+      lookbackMinutes: 40,
+      digestChannel: '',
+    });
+
+    const call = mockRunSessionVertical.mock.calls[0][0];
+    // {{slackUserId}} inside the previousItems JSON must NOT be substituted —
+    // interpolatePrompt is single-pass, so the already-substituted previousItems
+    // string is not re-scanned.
+    expect(call.input).toContain('{{slackUserId}}');
+    // But the top-level {{slackUserId}} placeholder IS substituted
+    expect(call.input).toContain('Watch REAL_USER');
+  });
+
+  describe('previousItemsJson schedule isolation', () => {
+    it("two schedules' runs don't cross-contaminate each other's dedup memory", () => {
+      const itemsA = [{ channel: '#a', from: 'Alice', about: 'ping', urgency: 'low' }];
+      const itemsB = [{ channel: '#b', from: 'Bob', about: 'pong', urgency: 'high' }];
+
+      const runA = insertRun({
+        workflowKind: 'slack-watcher',
+        trigger: 'cron',
+        scheduleId: 'sched-A',
+      });
+      finishRun(runA.id, {
+        status: 'done',
+        result: { outcome: 'done', window: '40m', summary: 'a', digestSent: true, items: itemsA },
+      });
+
+      const runB = insertRun({
+        workflowKind: 'slack-watcher',
+        trigger: 'cron',
+        scheduleId: 'sched-B',
+      });
+      finishRun(runB.id, {
+        status: 'done',
+        result: { outcome: 'done', window: '40m', summary: 'b', digestSent: true, items: itemsB },
+      });
+
+      expect(previousItemsJson('sched-A')).toBe(JSON.stringify(itemsA));
+      expect(previousItemsJson('sched-B')).toBe(JSON.stringify(itemsB));
+      // sched-A must not see sched-B's items and vice-versa
+      expect(previousItemsJson('sched-A')).not.toBe(JSON.stringify(itemsB));
+      expect(previousItemsJson('sched-B')).not.toBe(JSON.stringify(itemsA));
+    });
   });
 });

--- a/server/workflows/slack-watcher/run.ts
+++ b/server/workflows/slack-watcher/run.ts
@@ -6,8 +6,9 @@
  * spec/slack-watcher.md §Slack app tokens.
  */
 import { resolveSchedulePrompt } from '../../schedule-prompt.js';
-import { listRunsForWorkflow } from '../../repositories/runs.js';
+import { listRunsForWorkflow, listRunsForSchedule } from '../../repositories/runs.js';
 import { runSessionVertical } from '../../services/session-vertical-service.js';
+import { interpolatePrompt } from '../../prompt-interpolate.js';
 import { SLACK_WATCHER_SCHEMA } from './schema.js';
 
 export interface RunSlackWatcherInput {
@@ -24,6 +25,8 @@ export interface RunSlackWatcherInput {
   lookbackMinutes: number;
   digestChannel: string;
   trigger?: 'cron' | 'manual';
+  model?: string | null;
+  timeoutMs?: number | null;
 }
 
 export interface SlackWatcherItem {
@@ -45,11 +48,17 @@ export interface SlackWatcherResult {
   items: SlackWatcherItem[];
 }
 
-/** Items from the most recent finished run — injected as the skill's dedup memory. */
-export function previousItemsJson(): string {
-  const last = listRunsForWorkflow('slack-watcher').find(
-    (r) => r.status === 'done' && r.result_json,
-  );
+/**
+ * Items from the most recent finished run for the given schedule — injected
+ * as the skill's dedup memory. When scheduleId is provided, filters by
+ * `runs.schedule_id` so that two watcher schedules do not cross-contaminate
+ * each other's dedup memory. When null/undefined, falls back to the global
+ * kind-level list (legacy behaviour for callers without a scheduleId).
+ */
+export function previousItemsJson(scheduleId?: string | null): string {
+  const runs =
+    scheduleId != null ? listRunsForSchedule(scheduleId) : listRunsForWorkflow('slack-watcher');
+  const last = runs.find((r) => r.status === 'done' && r.result_json);
   if (!last) return '[]';
   try {
     const result = JSON.parse(last.result_json!) as { items?: unknown };
@@ -66,14 +75,17 @@ export async function runSlackWatcher(
     scheduleId: input.scheduleId,
     kind: 'slack-watcher',
   });
-  const prompt = skillContent
-    .replace(/\{\{slackUserId\}\}/g, input.slackUserId)
-    .replace(/\{\{digestTarget\}\}/g, input.digestTarget)
-    .replace(/\{\{telegramChatId\}\}/g, input.telegramChatId)
-    .replace(/\{\{digestUserId\}\}/g, input.digestUserId)
-    .replace(/\{\{lookbackMinutes\}\}/g, String(input.lookbackMinutes))
-    .replace(/\{\{digestChannel\}\}/g, input.digestChannel)
-    .replace(/\{\{previousItems\}\}/g, previousItemsJson());
+  const prompt = interpolatePrompt(skillContent, {
+    slackUserId: input.slackUserId,
+    digestTarget: input.digestTarget,
+    telegramChatId: input.telegramChatId,
+    digestUserId: input.digestUserId,
+    lookbackMinutes: input.lookbackMinutes,
+    digestChannel: input.digestChannel,
+    // previousItems is pre-stringified JSON — passed as a string scalar so it
+    // lands verbatim (interpolatePrompt calls String() on scalars).
+    previousItems: previousItemsJson(input.scheduleId),
+  });
 
   return runSessionVertical<SlackWatcherResult>({
     kind: 'slack-watcher',
@@ -82,5 +94,7 @@ export async function runSlackWatcher(
     input: prompt,
     outputSchema: SLACK_WATCHER_SCHEMA,
     trigger: input.trigger ?? 'cron',
+    model: input.model,
+    timeoutMs: input.timeoutMs,
   });
 }

--- a/server/workflows/types.ts
+++ b/server/workflows/types.ts
@@ -13,12 +13,24 @@ export interface RunContext {
   event?: unknown;
   /** How this invocation was triggered — cron poller or manual run-now. */
   trigger?: 'cron' | 'manual';
+  /** Per-schedule model override; null means harness default. */
+  model?: string | null;
+  /** Per-schedule session timeout in ms; null means DEFAULT_TIMEOUT_MS (300000). */
+  timeoutMs?: number | null;
 }
 
 export interface WorkflowType {
   kind: string;
   displayName: string;
   surfaces: SurfaceKind[];
+  /**
+   * How this workflow's runs are executed — drives capability flags in the API
+   * (supportsTimeout) and the UI field visibility matrix.
+   * 'session'  = headless agent session (runSessionVertical)
+   * 'task'     = loop task (doc-drift, prod-log-triage)
+   * 'chat'     = chat-based (daily-plan)
+   */
+  execution?: 'session' | 'task' | 'chat';
   /** JSON Schema for schedule instance config — drives the /schedules form. */
   config?: JsonSchema;
   /** JSON Schema for this workflow's item shape — drives the client's schema-driven default

--- a/server/workflows/weekly-update/index.test.ts
+++ b/server/workflows/weekly-update/index.test.ts
@@ -15,10 +15,15 @@ function makeRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     id: 'sched1',
     kind: 'weekly-update',
     repo_path: '/repo',
+    name: null,
     cron: '0 9 * * 1',
+    timezone: null,
     enabled: 1,
+    model: null,
+    timeout_ms: null,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }
@@ -58,5 +63,35 @@ describe('weekly-update workflow registration', () => {
     const call = mockRunWeeklyUpdate.mock.calls[0][0];
     expect(call.repoPath).toBe('/repo');
     expect(call.scheduleId).toBe('sched-42');
+  });
+
+  it('threads ctx.model and ctx.timeoutMs into runWeeklyUpdate', async () => {
+    const wf = getWorkflow('weekly-update')!;
+    const row = makeRow({ id: 'sched-99' });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: {},
+      scheduleId: row.id,
+      model: 'claude-sonnet-4-6',
+      timeoutMs: 180000,
+    });
+
+    const call = mockRunWeeklyUpdate.mock.calls[0][0];
+    expect(call.model).toBe('claude-sonnet-4-6');
+    expect(call.timeoutMs).toBe(180000);
+  });
+
+  it('passes undefined model/timeoutMs when ctx has none', async () => {
+    const wf = getWorkflow('weekly-update')!;
+    const row = makeRow({ id: 'sched-100' });
+    await wf.run!({
+      repoPath: row.repo_path,
+      config: {},
+      scheduleId: row.id,
+    });
+
+    const call = mockRunWeeklyUpdate.mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
   });
 });

--- a/server/workflows/weekly-update/index.ts
+++ b/server/workflows/weekly-update/index.ts
@@ -10,6 +10,7 @@ export const weeklyUpdateWorkflow: WorkflowType = {
   kind: 'weekly-update',
   displayName: 'Weekly Update',
   surfaces: ['artifact'],
+  execution: 'session',
   output: WEEKLY_UPDATE_SCHEMA,
   trigger: { kind: 'cron' },
   run: (ctx: RunContext) => {
@@ -22,6 +23,8 @@ export const weeklyUpdateWorkflow: WorkflowType = {
       repoPath: ctx.repoPath,
       scheduleId: ctx.scheduleId,
       trigger: ctx.trigger,
+      model: ctx.model,
+      timeoutMs: ctx.timeoutMs,
     }).catch((err) => {
       logger.error(
         { err, repo_path: ctx.repoPath, schedule_id: ctx.scheduleId },

--- a/server/workflows/weekly-update/run.test.ts
+++ b/server/workflows/weekly-update/run.test.ts
@@ -45,4 +45,31 @@ describe('runWeeklyUpdate', () => {
     expect(call.outputSchema).toBe(WEEKLY_UPDATE_SCHEMA);
     expect(call.trigger).toBe('manual');
   });
+
+  it('passes model and timeoutMs through to runSessionVertical', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Weekly summary prompt.');
+    vi.mocked(runSessionVertical).mockResolvedValue({ result: { period: 'week' } });
+
+    await runWeeklyUpdate({
+      repoPath: '/repos/my-app',
+      scheduleId: 'sched-2',
+      model: 'claude-opus-4-8',
+      timeoutMs: 300000,
+    });
+
+    const call = vi.mocked(runSessionVertical).mock.calls[0][0];
+    expect(call.model).toBe('claude-opus-4-8');
+    expect(call.timeoutMs).toBe(300000);
+  });
+
+  it('passes undefined model and timeoutMs when not specified', async () => {
+    mockResolveSchedulePrompt.mockResolvedValue('Summarize.');
+    vi.mocked(runSessionVertical).mockResolvedValue({ result: { period: 'week' } });
+
+    await runWeeklyUpdate({ repoPath: '/repos/my-app', scheduleId: 'sched-3' });
+
+    const call = vi.mocked(runSessionVertical).mock.calls[0][0];
+    expect(call.model).toBeUndefined();
+    expect(call.timeoutMs).toBeUndefined();
+  });
 });

--- a/server/workflows/weekly-update/run.ts
+++ b/server/workflows/weekly-update/run.ts
@@ -11,6 +11,8 @@ export interface RunWeeklyUpdateInput {
   repoPath: string;
   scheduleId?: string | null;
   trigger?: 'cron' | 'manual';
+  model?: string | null;
+  timeoutMs?: number | null;
 }
 
 export interface WeeklyUpdateResult {
@@ -35,5 +37,7 @@ export async function runWeeklyUpdate(
     input: prompt,
     outputSchema: WEEKLY_UPDATE_SCHEMA,
     trigger: input.trigger ?? 'cron',
+    model: input.model,
+    timeoutMs: input.timeoutMs,
   });
 }

--- a/spec/schedule-configurability.md
+++ b/spec/schedule-configurability.md
@@ -1,0 +1,392 @@
+# Schedule Configurability
+
+Status: FINAL — revised after 5-persona review (backend architect, security, UX, SRE, YAGNI)
+Date: 2026-07-24
+
+## 0. Problem
+
+An audit of the schedules surface found a split between what a schedule row can express and
+what the runtime actually honors. Today a schedule is `(kind, repo_path)`-unique with an
+editable cron, enabled flag, and kind-specific `config_json`; the per-kind prompt body lives
+in `schedule_skills` (DB-authoritative, editable in Settings). Everything else is hardcoded:
+
+| #   | Hardcoded thing                            | Where                                                                                            |
+| --- | ------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| 1   | One schedule per `(kind, repo_path)`       | `UNIQUE` constraint in `server/db/schema.ts`                                                     |
+| 2   | `repo_path` immutable after create         | `updateSchedule()` only patches cron/enabled/config                                              |
+| 3   | Cron timezone = UTC                        | `server/schedules/cron.ts` hardcodes `timezone: 'UTC'`                                           |
+| 4   | Model = harness default                    | `runSessionVertical` never receives `model`; task-backed kinds never stamp `tasks.model`         |
+| 5   | Headless session timeout = 5 min           | `DEFAULT_TIMEOUT_MS = 300_000` in `server/agent-session/session.ts`                              |
+| 6   | Prompt is per-kind only                    | `resolveSchedulePrompt()` ignores `scheduleId`; the `schedules.prompt` column exists but is dead |
+| 7   | `{{placeholder}}` sets                     | hand-written `.replace()` chains in each workflow `run.ts`                                       |
+| 8   | `baseBranch: 'main'`, branch name prefixes | `doc-drift/run.ts`, `prod-log-triage/run.ts`                                                     |
+| 9   | The set of kinds                           | code registry — a new kind requires a deploy                                                     |
+
+This spec makes 1–8 data (editable from the `/schedules` UI) and adds a generic
+**custom** kind as the UI-side answer to 9.
+
+## 1. Goals / non-goals
+
+**Goals**
+
+- Every per-schedule knob editable from the UI: name, repo, cron, timezone, enabled,
+  model, session timeout, kind config, and a per-schedule prompt override.
+- Multiple independently-configured schedules of the same kind against the same repo.
+- Generic `{{key}}` interpolation so skill-body edits and config fields compose without
+  code changes.
+- A `custom` kind: cron + prompt + generic result envelope, no code registration.
+
+**Non-goals**
+
+- Authoring new _structured_ workflow kinds (bespoke output schemas, feed cards,
+  task-backed loops) from the UI. That stays code.
+- Per-schedule harness/substrate selection (stays default harness + pty).
+- Changing the poller cadence or cron grammar (5-field, minute granularity).
+- Seconds-level scheduling, catch-up/backfill for missed windows. (DST fall-back
+  double-fire is handled — see §3.)
+
+**Scope adjudications from review** (recorded so implementation doesn't relitigate):
+
+- `repoPath` stays PATCHable (explicit user requirement; cheap for a single-user tool).
+- `branchPrefix` stays (schema-driven cost is one property + one template string), with
+  refname validation (§6).
+- `name` is optional for built-in kinds, **required for `custom`** (custom cards are
+  otherwise indistinguishable).
+- Kind capability flags stay API-driven (§8) — the client must not hardcode kind lists;
+  that's the anti-pattern this spec exists to remove.
+- Cut: nothing user-visible. All items from the original audit ship.
+
+## 2. Data model
+
+### 2.1 `schedules` table
+
+Final shape (this exact DDL replaces the current `CREATE TABLE schedules` in
+`server/db/schema.ts` — **the SCHEMA constant must be updated in the same change**,
+or fresh installs/`createTestDb()` re-create the UNIQUE constraint and silently
+re-break multi-instance):
+
+```sql
+CREATE TABLE IF NOT EXISTS schedules (
+  id            TEXT PRIMARY KEY,
+  kind          TEXT NOT NULL,
+  repo_path     TEXT NOT NULL,
+  name          TEXT,                -- NEW: display name; NULL → kind displayName
+  cron          TEXT NOT NULL,
+  timezone      TEXT,                -- NEW: IANA zone; NULL → 'UTC'
+  enabled       INTEGER NOT NULL DEFAULT 1,
+  model         TEXT,                -- NEW: harness model id; NULL → harness default
+  timeout_ms    INTEGER,             -- NEW: headless session timeout; NULL → 300000
+  last_run_at   TEXT,
+  config_json   TEXT,
+  prompt        TEXT,                -- EXISTING dead column, now live: per-schedule prompt override
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+-- No UNIQUE(kind, repo_path). No secondary indexes needed today; add here if query
+-- patterns change (the dropped UNIQUE index was never used for lookups the poller does).
+```
+
+Migration (forward-only, in `server/db/migrations.ts`):
+
+- **Idempotency guard**: run the rebuild only when
+  `!columnsOf(instance, 'schedules').has('timezone')`. (The existing `addColumn` guards
+  for `config_json`/`prompt` at migrations.ts:908–910 run _before_ this block and stay.)
+- **Transaction-wrapped**, matching `rebuildAgentsTable` and the `permission_prompts`
+  rebuild: `CREATE TABLE schedules_new (…) → INSERT INTO schedules_new (id, kind,
+repo_path, cron, enabled, last_run_at, config_json, prompt, created_at, updated_at)
+SELECT … FROM schedules → DROP TABLE schedules → ALTER TABLE schedules_new RENAME TO
+schedules`. A crash mid-rebuild must not lose the table.
+- `name`, `timezone`, `model`, `timeout_ms` are deliberately absent from the
+  INSERT/SELECT — they default to NULL for all migrated rows, which reproduces today's
+  behavior exactly (§11).
+- No FK constraints reference `schedules` (`runs.schedule_id` / `tasks.schedule_id` are
+  plain TEXT); row ids and `last_run_at` are preserved, so runs history and the live
+  prod schedules survive untouched.
+
+### 2.2 Repository layer (`server/repositories/schedules.ts`)
+
+- `upsertSchedule()` is **deleted**, replaced by `createSchedule()`: pure insert.
+  - The post-insert SELECT must switch to `WHERE id = ?` (the fresh nanoid). The current
+    `WHERE kind = ? AND repo_path = ?` lookup is only valid under the UNIQUE constraint;
+    after the drop it can return the wrong row.
+  - `ON CONFLICT(kind, repo_path)` must not appear in any query after the migration
+    (undefined without the constraint). Verified callers at time of writing: only
+    `routes/schedules.ts`. If a `schedule create` CLI command is added later it must use
+    pure-insert semantics.
+- `updateSchedule()` accepts the full patchable set: `name`, `repoPath`, `cron`,
+  `timezone`, `enabled`, `model`, `timeoutMs`, `config`, `prompt`. `kind` is immutable
+  (delete + recreate — a kind change invalidates config/prompt anyway).
+- `ScheduleRow` gains `name`, `timezone`, `model`, `timeout_ms`, `prompt` — **and
+  `SCHEDULE_COLUMNS` must list them**, or every read silently returns `undefined` for
+  the new fields even after the migration.
+
+## 3. Cron evaluation with timezone
+
+`isCronDue(expr, now, timezone?)` in `server/schedules/cron.ts`:
+
+- `timezone ?? 'UTC'` passed to croner (native support).
+- The module-level `cache: Map<string, Cron>` key changes from bare `expr` to
+  `` `${timezone ?? 'UTC'}\n${expr}` `` **atomically with the signature change** (the
+  map is in-memory; no entry migration needed — old-format keys are simply never hit
+  again). `\n` cannot collide: croner rejects expressions containing newlines, and
+  timezone is validated at write time. Entries are not evicted on schedule
+  update/delete — orphaned entries are unreachable and bounded by distinct (tz, expr)
+  pairs ever seen; acceptable at this scale (revisit with an LRU if schedule counts
+  reach hundreds).
+- `pollSchedules()` (server/poller/schedule-cron.ts) changes to
+  `isCronDue(row.cron, now, row.timezone)`. Audit test call sites for the new argument.
+- **Same-minute refire guard**: skip a row when `last_run_at` falls in the same UTC
+  minute as `now`. This closes both the poller-tick-jitter double-fire and the DST
+  fall-back double-fire (one UTC minute matching twice), which matters for task-backed
+  kinds (two tasks in one minute) and is harmless-but-noisy for digests.
+- **Write-time validation** (both `POST` and `PATCH` — note neither currently validates
+  cron beyond non-empty): construct `new Cron(expr, { timezone, paused: true })` in a
+  try/catch and rethrow as `badRequest` 400 saying whether the expression or the
+  timezone is invalid. Never let croner's throw escape as a 500. Runtime behavior for
+  a row that somehow holds bad data stays "never matches".
+
+## 4. Prompt resolution & generic interpolation
+
+### 4.1 Resolution precedence
+
+`resolveSchedulePrompt({ scheduleId, kind })` (server/schedule-prompt.ts) becomes:
+
+1. `schedules.prompt` for `scheduleId` — if non-empty, use it.
+2. `schedule_skills[kind]` — lazily seeded from shipped SKILL.md (unchanged).
+
+All call sites already pass `scheduleId` (the parameter exists and is currently
+ignored) — only the function body changes; no call-site updates needed.
+
+`skillContentOverridesForScheduleId()` (server/schedule-prompt.ts:66, used by all five
+task-lifecycle entry points for doc-drift / prod-log-triage) currently calls
+`resolveScheduleSkillContent(schedule.kind)` unconditionally and never reads
+`schedule.prompt`. **Rewrite its body**: if `schedule.prompt` is non-empty, return
+`{ [schedule.kind]: schedule.prompt }`; otherwise fall back to
+`resolveScheduleSkillContent(schedule.kind)` as today. Log the branch taken
+(`prompt_source: 'schedule_override' | 'kind_skill'`) at debug level in both functions.
+
+New endpoint `GET /api/schedules/:id/effective-prompt` returns
+`{ content: string, source: 'override' | 'kind_skill' }` from `resolveSchedulePrompt` —
+the UI preview shows exactly what the runtime resolves, with zero client-side
+duplication of resolution or interpolation logic.
+
+### 4.2 Interpolation
+
+New `interpolatePrompt(body: string, vars: Record<string, unknown>): string`:
+
+- Replaces every `{{key}}` where `key` is a var; scalars via `String(v)`,
+  objects/arrays via `JSON.stringify`.
+- **Exactly one pass** — a single sweep; the output is never re-scanned. A var value
+  containing `{{otherKey}}` stays literal in the output (test-matrix case). No loops,
+  no recursion.
+- Unknown placeholders are left intact (visible signal, not silent deletion).
+- Var set = resolved schedule config (post-defaults) **plus** workflow-declared extras
+  (e.g. slack-watcher's `previousItems`). The hand-written `.replace()` chains are
+  deleted. Behavior-preserving: current placeholder names equal the config keys.
+- **Scope**: applies to session-vertical kinds and `custom` only. Task-backed kinds'
+  prompts are code-built (`buildDocDriftPrompt` / `buildTriagePrompt`); their skill
+  bodies reach the agent via the overlay plugin (§4.1) uninterpolated, as today.
+- Design note (accepted): config values are injected verbatim into agent prompts. That
+  is the existing posture for `previousItems` (raw Slack content) and is the user's own
+  configuration in a single-user tool; interpolation does not widen it.
+
+**Multi-instance dedup fix**: `previousItemsJson()` in slack-watcher currently reads the
+latest done run for the _kind_, globally. With multiple watcher schedules allowed, it
+must become `previousItemsJson(scheduleId)` filtering `runs.schedule_id` (use
+`listRunsForSchedule`), or two watchers cross-contaminate each other's dedup memory.
+
+## 5. Model & timeout threading
+
+`RunContext` (server/workflows/types.ts) gains `model?: string | null` and
+`timeoutMs?: number | null`, populated by `executeScheduleRun` from the row.
+
+Full threading path (each layer is a real code change — missing any one silently falls
+back to defaults with no error):
+
+1. `ScheduleRow` + `SCHEDULE_COLUMNS` (§2.2).
+2. `executeScheduleRun` reads `row.model` / `row.timeout_ms` into `RunContext`, and
+   logs run start: `logger.info({ schedule_id, kind, trigger, model: row.model ??
+'default', timeout_ms: row.timeout_ms ?? 300000, prompt_source }, 'schedule run
+started')` — today nothing is logged on success.
+3. Each workflow's `run(ctx)` in `*/index.ts` threads `ctx.model` / `ctx.timeoutMs`
+   into its service-layer input struct. Structs needing new optional fields:
+   `RunSlackWatcherInput`, `RunWeeklyUpdateInput`, `RunOvernightLogSummaryInput`
+   (model + timeoutMs); `CreateDocDriftTaskFromScheduleInput`,
+   `CreateTriageTaskFromScheduleInput` (model only); `RunDailyPlanFromScheduleInput`
+   (model only).
+4. Sinks:
+   - **Session verticals** (slack-watcher, weekly-update, overnight-log-summary,
+     custom): `runSessionVertical` already accepts `model`; add `timeoutMs`, forwarded
+     to `runAgentSession` (`timeoutMs ?? DEFAULT_TIMEOUT_MS`).
+   - **Task-backed**: stamp the task row's `model` on insert (`tasks.model` +
+     `applyModel()` plumbing already exist end-to-end). `timeout_ms` does not apply to
+     loop tasks; the UI hides the field (§8 capability flags).
+   - **daily-plan**: `CreateChatOptions` gains `model?: string | null`; `createChat`
+     applies it via `applyModel(flags, model)` (it currently has no model path at all).
+     `timeout_ms` N/A.
+
+**Validation & quoting (security-critical)**: the session-vertical launch string is
+executed via `sh -c`, and `applyModel` (server/harnesses/shared.ts:25) appends
+`--model ${model}` **unquoted** — a model value with shell metacharacters would execute.
+Two independent fixes, both required:
+
+- Write-time: `POST`/`PATCH` reject `model` not matching `^[a-zA-Z0-9._:/-]{1,128}$`.
+- Defense-in-depth: `applyModel` wraps the value with `shellQuoteSingle`
+  (server/shell-quote.ts) regardless of source.
+
+`timeoutMs` validation: positive integer, `10_000 ≤ v ≤ 86_400_000` (10 s–24 h); 400
+outside the range. (Node `setTimeout` misbehaves at 0/negative/`>2^31-1`.) NULL/omitted
+→ `DEFAULT_TIMEOUT_MS`.
+
+UI: model is a free-text input with a datalist from a small client constant
+(`KNOWN_MODELS` in `src/lib/models.ts` — no model picker exists anywhere in the UI
+today, so this is new); empty = harness default. Timeout renders in minutes, stored
+as ms.
+
+## 6. Task-backed config additions
+
+`DOC_DRIFT_CONFIG_SCHEMA` and `PROD_LOG_TRIAGE_CONFIG_SCHEMA` gain:
+
+- `baseBranch` (string, default `'main'`) → replaces hardcoded `baseBranch: 'main'`.
+- `branchPrefix` (string, defaults `'doc-drift'` / `'triage'`) → branch becomes
+  `` `${branchPrefix}/${short}-${dateStamp}` ``.
+- Both carry `"format": "single-line"` in their JSON Schema; `SchemaConfigForm` renders
+  `format === 'single-line'` strings as `<Input>` instead of the 4-row `<Textarea>`
+  (replacing the current hardcoded `verify`/`logCommand` property-name checks with a
+  generic mechanism).
+- Write-time validation: both must match `^[a-zA-Z0-9._/-]{1,80}$` (git-refname-safe
+  subset). Branch strings flow into `execFile('git', …)` — no shell risk — but an
+  invalid refname fails task setup late and confusingly; reject early with a 400.
+
+Task title/description templates stay code (cosmetic; not worth config surface).
+
+daily-plan and weekly-update deliberately get **no** kind config: their tunables are the
+prompt body (per-kind or per-schedule) plus the new first-class fields.
+
+## 7. The `custom` kind
+
+A registered workflow (`server/workflows/custom/`) whose behavior is entirely data:
+
+- `kind: 'custom'`, `displayName: 'Custom Prompt'`, `surfaces: ['artifact']`,
+  `trigger: { kind: 'cron' }` — registering with a cron trigger + `run` handler makes it
+  appear in `listCronWorkflowKinds()` automatically, so `assertCronKind` accepts it with
+  no route changes.
+- **Prompt**: `schedules.prompt`, required — `POST`/`PATCH` reject an enabled custom
+  schedule with an empty prompt. Not in `CRON_PROMPT_KINDS` (no SKILL.md seed, nothing
+  in Settings → Schedule skills); its `run()` reads the schedule row's prompt directly
+  and never calls `resolveScheduleSkillContent` (which would throw for an unseeded kind).
+- **Name**: required for custom (§1 adjudication) — cards would otherwise be
+  indistinguishable.
+- **Config**: none in v1. `{{...}}` interpolation still runs (extras only).
+- **Output**: the universal envelope (`RUN_RESULT_SCHEMA` from `@octomux/types`:
+  outcome/summary/links) as its full output schema — renders with the generic
+  runs-feed card, no new UI.
+- **Run lifecycle**: the custom kind's run wrapper owns its `runs` row — `insertRun` on
+  entry, `finishRun(status: 'failed')` in its catch — rather than trusting the prompt to
+  reach `submit_result`. (Session verticals get this from `runAgentSession`'s existing
+  run handling; the wrapper must not leave a row stuck at `running`.)
+- **Run**: `runSessionVertical` in `repo_path` with the schedule's model/timeout.
+
+Multiple custom schedules per repo are the point — this is why §2 drops the UNIQUE
+constraint rather than special-casing.
+
+## 8. API surface
+
+- `GET /api/schedules/kinds` — each kind gains capability flags so the client renders
+  correctly **without hardcoding kind lists**: `promptRequired: boolean` (true for
+  custom) and `supportsTimeout: boolean` (true for session-vertical kinds; false for
+  task-backed + daily-plan). Derive server-side from a new
+  `execution: 'session' | 'task' | 'chat'` field on `WorkflowType` — each workflow
+  already knows its nature; the route computes the flags.
+- `POST /api/schedules` — always creates (201). New optional fields: `name`, `timezone`,
+  `model`, `timeoutMs`, `prompt`. Validation: cron+timezone (§3), config vs kind schema
+  (existing), model regex + timeout bounds (§5), refname fields (§6), prompt + name
+  presence for custom (§7).
+- `PATCH /api/schedules/:id` — accepts the same fields plus `repoPath`. Same validation
+  (including the cron-syntax check `PATCH` never had).
+- `GET /api/schedules` — returns the new columns.
+- `GET /api/schedules/:id/effective-prompt` — §4.1.
+- No changes to `/api/schedule-skills` (per-kind default bodies).
+
+**Back-compat**: POST loses upsert-on-conflict semantics. No CLI/plugin callers at time
+of writing (verified); any future `schedule create` CLI command uses pure-insert.
+Existing rows migrate with all new columns NULL → behavior identical to today.
+
+## 9. UI (`/schedules`)
+
+Create stays the existing **inline panel** (there is no create dialog today — the spec
+deliberately keeps the pattern); edit stays expand-in-place on the card.
+
+**Field visibility matrix (create panel):**
+
+| Field                                | Visibility                                                                                                                                                                                |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| kind, repo, cron + timezone, enabled | always                                                                                                                                                                                    |
+| name                                 | always for custom (required); for built-ins inside "Advanced" (optional)                                                                                                                  |
+| model, timeout                       | "Advanced" disclosure, collapsed by default; timeout only when `supportsTimeout`                                                                                                          |
+| config form                          | when the kind has a config schema (existing behavior)                                                                                                                                     |
+| prompt                               | custom: always visible, required, submit disabled + required indicator while empty (extends the existing `canSubmit` pattern); other kinds: hidden behind an "Override prompt" disclosure |
+
+**Timezone field**: a searchable combobox (not a native select — `Intl.supportedValuesOf('timeZone')`
+returns ~400 entries), filter-on-type, placeholder "UTC" (the stored NULL), plus a
+"Use browser timezone" action that fills `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+Options display as `Zone/Name (UTC±H:MM)` resolved at the current instant.
+
+**Prompt override editor (edit card)**: collapsed by default. When no override exists it
+shows a read-only, code-font preview fetched lazily from
+`GET /api/schedules/:id/effective-prompt`; `{{tokens}}` are shown raw with a hint that
+they're replaced at runtime by same-named config values. "Override" copies the kind
+default into an editable textarea (no blank-canvas start); "Reset to kind default" sets
+`prompt = NULL` behind a confirm when the override is non-empty. No staleness indicator
+in v1 (override > kind precedence is documented behavior).
+
+**Multi-instance disambiguation**: cards show `name ?? displayName` + kind badge; when
+two unnamed rows share `(kind, repo_path)`, append the cron expression in monospace as
+the disambiguator. The delete confirm shows `name ?? kind` **plus cron**, never just
+`kind · repo_path` (which is now ambiguous). Kind renders as a non-interactive badge in
+the edit card (immutable — delete + recreate).
+
+**Client changes checklist** (must land atomically with the server changes — the SPA
+treats all new fields as nullable on read for forward-compat): `ScheduleRow`
+(+name/timezone/model/timeout_ms/prompt), `ScheduleKindInfo` (+promptRequired/
+supportsTimeout/execution), `CreateScheduleInput` / `UpdateScheduleInput` (+ all new
+fields, `repoPath` on update), `schedulesApi` (+effective-prompt fetch), `ScheduleForm`
+and `ScheduleDetail` state + fields, `SchemaConfigForm` (`format: 'single-line'` →
+`<Input>`), new timezone combobox component, `KNOWN_MODELS` constant.
+
+## 10. Testing
+
+Per repo conventions (vitest, `createTestDb()`, supertest against `createApp()`,
+table-driven `it.each`):
+
+- Migration: pre-migration rows survive the rebuild (ids, last_run_at intact); two
+  same-kind/same-repo inserts succeed post-migration; **migration is idempotent across
+  restarts** (guard on existing `timezone` column).
+- `isCronDue`: timezone cases (offset zones, DST spring/fall boundaries, invalid zone →
+  false), compound cache keying (same expr, two zones → independent matches),
+  same-minute refire guard.
+- `interpolatePrompt` table: scalars, objects, unknown placeholders untouched, repeated
+  keys, **single-pass** (`vars.a = '{{b}}'` stays literal).
+- Prompt precedence: override > kind skill > lazy seed; `skillContentOverridesForScheduleId`
+  honors the override; effective-prompt endpoint reports source.
+- slack-watcher dedup: two schedules of the same kind each see only their own previous
+  items (`previousItemsJson(scheduleId)`).
+- Route validation table: bad cron 400, bad timezone 400, model regex 400, timeout
+  bounds 400, refname fields 400, custom without prompt/name 400, PATCH repoPath.
+- Threading: session vertical receives row model/timeout; doc-drift/triage task insert
+  stamps `tasks.model`; `applyModel` output is shell-quoted.
+- Custom kind: run row created on entry, finishes `failed` on crash (never stuck at
+  `running`).
+- Component tests for new form fields; **mock `Intl.supportedValuesOf` (undefined in
+  JSDOM)**.
+
+## 11. Rollout
+
+Single release; forward-only migration — back up `~/.octomux/data/tasks.db` first (repo
+policy). The `SCHEMA` constant, migration, API, and client types all ship in one change
+(§2.1, §9). The live instance's existing schedules keep firing identically: all new
+columns NULL = today's behavior, row ids and runs history preserved, and the
+slack-watcher `.replace()` chain deletion is behavior-preserving because the config keys
+equal the current placeholder names. The one intentional behavior change to watch on the
+live box: the same-minute refire guard (§3) — strictly a de-duplication, never a missed
+scheduled minute.

--- a/src/components/schedules/SchemaConfigForm.test.tsx
+++ b/src/components/schedules/SchemaConfigForm.test.tsx
@@ -37,4 +37,90 @@ describe('SchemaConfigForm', () => {
     await user.type(screen.getByLabelText('Log command'), 'flyctl logs');
     expect(onChange).toHaveBeenCalled();
   });
+
+  describe('format: single-line', () => {
+    it('renders a string property with format single-line as Input (not Textarea)', () => {
+      const singleLineSchema = {
+        type: 'object',
+        properties: {
+          baseBranch: {
+            type: 'string',
+            title: 'Base branch',
+            default: 'main',
+            format: 'single-line',
+          },
+        },
+      };
+      render(
+        <SchemaConfigForm
+          schema={singleLineSchema}
+          value={{ baseBranch: 'main' }}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const field = screen.getByLabelText('Base branch');
+      expect(field.tagName.toLowerCase()).toBe('input');
+    });
+
+    it('renders a string property without format as Textarea', () => {
+      const multiLineSchema = {
+        type: 'object',
+        properties: {
+          description: { type: 'string', title: 'Description', default: '' },
+        },
+      };
+      render(
+        <SchemaConfigForm
+          schema={multiLineSchema}
+          value={{ description: '' }}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const field = screen.getByLabelText('Description');
+      expect(field.tagName.toLowerCase()).toBe('textarea');
+    });
+
+    it('backward compat: logCommand without format renders as Textarea', () => {
+      render(
+        <SchemaConfigForm
+          schema={schema}
+          value={{ logCommand: 'gh run list' }}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const field = screen.getByLabelText('Log command');
+      expect(field.tagName.toLowerCase()).toBe('textarea');
+    });
+
+    it('calls onChange when single-line input changes', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const singleLineSchema = {
+        type: 'object',
+        properties: {
+          branchPrefix: {
+            type: 'string',
+            title: 'Branch prefix',
+            default: 'doc-drift',
+            format: 'single-line',
+          },
+        },
+      };
+      render(
+        <SchemaConfigForm
+          schema={singleLineSchema}
+          value={{ branchPrefix: 'doc-drift' }}
+          onChange={onChange}
+        />,
+      );
+
+      const field = screen.getByLabelText('Branch prefix');
+      await user.clear(field);
+      await user.type(field, 'my-prefix');
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/schedules/SchemaConfigForm.tsx
+++ b/src/components/schedules/SchemaConfigForm.tsx
@@ -11,6 +11,7 @@ interface SchemaProperty {
   default?: unknown;
   minimum?: number;
   enum?: string[];
+  format?: string;
 }
 
 interface SchemaConfigFormProps {
@@ -107,14 +108,38 @@ export function SchemaConfigForm({ schema, value, onChange }: SchemaConfigFormPr
           );
         }
 
+        // Generic mechanism: `format: 'single-line'` renders as Input (one line).
+        // Backward compat: properties named `verify` or `logCommand` without
+        // `format: 'single-line'` keep their existing multi-line mono rendering.
+        const isSingleLine = prop.format === 'single-line';
+        const isCodeLike = key === 'verify' || key === 'logCommand';
+
+        if (isSingleLine) {
+          return (
+            <div key={key} className="flex flex-col gap-1.5">
+              <Label htmlFor={`config-${key}`}>{label}</Label>
+              <Input
+                id={`config-${key}`}
+                data-testid={`schedule-config-${key}`}
+                className={isCodeLike ? 'font-mono text-sm' : undefined}
+                value={typeof current === 'string' ? current : ''}
+                onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+              />
+              {prop.description ? (
+                <p className="text-[10px] text-muted-soft">{prop.description}</p>
+              ) : null}
+            </div>
+          );
+        }
+
         return (
           <div key={key} className="flex flex-col gap-1.5 sm:col-span-2">
             <Label htmlFor={`config-${key}`}>{label}</Label>
             <Textarea
               id={`config-${key}`}
               data-testid={`schedule-config-${key}`}
-              className={key === 'verify' || key === 'logCommand' ? 'font-mono text-sm' : undefined}
-              rows={key === 'verify' || key === 'logCommand' ? 3 : 4}
+              className={isCodeLike ? 'font-mono text-sm' : undefined}
+              rows={isCodeLike ? 3 : 4}
               value={typeof current === 'string' ? current : ''}
               onChange={(e) => onChange({ ...value, [key]: e.target.value })}
             />

--- a/src/components/schedules/TimezoneField.test.tsx
+++ b/src/components/schedules/TimezoneField.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TimezoneField } from './TimezoneField';
+
+// JSDOM does not implement Intl.supportedValuesOf — mock it before each test.
+const FAKE_ZONES = [
+  'America/New_York',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+];
+
+describe('TimezoneField', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Intl', {
+      ...Intl,
+      supportedValuesOf: vi.fn((key: string) => (key === 'timeZone' ? FAKE_ZONES : [])),
+      DateTimeFormat: Intl.DateTimeFormat,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders with UTC placeholder when value is empty', () => {
+    render(<TimezoneField value="" onChange={vi.fn()} />);
+    const input = screen.getByTestId('timezone-input');
+    expect(input).toBeTruthy();
+    expect((input as HTMLInputElement).placeholder).toBe('UTC');
+  });
+
+  it('opens dropdown on focus and shows timezone options', async () => {
+    const user = userEvent.setup();
+    render(<TimezoneField value="" onChange={vi.fn()} />);
+
+    await user.click(screen.getByTestId('timezone-input'));
+
+    expect(await screen.findByTestId('timezone-dropdown')).toBeTruthy();
+    expect(screen.getByTestId('timezone-use-browser')).toBeTruthy();
+    expect(screen.getByTestId('timezone-option-utc')).toBeTruthy();
+  });
+
+  it('filters options by typed text', async () => {
+    const user = userEvent.setup();
+    render(<TimezoneField value="" onChange={vi.fn()} />);
+
+    await user.click(screen.getByTestId('timezone-input'));
+    await user.type(screen.getByTestId('timezone-input'), 'America');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('timezone-option-America/New_York')).toBeTruthy();
+      expect(screen.queryByTestId('timezone-option-America/Los_Angeles')).toBeTruthy();
+      // Europe/London should not match "America"
+      expect(screen.queryByTestId('timezone-option-Europe/London')).toBeNull();
+    });
+  });
+
+  it('calls onChange when a timezone is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TimezoneField value="" onChange={onChange} />);
+
+    await user.click(screen.getByTestId('timezone-input'));
+    await user.type(screen.getByTestId('timezone-input'), 'Tokyo');
+
+    const option = await screen.findByTestId('timezone-option-Asia/Tokyo');
+    await user.pointer({ target: option, keys: '[MouseLeft]' });
+
+    expect(onChange).toHaveBeenCalledWith('Asia/Tokyo');
+  });
+
+  it('"Use browser timezone" fills browser timezone via onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    // Stub resolvedOptions to return a known timezone
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+      timeZone: 'Europe/London',
+      locale: 'en',
+      calendar: 'gregory',
+      numberingSystem: 'latn',
+      hour12: false,
+      hourCycle: 'h23',
+    });
+
+    render(<TimezoneField value="" onChange={onChange} />);
+    await user.click(screen.getByTestId('timezone-input'));
+
+    const browserBtn = await screen.findByTestId('timezone-use-browser');
+    await user.pointer({ target: browserBtn, keys: '[MouseLeft]' });
+
+    expect(onChange).toHaveBeenCalledWith('Europe/London');
+  });
+
+  it('falls back gracefully when Intl.supportedValuesOf is undefined (JSDOM default)', () => {
+    // Remove the mock to simulate JSDOM without the method
+    vi.unstubAllGlobals();
+    vi.stubGlobal('Intl', {
+      ...Intl,
+      supportedValuesOf: undefined,
+      DateTimeFormat: Intl.DateTimeFormat,
+    });
+
+    const onChange = vi.fn();
+    expect(() => render(<TimezoneField value="" onChange={onChange} />)).not.toThrow();
+  });
+
+  it('shows "No matching timezones" when filter matches nothing', async () => {
+    const user = userEvent.setup();
+    render(<TimezoneField value="" onChange={vi.fn()} />);
+
+    await user.click(screen.getByTestId('timezone-input'));
+    await user.type(screen.getByTestId('timezone-input'), 'zzznomatch');
+
+    await waitFor(() => {
+      expect(screen.getByText(/no matching timezones/i)).toBeTruthy();
+    });
+  });
+
+  it('calls onChange with empty string when UTC option is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<TimezoneField value="Asia/Tokyo" onChange={onChange} />);
+
+    await user.click(screen.getByTestId('timezone-input'));
+    const utcOption = await screen.findByTestId('timezone-option-utc');
+    await user.pointer({ target: utcOption, keys: '[MouseLeft]' });
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+});

--- a/src/components/schedules/TimezoneField.tsx
+++ b/src/components/schedules/TimezoneField.tsx
@@ -1,0 +1,206 @@
+/**
+ * src/components/schedules/TimezoneField.tsx
+ *
+ * Searchable timezone combobox backed by Intl.supportedValuesOf('timeZone').
+ * Empty value is stored as NULL on the server, which defaults to UTC.
+ *
+ * Options are labeled "Zone/Name (UTC±H:MM)" using Intl.DateTimeFormat for the
+ * current-instant offset. A "Use browser timezone" action fills the current
+ * browser zone.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+/** All IANA timezone names available in this runtime. Empty array in JSDOM. */
+function getSupportedTimezones(): string[] {
+  if (typeof Intl.supportedValuesOf === 'function') {
+    return Intl.supportedValuesOf('timeZone');
+  }
+  return [];
+}
+
+/** Format a UTC offset like "+05:30" or "-08:00" from minutes-east. */
+function formatOffset(offsetMinutes: number): string {
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const abs = Math.abs(offsetMinutes);
+  const h = Math.floor(abs / 60)
+    .toString()
+    .padStart(2, '0');
+  const m = (abs % 60).toString().padStart(2, '0');
+  return `${sign}${h}:${m}`;
+}
+
+/** Build the display label for a timezone: "Zone/Name (UTC±H:MM)". */
+function tzLabel(tz: string): string {
+  try {
+    // Intl.DateTimeFormat resolves the current offset (honors DST).
+    const fmt = new Intl.DateTimeFormat('en', { timeZone: tz, timeZoneName: 'shortOffset' });
+    const parts = fmt.formatToParts(new Date());
+    const offsetPart = parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+    // offsetPart is like "GMT+5:30" or "GMT-8"; normalize to "UTC±H:MM"
+    const normalized = offsetPart.replace('GMT', 'UTC');
+    return `${tz} (${normalized})`;
+  } catch {
+    return tz;
+  }
+}
+
+interface TimezoneFieldProps {
+  id?: string;
+  value: string; // empty string means UTC (stored as NULL)
+  onChange: (tz: string) => void;
+  label?: string;
+}
+
+export function TimezoneField({
+  id = 'schedule-timezone',
+  value,
+  onChange,
+  label = 'Timezone',
+}: TimezoneFieldProps) {
+  const allZones = useMemo(() => getSupportedTimezones(), []);
+  const [filter, setFilter] = useState('');
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // The display string shown in the text input
+  const displayValue = useMemo(() => {
+    if (!value) return '';
+    if (allZones.length === 0) return value;
+    return tzLabel(value);
+  }, [value, allZones]);
+
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return allZones.slice(0, 100); // cap for perf when empty
+    const q = filter.toLowerCase();
+    return allZones.filter((tz) => tz.toLowerCase().includes(q)).slice(0, 100);
+  }, [allZones, filter]);
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilter(e.target.value);
+      setOpen(true);
+      // If the user clears the field, reset to UTC (empty = NULL)
+      if (!e.target.value) onChange('');
+    },
+    [onChange],
+  );
+
+  const handleSelect = useCallback(
+    (tz: string) => {
+      onChange(tz);
+      setFilter('');
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  const handleUseBrowserTz = useCallback(() => {
+    const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    onChange(browserTz);
+    setFilter('');
+    setOpen(false);
+  }, [onChange]);
+
+  const handleBlur = useCallback((e: React.FocusEvent) => {
+    // Close only if focus leaves the whole container
+    if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+      setOpen(false);
+      setFilter('');
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-1.5" ref={containerRef} onBlur={handleBlur}>
+      <Label htmlFor={id}>{label}</Label>
+      <div className="relative">
+        <Input
+          id={id}
+          data-testid="timezone-input"
+          autoComplete="off"
+          placeholder="UTC"
+          value={open ? filter : displayValue}
+          onFocus={() => {
+            setFilter('');
+            setOpen(true);
+          }}
+          onChange={handleInputChange}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setOpen(false);
+              setFilter('');
+            }
+            if (e.key === 'Enter' && filtered.length === 1) {
+              handleSelect(filtered[0]);
+            }
+          }}
+        />
+        {open && (
+          <div
+            data-testid="timezone-dropdown"
+            className="absolute z-50 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-glass-edge bg-[#0B0C0F] py-1 shadow-lg"
+          >
+            {/* Browser timezone shortcut */}
+            <button
+              type="button"
+              data-testid="timezone-use-browser"
+              className="w-full px-3 py-1.5 text-left text-xs text-[#3B82F6] hover:bg-glass-l1"
+              onMouseDown={(e) => {
+                e.preventDefault(); // prevent blur before click
+                handleUseBrowserTz();
+              }}
+            >
+              Use browser timezone
+            </button>
+            {/* UTC / empty option */}
+            <button
+              type="button"
+              data-testid="timezone-option-utc"
+              className="w-full px-3 py-1.5 text-left text-xs text-muted-foreground hover:bg-glass-l1"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect('');
+              }}
+            >
+              UTC (default)
+            </button>
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-muted-soft">No matching timezones</p>
+            ) : (
+              filtered.map((tz) => (
+                <button
+                  key={tz}
+                  type="button"
+                  data-testid={`timezone-option-${tz}`}
+                  className={`w-full px-3 py-1.5 text-left text-xs hover:bg-glass-l1 ${value === tz ? 'text-[#3B82F6]' : 'text-foreground'}`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(tz);
+                  }}
+                >
+                  {tzLabel(tz)}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+      {value && (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-auto w-fit p-0 text-[10px] text-muted-foreground hover:text-foreground"
+          onClick={handleUseBrowserTz}
+        >
+          Use browser timezone
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export { formatOffset, tzLabel };

--- a/src/lib/api/schedulesApi.ts
+++ b/src/lib/api/schedulesApi.ts
@@ -12,10 +12,15 @@ export interface ScheduleRow {
   id: string;
   kind: string;
   repo_path: string;
+  name: string | null;
   cron: string;
+  timezone: string | null;
   enabled: number;
+  model: string | null;
+  timeout_ms: number | null;
   last_run_at: string | null;
   config_json: string | null;
+  prompt: string | null;
 }
 
 export interface ScheduleSkill {
@@ -27,6 +32,9 @@ export interface ScheduleKindInfo {
   kind: string;
   displayName: string;
   configSchema: Record<string, unknown> | null;
+  execution: 'session' | 'task' | 'chat';
+  promptRequired: boolean;
+  supportsTimeout: boolean;
 }
 
 export interface CreateScheduleInput {
@@ -35,12 +43,23 @@ export interface CreateScheduleInput {
   cron: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  name?: string;
+  timezone?: string;
+  model?: string;
+  timeoutMs?: number;
+  prompt?: string;
 }
 
 export interface UpdateScheduleInput {
   cron?: string;
   enabled?: boolean;
   config?: Record<string, unknown>;
+  name?: string | null;
+  repoPath?: string;
+  timezone?: string | null;
+  model?: string | null;
+  timeoutMs?: number | null;
+  prompt?: string | null;
 }
 
 export const schedulesApi = {
@@ -54,6 +73,10 @@ export const schedulesApi = {
   runScheduleNow: (id: string) =>
     request<{ ok: boolean }>(`/schedules/${id}/run`, { method: 'POST' }),
   getScheduleRuns: (id: string) => request<{ runs: WorkflowRunRow[] }>(`/schedules/${id}/runs`),
+  getEffectivePrompt: (id: string) =>
+    request<{ content: string; source: 'override' | 'kind_skill' }>(
+      `/schedules/${id}/effective-prompt`,
+    ),
 };
 
 export const scheduleSkillsApi = {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,12 @@
+/**
+ * src/lib/models.ts
+ *
+ * Known Claude model IDs for datalist suggestions. Empty input = harness default.
+ */
+
+export const KNOWN_MODELS = [
+  'claude-fable-5',
+  'claude-opus-4-8',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5-20251001',
+] as const;

--- a/src/pages/SchedulesPage.test.tsx
+++ b/src/pages/SchedulesPage.test.tsx
@@ -5,8 +5,15 @@ import SchedulesPage from './SchedulesPage';
 import { renderWithRouter } from '../test-helpers';
 import type { ScheduleRow } from '@/lib/api/schedulesApi';
 
-const { taskApiProxy, reviewApiProxy, configApiProxy, loopApiProxy, schedulesApiProxy, apiMock } =
-  await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
+const {
+  taskApiProxy,
+  reviewApiProxy,
+  configApiProxy,
+  loopApiProxy,
+  schedulesApiProxy,
+  schedulesApiMock,
+  apiMock,
+} = await vi.hoisted(async () => (await import('../test-helpers')).setupApiMock());
 
 vi.mock('@/lib/api/taskApi', () => ({ taskApi: taskApiProxy }));
 vi.mock('@/lib/api/reviewApi', () => ({ reviewApi: reviewApiProxy }));
@@ -20,6 +27,28 @@ vi.mock('@/components/fields/RepoPickerField', () => ({
       value={value}
       onChange={(e) => onChange(e.target.value)}
     />
+  ),
+}));
+// TimezoneField uses Intl.supportedValuesOf which is not in JSDOM — mock the component.
+vi.mock('@/components/schedules/TimezoneField', () => ({
+  TimezoneField: ({
+    value,
+    onChange,
+    label,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    label?: string;
+  }) => (
+    <div>
+      <label htmlFor="mock-timezone">{label ?? 'Timezone'}</label>
+      <input
+        id="mock-timezone"
+        data-testid="timezone-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
   ),
 }));
 vi.mock('@/lib/event-source', () => ({
@@ -37,10 +66,15 @@ function makeSchedule(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
     id: 'sched-1',
     kind: 'prod-log-triage',
     repo_path: '/repo',
+    name: null,
     cron: '0 7 * * 1-5',
+    timezone: null,
     enabled: 1,
+    model: null,
+    timeout_ms: null,
     last_run_at: null,
     config_json: null,
+    prompt: null,
     ...overrides,
   };
 }
@@ -53,6 +87,9 @@ describe('SchedulesPage', () => {
         {
           kind: 'prod-log-triage',
           displayName: 'Prod Log Triage',
+          execution: 'task',
+          promptRequired: false,
+          supportsTimeout: false,
           configSchema: {
             type: 'object',
             properties: {
@@ -61,9 +98,22 @@ describe('SchedulesPage', () => {
             },
           },
         },
+        {
+          kind: 'custom',
+          displayName: 'Custom Prompt',
+          execution: 'session',
+          promptRequired: true,
+          supportsTimeout: true,
+          configSchema: null,
+        },
       ],
     });
     apiMock.listLoops.mockResolvedValue([]);
+    // getEffectivePrompt is not in the base schedulesApiMock defaults — add it directly.
+    (schedulesApiMock as Record<string, unknown>).getEffectivePrompt = vi.fn().mockResolvedValue({
+      content: 'Default prompt content with {{placeholder}}',
+      source: 'kind_skill',
+    });
   });
 
   it('shows empty state when no schedules', async () => {
@@ -193,5 +243,153 @@ describe('SchedulesPage', () => {
 
     await waitFor(() => expect(apiMock.deleteSchedule).toHaveBeenCalledWith('sched-1'));
     expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  // ── New behavior tests ────────────────────────────────────────────────────
+
+  it('custom kind: submit disabled when name or prompt is empty', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([]);
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+
+    // Switch to custom kind
+    const kindSelect = screen.getByTestId('schedule-kind');
+    await user.selectOptions(kindSelect, 'custom');
+
+    // Fill repo but leave name and prompt empty
+    await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
+
+    const submitBtn = screen.getByTestId('schedule-submit');
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('custom kind: submit enabled when name and prompt are filled', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([]);
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+
+    const kindSelect = screen.getByTestId('schedule-kind');
+    await user.selectOptions(kindSelect, 'custom');
+
+    await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
+    await user.type(screen.getByTestId('schedule-name'), 'My daily custom');
+    await user.type(screen.getByTestId('schedule-prompt'), 'Do something useful every day.');
+
+    const submitBtn = screen.getByTestId('schedule-submit');
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('custom kind: createSchedule payload includes name and prompt', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([]);
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+
+    const kindSelect = screen.getByTestId('schedule-kind');
+    await user.selectOptions(kindSelect, 'custom');
+
+    await user.type(screen.getByTestId('schedule-repo-path'), '/my/repo');
+    await user.type(screen.getByTestId('schedule-name'), 'My custom');
+    await user.type(screen.getByTestId('schedule-prompt'), 'Run something.');
+
+    await user.click(screen.getByTestId('schedule-submit'));
+
+    await waitFor(() => expect(apiMock.createSchedule).toHaveBeenCalledTimes(1));
+    expect(apiMock.createSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'custom',
+        repoPath: '/my/repo',
+        name: 'My custom',
+        prompt: 'Run something.',
+      }),
+    );
+  });
+
+  it('advanced disclosure is collapsed by default', async () => {
+    apiMock.listSchedules.mockResolvedValue([]);
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByText(/no schedules yet/i);
+
+    // Advanced <details> summary should exist but content should not be visible by default
+    expect(screen.getByText('Advanced')).toBeTruthy();
+    // The name input for non-custom should not be immediately visible (inside collapsed details)
+    // Note: The details element may not be 'open' by default in tests; we just verify it exists.
+    const advancedDetails = screen.getByText('Advanced').closest('details');
+    expect(advancedDetails).toBeTruthy();
+    expect(advancedDetails?.hasAttribute('open')).toBe(false);
+  });
+
+  it('patch payload includes new fields when saving edit panel', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([
+      makeSchedule({ id: 'sched-1', kind: 'prod-log-triage', model: null, timeout_ms: null }),
+    ]);
+    apiMock.getScheduleRuns.mockResolvedValue({ runs: [] });
+
+    renderWithRouter(<SchedulesPage />);
+    await user.click(await screen.findByTestId('schedule-expand-sched-1'));
+
+    // Fill in the model field
+    const modelInput = await screen.findByTestId('schedule-edit-model-sched-1');
+    await user.clear(modelInput);
+    await user.type(modelInput, 'claude-opus-4-8');
+
+    await user.click(screen.getByTestId('schedule-save-sched-1'));
+
+    await waitFor(() =>
+      expect(apiMock.updateSchedule).toHaveBeenCalledWith(
+        'sched-1',
+        expect.objectContaining({ model: 'claude-opus-4-8' }),
+      ),
+    );
+  });
+
+  it('effective-prompt preview is fetched when prompt override panel is expanded', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([makeSchedule({ id: 'sched-1' })]);
+    apiMock.getScheduleRuns.mockResolvedValue({ runs: [] });
+
+    renderWithRouter(<SchedulesPage />);
+    await user.click(await screen.findByTestId('schedule-expand-sched-1'));
+
+    // Click the "Override prompt" toggle
+    const expandBtn = await screen.findByTestId('prompt-override-expand');
+    await user.click(expandBtn);
+
+    await waitFor(() =>
+      expect(
+        (schedulesApiMock as Record<string, ReturnType<typeof vi.fn>>).getEffectivePrompt,
+      ).toHaveBeenCalledWith('sched-1'),
+    );
+    expect(await screen.findByTestId('prompt-preview')).toBeTruthy();
+  });
+
+  it('card title shows name when set, falls back to displayName', async () => {
+    apiMock.listSchedules.mockResolvedValue([
+      makeSchedule({ id: 'sched-named', name: 'My Named Schedule', kind: 'prod-log-triage' }),
+    ]);
+    renderWithRouter(<SchedulesPage />);
+
+    await screen.findByTestId('schedule-row-sched-named');
+    expect(screen.getByTestId('schedule-expand-sched-named').textContent).toBe('My Named Schedule');
+  });
+
+  it('delete dialog shows schedule name + cron, not just kind·repo_path', async () => {
+    const user = userEvent.setup();
+    apiMock.listSchedules.mockResolvedValue([
+      makeSchedule({ id: 'sched-1', name: 'My special run', cron: '0 8 * * 1' }),
+    ]);
+    renderWithRouter(<SchedulesPage />);
+
+    await user.click(await screen.findByTestId('schedule-delete-sched-1'));
+    const dialog = await screen.findByTestId('confirm-delete-schedule');
+    expect(dialog.textContent).toContain('My special run');
+    expect(dialog.textContent).toContain('0 8 * * 1');
   });
 });

--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -6,9 +6,11 @@ import { useResource } from '@/lib/use-resource';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FormSelect } from '@/components/ui/form-select';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Dialog,
   DialogContent,
@@ -23,6 +25,8 @@ import { SchemaConfigForm, defaultsFromSchema } from '@/components/schedules/Sch
 import { CronPresetField } from '@/components/schedules/CronPresetField';
 import { CRON_PRESETS } from '@/components/schedules/cronPresets';
 import { RepoPickerField } from '@/components/fields/RepoPickerField';
+import { TimezoneField } from '@/components/schedules/TimezoneField';
+import { KNOWN_MODELS } from '@/lib/models';
 
 function parseConfigJson(configJson: string | null): Record<string, unknown> {
   if (!configJson) return {};
@@ -33,16 +37,49 @@ function parseConfigJson(configJson: string | null): Record<string, unknown> {
   }
 }
 
+/** Convert timeout_ms (stored) to minutes (displayed). Returns '' for null. */
+function msToMinutes(ms: number | null | undefined): string {
+  if (ms == null) return '';
+  return String(Math.round(ms / 60_000));
+}
+
+/** Convert displayed minutes string to ms. Returns undefined for empty/invalid. */
+function minutesToMs(mins: string): number | undefined {
+  const n = Number.parseInt(mins, 10);
+  if (Number.isNaN(n) || n <= 0) return undefined;
+  return n * 60_000;
+}
+
+// ─── Models datalist ──────────────────────────────────────────────────────────
+
+function ModelsDatalist({ id }: { id: string }) {
+  return (
+    <datalist id={id}>
+      {KNOWN_MODELS.map((m) => (
+        <option key={m} value={m} />
+      ))}
+    </datalist>
+  );
+}
+
+// ─── ScheduleForm (create panel) ─────────────────────────────────────────────
+
 function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreated: () => void }) {
   const [kind, setKind] = useState('');
   const [repoPath, setRepoPath] = useState('');
   const [cron, setCron] = useState(CRON_PRESETS[0].cron);
+  const [timezone, setTimezone] = useState('');
   const [enabled, setEnabled] = useState(true);
   const [config, setConfig] = useState<Record<string, unknown>>({});
+  const [name, setName] = useState('');
+  const [model, setModel] = useState('');
+  const [timeoutMins, setTimeoutMins] = useState('');
+  const [prompt, setPrompt] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const selectedKind = useMemo(() => kinds.find((k) => k.kind === kind) ?? null, [kinds, kind]);
+  const isCustom = kind === 'custom';
 
   useEffect(() => {
     if (!kind && kinds.length > 0) setKind(kinds[0].kind);
@@ -56,7 +93,12 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     setConfig(defaultsFromSchema(selectedKind.configSchema));
   }, [selectedKind]);
 
-  const canSubmit = kind.length > 0 && repoPath.trim().length > 0 && cron.trim().length > 0;
+  const canSubmit =
+    kind.length > 0 &&
+    repoPath.trim().length > 0 &&
+    cron.trim().length > 0 &&
+    // custom requires both name and prompt
+    (!isCustom || (name.trim().length > 0 && prompt.trim().length > 0));
 
   const handleSubmit = useCallback(async () => {
     if (!canSubmit) return;
@@ -65,6 +107,7 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     try {
       const payloadConfig =
         selectedKind?.configSchema && Object.keys(config).length > 0 ? config : undefined;
+      const timeoutMs = minutesToMs(timeoutMins);
 
       await schedulesApi.createSchedule({
         kind,
@@ -72,11 +115,21 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
         cron: cron.trim(),
         enabled,
         ...(payloadConfig ? { config: payloadConfig } : {}),
+        ...(name.trim() ? { name: name.trim() } : {}),
+        ...(timezone ? { timezone } : {}),
+        ...(model.trim() ? { model: model.trim() } : {}),
+        ...(timeoutMs != null ? { timeoutMs } : {}),
+        ...(prompt.trim() ? { prompt: prompt.trim() } : {}),
       });
 
       setRepoPath('');
       setCron(CRON_PRESETS[0].cron);
+      setTimezone('');
       setEnabled(true);
+      setName('');
+      setModel('');
+      setTimeoutMins('');
+      setPrompt('');
       if (selectedKind?.configSchema) {
         setConfig(defaultsFromSchema(selectedKind.configSchema));
       } else {
@@ -88,7 +141,21 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
     } finally {
       setSubmitting(false);
     }
-  }, [canSubmit, kind, repoPath, cron, enabled, config, selectedKind, onCreated]);
+  }, [
+    canSubmit,
+    kind,
+    repoPath,
+    cron,
+    timezone,
+    enabled,
+    config,
+    name,
+    model,
+    timeoutMins,
+    prompt,
+    selectedKind,
+    onCreated,
+  ]);
 
   return (
     <GlassPanel level={2} className="flex flex-col gap-3 rounded-2xl p-4">
@@ -115,6 +182,41 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
         <CronPresetField value={cron} onChange={setCron} />
       </div>
 
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <TimezoneField value={timezone} onChange={setTimezone} />
+      </div>
+
+      {/* Custom kind: name + prompt always visible and required */}
+      {isCustom && (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="schedule-name-custom">
+              Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="schedule-name-custom"
+              data-testid="schedule-name"
+              placeholder="My custom schedule"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="schedule-prompt-custom">
+              Prompt <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="schedule-prompt-custom"
+              data-testid="schedule-prompt"
+              placeholder="What should the agent do on each run?"
+              rows={4}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+
       <label className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
         <input
           type="checkbox"
@@ -140,6 +242,57 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
         </details>
       ) : null}
 
+      {/* Advanced: name (for built-ins), model, timeout */}
+      <details className="group">
+        <summary className="flex w-fit cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+          Advanced
+        </summary>
+        <div className="mt-3 flex flex-col gap-3">
+          {/* Name only shown here for non-custom kinds */}
+          {!isCustom && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="schedule-name">Name (optional)</Label>
+              <Input
+                id="schedule-name"
+                data-testid="schedule-name"
+                placeholder="Leave blank to use kind display name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="schedule-model">Model (optional)</Label>
+            <ModelsDatalist id="schedule-models-list" />
+            <Input
+              id="schedule-model"
+              data-testid="schedule-model"
+              list="schedule-models-list"
+              placeholder="Harness default"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            />
+          </div>
+          {selectedKind?.supportsTimeout && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="schedule-timeout">Timeout (minutes, optional)</Label>
+              <Input
+                id="schedule-timeout"
+                data-testid="schedule-timeout"
+                type="number"
+                min={1}
+                placeholder="5"
+                value={timeoutMins}
+                onChange={(e) => setTimeoutMins(e.target.value)}
+              />
+              <p className="text-[10px] text-muted-soft">
+                Defaults to 5 minutes (300 s). Min 10 s, max 24 h.
+              </p>
+            </div>
+          )}
+        </div>
+      </details>
+
       {error && <p className="text-xs text-destructive">{error}</p>}
 
       <div>
@@ -151,10 +304,17 @@ function ScheduleForm({ kinds, onCreated }: { kinds: ScheduleKindInfo[]; onCreat
         >
           {submitting ? 'Creating…' : 'New schedule'}
         </Button>
+        {isCustom && (!name.trim() || !prompt.trim()) && (
+          <p className="mt-1.5 text-[10px] text-muted-foreground">
+            Name and prompt are required for custom schedules.
+          </p>
+        )}
       </div>
     </GlassPanel>
   );
 }
+
+// ─── Runs list ────────────────────────────────────────────────────────────────
 
 function runDestination(run: WorkflowRunRow): string | null {
   if (run.task_id) return `/tasks/${run.task_id}`;
@@ -215,6 +375,200 @@ function ScheduleRuns({ scheduleId }: { scheduleId: string }) {
   );
 }
 
+// ─── Prompt override editor ───────────────────────────────────────────────────
+
+function PromptOverrideEditor({
+  scheduleId,
+  currentPrompt,
+  onSave,
+}: {
+  scheduleId: string;
+  currentPrompt: string | null;
+  onSave: (prompt: string | null) => Promise<void>;
+}) {
+  const [mode, setMode] = useState<'collapsed' | 'preview' | 'editing'>('collapsed');
+  const [preview, setPreview] = useState<{
+    content: string;
+    source: 'override' | 'kind_skill';
+  } | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  const fetchPreview = useCallback(() => {
+    schedulesApi.getEffectivePrompt(scheduleId).then((res) => setPreview(res));
+  }, [scheduleId]);
+
+  const handleExpand = useCallback(() => {
+    setMode('preview');
+    fetchPreview();
+  }, [fetchPreview]);
+
+  const handleOverride = useCallback(() => {
+    if (preview) {
+      setEditValue(preview.content);
+    }
+    setMode('editing');
+  }, [preview]);
+
+  const handleSaveOverride = useCallback(async () => {
+    setSaving(true);
+    try {
+      await onSave(editValue.trim() || null);
+      setMode('preview');
+      fetchPreview();
+    } finally {
+      setSaving(false);
+    }
+  }, [editValue, onSave, fetchPreview]);
+
+  const handleReset = useCallback(async () => {
+    setSaving(true);
+    try {
+      await onSave(null);
+      setConfirmReset(false);
+      setMode('preview');
+      fetchPreview();
+    } finally {
+      setSaving(false);
+    }
+  }, [onSave, fetchPreview]);
+
+  if (mode === 'collapsed') {
+    return (
+      <button
+        type="button"
+        data-testid="prompt-override-expand"
+        className="text-xs text-muted-foreground hover:text-foreground"
+        onClick={handleExpand}
+      >
+        {currentPrompt ? '▸ Edit prompt override' : '▸ Override prompt'}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="prompt-override-panel">
+      <div className="flex items-center gap-2">
+        <p className="text-xs font-medium text-muted-foreground">
+          Prompt{' '}
+          {preview?.source === 'override' ? (
+            <Badge variant="outline" className="text-[10px]">
+              override
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-[10px]">
+              kind default
+            </Badge>
+          )}
+        </p>
+        <button
+          type="button"
+          className="text-[10px] text-muted-foreground hover:text-foreground"
+          onClick={() => setMode('collapsed')}
+        >
+          Collapse
+        </button>
+      </div>
+
+      {mode === 'preview' && (
+        <>
+          {preview ? (
+            <pre
+              data-testid="prompt-preview"
+              className="max-h-48 overflow-auto rounded-lg border border-glass-edge bg-glass-l1 p-3 font-mono text-[11px] text-foreground"
+            >
+              {preview.content}
+            </pre>
+          ) : (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          )}
+          <p className="text-[10px] text-muted-soft">
+            {'{{tokens}}'} are replaced at runtime by the config value with the same name.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              data-testid="prompt-override-btn"
+              onClick={handleOverride}
+            >
+              Override
+            </Button>
+            {currentPrompt && (
+              <Button
+                size="sm"
+                variant="outline"
+                data-testid="prompt-reset-btn"
+                onClick={() => setConfirmReset(true)}
+              >
+                Reset to kind default
+              </Button>
+            )}
+          </div>
+          {confirmReset && (
+            <div className="flex items-center gap-2 rounded-lg border border-glass-edge bg-glass-l1 p-3 text-xs">
+              <span>Remove your prompt override and use the kind default?</span>
+              <Button
+                size="sm"
+                variant="destructive"
+                data-testid="prompt-reset-confirm"
+                disabled={saving}
+                onClick={handleReset}
+              >
+                Reset
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setConfirmReset(false)}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      {mode === 'editing' && (
+        <>
+          <Textarea
+            data-testid="prompt-override-textarea"
+            rows={8}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            className="font-mono text-sm"
+          />
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              data-testid="prompt-override-save"
+              disabled={saving}
+              onClick={handleSaveOverride}
+            >
+              {saving ? 'Saving…' : 'Save override'}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={saving}
+              onClick={() => {
+                setMode('preview');
+                fetchPreview();
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── ScheduleDetail (edit card) ───────────────────────────────────────────────
+
 function ScheduleDetail({
   row,
   kindInfo,
@@ -231,6 +585,11 @@ function ScheduleDetail({
   const [config, setConfig] = useState<Record<string, unknown>>(() =>
     parseConfigJson(row.config_json),
   );
+  const [repoPath, setRepoPath] = useState(row.repo_path);
+  const [name, setName] = useState(row.name ?? '');
+  const [timezone, setTimezone] = useState(row.timezone ?? '');
+  const [model, setModel] = useState(row.model ?? '');
+  const [timeoutMins, setTimeoutMins] = useState(msToMinutes(row.timeout_ms));
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -239,15 +598,26 @@ function ScheduleDetail({
     setCron(row.cron);
     setEnabled(row.enabled === 1);
     setConfig(parseConfigJson(row.config_json));
+    setRepoPath(row.repo_path);
+    setName(row.name ?? '');
+    setTimezone(row.timezone ?? '');
+    setModel(row.model ?? '');
+    setTimeoutMins(msToMinutes(row.timeout_ms));
   }, [row]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     setError(null);
     try {
+      const timeoutMs = minutesToMs(timeoutMins);
       await schedulesApi.updateSchedule(row.id, {
         cron: cron.trim(),
         enabled,
+        repoPath: repoPath.trim() || undefined,
+        name: name.trim() ? name.trim() : null,
+        timezone: timezone || null,
+        model: model.trim() ? model.trim() : null,
+        timeoutMs: timeoutMs != null ? timeoutMs : null,
         ...(kindInfo?.configSchema ? { config } : {}),
       });
       onSaved();
@@ -256,7 +626,27 @@ function ScheduleDetail({
     } finally {
       setSaving(false);
     }
-  }, [row.id, cron, enabled, config, kindInfo, onSaved]);
+  }, [
+    row.id,
+    cron,
+    enabled,
+    repoPath,
+    name,
+    timezone,
+    model,
+    timeoutMins,
+    config,
+    kindInfo,
+    onSaved,
+  ]);
+
+  const handlePromptSave = useCallback(
+    async (prompt: string | null) => {
+      await schedulesApi.updateSchedule(row.id, { prompt });
+      onSaved();
+    },
+    [row.id, onSaved],
+  );
 
   const handleRunNow = useCallback(async () => {
     setRunning(true);
@@ -273,6 +663,15 @@ function ScheduleDetail({
 
   return (
     <div className="flex flex-col gap-4 border-t border-glass-edge pt-3">
+      {/* Kind badge — immutable */}
+      <div className="flex items-center gap-2">
+        <p className="text-[10px] text-muted-foreground">Kind</p>
+        <Badge variant="outline" className="font-mono text-[10px]">
+          {row.kind}
+        </Badge>
+        <p className="text-[10px] text-muted-soft">(immutable — delete and recreate to change)</p>
+      </div>
+
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <CronPresetField
           id={`schedule-edit-cron-${row.id}`}
@@ -281,16 +680,77 @@ function ScheduleDetail({
           presetTestId={`schedule-edit-cron-preset-${row.id}`}
           customTestId={`schedule-edit-cron-${row.id}`}
         />
-        <div className="flex items-end gap-3 pb-1">
-          <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
-            <Switch
-              checked={enabled}
-              onChange={setEnabled}
-              aria-label={`Enable ${row.kind} schedule`}
-            />
-            Enabled
-          </label>
+        <TimezoneField
+          id={`schedule-edit-timezone-${row.id}`}
+          value={timezone}
+          onChange={setTimezone}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* Name */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`schedule-edit-name-${row.id}`}>Name</Label>
+          <Input
+            id={`schedule-edit-name-${row.id}`}
+            data-testid={`schedule-edit-name-${row.id}`}
+            placeholder={kindInfo?.displayName ?? row.kind}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
         </div>
+        {/* Repo path */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`schedule-edit-repo-${row.id}`}>Repository</Label>
+          <Input
+            id={`schedule-edit-repo-${row.id}`}
+            data-testid={`schedule-edit-repo-${row.id}`}
+            value={repoPath}
+            onChange={(e) => setRepoPath(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* Model */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`schedule-edit-model-${row.id}`}>Model</Label>
+          <ModelsDatalist id={`schedule-edit-models-list-${row.id}`} />
+          <Input
+            id={`schedule-edit-model-${row.id}`}
+            data-testid={`schedule-edit-model-${row.id}`}
+            list={`schedule-edit-models-list-${row.id}`}
+            placeholder="Harness default"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+          />
+        </div>
+        {/* Timeout — only when supportsTimeout */}
+        {kindInfo?.supportsTimeout && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={`schedule-edit-timeout-${row.id}`}>Timeout (minutes)</Label>
+            <Input
+              id={`schedule-edit-timeout-${row.id}`}
+              data-testid={`schedule-edit-timeout-${row.id}`}
+              type="number"
+              min={1}
+              placeholder="5"
+              value={timeoutMins}
+              onChange={(e) => setTimeoutMins(e.target.value)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+          <Switch
+            checked={enabled}
+            onChange={setEnabled}
+            aria-label={`Enable ${row.kind} schedule`}
+          />
+          Enabled
+        </label>
       </div>
 
       {kindInfo?.configSchema ? (
@@ -299,6 +759,13 @@ function ScheduleDetail({
           <SchemaConfigForm schema={kindInfo.configSchema} value={config} onChange={setConfig} />
         </div>
       ) : null}
+
+      {/* Prompt override editor */}
+      <PromptOverrideEditor
+        scheduleId={row.id}
+        currentPrompt={row.prompt ?? null}
+        onSave={handlePromptSave}
+      />
 
       {error && <p className="text-xs text-destructive">{error}</p>}
 
@@ -330,27 +797,30 @@ function ScheduleDetail({
   );
 }
 
+// ─── Delete dialog ────────────────────────────────────────────────────────────
+
 function ScheduleDeleteDialog({
   schedule,
+  kindDisplayName,
   onOpenChange,
   onConfirm,
 }: {
   schedule: ScheduleRow | null;
+  kindDisplayName: string;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void | Promise<void>;
 }) {
   const [busy, setBusy] = useState(false);
+  const label = schedule ? (schedule.name ?? kindDisplayName) : '';
   return (
     <Dialog open={schedule !== null} onOpenChange={onOpenChange}>
       <DialogContent data-testid="confirm-delete-schedule" className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Delete schedule?</DialogTitle>
           <DialogDescription>
-            This stops{' '}
-            <span className="font-medium text-foreground">
-              {schedule?.kind} · {schedule?.repo_path}
-            </span>{' '}
-            from firing. Past runs are unaffected.
+            This stops <span className="font-medium text-foreground">{label}</span>{' '}
+            <span className="font-mono text-muted-foreground">{schedule?.cron}</span> from firing.
+            Past runs are unaffected.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -379,6 +849,34 @@ function ScheduleDeleteDialog({
   );
 }
 
+// ─── Card title logic ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the card title for a schedule row.
+ * - Shows `name ?? displayName` as the main text.
+ * - Appends the cron in monospace when two unnamed rows share (kind, repo_path).
+ */
+function cardTitle(
+  row: ScheduleRow,
+  displayName: string,
+  allSchedules: ScheduleRow[],
+): { title: string; showCron: boolean } {
+  const title = row.name ?? displayName;
+  // Multi-instance disambiguation: when two unnamed rows share (kind, repo_path)
+  const hasCollision =
+    !row.name &&
+    allSchedules.some(
+      (other) =>
+        other.id !== row.id &&
+        other.kind === row.kind &&
+        other.repo_path === row.repo_path &&
+        !other.name,
+    );
+  return { title, showCron: hasCollision };
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
 export default function SchedulesPage() {
   const [searchParams] = useSearchParams();
   const { data, loading, refresh } = useResource<ScheduleRow[]>('schedules', () =>
@@ -404,6 +902,8 @@ export default function SchedulesPage() {
     [refresh],
   );
 
+  const deleteKindInfo = deleteTarget ? (kindByName.get(deleteTarget.kind) ?? null) : null;
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto p-6">
       <PageHeader
@@ -426,66 +926,80 @@ export default function SchedulesPage() {
         <p className="text-sm text-muted-foreground">No schedules yet.</p>
       ) : (
         <ul className="flex flex-col gap-2">
-          {schedules.map((row) => (
-            <li key={row.id}>
-              <GlassPanel
-                level={2}
-                specular
-                data-testid={`schedule-row-${row.id}`}
-                className="flex flex-col gap-2 rounded-2xl px-4 py-3"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    data-testid={`schedule-expand-${row.id}`}
-                    className="truncate text-sm font-medium text-foreground hover:text-primary"
-                    onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
-                  >
-                    {row.kind}
-                  </button>
-                  <span className="truncate text-xs text-muted-foreground">{row.repo_path}</span>
-                  <Badge variant="outline" className="font-mono">
-                    {row.cron}
-                  </Badge>
-                  <span className="text-[10px] text-muted-soft">
-                    {row.last_run_at ? `last run ${timeAgo(row.last_run_at)}` : 'never run'}
-                  </span>
-                  <div className="ml-auto flex items-center gap-3">
-                    <Switch
-                      checked={row.enabled === 1}
-                      onChange={() => handleToggle(row)}
-                      aria-label={`Toggle ${row.kind} schedule`}
-                    />
+          {schedules.map((row) => {
+            const kindInfo = kindByName.get(row.kind) ?? null;
+            const displayName = kindInfo?.displayName ?? row.kind;
+            const { title, showCron } = cardTitle(row, displayName, schedules);
+            return (
+              <li key={row.id}>
+                <GlassPanel
+                  level={2}
+                  specular
+                  data-testid={`schedule-row-${row.id}`}
+                  className="flex flex-col gap-2 rounded-2xl px-4 py-3"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      data-testid={`schedule-delete-${row.id}`}
-                      className="text-xs text-destructive hover:underline"
-                      onClick={() => setDeleteTarget(row)}
+                      data-testid={`schedule-expand-${row.id}`}
+                      className="truncate text-sm font-medium text-foreground hover:text-primary"
+                      onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
                     >
-                      Delete
+                      {title}
                     </button>
+                    {/* Kind badge */}
+                    <Badge variant="outline" className="font-mono text-[10px]">
+                      {row.kind}
+                    </Badge>
+                    <span className="truncate text-xs text-muted-foreground">{row.repo_path}</span>
+                    <Badge variant="outline" className="font-mono">
+                      {row.cron}
+                    </Badge>
+                    {/* Disambiguation: cron in monospace when two unnamed rows collide */}
+                    {showCron && (
+                      <span className="font-mono text-[10px] text-muted-soft">{row.cron}</span>
+                    )}
+                    <span className="text-[10px] text-muted-soft">
+                      {row.last_run_at ? `last run ${timeAgo(row.last_run_at)}` : 'never run'}
+                    </span>
+                    <div className="ml-auto flex items-center gap-3">
+                      <Switch
+                        checked={row.enabled === 1}
+                        onChange={() => handleToggle(row)}
+                        aria-label={`Toggle ${row.kind} schedule`}
+                      />
+                      <button
+                        type="button"
+                        data-testid={`schedule-delete-${row.id}`}
+                        className="text-xs text-destructive hover:underline"
+                        onClick={() => setDeleteTarget(row)}
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </div>
-                </div>
-                {expandedId === row.id && (
-                  <ScheduleDetail
-                    key={`${row.id}-${runsKey}`}
-                    row={row}
-                    kindInfo={kindByName.get(row.kind) ?? null}
-                    onSaved={refresh}
-                    onRunStarted={() => {
-                      setRunsKey((k) => k + 1);
-                      refresh();
-                    }}
-                  />
-                )}
-              </GlassPanel>
-            </li>
-          ))}
+                  {expandedId === row.id && (
+                    <ScheduleDetail
+                      key={`${row.id}-${runsKey}`}
+                      row={row}
+                      kindInfo={kindInfo}
+                      onSaved={refresh}
+                      onRunStarted={() => {
+                        setRunsKey((k) => k + 1);
+                        refresh();
+                      }}
+                    />
+                  )}
+                </GlassPanel>
+              </li>
+            );
+          })}
         </ul>
       )}
 
       <ScheduleDeleteDialog
         schedule={deleteTarget}
+        kindDisplayName={deleteKindInfo?.displayName ?? deleteTarget?.kind ?? ''}
         onOpenChange={(open) => !open && setDeleteTarget(null)}
         onConfirm={async () => {
           if (!deleteTarget) return;


### PR DESCRIPTION
## What

Implements `spec/schedule-configurability.md` (included in this PR): every hardcoded schedule behavior becomes per-row data editable from `/schedules`.

- **Multi-instance schedules** — drops `UNIQUE(kind, repo_path)` via an idempotent, transaction-wrapped table rebuild (rows, ids, and run history preserved; `SCHEMA` constant updated in lockstep so fresh installs match).
- **New per-schedule fields** — `name`, `timezone` (IANA, evaluated natively by croner with a compound cache key), `model`, `timeout_ms`, and a live `prompt` override that beats the kind-level `schedule_skills` body in both the session-vertical and task-backed overlay paths.
- **Generic `{{key}}` interpolation** (`server/prompt-interpolate.ts`, single-pass) replaces the hand-written `.replace()` chains — any config field is usable in any prompt body without code changes.
- **`custom` workflow kind** — prompt-only cron schedule emitting the universal outcome/summary/links envelope; multiple per repo.
- **Config-driven `baseBranch`/`branchPrefix`** for doc-drift and prod-log-triage (refname-safe pattern, `format: single-line` rendered as inputs); `tasks.model` stamped through the insert helpers.
- **Routes** — POST is a pure create; PATCH covers the full field set incl. `repoPath`; cron/timezone/model/timeout validated at write time (400s, never 500s); `/kinds` exposes capability flags; new `GET /api/schedules/:id/effective-prompt`.
- **UI** — field-visibility matrix with an Advanced disclosure, searchable timezone combobox, model datalist, timeout in minutes, prompt-override editor with effective-prompt preview, and name/cron disambiguation for same-kind cards and the delete dialog.

Hardening found during spec review: `applyModel` now shell-quotes the model value (it previously landed unquoted in a `sh -c` string), a same-minute refire guard covers poller jitter and DST fall-back, and slack-watcher dedup memory is per-schedule so multiple watchers can't cross-contaminate.

## Why

An audit found 9 hardcoded schedule behaviors (constraint, timezone, model, timeout, prompt scope, placeholders, branch names, kind set) that could only be changed by editing code. This makes 1–8 data and answers 9 with the generic custom kind. Spec was reviewed by five persona passes (backend, security, UX, SRE, YAGNI) before implementation; adjudications recorded in spec §1.

## Testing

- `bun run typecheck` clean; `bun run lint` introduces no new errors vs base.
- `bun run test`: **4110/4111** — the single failure (`HomePage` composer hydration) fails identically on the untouched base tree under suite load (pre-existing flake, unrelated).
- New/extended coverage: migration idempotency + row survival + duplicate-(kind,repo) inserts, cron timezone/DST/cache-key table, same-minute guard, interpolation single-pass table, prompt precedence incl. task-backed overlay, route validation table, per-schedule slack-watcher dedup, custom-kind failure lifecycle (no runs row stuck at running), quoted-model launch commands, and component tests for the new form fields (with `Intl.supportedValuesOf` mocked for JSDOM).

**Deploy note:** back up `~/.octomux/data/tasks.db` before upgrading across the schedules table rebuild (forward-only migration). Existing rows keep firing identically — all new columns start NULL.