### PR TITLE
refactor(agents): rename agents to workers and agent_configs to agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,17 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
 - `e2e/` — Playwright E2E tests
 
 DB migrations are forward-only. Back up `~/.octomux/data/tasks.db` (prod) or
-`./data/tasks.db` (dev) before upgrading across the harness-abstraction
-migration (renames `agents.claude_session_id` → `harness_session_id`, adds
-`tasks.harness_id` / `agents.harness_id` / `agents.hook_token`, relaxes
-`permission_prompts.session_id` to nullable).
+`./data/tasks.db` (dev) before upgrading across either of these:
+
+- **harness abstraction** — renames `workers.claude_session_id` → `harness_session_id`,
+  adds `tasks.harness_id` / `workers.harness_id` / `workers.hook_token`, relaxes
+  `permission_prompts.session_id` to nullable.
+- **agents/workers rename** — `agents` → `workers` (per-task tmux worker) and
+  `agent_configs` → `agents` (persistent conductor agent), in that mandatory order.
+  Runs in `renameAgentWorkerTables()` **before** `SCHEMA` executes in `initDb()`, or
+  `CREATE TABLE IF NOT EXISTS workers` would create an empty placeholder ahead of the
+  rename and orphan every worker row. SQLite rewrites dependent `REFERENCES` clauses
+  automatically (`legacy_alter_table = 0`).
 
 ## Logging
 
@@ -86,9 +93,17 @@ draft → setting_up → running → closed/error
 Error at any point → error state with message in `task.error`
 
 Per task: git worktree at `<repo>/.worktrees/<id>`, tmux session `octomux-agent-<id>`,
-branch `agents/<id>`. Each agent = tmux window within the session.
+branch `agents/<id>`. Each **worker** = tmux window within the session.
 
-- **close** = stop agents + kill tmux session. Preserves worktree and branch (for resume).
+"Agent" means three distinct things; keep them straight:
+
+| Concept                            | Table     | Routes                                     |
+| ---------------------------------- | --------- | ------------------------------------------ |
+| per-task tmux worker               | `workers` | `/api/workers`, `/api/tasks/:id/workers`   |
+| persistent conductor agent         | `agents`  | `/api/agents`                              |
+| agent _role_ definition (markdown) | none      | `/api/agent-roles` (from the plugin files) |
+
+- **close** = stop workers + kill tmux session. Preserves worktree and branch (for resume).
 - **delete** = kill tmux session + remove worktree + delete branch + delete DB rows. Full cleanup.
 
 ## Per-task model override
@@ -133,17 +148,48 @@ the `agent_learnings` table and `server/routes/learnings.ts`.
 Cron-triggered runs replaced the old `octomux team` command (deleted in `90cf49e`). Multiple
 schedules per `(kind, repo_path)` are allowed (the old UNIQUE constraint is gone). Each row
 carries a 5-field cron plus per-schedule `name`, `timezone` (IANA, NULL → UTC), `model`,
-`timeout_ms` (headless session timeout, NULL → 5 min), `config_json`, and `prompt` (per-schedule
-override of the kind's `schedule_skills` body — see spec/schedule-configurability.md).
+`timeout_ms` (headless session timeout, NULL → 5 min), `config_json`, and `prompt`.
+
+**Kinds are presets, schedule rows are self-contained** (spec/schedule-kinds-as-presets.md).
+A kind is a JSON file — `<pkg>/kinds/*.json` (built-in) plus `~/.octomux/kinds/*.json` (home,
+UI-authored, `session`-only, wins on collision) — loaded by `server/workflows/presets.ts` and
+merged with the code handlers that `registerWorkflow()` registers. Presets are read **only when
+the UI builds a create form**: prompt and config are copied into the row at create time with ajv
+defaults materialized on write, so `executeScheduleRun` reads the row and nothing else. There is
+no resolution chain, no per-kind DB table, and editing a preset never touches existing schedules.
+`listCronWorkflowKinds()` = "kinds that have a preset".
+
 `poller/schedule-cron.ts` calls `isCronDue(expr, now, timezone)` (`server/schedules/cron.ts`,
 `croner`) with a same-minute refire guard, and hands due rows to
 `poller/execute-schedule-run.ts`, which threads model/timeout into the workflow's `RunContext`.
 Session-vertical prompts interpolate `{{configKey}}` placeholders generically
-(`server/prompt-interpolate.ts`, single-pass). The `custom` kind is a prompt-only session
-vertical (prompt + name required, generic outcome/summary/links envelope). Managed from
-`/schedules` in the UI and `server/routes/schedules.ts` (`GET/POST /api/schedules`,
-`PATCH /api/schedules/:id`, `POST /api/schedules/:id/run`,
-`GET /api/schedules/:id/effective-prompt`).
+(`server/prompt-interpolate.ts`, single-pass). Managed from `/schedules` and Settings → Kinds
+in the UI; `server/routes/schedules.ts` (`GET/POST /api/schedules`, `PATCH /api/schedules/:id`,
+`POST /api/schedules/:id/run`, `GET /api/schedules/:id/export`, `POST /api/schedules/import`)
+and `server/routes/kinds.ts` (`GET /api/kinds`, `PUT`/`DELETE /api/kinds/:kind`, home tier only).
+
+## Skills and agent roles
+
+Both ship in the bundled plugin (`plugin/skills/`, `plugin/agents/`) and reach launched
+agents via `--plugin-dir`. **Single source — there is no repo or home tier.** Earlier
+revisions had `<repo>/.octomux/{skills,agents}` and `~/.octomux/agents`; nothing ever
+delivered them (`syncAgents()` is a no-op in both harnesses), so they were listed over
+REST and invisible to every running agent. They are gone; don't reintroduce them.
+
+Users' own skills/subagents live in Claude Code's native `~/.claude/skills/`,
+`~/.claude/agents/`, and `<repo>/.claude/` — the harness reads those directly and octomux
+neither manages nor lists them. Repo-specific customization goes there.
+
+The skills are also installable into a user's own sessions via the plugin marketplace
+(`.claude-plugin/marketplace.json`): `/plugin marketplace add ShreyPaharia/octomux-agents`
+then `/plugin install octomux@octomux`.
+
+`workflows/review-deep.js` is a Claude Code _workflow_ script, which plugins cannot ship —
+`octomux init` installs it to `~/.claude/workflows/` copy-if-absent.
+
+The six cron-kind `SKILL.md` files were folded into `kinds/*.json`; the prompt lives there
+now, and the overlay plugin (`server/octomux-plugin.ts`) is the only delivery path for
+task-backed schedule prompts.
 
 ## Testing Patterns
 

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -201,14 +201,14 @@ export function createClient(serverUrl: string): OctomuxClient {
       return request<void>(`/tasks/${encodeURIComponent(id)}`, { method: 'DELETE' });
     },
     addAgent(taskId, data) {
-      return request<Agent>(`/tasks/${encodeURIComponent(taskId)}/agents`, {
+      return request<Agent>(`/tasks/${encodeURIComponent(taskId)}/workers`, {
         method: 'POST',
         body: JSON.stringify(data || {}),
       });
     },
     stopAgent(taskId, agentId) {
       return request<void>(
-        `/tasks/${encodeURIComponent(taskId)}/agents/${encodeURIComponent(agentId)}`,
+        `/tasks/${encodeURIComponent(taskId)}/workers/${encodeURIComponent(agentId)}`,
         { method: 'DELETE' },
       );
     },
@@ -223,7 +223,7 @@ export function createClient(serverUrl: string): OctomuxClient {
     },
     sendMessage(taskId, agentId, message) {
       return request<{ success: boolean }>(
-        `/tasks/${encodeURIComponent(taskId)}/agents/${encodeURIComponent(agentId)}/message`,
+        `/tasks/${encodeURIComponent(taskId)}/workers/${encodeURIComponent(agentId)}/message`,
         { method: 'POST', body: JSON.stringify({ message }) },
       );
     },

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,7 +1,7 @@
 import { createRequestCore, qs } from '@octomux/api-client';
 import type {
   AddRefRequest,
-  Agent,
+  Worker,
   CreateTaskRequest,
   RunMode,
   Task,
@@ -11,7 +11,7 @@ import type {
   WorkflowStatus,
 } from '@octomux/types';
 
-export type { Agent, RunMode, Task, TaskExternalRef, TaskUpdate, WorkflowStatus };
+export type { Worker, RunMode, Task, TaskExternalRef, TaskUpdate, WorkflowStatus };
 
 export interface InlineCommentRow {
   id: string;
@@ -99,7 +99,7 @@ export interface OctomuxClient {
       skeleton?: string;
       notify_agent_id?: string | null;
     },
-  ): Promise<Agent>;
+  ): Promise<Worker>;
   stopAgent(taskId: string, agentId: string): Promise<void>;
   startLoop(data: { taskId: string; spec: LoopSpecInput }): Promise<LoopRunResult>;
   startLoopGroup(data: {
@@ -201,7 +201,7 @@ export function createClient(serverUrl: string): OctomuxClient {
       return request<void>(`/tasks/${encodeURIComponent(id)}`, { method: 'DELETE' });
     },
     addAgent(taskId, data) {
-      return request<Agent>(`/tasks/${encodeURIComponent(taskId)}/workers`, {
+      return request<Worker>(`/tasks/${encodeURIComponent(taskId)}/workers`, {
         method: 'POST',
         body: JSON.stringify(data || {}),
       });

--- a/cli/src/commands/add-agent.test.ts
+++ b/cli/src/commands/add-agent.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
 import { registerAddAgent } from './add-agent.js';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 
-function makeAgent(partial: Partial<Agent> = {}): Agent {
+function makeAgent(partial: Partial<Worker> = {}): Worker {
   return {
     id: 'agent-1',
     task_id: 'task-1',

--- a/cli/src/commands/get-task.ts
+++ b/cli/src/commands/get-task.ts
@@ -36,10 +36,10 @@ export function registerGetTask(program: Command): void {
       console.log(label('Created', task.created_at));
       console.log(label('Updated', task.updated_at));
 
-      if (task.agents && task.agents.length > 0) {
+      if (task.workers && task.workers.length > 0) {
         console.log('');
         heading('Agents');
-        for (const agent of task.agents) {
+        for (const agent of task.workers) {
           console.log(
             `  ${agent.label.padEnd(20)} ${colorAgentStatus(agent.status).padEnd(18 + 10)} window:${agent.window_index}`,
           );

--- a/e2e/keystroke-routing.spec.ts
+++ b/e2e/keystroke-routing.spec.ts
@@ -24,7 +24,7 @@ async function getTask(page: Page, id: string) {
   return (await res.json()) as {
     id: string;
     tmux_session: string;
-    agents: { window_index: number }[];
+    workers: { window_index: number }[];
   };
 }
 
@@ -48,13 +48,13 @@ test.describe('keystroke routing', () => {
     expect(addRes.ok()).toBeTruthy();
 
     let detail = await getTask(page, task.id);
-    for (let i = 0; i < 20 && detail.agents.length < 2; i++) {
+    for (let i = 0; i < 20 && detail.workers.length < 2; i++) {
       await page.waitForTimeout(250);
       detail = await getTask(page, task.id);
     }
-    expect(detail.agents.length).toBeGreaterThanOrEqual(2);
+    expect(detail.workers.length).toBeGreaterThanOrEqual(2);
 
-    const [agent1, agent2] = detail.agents;
+    const [agent1, agent2] = detail.workers;
     await page.goto(`/tasks/${task.id}`);
     await page.waitForTimeout(2000);
 
@@ -111,8 +111,8 @@ test.describe('keystroke routing', () => {
     await typeIntoTerminal(page, typedB);
     await page.waitForTimeout(500);
 
-    const paneA = await tmuxCapture(detailA.tmux_session, detailA.agents[0].window_index);
-    const paneB = await tmuxCapture(detailB.tmux_session, detailB.agents[0].window_index);
+    const paneA = await tmuxCapture(detailA.tmux_session, detailA.workers[0].window_index);
+    const paneB = await tmuxCapture(detailB.tmux_session, detailB.workers[0].window_index);
 
     expect(paneA).toContain(typedA);
     expect(paneA).not.toContain(typedB);

--- a/e2e/keystroke-routing.spec.ts
+++ b/e2e/keystroke-routing.spec.ts
@@ -44,7 +44,7 @@ test.describe('keystroke routing', () => {
     const task = await tracker.create(page, { title: 'Routing Within' });
     await waitForStatus(page, task.id, 'running');
 
-    const addRes = await page.request.post(`${API}/tasks/${task.id}/agents`, { data: {} });
+    const addRes = await page.request.post(`${API}/tasks/${task.id}/workers`, { data: {} });
     expect(addRes.ok()).toBeTruthy();
 
     let detail = await getTask(page, task.id);

--- a/e2e/task-detail.spec.ts
+++ b/e2e/task-detail.spec.ts
@@ -49,7 +49,7 @@ test.describe('Task Detail', () => {
   });
 
   test('switches between agent tabs', async ({ page }) => {
-    await page.request.post(`http://localhost:7777/api/tasks/${taskId}/agents`, {
+    await page.request.post(`http://localhost:7777/api/tasks/${taskId}/workers`, {
       data: {},
     });
 

--- a/packages/test-fixtures/src/index.ts
+++ b/packages/test-fixtures/src/index.ts
@@ -1,4 +1,4 @@
-import type { Agent, Task, UserTerminal } from '@octomux/types';
+import type { Worker, Task, UserTerminal } from '@octomux/types';
 
 // ─── Shared constants ─────────────────────────────────────────────────────────
 
@@ -33,23 +33,23 @@ const AGENT_FIXTURE_BASE = {
   agent: null,
   notify_agent_id: null,
   created_at: FIXTURE_TIMESTAMP,
-} satisfies Omit<Agent, 'id' | 'harness_session_id'>;
+} satisfies Omit<Worker, 'id' | 'harness_session_id'>;
 
 /** Server test default — includes orchestrator-assigned session id. */
-export const SERVER_AGENT_DEFAULTS: Agent = {
+export const SERVER_AGENT_DEFAULTS: Worker = {
   ...AGENT_FIXTURE_BASE,
   id: 'test-agent-01',
   harness_session_id: 'test-session-uuid-01',
 };
 
 /** Frontend test default — harness issues session id at runtime. */
-export const FRONTEND_AGENT_DEFAULTS: Agent = {
+export const FRONTEND_AGENT_DEFAULTS: Worker = {
   ...AGENT_FIXTURE_BASE,
   id: 'agent-01',
   harness_session_id: null,
 };
 
-export function makeAgent(overrides: Partial<Agent> = {}): Agent {
+export function makeAgent(overrides: Partial<Worker> = {}): Worker {
   return { ...FRONTEND_AGENT_DEFAULTS, ...overrides };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -67,7 +67,7 @@ export const WORKFLOW_STATUSES: readonly WorkflowStatus[] = [
   'done',
 ] as const;
 
-export type AgentStatus = 'running' | 'idle' | 'waiting' | 'stopped';
+export type WorkerStatus = 'running' | 'idle' | 'waiting' | 'stopped';
 export type HookActivity = 'active' | 'idle' | 'waiting';
 export type DerivedTaskStatus = 'working' | 'needs_attention' | 'done';
 
@@ -152,7 +152,7 @@ export interface Task {
   current_summary_updated_at: string | null;
   created_at: string;
   updated_at: string;
-  agents?: Agent[];
+  workers?: Worker[];
   user_terminals?: UserTerminal[];
   pending_prompts?: PermissionPrompt[];
   derived_status?: DerivedTaskStatus | null;
@@ -162,13 +162,13 @@ export interface Task {
   existing_review_id?: string | null;
 }
 
-export interface Agent {
+export interface Worker {
   id: string;
   /** Phase 2a: null for standalone agents (orchestrator, chats). */
   task_id: string | null;
   window_index: number;
   label: string;
-  status: AgentStatus;
+  status: WorkerStatus;
   harness_id: string;
   harness_session_id: string | null;
   /** Per-agent token used to authenticate hook callbacks. */

--- a/server/api.agents.test.ts
+++ b/server/api.agents.test.ts
@@ -36,10 +36,10 @@ describe('agents CRUD routes', () => {
     app = createApp();
   });
 
-  describe('POST /api/agent-configs', () => {
+  describe('POST /api/agents', () => {
     it('creates an agent and returns it with derived status/session_id', async () => {
       const res = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Ops Agent', system_prompt: 'You watch prod.' });
 
       expect(res.status).toBe(201);
@@ -52,7 +52,7 @@ describe('agents CRUD routes', () => {
 
     it('accepts an optional channel + object channel_config (stored as JSON)', async () => {
       const res = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({
           name: 'Telegram Agent',
           system_prompt: 'p',
@@ -66,76 +66,70 @@ describe('agents CRUD routes', () => {
     });
 
     it('rejects a missing name with 400', async () => {
-      const res = await request(app).post('/api/agent-configs').send({ system_prompt: 'p' });
+      const res = await request(app).post('/api/agents').send({ system_prompt: 'p' });
       expect(res.status).toBe(400);
     });
 
     it('rejects a blank system_prompt with 400', async () => {
-      const res = await request(app)
-        .post('/api/agent-configs')
-        .send({ name: 'X', system_prompt: '   ' });
+      const res = await request(app).post('/api/agents').send({ name: 'X', system_prompt: '   ' });
       expect(res.status).toBe(400);
     });
   });
 
-  describe('GET /api/agent-configs', () => {
+  describe('GET /api/agents', () => {
     it('lists all agents with status', async () => {
-      await request(app).post('/api/agent-configs').send({ name: 'A', system_prompt: 'p1' });
-      await request(app).post('/api/agent-configs').send({ name: 'B', system_prompt: 'p2' });
+      await request(app).post('/api/agents').send({ name: 'A', system_prompt: 'p1' });
+      await request(app).post('/api/agents').send({ name: 'B', system_prompt: 'p2' });
 
-      const res = await request(app).get('/api/agent-configs');
+      const res = await request(app).get('/api/agents');
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(2);
       expect(res.body.every((a: { status: string }) => a.status === 'stopped')).toBe(true);
     });
 
     it('returns an empty list when there are no agents', async () => {
-      const res = await request(app).get('/api/agent-configs');
+      const res = await request(app).get('/api/agents');
       expect(res.status).toBe(200);
       expect(res.body).toEqual([]);
     });
 
     it('never throws even if the liveness probe errors (defaults to stopped)', async () => {
-      const create = await request(app)
-        .post('/api/agent-configs')
-        .send({ name: 'A', system_prompt: 'p' });
-      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      const create = await request(app).post('/api/agents').send({ name: 'A', system_prompt: 'p' });
+      await request(app).post(`/api/agents/${create.body.id}/session`);
 
       aliveOverride = () => Promise.reject(new Error('tmux exploded'));
 
-      const res = await request(app).get('/api/agent-configs');
+      const res = await request(app).get('/api/agents');
       expect(res.status).toBe(200);
       expect(res.body[0].status).toBe('stopped');
     });
   });
 
-  describe('GET /api/agent-configs/:id', () => {
+  describe('GET /api/agents/:id', () => {
     it('returns 404 for an unknown id', async () => {
-      const res = await request(app).get('/api/agent-configs/does-not-exist');
+      const res = await request(app).get('/api/agents/does-not-exist');
       expect(res.status).toBe(404);
     });
 
     it('returns the agent with status idle once its session is alive', async () => {
-      const create = await request(app)
-        .post('/api/agent-configs')
-        .send({ name: 'A', system_prompt: 'p' });
-      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      const create = await request(app).post('/api/agents').send({ name: 'A', system_prompt: 'p' });
+      await request(app).post(`/api/agents/${create.body.id}/session`);
 
-      const res = await request(app).get(`/api/agent-configs/${create.body.id}`);
+      const res = await request(app).get(`/api/agents/${create.body.id}`);
       expect(res.status).toBe(200);
       expect(res.body.status).toBe('idle');
       expect(res.body.session_id).toEqual(expect.any(String));
     });
   });
 
-  describe('PATCH /api/agent-configs/:id', () => {
+  describe('PATCH /api/agents/:id', () => {
     it('updates given fields and leaves others untouched', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Original', system_prompt: 'orig' });
 
       const res = await request(app)
-        .patch(`/api/agent-configs/${create.body.id}`)
+        .patch(`/api/agents/${create.body.id}`)
         .send({ name: 'Renamed' });
 
       expect(res.status).toBe(200);
@@ -145,69 +139,67 @@ describe('agents CRUD routes', () => {
 
     it('rejects an empty name with 400', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Original', system_prompt: 'orig' });
 
-      const res = await request(app)
-        .patch(`/api/agent-configs/${create.body.id}`)
-        .send({ name: '   ' });
+      const res = await request(app).patch(`/api/agents/${create.body.id}`).send({ name: '   ' });
 
       expect(res.status).toBe(400);
     });
 
     it('returns 404 for an unknown id', async () => {
-      const res = await request(app).patch('/api/agent-configs/does-not-exist').send({ name: 'X' });
+      const res = await request(app).patch('/api/agents/does-not-exist').send({ name: 'X' });
       expect(res.status).toBe(404);
     });
   });
 
-  describe('DELETE /api/agent-configs/:id', () => {
+  describe('DELETE /api/agents/:id', () => {
     it('deletes the agent and stops its session if it has one', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Doomed', system_prompt: 'p' });
-      await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      await request(app).post(`/api/agents/${create.body.id}/session`);
 
       const runner = await import('./orchestrator/runner.js');
 
-      const res = await request(app).delete(`/api/agent-configs/${create.body.id}`);
+      const res = await request(app).delete(`/api/agents/${create.body.id}`);
       expect(res.status).toBe(204);
       expect(runner.stopConversation).toHaveBeenCalledTimes(1);
 
-      const getRes = await request(app).get(`/api/agent-configs/${create.body.id}`);
+      const getRes = await request(app).get(`/api/agents/${create.body.id}`);
       expect(getRes.status).toBe(404);
     });
 
     it('deletes an agent that never had a session without calling stopConversation', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Never started', system_prompt: 'p' });
 
       const runner = await import('./orchestrator/runner.js');
 
-      const res = await request(app).delete(`/api/agent-configs/${create.body.id}`);
+      const res = await request(app).delete(`/api/agents/${create.body.id}`);
       expect(res.status).toBe(204);
       expect(runner.stopConversation).not.toHaveBeenCalled();
     });
 
     it('returns 404 for an unknown id', async () => {
-      const res = await request(app).delete('/api/agent-configs/does-not-exist');
+      const res = await request(app).delete('/api/agents/does-not-exist');
       expect(res.status).toBe(404);
     });
   });
 
-  describe('POST /api/agent-configs/:id/session', () => {
+  describe('POST /api/agents/:id/session', () => {
     it('returns 404 for an unknown agent', async () => {
-      const res = await request(app).post('/api/agent-configs/does-not-exist/session');
+      const res = await request(app).post('/api/agents/does-not-exist/session');
       expect(res.status).toBe(404);
     });
 
     it('starts a fresh session with the agent name + system prompt', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Ops Agent', system_prompt: 'You watch prod.' });
 
-      const res = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      const res = await request(app).post(`/api/agents/${create.body.id}/session`);
       expect(res.status).toBe(200);
       expect(res.body.title).toBe('Ops Agent');
       expect(res.body.agent_id).toBe(create.body.id);
@@ -220,11 +212,11 @@ describe('agents CRUD routes', () => {
 
     it('reuses the existing session on a second call instead of starting another', async () => {
       const create = await request(app)
-        .post('/api/agent-configs')
+        .post('/api/agents')
         .send({ name: 'Ops Agent', system_prompt: 'p' });
 
-      const first = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
-      const second = await request(app).post(`/api/agent-configs/${create.body.id}/session`);
+      const first = await request(app).post(`/api/agents/${create.body.id}/session`);
+      const second = await request(app).post(`/api/agents/${create.body.id}/session`);
 
       expect(second.body.id).toBe(first.body.id);
 

--- a/server/api.archive.test.ts
+++ b/server/api.archive.test.ts
@@ -24,14 +24,14 @@ vi.mock('./task-engine/index.js', async () => {
       db.prepare(
         `UPDATE tasks SET runtime_state = 'idle', updated_at = datetime('now') WHERE id = ?`,
       ).run(task.id);
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE task_id = ?`).run(task.id);
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE task_id = ?`).run(task.id);
     }),
     softDeleteTask: vi.fn(async (task: any) => {
       const db = getDb();
       db.prepare(
         `UPDATE tasks SET deleted_at = datetime('now'), runtime_state = 'idle', updated_at = datetime('now') WHERE id = ?`,
       ).run(task.id);
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE task_id = ?`).run(task.id);
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE task_id = ?`).run(task.id);
     }),
     deleteTask: vi.fn(),
     resumeTask: vi.fn(),

--- a/server/api.loop-groups.test.ts
+++ b/server/api.loop-groups.test.ts
@@ -196,7 +196,7 @@ describe('loop-group routes', () => {
       const [runA, runB] = createRes.body.loopRuns;
       db.prepare(`UPDATE loop_runs SET status = 'done' WHERE id IN (?, ?)`).run(runA.id, runB.id);
 
-      const agentRow = db.prepare('SELECT hook_token FROM agents LIMIT 1').get() as {
+      const agentRow = db.prepare('SELECT hook_token FROM workers LIMIT 1').get() as {
         hook_token: string;
       };
 
@@ -223,7 +223,7 @@ describe('loop-group routes', () => {
       const createRes = await request(app)
         .post('/api/loop-groups')
         .send({ repoPath: '/repo', baseBranch: 'main', spec: VALID_SPEC, n: 2 });
-      const agentRow = db.prepare('SELECT hook_token FROM agents LIMIT 1').get() as {
+      const agentRow = db.prepare('SELECT hook_token FROM workers LIMIT 1').get() as {
         hook_token: string;
       };
 

--- a/server/api.loops.test.ts
+++ b/server/api.loops.test.ts
@@ -110,7 +110,7 @@ describe('loop routes', () => {
     });
 
     it('returns 400 when the task has no active agent', async () => {
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE id = 'a1'`).run();
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE id = 'a1'`).run();
       const res = await request(app)
         .post('/api/loops')
         .send({ taskId: 't1', spec: { prompt: 'x', verify: 'y', maxIterations: 5 } });

--- a/server/api.reviews.test.ts
+++ b/server/api.reviews.test.ts
@@ -188,7 +188,7 @@ describe('POST /api/tasks/:id/review-runs', () => {
     const db = getDb();
     db.prepare(`UPDATE tasks SET runtime_state = 'running' WHERE id = 'task-rev1'`).run();
     db.prepare(
-      `INSERT INTO agents (id, task_id, window_index, label, status, hook_token)
+      `INSERT INTO workers (id, task_id, window_index, label, status, hook_token)
        VALUES ('ag1', 'task-rev1', 0, 'Agent', 'running', '')`,
     ).run();
     const res = await request(app).post('/api/tasks/task-rev1/review-runs').send();

--- a/server/api.soft-delete.test.ts
+++ b/server/api.soft-delete.test.ts
@@ -19,7 +19,7 @@ vi.mock('./task-engine/index.js', async () => {
                           updated_at = datetime('now')
            WHERE id = ?`,
       ).run(task.id);
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE task_id = ?`).run(task.id);
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE task_id = ?`).run(task.id);
     }),
     deleteTask: vi.fn(),
     resumeTask: vi.fn(),

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -36,14 +36,14 @@ vi.mock('./task-engine/index.js', async () => {
       db.prepare(
         `UPDATE tasks SET runtime_state = 'idle', updated_at = datetime('now') WHERE id = ?`,
       ).run(task.id);
-      db.prepare('UPDATE agents SET status = ? WHERE task_id = ?').run('stopped', task.id);
+      db.prepare('UPDATE workers SET status = ? WHERE task_id = ?').run('stopped', task.id);
     }),
     softDeleteTask: vi.fn(async (task: any) => {
       const db = getDb();
       db.prepare(
         `UPDATE tasks SET deleted_at = datetime('now'), runtime_state = 'idle', updated_at = datetime('now') WHERE id = ?`,
       ).run(task.id);
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE task_id = ?`).run(task.id);
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE task_id = ?`).run(task.id);
     }),
     deleteTask: vi.fn(),
     resumeTask: vi.fn(async (task: any) => {
@@ -52,7 +52,7 @@ vi.mock('./task-engine/index.js', async () => {
         `UPDATE tasks SET runtime_state = 'running', updated_at = datetime('now') WHERE id = ?`,
       ).run(task.id);
       db.prepare(
-        "UPDATE agents SET status = 'running' WHERE task_id = ? AND status = 'stopped'",
+        "UPDATE workers SET status = 'running' WHERE task_id = ? AND status = 'stopped'",
       ).run(task.id);
     }),
     addAgent: vi.fn(async (_task: any, _opts?: any) => ({
@@ -91,14 +91,14 @@ vi.mock('./task-engine/index.js', async () => {
       const { getDb } = await import('./db.js');
       const db = getDb();
       db.prepare(
-        `UPDATE agents SET task_id = ?, window_index = ?, tmux_session = ?, status = 'running' WHERE id = ?`,
+        `UPDATE workers SET task_id = ?, window_index = ?, tmux_session = ?, status = 'running' WHERE id = ?`,
       ).run(
         toTaskId,
         toTaskId === null ? 0 : 7,
         toTaskId === null ? `octomux-chat-${agent.id}` : null,
         agent.id,
       );
-      return db.prepare('SELECT * FROM agents WHERE id = ?').get(agent.id);
+      return db.prepare('SELECT * FROM workers WHERE id = ?').get(agent.id);
     }),
   };
 });
@@ -126,33 +126,35 @@ vi.mock('./chats.js', async () => {
         counter += 1;
         const id = `chat-test-${counter.toString().padStart(2, '0')}`;
         db.prepare(
-          `INSERT INTO agents
+          `INSERT INTO workers
              (id, task_id, window_index, label, status, harness_id, harness_session_id,
               hook_token, hook_activity, tmux_session, agent, created_at)
            VALUES (?, NULL, 0, ?, 'running', 'claude-code', ?, '', 'active', ?, ?, datetime('now'))`,
         ).run(id, opts.label ?? 'Chat', `sid-${id}`, `octomux-chat-${id}`, opts.agent ?? null);
-        return db.prepare('SELECT * FROM agents WHERE id = ?').get(id);
+        return db.prepare('SELECT * FROM workers WHERE id = ?').get(id);
       },
     ),
     listChats: vi.fn(() => {
       const db = getDb();
-      return db.prepare(`SELECT * FROM agents WHERE task_id IS NULL ORDER BY created_at ASC`).all();
+      return db
+        .prepare(`SELECT * FROM workers WHERE task_id IS NULL ORDER BY created_at ASC`)
+        .all();
     }),
     getChat: vi.fn((id: string) => {
       const db = getDb();
-      return db.prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`).get(id) ?? null;
+      return db.prepare(`SELECT * FROM workers WHERE id = ? AND task_id IS NULL`).get(id) ?? null;
     }),
     closeChat: vi.fn(async (chat: { id: string }) => {
       const db = getDb();
       db.prepare(
-        `UPDATE agents SET status = 'stopped', hook_activity = 'idle',
+        `UPDATE workers SET status = 'stopped', hook_activity = 'idle',
             hook_activity_updated_at = datetime('now')
           WHERE id = ?`,
       ).run(chat.id);
     }),
     deleteChat: vi.fn(async (chat: { id: string }) => {
       const db = getDb();
-      db.prepare('DELETE FROM agents WHERE id = ?').run(chat.id);
+      db.prepare('DELETE FROM workers WHERE id = ?').run(chat.id);
     }),
   };
 });
@@ -265,15 +267,15 @@ const notFoundCases = [
     url: '/api/tasks/nonexistent/start',
   },
   {
-    name: 'POST /api/tasks/:id/agents',
+    name: 'POST /api/tasks/:id/workers',
     method: 'post' as const,
-    url: '/api/tasks/nonexistent/agents',
+    url: '/api/tasks/nonexistent/workers',
     body: {},
   },
   {
-    name: 'DELETE /api/tasks/:id/agents/:agentId',
+    name: 'DELETE /api/tasks/:id/workers/:agentId',
     method: 'delete' as const,
-    url: '/api/tasks/nonexistent/agents/agent1',
+    url: '/api/tasks/nonexistent/workers/agent1',
   },
 
   {
@@ -282,9 +284,9 @@ const notFoundCases = [
     url: '/api/tasks/nonexistent/user-terminal',
   },
   {
-    name: 'POST /api/tasks/:id/agents/:agentId/message',
+    name: 'POST /api/tasks/:id/workers/:agentId/message',
     method: 'post' as const,
-    url: '/api/tasks/nonexistent/agents/agent1/message',
+    url: '/api/tasks/nonexistent/workers/agent1/message',
     body: { message: 'hello' },
   },
 ];
@@ -904,7 +906,7 @@ describe('DELETE /api/tasks/:id', () => {
     await request(app).delete(`/api/tasks/${DEFAULTS.task.id}`);
     // Agents still exist but are stopped
     const agents = db
-      .prepare('SELECT * FROM agents WHERE task_id = ?')
+      .prepare('SELECT * FROM workers WHERE task_id = ?')
       .all(DEFAULTS.task.id) as any[];
     expect(agents).toHaveLength(1);
     expect(agents[0].status).toBe('stopped');
@@ -1335,16 +1337,16 @@ describe('PATCH /api/tasks/:id/base', () => {
   });
 });
 
-// ─── POST /api/tasks/:id/agents ──────────────────────────────────────────────
+// ─── POST /api/tasks/:id/workers ──────────────────────────────────────────────
 
-describe('POST /api/tasks/:id/agents', () => {
+describe('POST /api/tasks/:id/workers', () => {
   // ─── Status gating (table-driven) ──────────────────────────────────────
 
   const nonRunningStates = ['idle', 'setting_up', 'error'];
 
   it.each(nonRunningStates)('returns 400 when task runtime_state is %s', async (state) => {
     insertTask(db, { runtime_state: state as any });
-    const res = await request(app).post(`/api/tasks/${DEFAULTS.task.id}/agents`).send({});
+    const res = await request(app).post(`/api/tasks/${DEFAULTS.task.id}/workers`).send({});
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('running');
   });
@@ -1353,7 +1355,7 @@ describe('POST /api/tasks/:id/agents', () => {
     insertTask(db, { ...DEFAULTS.runningTask });
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers`)
       .send({ prompt: 'Write tests' });
 
     expect(res.status).toBe(201);
@@ -1364,28 +1366,32 @@ describe('POST /api/tasks/:id/agents', () => {
   it('passes prompt to addAgent', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers`)
       .send({ prompt: 'Write comprehensive tests' });
 
-    expect(vi.mocked(addAgent).mock.calls[0][1]).toMatchObject({
+    // Assert the call this test made, not `calls[0]`: `beforeEach` runs
+    // `restoreAllMocks` (spies) rather than `clearAllMocks`, so this mock's call
+    // history can carry over from an earlier test in the file and index 0 is
+    // then somebody else's call.
+    expect(vi.mocked(addAgent).mock.lastCall?.[1]).toMatchObject({
       prompt: 'Write comprehensive tests',
     });
   });
 
   it('works without prompt', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
-    const res = await request(app).post(`/api/tasks/${DEFAULTS.task.id}/agents`).send({});
+    const res = await request(app).post(`/api/tasks/${DEFAULTS.task.id}/workers`).send({});
     expect(res.status).toBe(201);
-    expect(vi.mocked(addAgent).mock.calls[0][1]).toMatchObject({ prompt: undefined });
+    expect(vi.mocked(addAgent).mock.lastCall?.[1]).toMatchObject({ prompt: undefined });
   });
 });
 
-// ─── DELETE /api/tasks/:id/agents/:agentId ───────────────────────────────────
+// ─── DELETE /api/tasks/:id/workers/:agentId ───────────────────────────────────
 
-describe('DELETE /api/tasks/:id/agents/:agentId', () => {
+describe('DELETE /api/tasks/:id/workers/:agentId', () => {
   it('returns 404 for nonexistent agent on existing task', async () => {
     insertTask(db);
-    const res = await request(app).delete(`/api/tasks/${DEFAULTS.task.id}/agents/nonexistent`);
+    const res = await request(app).delete(`/api/tasks/${DEFAULTS.task.id}/workers/nonexistent`);
     expect(res.status).toBe(404);
   });
 
@@ -1394,7 +1400,7 @@ describe('DELETE /api/tasks/:id/agents/:agentId', () => {
     insertTask(db, { id: 'task-b' });
     insertAgent(db, { id: 'agent-on-b', task_id: 'task-b' });
 
-    const res = await request(app).delete('/api/tasks/task-a/agents/agent-on-b');
+    const res = await request(app).delete('/api/tasks/task-a/workers/agent-on-b');
     expect(res.status).toBe(404);
   });
 
@@ -1403,7 +1409,7 @@ describe('DELETE /api/tasks/:id/agents/:agentId', () => {
     insertAgent(db);
 
     const res = await request(app).delete(
-      `/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}`,
+      `/api/tasks/${DEFAULTS.task.id}/workers/${DEFAULTS.agent.id}`,
     );
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -1820,9 +1826,9 @@ describe('GET /api/tasks with permission prompts', () => {
   });
 });
 
-// ─── POST /api/tasks/:id/agents/:agentId/message ────────────────────────────
+// ─── POST /api/tasks/:id/workers/:agentId/message ────────────────────────────
 
-describe('POST /api/tasks/:id/agents/:agentId/message', () => {
+describe('POST /api/tasks/:id/workers/:agentId/message', () => {
   it('sends message via tmux send-keys and returns success', async () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db);
@@ -1835,7 +1841,7 @@ describe('POST /api/tasks/:id/agents/:agentId/message', () => {
     }) as any);
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers/${DEFAULTS.agent.id}/message`)
       .send({ message: 'hello agent' });
 
     expect(res.status).toBe(200);
@@ -1872,7 +1878,7 @@ describe('POST /api/tasks/:id/agents/:agentId/message', () => {
     insertTask(db, { ...DEFAULTS.runningTask });
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents/nonexistent/message`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers/nonexistent/message`)
       .send({ message: 'hello' });
 
     expect(res.status).toBe(404);
@@ -1884,7 +1890,7 @@ describe('POST /api/tasks/:id/agents/:agentId/message', () => {
     insertAgent(db);
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers/${DEFAULTS.agent.id}/message`)
       .send({ message: 'hello' });
 
     expect(res.status).toBe(400);
@@ -1896,7 +1902,7 @@ describe('POST /api/tasks/:id/agents/:agentId/message', () => {
     insertAgent(db);
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers/${DEFAULTS.agent.id}/message`)
       .send({});
 
     expect(res.status).toBe(400);
@@ -1908,7 +1914,7 @@ describe('POST /api/tasks/:id/agents/:agentId/message', () => {
     insertAgent(db);
 
     const res = await request(app)
-      .post(`/api/tasks/${DEFAULTS.task.id}/agents/${DEFAULTS.agent.id}/message`)
+      .post(`/api/tasks/${DEFAULTS.task.id}/workers/${DEFAULTS.agent.id}/message`)
       .send({ message: '' });
 
     expect(res.status).toBe(400);
@@ -2250,29 +2256,29 @@ describe('DELETE /api/worktrees/:id', () => {
   });
 });
 
-describe('PATCH /api/agents/:id/task', () => {
+describe('PATCH /api/workers/:id/task', () => {
   it('404 when agent does not exist', async () => {
-    const res = await request(app).patch('/api/agents/missing/task').send({ task_id: null });
+    const res = await request(app).patch('/api/workers/missing/task').send({ task_id: null });
     expect(res.status).toBe(404);
   });
 
   it('400 when body missing task_id key', async () => {
     insertAgent(db, { id: 'aBody', task_id: null });
-    const res = await request(app).patch('/api/agents/aBody/task').send({});
+    const res = await request(app).patch('/api/workers/aBody/task').send({});
     expect(res.status).toBe(400);
   });
 
   it('400 when task_id equals current task_id (no-op)', async () => {
     insertTask(db, { id: 'tSame', runtime_state: 'running' });
     insertAgent(db, { id: 'aSame', task_id: 'tSame' });
-    const res = await request(app).patch('/api/agents/aSame/task').send({ task_id: 'tSame' });
+    const res = await request(app).patch('/api/workers/aSame/task').send({ task_id: 'tSame' });
     expect(res.status).toBe(400);
   });
 
   it('404 when target task does not exist', async () => {
     insertAgent(db, { id: 'aOrph', task_id: null });
     const res = await request(app)
-      .patch('/api/agents/aOrph/task')
+      .patch('/api/workers/aOrph/task')
       .send({ task_id: 'does-not-exist' });
     expect(res.status).toBe(404);
   });
@@ -2280,7 +2286,7 @@ describe('PATCH /api/agents/:id/task', () => {
   it('409 when target task is not active', async () => {
     insertTask(db, { id: 'tClosed', runtime_state: 'idle' });
     insertAgent(db, { id: 'aC', task_id: null });
-    const res = await request(app).patch('/api/agents/aC/task').send({ task_id: 'tClosed' });
+    const res = await request(app).patch('/api/workers/aC/task').send({ task_id: 'tClosed' });
     expect(res.status).toBe(409);
   });
 
@@ -2288,7 +2294,7 @@ describe('PATCH /api/agents/:id/task', () => {
     insertTask(db, { id: 'tFrom', runtime_state: 'running' });
     insertAgent(db, { id: 'aDet', task_id: 'tFrom' });
 
-    const res = await request(app).patch('/api/agents/aDet/task').send({ task_id: null });
+    const res = await request(app).patch('/api/workers/aDet/task').send({ task_id: null });
     expect(res.status).toBe(200);
     expect(res.body.task_id).toBeNull();
     expect(res.body.tmux_session).toBe('octomux-chat-aDet');
@@ -2299,7 +2305,7 @@ describe('PATCH /api/agents/:id/task', () => {
     insertTask(db, { id: 'tB', runtime_state: 'running' });
     insertAgent(db, { id: 'aMove', task_id: 'tA' });
 
-    const res = await request(app).patch('/api/agents/aMove/task').send({ task_id: 'tB' });
+    const res = await request(app).patch('/api/workers/aMove/task').send({ task_id: 'tB' });
     expect(res.status).toBe(200);
     expect(res.body.task_id).toBe('tB');
   });
@@ -2308,9 +2314,9 @@ describe('PATCH /api/agents/:id/task', () => {
     insertTask(db, { id: 'tTarget', runtime_state: 'running' });
     insertAgent(db, { id: 'aChat', task_id: null });
     // Standalone agents carry their own tmux_session.
-    db.prepare(`UPDATE agents SET tmux_session = 'octomux-chat-aChat' WHERE id = 'aChat'`).run();
+    db.prepare(`UPDATE workers SET tmux_session = 'octomux-chat-aChat' WHERE id = 'aChat'`).run();
 
-    const res = await request(app).patch('/api/agents/aChat/task').send({ task_id: 'tTarget' });
+    const res = await request(app).patch('/api/workers/aChat/task').send({ task_id: 'tTarget' });
     expect(res.status).toBe(200);
     expect(res.body.task_id).toBe('tTarget');
   });
@@ -2406,11 +2412,11 @@ describe('agent name validation', () => {
     });
   });
 
-  describe('POST /api/tasks/:id/agents', () => {
+  describe('POST /api/tasks/:id/workers', () => {
     it.each(invalidAgentCases)('rejects $name as agent → 400', async ({ agent }) => {
       insertTask(db, { ...DEFAULTS.runningTask });
       const res = await request(app)
-        .post(`/api/tasks/${DEFAULTS.runningTask.id}/agents`)
+        .post(`/api/tasks/${DEFAULTS.runningTask.id}/workers`)
         .send({ agent });
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/Invalid agent name/);

--- a/server/api.test.ts
+++ b/server/api.test.ts
@@ -10,7 +10,7 @@ import {
   getTask,
   DEFAULTS,
 } from './test-helpers.js';
-import type { Task, Agent } from './types.js';
+import type { Task, Worker } from './types.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -314,8 +314,8 @@ describe('GET /api/tasks', () => {
     const res = await request(app).get('/api/tasks');
     expect(res.body).toHaveLength(1);
     expect(res.body[0].id).toBe(DEFAULTS.task.id);
-    expect(res.body[0].agents).toHaveLength(1);
-    expect(res.body[0].agents[0].label).toBe(DEFAULTS.agent.label);
+    expect(res.body[0].workers).toHaveLength(1);
+    expect(res.body[0].workers[0].label).toBe(DEFAULTS.agent.label);
   });
 
   it('orders by created_at DESC', async () => {
@@ -329,7 +329,7 @@ describe('GET /api/tasks', () => {
   it('returns empty agents array for tasks without agents', async () => {
     insertTask(db);
     const res = await request(app).get('/api/tasks');
-    expect(res.body[0].agents).toEqual([]);
+    expect(res.body[0].workers).toEqual([]);
   });
 
   it('filters tasks by repo_path query param', async () => {
@@ -479,7 +479,7 @@ describe('GET /api/tasks/:id', () => {
     const res = await request(app).get(`/api/tasks/${DEFAULTS.task.id}`);
     expect(res.status).toBe(200);
     expect(res.body.title).toBe(DEFAULTS.task.title);
-    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.workers).toHaveLength(1);
   });
 
   it('returns all task fields', async () => {
@@ -706,7 +706,7 @@ describe('PATCH /api/tasks/:id', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.runtime_state).toBe('idle');
-    expect(res.body.agents).toHaveLength(1);
+    expect(res.body.workers).toHaveLength(1);
   });
 
   it('updates updated_at timestamp', async () => {
@@ -1768,7 +1768,7 @@ describe('GET /api/tasks with permission prompts', () => {
           id: `a${i}`,
           task_id: 't1',
           window_index: i,
-          hook_activity: activity as Agent['hook_activity'],
+          hook_activity: activity as Worker['hook_activity'],
         });
       });
 

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -19,7 +19,7 @@ import { resolveHarnessFlags } from './harness-flags.js';
 import { childLogger } from './logger.js';
 import { execTmux } from './tmux-bin.js';
 import { shellQuoteSingle } from './shell-quote.js';
-import type { Agent } from './types.js';
+import type { Worker } from './types.js';
 
 const logger = childLogger('chats');
 
@@ -54,7 +54,7 @@ export interface CreateChatOptions {
 /**
  * Create a standalone agent row + tmux session + launch claude in it.
  */
-export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
+export async function createChat(opts: CreateChatOptions = {}): Promise<Worker> {
   const id = nanoid(12);
   const label = opts.label ?? 'Chat';
   const cwd = opts.cwd ?? chatDirFor(id);
@@ -142,15 +142,15 @@ export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
     throw err;
   }
 
-  return getWorker(id) as Agent;
+  return getWorker(id) as Worker;
 }
 
 /** List all standalone agents (task_id IS NULL), oldest first. */
-export function listChats(): Agent[] {
+export function listChats(): Worker[] {
   return listChatAgents();
 }
 
-export function getChat(id: string): Agent | null {
+export function getChat(id: string): Worker | null {
   return getChatAgent(id) ?? null;
 }
 
@@ -185,7 +185,7 @@ async function killChatSession(id: string, session: string, op: string): Promise
  * Close a chat: stop the tmux session and mark the agent row stopped.
  * Preserves the DB row + scratch dir so history remains visible.
  */
-export async function closeChat(chat: Agent): Promise<void> {
+export async function closeChat(chat: Worker): Promise<void> {
   logger.info({ chat_id: chat.id, operation: 'closeChat' }, 'closeChat: start');
 
   stopChatAgent(chat.id);
@@ -200,7 +200,7 @@ export async function closeChat(chat: Agent): Promise<void> {
 /**
  * Delete a chat: kill tmux, remove scratch dir, delete DB row.
  */
-export async function deleteChat(chat: Agent): Promise<void> {
+export async function deleteChat(chat: Worker): Promise<void> {
   logger.info({ chat_id: chat.id, operation: 'deleteChat' }, 'deleteChat: start');
 
   if (chat.tmux_session) {

--- a/server/chats.ts
+++ b/server/chats.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { octomuxRoot } from './octomux-root.js';
 import { nanoid } from 'nanoid';
 import {
-  getAgent,
+  getWorker,
   insertChatAgent,
   listChatAgents,
   getChatAgent,
@@ -142,7 +142,7 @@ export async function createChat(opts: CreateChatOptions = {}): Promise<Agent> {
     throw err;
   }
 
-  return getAgent(id) as Agent;
+  return getWorker(id) as Agent;
 }
 
 /** List all standalone agents (task_id IS NULL), oldest first. */

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -37,14 +37,14 @@ describe('Database', () => {
       expect(columns.map((c) => c.name)).toContain(col);
     });
 
-    it.each(AGENTS_TABLE_COLUMNS)('agents table has column: %s', (col) => {
-      const columns = db.pragma('table_info(agents)') as { name: string }[];
+    it.each(AGENTS_TABLE_COLUMNS)('workers table has column: %s', (col) => {
+      const columns = db.pragma('table_info(workers)') as { name: string }[];
       expect(columns.map((c) => c.name)).toContain(col);
     });
 
     const indexCases = [
       { table: 'tasks', index: 'idx_tasks_active_worktree' },
-      { table: 'agents', index: 'idx_agents_task' },
+      { table: 'workers', index: 'idx_workers_task' },
     ];
 
     it.each(indexCases)('creates $index on $table', ({ table, index }) => {
@@ -58,7 +58,7 @@ describe('Database', () => {
   // ─── Constraint Tests ───────────────────────────────────────────────────
 
   describe('constraints', () => {
-    it('enforces foreign key on agents.task_id', () => {
+    it('enforces foreign key on workers.task_id', () => {
       expect(() => insertAgent(db, { task_id: 'nonexistent' })).toThrow();
     });
 
@@ -106,7 +106,7 @@ describe('Database', () => {
 
     it('auto-populates created_at on agents', () => {
       insertTask(db);
-      db.prepare('INSERT INTO agents (id, task_id, window_index, label) VALUES (?, ?, ?, ?)').run(
+      db.prepare('INSERT INTO workers (id, task_id, window_index, label) VALUES (?, ?, ?, ?)').run(
         'auto-agent',
         DEFAULTS.task.id,
         0,
@@ -173,7 +173,7 @@ describe('Database', () => {
     const migrationColumns = [
       { table: 'tasks', column: 'initial_prompt' },
       { table: 'tasks', column: 'worktree_id' },
-      { table: 'agents', column: 'harness_session_id' },
+      { table: 'workers', column: 'harness_session_id' },
     ];
 
     it.each(migrationColumns)('$table has $column column (migration)', ({ table, column }) => {
@@ -192,8 +192,8 @@ describe('Database', () => {
       expect(cols).toEqual(PERMISSION_PROMPTS_TABLE_COLUMNS);
     });
 
-    it('adds hook_activity column to agents table', () => {
-      const cols = (db.pragma('table_info(agents)') as { name: string }[]).map((c) => c.name);
+    it('adds hook_activity column to workers table', () => {
+      const cols = (db.pragma('table_info(workers)') as { name: string }[]).map((c) => c.name);
       expect(cols).toContain('hook_activity');
       expect(cols).toContain('hook_activity_updated_at');
     });
@@ -232,7 +232,7 @@ describe('Database', () => {
 
       initDb(db);
 
-      const agent = db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get('a1') as {
+      const agent = db.prepare('SELECT hook_activity FROM workers WHERE id = ?').get('a1') as {
         hook_activity: string;
       };
       expect(agent.hook_activity).toBe(expected);
@@ -254,8 +254,8 @@ describe('Database', () => {
       expect(cols).toContain('worktree_id');
     });
 
-    it('makes agents.task_id nullable', () => {
-      const rows = db.pragma('table_info(agents)') as Array<{
+    it('makes workers.task_id nullable', () => {
+      const rows = db.pragma('table_info(workers)') as Array<{
         name: string;
         notnull: number;
       }>;
@@ -263,8 +263,8 @@ describe('Database', () => {
       expect(col.notnull).toBe(0);
     });
 
-    it('adds agents.tmux_session and agents.agent columns; drops legacy pinned', () => {
-      const cols = (db.pragma('table_info(agents)') as Array<{ name: string }>).map((c) => c.name);
+    it('adds workers.tmux_session and workers.agent columns; drops legacy pinned', () => {
+      const cols = (db.pragma('table_info(workers)') as Array<{ name: string }>).map((c) => c.name);
       expect(cols).toContain('tmux_session');
       expect(cols).toContain('agent');
       expect(cols).not.toContain('pinned');
@@ -277,14 +277,14 @@ describe('Database', () => {
 
     it('removes legacy seeded orchestrator agent row', () => {
       const row = db
-        .prepare(`SELECT id FROM agents WHERE id = 'orchestrator' AND task_id IS NULL`)
+        .prepare(`SELECT id FROM workers WHERE id = 'orchestrator' AND task_id IS NULL`)
         .get();
       expect(row).toBeUndefined();
     });
 
     it('allows inserting a standalone agent with NULL task_id', () => {
       const stmt = db.prepare(
-        `INSERT INTO agents (id, task_id, window_index, label, tmux_session)
+        `INSERT INTO workers (id, task_id, window_index, label, tmux_session)
          VALUES (?, NULL, 0, 'chat', 'octomux-agent-chat-1')`,
       );
       expect(() => stmt.run('chat-1')).not.toThrow();
@@ -399,14 +399,14 @@ describe('Database', () => {
       expect(row.harness_id).toBe('claude-code');
     });
 
-    it('adds harness_id and hook_token to agents with defaults', () => {
+    it('adds harness_id and hook_token to workers with defaults', () => {
       const db = createTestDb();
       db.prepare(
-        `INSERT INTO agents (id, task_id, window_index, label, harness_session_id, agent)
+        `INSERT INTO workers (id, task_id, window_index, label, harness_session_id, agent)
          VALUES ('a1', NULL, 0, 'Agent 1', 'old-session-uuid', NULL)`,
       ).run();
       const row = db
-        .prepare(`SELECT harness_id, hook_token FROM agents WHERE id = ?`)
+        .prepare(`SELECT harness_id, hook_token FROM workers WHERE id = ?`)
         .get('a1') as {
         harness_id: string;
         hook_token: string;
@@ -419,7 +419,7 @@ describe('Database', () => {
       const db = createTestDb();
       initDb(db);
       initDb(db);
-      const cols = db.pragma('table_info(agents)') as Array<{ name: string }>;
+      const cols = db.pragma('table_info(workers)') as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names.filter((n) => n === 'harness_id')).toHaveLength(1);
       expect(names.filter((n) => n === 'hook_token')).toHaveLength(1);
@@ -649,31 +649,34 @@ describe('claude_session_id rename', () => {
 
     initDb(db);
 
-    const cols = db.pragma('table_info(agents)') as Array<{ name: string }>;
+    // Pre-rename simulation: `agents` had no `agent_configs` sibling, so the
+    // 2026-07-25 agents/workers rename renames `agents` -> `workers` (step 2,
+    // agent_configs -> agents, no-ops since there's nothing to rename).
+    const cols = db.pragma('table_info(workers)') as Array<{ name: string }>;
     const names = cols.map((c) => c.name);
     expect(names).toContain('harness_session_id');
     expect(names).not.toContain('claude_session_id');
 
-    const row = db.prepare(`SELECT harness_session_id FROM agents WHERE id = ?`).get('a1') as {
+    const row = db.prepare(`SELECT harness_session_id FROM workers WHERE id = ?`).get('a1') as {
       harness_session_id: string;
     };
     expect(row.harness_session_id).toBe('old-uuid');
 
-    const indexes = db.pragma('index_list(agents)') as Array<{ name: string }>;
-    expect(indexes.map((i) => i.name)).toContain('idx_agents_harness_session_id');
+    const indexes = db.pragma('index_list(workers)') as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain('idx_workers_harness_session_id');
     expect(indexes.map((i) => i.name)).not.toContain('idx_agents_claude_session_id');
   });
 });
 
-describe('agents feature: agent_configs table + orchestrator_conversations.agent_id', () => {
-  it('creates the agent_configs table on a fresh DB', () => {
+describe('agents feature: agents table (conductor) + orchestrator_conversations.agent_id', () => {
+  it('creates the agents table on a fresh DB', () => {
     const db = createTestDb();
     const tables = db
       .prepare(`SELECT name FROM sqlite_master WHERE type = 'table'`)
       .all() as Array<{ name: string }>;
-    expect(tables.map((t) => t.name)).toContain('agent_configs');
+    expect(tables.map((t) => t.name)).toContain('agents');
 
-    const cols = db.pragma('table_info(agent_configs)') as Array<{ name: string }>;
+    const cols = db.pragma('table_info(agents)') as Array<{ name: string }>;
     const names = cols.map((c) => c.name);
     expect(names).toEqual(
       expect.arrayContaining([

--- a/server/db.ts
+++ b/server/db.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import { childLogger } from './logger.js';
 import { octomuxRoot } from './octomux-root.js';
 import { SCHEMA, applyPragmas } from './db/schema.js';
-import { runMigrations } from './db/migrations.js';
+import { runMigrations, renameAgentWorkerTables } from './db/migrations.js';
 
 export { SCHEMA } from './db/schema.js';
 
@@ -71,6 +71,10 @@ export function pingDb(): void {
 /** Initialize a database with schema and pragmas. */
 export function initDb(instance: Database.Database): void {
   applyPragmas(instance);
+  // Must run before SCHEMA — see the doc comment on renameAgentWorkerTables
+  // for why (SCHEMA's `CREATE TABLE IF NOT EXISTS workers` would otherwise
+  // create an empty placeholder ahead of the real rename on old installs).
+  renameAgentWorkerTables(instance);
   instance.exec(SCHEMA);
   runMigrations(instance);
 }

--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -31,7 +31,7 @@ describe('runMigrations (isolated)', () => {
     }
     expect(taskCols).not.toContain('status');
 
-    const agentCols = (db.pragma('table_info(agents)') as Array<{ name: string }>).map(
+    const agentCols = (db.pragma('table_info(workers)') as Array<{ name: string }>).map(
       (c) => c.name,
     );
     for (const col of AGENTS_TABLE_COLUMNS) {

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -51,7 +51,7 @@ export function addColumn(
 }
 
 function agentFkIsNotNull(instance: Database.Database): boolean {
-  const rows = instance.pragma('table_info(agents)') as Array<{
+  const rows = instance.pragma('table_info(workers)') as Array<{
     name: string;
     notnull: number;
   }>;
@@ -60,7 +60,7 @@ function agentFkIsNotNull(instance: Database.Database): boolean {
 }
 
 /**
- * Rebuild the `agents` table to make `task_id` nullable while preserving rows,
+ * Rebuild the `workers` table to make `task_id` nullable while preserving rows,
  * FK, cascade behaviour, and indexes. SQLite < 3.35 can't ALTER a column's
  * NOT NULL in place; a table rebuild is the supported path.
  */
@@ -68,7 +68,7 @@ function rebuildAgentsTable(instance: Database.Database): void {
   instance
     .transaction(() => {
       // Capture dynamically-added columns that may not exist in the CREATE.
-      const oldCols = (instance.pragma('table_info(agents)') as Array<{ name: string }>).map(
+      const oldCols = (instance.pragma('table_info(workers)') as Array<{ name: string }>).map(
         (c) => c.name,
       );
       const has = (c: string) => oldCols.includes(c);
@@ -105,14 +105,14 @@ function rebuildAgentsTable(instance: Database.Database): void {
         'created_at',
       ].join(', ');
 
-      instance.exec(`INSERT INTO agents_new SELECT ${selectCols} FROM agents`);
-      instance.exec(`DROP TABLE agents`);
-      instance.exec(`ALTER TABLE agents_new RENAME TO agents`);
+      instance.exec(`INSERT INTO agents_new SELECT ${selectCols} FROM workers`);
+      instance.exec(`DROP TABLE workers`);
+      instance.exec(`ALTER TABLE agents_new RENAME TO workers`);
 
       // Recreate indexes (idempotent CREATE IF NOT EXISTS).
-      instance.exec(`CREATE INDEX IF NOT EXISTS idx_agents_task ON agents(task_id)`);
+      instance.exec(`CREATE INDEX IF NOT EXISTS idx_workers_task ON workers(task_id)`);
       instance.exec(
-        `CREATE INDEX IF NOT EXISTS idx_agents_harness_session_id ON agents(harness_session_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_workers_harness_session_id ON workers(harness_session_id)`,
       );
     })
     .default();
@@ -126,43 +126,43 @@ export function runMigrations(instance: Database.Database): void {
   // were dropped after Phase 2a and are re-homed in the worktrees table.
   const taskCols = columnsOf(instance, 'tasks');
 
-  const agentCols = columnsOf(instance, 'agents');
+  const agentCols = columnsOf(instance, 'workers');
 
-  // Rename agents.claude_session_id -> agents.harness_session_id (step-1 of
+  // Rename workers.claude_session_id -> workers.harness_session_id (step-1 of
   // the harness abstraction). Must run BEFORE addColumn for harness_session_id
   // so the rename fires on old DBs before we try to add the new-named column.
   // Idempotent: only runs when the old column still exists.
   // SQLite 3.25+ supports RENAME COLUMN.
   if (agentCols.has('claude_session_id') && !agentCols.has('harness_session_id')) {
-    instance.exec(`ALTER TABLE agents RENAME COLUMN claude_session_id TO harness_session_id`);
+    instance.exec(`ALTER TABLE workers RENAME COLUMN claude_session_id TO harness_session_id`);
     instance.exec(`DROP INDEX IF EXISTS idx_agents_claude_session_id`);
     agentCols.delete('claude_session_id');
     agentCols.add('harness_session_id');
   }
 
-  addColumn(instance, 'agents', 'harness_session_id', 'harness_session_id TEXT', agentCols);
+  addColumn(instance, 'workers', 'harness_session_id', 'harness_session_id TEXT', agentCols);
   addColumn(
     instance,
-    'agents',
+    'workers',
     'hook_activity',
     "hook_activity TEXT NOT NULL DEFAULT 'active'",
     agentCols,
   );
   addColumn(
     instance,
-    'agents',
+    'workers',
     'hook_activity_updated_at',
     'hook_activity_updated_at TEXT',
     agentCols,
   );
   addColumn(
     instance,
-    'agents',
+    'workers',
     'harness_id',
     `harness_id TEXT NOT NULL DEFAULT 'claude-code'`,
     agentCols,
   );
-  addColumn(instance, 'agents', 'hook_token', `hook_token TEXT NOT NULL DEFAULT ''`, agentCols);
+  addColumn(instance, 'workers', 'hook_token', `hook_token TEXT NOT NULL DEFAULT ''`, agentCols);
 
   const taskRefCols = columnsOf(instance, 'task_external_refs');
   addColumn(instance, 'task_external_refs', 'metadata', 'metadata TEXT', taskRefCols);
@@ -183,7 +183,7 @@ export function runMigrations(instance: Database.Database): void {
   // Ensure the index exists (created here rather than SCHEMA to avoid ordering
   // issues when the old column is still named claude_session_id at SCHEMA time).
   instance.exec(
-    `CREATE INDEX IF NOT EXISTS idx_agents_harness_session_id ON agents(harness_session_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_workers_harness_session_id ON workers(harness_session_id)`,
   );
 
   // ─── Legacy pre-Phase-2a shim: add run_mode / backfill from no_worktree ──
@@ -225,9 +225,9 @@ export function runMigrations(instance: Database.Database): void {
       .default();
   }
 
-  // ─── Phase 2a migration: worktrees entity + agents.task_id nullable ──────
+  // ─── Phase 2a migration: worktrees entity + workers.task_id nullable ──────
   // Additive shape: introduces `worktrees` table, `tasks.worktree_id`,
-  // `agents.pinned`, `agents.tmux_session`, and nullable `agents.task_id`.
+  // `workers.pinned`, `workers.tmux_session`, and nullable `workers.task_id`.
   // Legacy columns on `tasks` (worktree, run_mode, etc.) remain for now;
   // a later phase rewrites consumers then drops them.
   const agentFk = agentFkIsNotNull(instance);
@@ -292,19 +292,19 @@ export function runMigrations(instance: Database.Database): void {
       .default();
   }
 
-  // Make agents.task_id nullable via table rebuild if currently NOT NULL.
+  // Make workers.task_id nullable via table rebuild if currently NOT NULL.
   if (agentFk) {
     rebuildAgentsTable(instance);
   }
 
-  // Add agents.tmux_session column (post-rebuild).
-  const agentCols2 = columnsOf(instance, 'agents');
-  addColumn(instance, 'agents', 'tmux_session', 'tmux_session TEXT', agentCols2);
-  addColumn(instance, 'agents', 'agent', 'agent TEXT', agentCols2);
+  // Add workers.tmux_session column (post-rebuild).
+  const agentCols2 = columnsOf(instance, 'workers');
+  addColumn(instance, 'workers', 'tmux_session', 'tmux_session TEXT', agentCols2);
+  addColumn(instance, 'workers', 'agent', 'agent TEXT', agentCols2);
   // Drop legacy `pinned` column from older installs (carried the singleton
   // orchestrator row). SQLite >= 3.35 supports DROP COLUMN.
   if (agentCols2.has('pinned')) {
-    instance.exec(`ALTER TABLE agents DROP COLUMN pinned`);
+    instance.exec(`ALTER TABLE workers DROP COLUMN pinned`);
     agentCols2.delete('pinned');
   }
 
@@ -351,7 +351,7 @@ export function runMigrations(instance: Database.Database): void {
   instance.exec(`DROP INDEX IF EXISTS idx_tasks_active_worktree`);
 
   // Drop the legacy seeded orchestrator agent row from older installs.
-  instance.prepare(`DELETE FROM agents WHERE id = 'orchestrator' AND task_id IS NULL`).run();
+  instance.prepare(`DELETE FROM workers WHERE id = 'orchestrator' AND task_id IS NULL`).run();
 
   // ─── Workflow / runtime_state migration ───────────────────────────────────
   // Add new columns to tasks if they don't exist yet (pre-wave-1 DBs).
@@ -454,7 +454,7 @@ export function runMigrations(instance: Database.Database): void {
       CREATE TABLE IF NOT EXISTS task_updates (
         id          TEXT PRIMARY KEY,
         task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-        agent_id    TEXT REFERENCES agents(id) ON DELETE SET NULL,
+        agent_id    TEXT REFERENCES workers(id) ON DELETE SET NULL,
         kind        TEXT NOT NULL,
         from_status TEXT,
         to_status   TEXT,
@@ -559,7 +559,7 @@ export function runMigrations(instance: Database.Database): void {
             created_at  TEXT NOT NULL DEFAULT (datetime('now')),
             resolved_at TEXT,
             FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
-            FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+            FOREIGN KEY (agent_id) REFERENCES workers(id) ON DELETE CASCADE
           )
         `);
         instance.exec(`INSERT INTO permission_prompts SELECT * FROM permission_prompts_old`);
@@ -580,13 +580,13 @@ export function runMigrations(instance: Database.Database): void {
       .default();
   }
 
-  // Resolve stale pending prompts and reset agents stuck in 'waiting'
+  // Resolve stale pending prompts and reset workers stuck in 'waiting'
   // (hook callbacks lost during the previous run's shutdown)
   instance.exec(
     `UPDATE permission_prompts SET status = 'resolved', resolved_at = datetime('now') WHERE status = 'pending'`,
   );
   instance.exec(
-    `UPDATE agents SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
+    `UPDATE workers SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
      WHERE hook_activity = 'waiting' AND status = 'running'`,
   );
 
@@ -730,10 +730,10 @@ export function runMigrations(instance: Database.Database): void {
        ON tasks(review_of_task_id) WHERE review_of_task_id IS NOT NULL`,
   );
 
-  // ── Intra-task sub-agents: notify_agent_id on agents (2026-06-11) ──────────
+  // ── Intra-task sub-workers: notify_agent_id on workers (2026-06-11) ──────────
   // When a sub-agent completes, its parent agent is notified via this link.
-  const agentCols3 = columnsOf(instance, 'agents');
-  addColumn(instance, 'agents', 'notify_agent_id', 'notify_agent_id TEXT', agentCols3);
+  const agentCols3 = columnsOf(instance, 'workers');
+  addColumn(instance, 'workers', 'notify_agent_id', 'notify_agent_id TEXT', agentCols3);
 
   // ── Orchestrator chat tables (2026-06-20, SHR-117) ───────────────────────
   // Forward-only; all created via CREATE TABLE IF NOT EXISTS for idempotency.
@@ -839,8 +839,8 @@ export function runMigrations(instance: Database.Database): void {
     orchConvCols,
   );
   // ── Conductor hook token (orchestrator gate auth) ───────────────────────────
-  // The conductor session is not an `agents` row, so its PreToolUse gate hook
-  // token has nowhere to live in the agents table. Persist it here so
+  // The conductor session is not a `workers` row, so its PreToolUse gate hook
+  // token has nowhere to live in the workers table. Persist it here so
   // requireHookToken can authenticate the conductor's gate callbacks. Forward-only.
   addColumn(instance, 'orchestrator_conversations', 'hook_token', 'hook_token TEXT', orchConvCols);
   // ── Conductor cwd (for resume) ──────────────────────────────────────────────
@@ -1040,11 +1040,17 @@ export function runMigrations(instance: Database.Database): void {
 
   // ── Agents feature: long-running agent config + owning conversation link
   // (2026-07-24) ─────────────────────────────────────────────────────────────
-  // Named `agent_configs` (not `agents`) — the `agents` table already exists
-  // and means something different (a per-task tmux-window worker). An agent's
-  // live session is an `orchestrator_conversations` row tagged with agent_id.
+  // Table named `agents` — the persistent conductor agent. Not to be confused
+  // with `workers` (a per-task tmux-window worker, renamed from `agents` in
+  // the 2026-07-25 agents/workers terminology cleanup below). An agent's live
+  // session is an `orchestrator_conversations` row tagged with agent_id.
+  //
+  // CREATE TABLE IF NOT EXISTS here is safe even on an old, not-yet-renamed
+  // install: at this point `agents` still means the old worker table, so this
+  // statement no-ops (table already exists under that name) and the real
+  // conductor table gets created once the rename below vacates the name.
   instance.exec(`
-    CREATE TABLE IF NOT EXISTS agent_configs (
+    CREATE TABLE IF NOT EXISTS agents (
       id             TEXT PRIMARY KEY,
       name           TEXT NOT NULL,
       system_prompt  TEXT NOT NULL,
@@ -1059,7 +1065,7 @@ export function runMigrations(instance: Database.Database): void {
     instance,
     'orchestrator_conversations',
     'agent_id',
-    'agent_id TEXT REFERENCES agent_configs(id) ON DELETE SET NULL',
+    'agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL',
     orchConvColsForAgent,
   );
 
@@ -1117,4 +1123,73 @@ export function runMigrations(instance: Database.Database): void {
       .default();
     logger.info('migrated schedule_skills into schedules.prompt/config_json and dropped the table');
   }
+}
+
+/**
+ * Rename `agents` → `workers` (per-task tmux worker) and `agent_configs` →
+ * `agents` (persistent conductor agent) — the 2026-07-25 terminology cleanup
+ * that resolves "agent" meaning three different things across the codebase.
+ *
+ * MUST run before `instance.exec(SCHEMA)`, not inside `runMigrations`. SCHEMA
+ * now declares the final `workers` table via `CREATE TABLE IF NOT EXISTS`; on
+ * an old, not-yet-renamed install that still has real data in a table named
+ * `agents`, running SCHEMA first would create a brand-new EMPTY `workers`
+ * table (since none exists yet under that name), and this function's guard
+ * (`workers` must not already exist) would then see `workers` present and
+ * skip the real rename — silently stranding all worker data in the orphaned
+ * `agents` table. Calling this first means `workers` never exists at SCHEMA
+ * time except via a real prior rename, so SCHEMA's `CREATE TABLE IF NOT
+ * EXISTS workers` always correctly no-ops post-rename.
+ *
+ * better-sqlite3 here runs SQLite 3.53.1 with `legacy_alter_table = 0`, under
+ * which `ALTER TABLE x RENAME TO y` rewrites `REFERENCES x(...)` clauses in
+ * dependent tables automatically (verified empirically, not just assumed):
+ * task_updates.agent_id and permission_prompts.agent_id get repointed to
+ * workers(id), and orchestrator_conversations.agent_id gets repointed to
+ * agents(id) — no separate FK-repair step needed.
+ *
+ * Order is mandatory: `agents` must become `workers` BEFORE `agent_configs`
+ * becomes `agents`, or step 2 collides with the still-existing `agents`
+ * table and errors loudly (proven safe — a reversed order throws instead of
+ * silently corrupting anything).
+ *
+ * Idempotent: guarded on `agents` existing AND `workers` NOT existing — false
+ * on fresh installs/test DBs (nothing named `agents` ever existed) and false
+ * on every boot after the first successful run (both tables already settled).
+ * Step 2 additionally no-ops when `agent_configs` doesn't exist (a DB old
+ * enough to predate the Agents feature entirely) — the "Agents feature"
+ * migration further down creates a fresh `agents` conductor table once step
+ * 1 has vacated the name, so there's nothing lost by skipping it here.
+ */
+export function renameAgentWorkerTables(instance: Database.Database): void {
+  const tableNames = new Set(
+    (
+      instance.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as Array<{
+        name: string;
+      }>
+    ).map((r) => r.name),
+  );
+  if (!tableNames.has('agents') || tableNames.has('workers')) return;
+
+  // Step 2 only applies when there's actually an `agent_configs` table to
+  // rename — a DB old enough to predate the Agents feature entirely (has the
+  // legacy `agents` worker table but never saw `agent_configs` created) has
+  // nothing to rename here; the "Agents feature" migration below creates a
+  // fresh `agents` conductor table once step 1 has vacated the name.
+  const hasAgentConfigs = tableNames.has('agent_configs');
+
+  instance
+    .transaction(() => {
+      instance.exec(`ALTER TABLE agents RENAME TO workers`);
+      // Legacy index names carried over from the old `agents` table; drop
+      // them so SCHEMA's `idx_workers_*` creation below doesn't leave a
+      // redundant duplicate index behind.
+      instance.exec(`DROP INDEX IF EXISTS idx_agents_task`);
+      instance.exec(`DROP INDEX IF EXISTS idx_agents_harness_session_id`);
+      if (hasAgentConfigs) {
+        instance.exec(`ALTER TABLE agent_configs RENAME TO agents`);
+      }
+    })
+    .default();
+  logger.info('renamed agents -> workers and agent_configs -> agents');
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_updates (
   id          TEXT PRIMARY KEY,
   task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
-  agent_id    TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  agent_id    TEXT REFERENCES workers(id) ON DELETE SET NULL,
   kind        TEXT NOT NULL,
   from_status TEXT,
   to_status   TEXT,
@@ -72,7 +72,11 @@ CREATE TABLE IF NOT EXISTS integrations (
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS agents (
+-- Per-task tmux worker (a Claude Code / Cursor process running inside a task's
+-- worktree, or a standalone chat with task_id NULL). Not to be confused with
+-- the 'agents' table (the persistent conductor agent, created in
+-- db/migrations.ts).
+CREATE TABLE IF NOT EXISTS workers (
     id                TEXT PRIMARY KEY,
     task_id           TEXT REFERENCES tasks(id) ON DELETE CASCADE,
     window_index      INTEGER NOT NULL,
@@ -95,10 +99,10 @@ CREATE TABLE IF NOT EXISTS permission_prompts (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     resolved_at TEXT,
     FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
-    FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+    FOREIGN KEY (agent_id) REFERENCES workers(id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_agents_task ON agents(task_id);
+CREATE INDEX IF NOT EXISTS idx_workers_task ON workers(task_id);
 CREATE INDEX IF NOT EXISTS idx_permission_prompts_task_id ON permission_prompts(task_id);
 CREATE INDEX IF NOT EXISTS idx_permission_prompts_status ON permission_prompts(status);
 CREATE INDEX IF NOT EXISTS idx_permission_prompts_agent_status ON permission_prompts(agent_id, status);

--- a/server/gateway/gateway.test.ts
+++ b/server/gateway/gateway.test.ts
@@ -8,7 +8,7 @@ import {
   updateConversation,
   getPrimaryAgentConversation,
 } from '../repositories/orchestrator.js';
-import { createAgent, getAgent } from '../repositories/agents-config.js';
+import { createAgent, getAgent } from '../repositories/agents.js';
 import { pushToConversation } from '../orchestrator/stream.js';
 
 /** A fake adapter that records outbound sends / typing indicators. */

--- a/server/gateway/gateway.ts
+++ b/server/gateway/gateway.ts
@@ -25,7 +25,7 @@ import {
   getConversation,
   getPrimaryAgentConversation,
 } from '../repositories/orchestrator.js';
-import { getAgentByChannel, listAgents, updateAgent } from '../repositories/agents-config.js';
+import { getAgentByChannel, listAgents, updateAgent } from '../repositories/agents.js';
 import { startConversation, sendTurn, interruptTurn } from '../orchestrator/runner.js';
 import type { StartConversationOpts } from '../orchestrator/runner.js';
 import {

--- a/server/hook-token.test.ts
+++ b/server/hook-token.test.ts
@@ -47,7 +47,7 @@ describe('ensureHookToken', () => {
     const agent = makeAgent();
     const token = await ensureHookToken(agent, null);
     expect(token).toMatch(/^[a-f0-9]{64}$/);
-    const row = getDb().prepare(`SELECT hook_token FROM agents WHERE id = 'a1'`).get() as {
+    const row = getDb().prepare(`SELECT hook_token FROM workers WHERE id = 'a1'`).get() as {
       hook_token: string;
     };
     expect(row.hook_token).toBe(token);
@@ -69,7 +69,7 @@ describe('ensureHookToken', () => {
     const token = await ensureHookToken(agent, null);
     expect(token).toBe('');
     // DB row should still have empty token — no write occurred.
-    const row = getDb().prepare(`SELECT hook_token FROM agents WHERE id = 'a3'`).get() as {
+    const row = getDb().prepare(`SELECT hook_token FROM workers WHERE id = 'a3'`).get() as {
       hook_token: string;
     };
     expect(row.hook_token).toBe('');
@@ -81,7 +81,7 @@ describe('ensureHookToken', () => {
     const agent = makeAgent({ id: 'a4', task_id: 't2' });
     const token = await ensureHookToken(agent, null);
     expect(token).toMatch(/^[a-f0-9]{64}$/);
-    const row = getDb().prepare(`SELECT hook_token FROM agents WHERE id = 'a4'`).get() as {
+    const row = getDb().prepare(`SELECT hook_token FROM workers WHERE id = 'a4'`).get() as {
       hook_token: string;
     };
     expect(row.hook_token).toBe(token);

--- a/server/hook-token.test.ts
+++ b/server/hook-token.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb, insertTask, insertAgent, DEFAULTS } from './test-helpers.js';
 import { ensureHookToken } from './hook-token.js';
 import { getDb } from './db.js';
-import type { Agent } from './types.js';
+import type { Worker } from './types.js';
 
 // Stub the harness's installHooks so the test doesn't write real files.
 vi.mock('./harnesses/index.js', async () => {
@@ -17,7 +17,7 @@ vi.mock('./harnesses/index.js', async () => {
   };
 });
 
-function makeAgent(overrides: Partial<Agent> = {}): Agent {
+function makeAgent(overrides: Partial<Worker> = {}): Worker {
   return {
     id: 'a1',
     task_id: null,

--- a/server/hook-token.ts
+++ b/server/hook-token.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { getTaskRuntimeState, setAgentHookToken } from './repositories/index.js';
 import { getHarness } from './harnesses/index.js';
 import { hookBaseUrl } from './hook-base-url.js';
-import type { Agent } from './types.js';
+import type { Worker } from './types.js';
 import { childLogger } from './logger.js';
 
 const logger = childLogger('hook-token');
@@ -19,7 +19,7 @@ const logger = childLogger('hook-token');
  * been closed have runtime_state = 'idle'. We gate on that to avoid
  * spurious writes to worktrees that are no longer actively running.
  */
-export async function ensureHookToken(agent: Agent, worktreePath: string | null): Promise<string> {
+export async function ensureHookToken(agent: Worker, worktreePath: string | null): Promise<string> {
   if (agent.hook_token && agent.hook_token !== '') return agent.hook_token;
 
   if (agent.task_id) {

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -46,7 +46,7 @@ describe('Hook endpoints', () => {
     it.each(activatableCases)(
       'sets $description to active when user submits a prompt',
       async ({ from }) => {
-        db.prepare(`UPDATE agents SET hook_activity = ? WHERE id = ?`).run(from, 'a1');
+        db.prepare(`UPDATE workers SET hook_activity = ? WHERE id = ?`).run(from, 'a1');
 
         await request(app)
           .post('/api/hooks/user-prompt-submit?token=tok-test')
@@ -58,7 +58,7 @@ describe('Hook endpoints', () => {
     );
 
     it('no-ops (200) when session_id is missing — valid token, nothing to attribute', async () => {
-      db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
+      db.prepare(`UPDATE workers SET hook_activity = 'idle' WHERE id = ?`).run('a1');
 
       await request(app).post('/api/hooks/user-prompt-submit?token=tok-test').send({}).expect(200);
 
@@ -135,7 +135,7 @@ describe('Hook endpoints', () => {
     });
 
     it('does not override idle state (Stop hook may have fired first)', async () => {
-      db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
+      db.prepare(`UPDATE workers SET hook_activity = 'idle' WHERE id = ?`).run('a1');
 
       await request(app)
         .post('/api/hooks/post-tool-use?token=tok-test')
@@ -300,7 +300,7 @@ describe('Hook endpoints', () => {
     // (resume / compaction / manual relaunch). Hooks then arrive with a session
     // id we never recorded.
     it('reattaches a drifted session to the sole agent and rebinds harness_session_id', async () => {
-      db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
+      db.prepare(`UPDATE workers SET hook_activity = 'idle' WHERE id = ?`).run('a1');
 
       await request(app)
         .post('/api/hooks/user-prompt-submit?token=tok-test')
@@ -308,7 +308,7 @@ describe('Hook endpoints', () => {
         .expect(200);
 
       // Rebound so subsequent hooks exact-match…
-      const row = db.prepare(`SELECT harness_session_id FROM agents WHERE id = ?`).get('a1') as {
+      const row = db.prepare(`SELECT harness_session_id FROM workers WHERE id = ?`).get('a1') as {
         harness_session_id: string;
       };
       expect(row.harness_session_id).toBe('sess-NEW');
@@ -324,17 +324,17 @@ describe('Hook endpoints', () => {
         hook_token: 'tok-test',
         hook_activity: 'idle',
       } as any);
-      db.prepare(`UPDATE agents SET hook_activity = 'idle' WHERE id = ?`).run('a1');
+      db.prepare(`UPDATE workers SET hook_activity = 'idle' WHERE id = ?`).run('a1');
 
       await request(app)
         .post('/api/hooks/user-prompt-submit?token=tok-test')
         .send({ session_id: 'sess-NEW' })
         .expect(200);
 
-      const a1 = db.prepare(`SELECT harness_session_id FROM agents WHERE id = 'a1'`).get() as {
+      const a1 = db.prepare(`SELECT harness_session_id FROM workers WHERE id = 'a1'`).get() as {
         harness_session_id: string;
       };
-      const a2 = db.prepare(`SELECT harness_session_id FROM agents WHERE id = 'a2'`).get() as {
+      const a2 = db.prepare(`SELECT harness_session_id FROM workers WHERE id = 'a2'`).get() as {
         harness_session_id: string;
       };
       expect(a1.harness_session_id).toBe('sess-123');
@@ -344,14 +344,14 @@ describe('Hook endpoints', () => {
     });
 
     it('does not resurrect a stopped agent (no live match for the token)', async () => {
-      db.prepare(`UPDATE agents SET status = 'stopped' WHERE id = 'a1'`).run();
+      db.prepare(`UPDATE workers SET status = 'stopped' WHERE id = 'a1'`).run();
 
       await request(app)
         .post('/api/hooks/user-prompt-submit?token=tok-test')
         .send({ session_id: 'sess-NEW' })
         .expect(200);
 
-      const a1 = db.prepare(`SELECT harness_session_id FROM agents WHERE id = 'a1'`).get() as {
+      const a1 = db.prepare(`SELECT harness_session_id FROM workers WHERE id = 'a1'`).get() as {
         harness_session_id: string;
       };
       expect(a1.harness_session_id).toBe('sess-123');
@@ -412,7 +412,7 @@ describe('findAgentByTokenAndSession', () => {
     const row = findAgentByTokenAndSession('tok-2', 'sess-bound');
     expect(row).toMatchObject({ id: 'a2', task_id: 't1' });
 
-    const reread = db.prepare(`SELECT harness_session_id FROM agents WHERE id = ?`).get('a2') as {
+    const reread = db.prepare(`SELECT harness_session_id FROM workers WHERE id = ?`).get('a2') as {
       harness_session_id: string;
     };
     expect(reread.harness_session_id).toBe('sess-bound');
@@ -464,7 +464,9 @@ describe('POST /api/hooks/session-start', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({});
 
-    const reread = db.prepare(`SELECT harness_session_id FROM agents WHERE id = ?`).get('a-ss') as {
+    const reread = db
+      .prepare(`SELECT harness_session_id FROM workers WHERE id = ?`)
+      .get('a-ss') as {
       harness_session_id: string;
     };
     expect(reread.harness_session_id).toBe('chat-xyz');
@@ -490,7 +492,9 @@ describe('POST /api/hooks/session-start', () => {
       .send({ session_id: 'sess-from-fallback' });
     expect(res.status).toBe(200);
 
-    const reread = db.prepare(`SELECT harness_session_id FROM agents WHERE id = ?`).get('a-ss') as {
+    const reread = db
+      .prepare(`SELECT harness_session_id FROM workers WHERE id = ?`)
+      .get('a-ss') as {
       harness_session_id: string;
     };
     expect(reread.harness_session_id).toBe('sess-from-fallback');

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -30,7 +30,7 @@ import {
   setAgentHookActivity,
   setAgentHookActivityIfNotIdle,
   countRunningAgentsExcept,
-} from './repositories/agent-runtime.js';
+} from './repositories/workers.js';
 import {
   getTaskWorkflowStatus,
   getTaskRuntimeState,

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -1491,7 +1491,7 @@ describe('pollAgentWindows', () => {
     );
 
     const agentRow = db
-      .prepare('SELECT status FROM agents WHERE id = ?')
+      .prepare('SELECT status FROM workers WHERE id = ?')
       .get('worker-agent-01') as { status: string };
     expect(agentRow.status).toBe('stopped');
   });

--- a/server/poller/hooks.ts
+++ b/server/poller/hooks.ts
@@ -1,6 +1,6 @@
 import { installHookSettings } from '../hook-settings.js';
 import { listActiveTasksForHooks } from '../repositories/tasks.js';
-import { getTaskHookToken } from '../repositories/agent-runtime.js';
+import { getTaskHookToken } from '../repositories/workers.js';
 
 /**
  * Ensure hooks are installed in all running task worktrees.

--- a/server/poller/reviewer-requests.ts
+++ b/server/poller/reviewer-requests.ts
@@ -15,7 +15,7 @@ import {
   setPrHeadSha,
 } from '../repositories/tasks.js';
 import { deleteWorktree } from '../repositories/worktrees.js';
-import { findFirstActiveAgent } from '../repositories/agent-runtime.js';
+import { findFirstActiveAgent } from '../repositories/workers.js';
 import { checkoutRef, fetchOriginQuiet, isAncestor } from '../task-engine/git.js';
 import { repoNameWithOwner } from './github-repo.js';
 

--- a/server/poller/status.ts
+++ b/server/poller/status.ts
@@ -13,7 +13,7 @@ import {
   listWatchedAgents,
   stopAgent,
   getNotifyAgentTarget,
-} from '../repositories/agent-runtime.js';
+} from '../repositories/workers.js';
 import type { Task } from '../types.js';
 import { pollTerminalActivity } from './terminal-activity.js';
 

--- a/server/poller/terminal-activity.ts
+++ b/server/poller/terminal-activity.ts
@@ -1,6 +1,6 @@
 import { broadcast } from '../events.js';
 import { execTmux } from '../tmux-bin.js';
-import { listRunningTerminals, updateUserTerminalStatus } from '../repositories/agent-runtime.js';
+import { listRunningTerminals, updateUserTerminalStatus } from '../repositories/workers.js';
 import type { UserTerminal } from '../types.js';
 
 const SHELL_COMMANDS = new Set(['zsh', 'bash', 'sh', 'fish', 'dash']);

--- a/server/repositories/agents.test.ts
+++ b/server/repositories/agents.test.ts
@@ -8,9 +8,9 @@ import {
   updateAgent,
   deleteAgent,
   getAgentByChannel,
-} from './agents-config.js';
+} from './agents.js';
 
-describe('agents-config repo', () => {
+describe('repositories/agents (conductor)', () => {
   beforeEach(() => {
     createTestDb();
   });
@@ -71,9 +71,7 @@ describe('agents-config repo', () => {
     const id = createAgent({ name: 'Original', system_prompt: 'orig prompt' });
 
     // Force a distinguishable updated_at by backdating the row first.
-    getDb()
-      .prepare(`UPDATE agent_configs SET updated_at = '2000-01-01 00:00:00' WHERE id = ?`)
-      .run(id);
+    getDb().prepare(`UPDATE agents SET updated_at = '2000-01-01 00:00:00' WHERE id = ?`).run(id);
     expect(getAgent(id)!.updated_at).toBe('2000-01-01 00:00:00');
 
     updateAgent(id, { system_prompt: 'new prompt' });

--- a/server/repositories/agents.ts
+++ b/server/repositories/agents.ts
@@ -1,14 +1,16 @@
 /**
- * Repository layer for the `agent_configs` table — long-running "Agents
- * feature" config rows (name, system prompt, channel binding). Not to be
- * confused with the `agents` table (per-task tmux-window workers).
+ * Repository layer for the `agents` table — long-running, persistent
+ * conductor agents (name, system prompt, channel binding). Not to be
+ * confused with `repositories/workers.ts` (the `workers` table — a per-task
+ * tmux-window worker, renamed from `agents` in the 2026-07-25 agents/workers
+ * terminology cleanup) or `server/agents.ts` (agent *role* definitions).
  * Plain exported functions — no base class, no ORM.
  */
 import { nanoid } from 'nanoid';
 import { getDb } from '../db.js';
 import { childLogger } from '../logger.js';
 
-const logger = childLogger('repositories/agents-config');
+const logger = childLogger('repositories/agents');
 
 export interface AgentConfig {
   id: string;
@@ -35,7 +37,7 @@ export function createAgent(input: CreateAgentInput): string {
   const id = nanoid(12);
   getDb()
     .prepare(
-      `INSERT INTO agent_configs (id, name, system_prompt, channel, channel_config)
+      `INSERT INTO agents (id, name, system_prompt, channel, channel_config)
        VALUES (?, ?, ?, ?, ?)`,
     )
     .run(id, input.name, input.system_prompt, input.channel ?? null, input.channel_config ?? null);
@@ -46,15 +48,15 @@ export function createAgent(input: CreateAgentInput): string {
 
 /** Fetch a single agent config by id (returns undefined if not found). */
 export function getAgent(id: string): AgentConfig | undefined {
-  return getDb()
-    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs WHERE id = ?`)
-    .get(id) as AgentConfig | undefined;
+  return getDb().prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agents WHERE id = ?`).get(id) as
+    | AgentConfig
+    | undefined;
 }
 
 /** All agent configs, newest first. */
 export function listAgents(): AgentConfig[] {
   return getDb()
-    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs ORDER BY created_at DESC`)
+    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agents ORDER BY created_at DESC`)
     .all() as AgentConfig[];
 }
 
@@ -75,7 +77,7 @@ export function updateAgent(id: string, patch: UpdateAgentInput): void {
 
   getDb()
     .prepare(
-      `UPDATE agent_configs
+      `UPDATE agents
        SET name = ?, system_prompt = ?, channel = ?, channel_config = ?, updated_at = datetime('now')
        WHERE id = ?`,
     )
@@ -86,7 +88,7 @@ export function updateAgent(id: string, patch: UpdateAgentInput): void {
 
 /** Delete an agent config by id. No-op if it doesn't exist. */
 export function deleteAgent(id: string): void {
-  getDb().prepare(`DELETE FROM agent_configs WHERE id = ?`).run(id);
+  getDb().prepare(`DELETE FROM agents WHERE id = ?`).run(id);
   logger.info({ agent_id: id }, 'agent config deleted');
 }
 
@@ -102,7 +104,7 @@ export function deleteAgent(id: string): void {
  */
 export function getAgentByChannel(channel: string, threadKey: string): AgentConfig | undefined {
   const candidates = getDb()
-    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agent_configs WHERE channel = ?`)
+    .prepare(`SELECT ${AGENT_CONFIG_COLUMNS} FROM agents WHERE channel = ?`)
     .all(channel) as AgentConfig[];
 
   let channelWide: AgentConfig | undefined;

--- a/server/repositories/index.ts
+++ b/server/repositories/index.ts
@@ -1,6 +1,6 @@
 export * from './tasks.js';
 export * from './worktrees.js';
-export * from './agent-runtime.js';
+export * from './workers.js';
 export * from './permission-prompts.js';
 export * from './hook-settings.js';
 export * from './config.js';
@@ -12,19 +12,11 @@ export * from './file-review-state.js';
 export * from './loop-runs.js';
 export * from './schedules.js';
 export * from './runs.js';
-// agents-config.ts (the Agents-feature config table) exports `getAgent`, which
-// collides with agent-runtime.ts's `getAgent` (the per-task tmux-window
-// agent) — re-export the colliding name under an alias; import the other
-// functions/type as-is, or import `getAgent` directly from
-// './agents-config.js' when unaliased access is needed.
-export {
-  createAgent,
-  listAgents,
-  updateAgent,
-  deleteAgent,
-  getAgentByChannel,
-  getAgent as getAgentConfig,
-} from './agents-config.js';
-export type { AgentConfig } from './agents-config.js';
+// workers.ts (the per-task tmux worker) exports `getWorker`; agents.ts (the
+// persistent conductor agent) exports `getAgent`. These used to collide
+// under the same name (`getAgent`) when both tables were named `agents` /
+// `agent_configs` — the 2026-07-25 agents/workers rename gave each its own
+// unambiguous name, so both re-export cleanly with no alias needed.
+export * from './agents.js';
 export * from './orchestrator.js';
 export * from '../integrations/store.js';

--- a/server/repositories/orchestrator.ts
+++ b/server/repositories/orchestrator.ts
@@ -22,7 +22,7 @@ export interface OrchestratorConversation {
   hook_token: string | null;
   /** The cwd the conductor session was launched from (used to resume a dead session). */
   cwd: string | null;
-  /** Agents feature: the `agent_configs` row this session belongs to, or null for an orchestrator-page conversation. */
+  /** Agents feature: the `agents` row this session belongs to, or null for an orchestrator-page conversation. */
   agent_id: string | null;
   created_at: string;
   updated_at: string;
@@ -75,7 +75,7 @@ export interface CreateConversationInput {
   tmux_window?: string;
   claude_session_id?: string;
   transcript_path?: string;
-  /** Agents feature: tag this conversation as the persistent session of an `agent_configs` row. */
+  /** Agents feature: tag this conversation as the persistent session of an `agents` row. */
   agent_id?: string;
 }
 

--- a/server/repositories/permission-prompts.test.ts
+++ b/server/repositories/permission-prompts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createTestDb, insertTask } from '../test-helpers.js';
-import { insertAgent } from './agent-runtime.js';
+import { insertAgent } from './workers.js';
 import {
   listPendingPromptsByTask,
   listPendingPromptsByTasks,

--- a/server/repositories/permission-prompts.ts
+++ b/server/repositories/permission-prompts.ts
@@ -60,7 +60,7 @@ export function listPendingPromptsByTask(taskId: string): PermissionPromptRow[] 
     .prepare(
       `SELECT pp.*, a.label as agent_label
        FROM permission_prompts pp
-       LEFT JOIN agents a ON pp.agent_id = a.id
+       LEFT JOIN workers a ON pp.agent_id = a.id
        WHERE pp.task_id = ? AND pp.status = 'pending'
        ORDER BY pp.created_at ASC`,
     )
@@ -79,7 +79,7 @@ export function listPendingPromptsByTasks(taskIds: string[]): PermissionPromptRo
     .prepare(
       `SELECT pp.*, a.label as agent_label
        FROM permission_prompts pp
-       LEFT JOIN agents a ON pp.agent_id = a.id
+       LEFT JOIN workers a ON pp.agent_id = a.id
        WHERE pp.task_id IN (${placeholders}) AND pp.status = 'pending'
        ORDER BY pp.created_at ASC`,
     )

--- a/server/repositories/workers.test.ts
+++ b/server/repositories/workers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createTestDb, insertTask, insertAgent as insertTestAgent } from '../test-helpers.js';
 import {
-  getAgent,
+  getWorker,
   listActiveAgents,
   listStoppedAgents,
   getTaskHookToken,
@@ -21,10 +21,10 @@ import {
   deleteUserTerminalsByTask,
   deleteUserTerminal,
   countAgentsForTask,
-} from './agent-runtime.js';
+} from './workers.js';
 import type Database from 'better-sqlite3';
 
-describe('repositories/agent-runtime', () => {
+describe('repositories/workers', () => {
   let db: Database.Database;
 
   beforeEach(() => {
@@ -34,9 +34,9 @@ describe('repositories/agent-runtime', () => {
     insertTask(db, { id: 'task-02', worktree: null });
   });
 
-  // ─── insertAgent / getAgent round-trip ────────────────────────────────────────
+  // ─── insertAgent / getWorker round-trip ────────────────────────────────────────
 
-  describe('insertAgent / getAgent', () => {
+  describe('insertAgent / getWorker', () => {
     it('inserts and reads back an agent', () => {
       const id = insertAgent({
         task_id: 'task-01',
@@ -48,7 +48,7 @@ describe('repositories/agent-runtime', () => {
         agent: null,
       });
       expect(id).toMatch(/^[a-zA-Z0-9_-]{12}$/);
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a).toBeDefined();
       expect(a!.task_id).toBe('task-01');
       expect(a!.window_index).toBe(0);
@@ -68,7 +68,7 @@ describe('repositories/agent-runtime', () => {
         harness_id: 'claude-code',
         hook_token: '',
       });
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a!.created_at).not.toBeNull();
     });
 
@@ -81,11 +81,11 @@ describe('repositories/agent-runtime', () => {
         harness_id: 'claude-code',
         hook_token: '',
       });
-      expect(getAgent('my-agent-id')).toBeDefined();
+      expect(getWorker('my-agent-id')).toBeDefined();
     });
 
     it('returns undefined for unknown id', () => {
-      expect(getAgent('no-such')).toBeUndefined();
+      expect(getWorker('no-such')).toBeUndefined();
     });
   });
 
@@ -110,7 +110,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
         notify_agent_id: 'parent-agent',
       });
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a!.notify_agent_id).toBe('parent-agent');
     });
 
@@ -122,7 +122,7 @@ describe('repositories/agent-runtime', () => {
         harness_id: 'claude-code',
         hook_token: '',
       });
-      expect(getAgent(id)!.notify_agent_id).toBeNull();
+      expect(getWorker(id)!.notify_agent_id).toBeNull();
     });
   });
 
@@ -234,7 +234,7 @@ describe('repositories/agent-runtime', () => {
         harness_session_id: null,
       });
       setAgentHarnessSessionId(id, 'new-session-id');
-      expect(getAgent(id)!.harness_session_id).toBe('new-session-id');
+      expect(getWorker(id)!.harness_session_id).toBe('new-session-id');
     });
   });
 
@@ -249,7 +249,7 @@ describe('repositories/agent-runtime', () => {
         status: 'stopped',
       }).id;
       setAgentWindowRunning(id, 5);
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a!.window_index).toBe(5);
       expect(a!.status).toBe('running');
     });
@@ -274,9 +274,9 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       stopAllAgents('task-01');
-      expect(getAgent(id1)!.status).toBe('stopped');
-      expect(getAgent(id1)!.hook_activity).toBe('idle');
-      expect(getAgent(id2)!.status).toBe('stopped');
+      expect(getWorker(id1)!.status).toBe('stopped');
+      expect(getWorker(id1)!.hook_activity).toBe('idle');
+      expect(getWorker(id2)!.status).toBe('stopped');
     });
 
     it('sets hook_activity_updated_at', () => {
@@ -288,7 +288,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       stopAllAgents('task-01');
-      expect(getAgent(id)!.hook_activity_updated_at).not.toBeNull();
+      expect(getWorker(id)!.hook_activity_updated_at).not.toBeNull();
     });
 
     it('does not affect agents of a different task', () => {
@@ -300,7 +300,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       stopAllAgents('task-01');
-      expect(getAgent(id)!.status).toBe('running');
+      expect(getWorker(id)!.status).toBe('running');
     });
   });
 
@@ -322,8 +322,8 @@ describe('repositories/agent-runtime', () => {
         status: 'stopped',
       }).id;
       stopRunningAgents('task-01');
-      expect(getAgent(id1)!.status).toBe('stopped');
-      expect(getAgent(id2)!.status).toBe('stopped');
+      expect(getWorker(id1)!.status).toBe('stopped');
+      expect(getWorker(id2)!.status).toBe('stopped');
     });
   });
 
@@ -353,10 +353,10 @@ describe('repositories/agent-runtime', () => {
         status: 'stopped',
       }).id;
       stopRunningAgentsForTask('task-01');
-      expect(getAgent(runId)!.status).toBe('stopped');
+      expect(getWorker(runId)!.status).toBe('stopped');
       // The discriminating case: a non-running, non-stopped agent must be left as-is.
-      expect(getAgent(idleId)!.status).toBe('idle');
-      expect(getAgent(stoppedId)!.status).toBe('stopped');
+      expect(getWorker(idleId)!.status).toBe('idle');
+      expect(getWorker(stoppedId)!.status).toBe('stopped');
     });
   });
 
@@ -406,7 +406,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       stopAgent(id);
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a!.status).toBe('stopped');
       expect(a!.hook_activity).toBe('idle');
     });
@@ -424,7 +424,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       hopAgentToTask(id, 'task-02', 3, null);
-      const a = getAgent(id);
+      const a = getWorker(id);
       expect(a!.task_id).toBe('task-02');
       expect(a!.window_index).toBe(3);
       expect(a!.tmux_session).toBeNull();
@@ -441,7 +441,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       hopAgentToTask(id, null, 0, 'standalone-session');
-      expect(getAgent(id)!.tmux_session).toBe('standalone-session');
+      expect(getWorker(id)!.tmux_session).toBe('standalone-session');
     });
 
     it('sets hook_activity_updated_at', () => {
@@ -453,7 +453,7 @@ describe('repositories/agent-runtime', () => {
         hook_token: '',
       });
       hopAgentToTask(id, 'task-02', 1, null);
-      expect(getAgent(id)!.hook_activity_updated_at).not.toBeNull();
+      expect(getWorker(id)!.hook_activity_updated_at).not.toBeNull();
     });
   });
 

--- a/server/repositories/workers.ts
+++ b/server/repositories/workers.ts
@@ -1,36 +1,38 @@
 /**
- * Repository layer for the `agents` and `user_terminals` tables.
+ * Repository layer for the `workers` (per-task tmux worker) and
+ * `user_terminals` tables. Not to be confused with `repositories/agents.ts`
+ * (the persistent conductor agent) or `server/agents.ts` (agent *role*
+ * definitions — orchestrator/planner/reviewer plugin skeletons).
  * Plain exported functions — no base class, no ORM, no new dependencies.
  * Always calls getDb() inside each function so setDb() test swaps work.
- *
- * Named `agent-runtime` to avoid colliding with the existing
- * `server/agents.ts` skeleton-definitions file.
  */
 import { nanoid } from 'nanoid';
 import { getDb } from '../db.js';
 import { childLogger } from '../logger.js';
 import type { Agent, UserTerminal } from '../types.js';
 
-const logger = childLogger('repositories/agent-runtime');
+const logger = childLogger('repositories/workers');
 
 // ─── Agent reads ──────────────────────────────────────────────────────────────
 
-/** Fetch a single agent by id. */
-export function getAgent(id: string): Agent | undefined {
-  return getDb().prepare('SELECT * FROM agents WHERE id = ?').get(id) as Agent | undefined;
+/** Fetch a single worker by id. */
+export function getWorker(id: string): Agent | undefined {
+  return getDb().prepare('SELECT * FROM workers WHERE id = ?').get(id) as Agent | undefined;
 }
 
 /** List all non-stopped agents for a task, ordered by window_index. */
 export function listActiveAgents(taskId: string): Agent[] {
   return getDb()
-    .prepare(`SELECT * FROM agents WHERE task_id = ? AND status != 'stopped' ORDER BY window_index`)
+    .prepare(
+      `SELECT * FROM workers WHERE task_id = ? AND status != 'stopped' ORDER BY window_index`,
+    )
     .all(taskId) as Agent[];
 }
 
 /** List all stopped agents for a task, ordered by window_index. */
 export function listStoppedAgents(taskId: string): Agent[] {
   return getDb()
-    .prepare(`SELECT * FROM agents WHERE task_id = ? AND status = 'stopped' ORDER BY window_index`)
+    .prepare(`SELECT * FROM workers WHERE task_id = ? AND status = 'stopped' ORDER BY window_index`)
     .all(taskId) as Agent[];
 }
 
@@ -40,14 +42,14 @@ export function listStoppedAgents(taskId: string): Agent[] {
  */
 export function getTaskHookToken(taskId: string): { hook_token: string } | undefined {
   return getDb()
-    .prepare(`SELECT hook_token FROM agents WHERE task_id = ? AND hook_token != '' LIMIT 1`)
+    .prepare(`SELECT hook_token FROM workers WHERE task_id = ? AND hook_token != '' LIMIT 1`)
     .get(taskId) as { hook_token: string } | undefined;
 }
 
 /** Fetch a single agent by id and task_id (returns undefined if not found or wrong task). */
 export function getAgentByIdAndTask(agentId: string, taskId: string): Agent | undefined {
   return getDb()
-    .prepare('SELECT * FROM agents WHERE id = ? AND task_id = ?')
+    .prepare('SELECT * FROM workers WHERE id = ? AND task_id = ?')
     .get(agentId, taskId) as Agent | undefined;
 }
 
@@ -57,7 +59,7 @@ export function findFirstActiveAgent(
 ): { id: string; window_index: number } | undefined {
   return getDb()
     .prepare(
-      `SELECT id, window_index FROM agents
+      `SELECT id, window_index FROM workers
        WHERE task_id = ? AND status != 'stopped'
        ORDER BY window_index ASC LIMIT 1`,
     )
@@ -72,7 +74,7 @@ export function listAgentsByTasks(taskIds: string[]): Agent[] {
   if (taskIds.length === 0) return [];
   const placeholders = taskIds.map(() => '?').join(',');
   return getDb()
-    .prepare(`SELECT * FROM agents WHERE task_id IN (${placeholders}) ORDER BY window_index`)
+    .prepare(`SELECT * FROM workers WHERE task_id IN (${placeholders}) ORDER BY window_index`)
     .all(...taskIds) as Agent[];
 }
 
@@ -107,7 +109,9 @@ export function getUserTerminalByIdAndTask(
  * getDb() call to this helper.
  */
 export function countAgentsForTask(taskId: string): number {
-  const row = getDb().prepare(`SELECT COUNT(*) AS n FROM agents WHERE task_id = ?`).get(taskId) as {
+  const row = getDb()
+    .prepare(`SELECT COUNT(*) AS n FROM workers WHERE task_id = ?`)
+    .get(taskId) as {
     n: number;
   };
   return row.n;
@@ -116,7 +120,7 @@ export function countAgentsForTask(taskId: string): number {
 /** List all agents for a task (all statuses), ordered by window_index. */
 export function listAllAgents(taskId: string): Agent[] {
   return getDb()
-    .prepare('SELECT * FROM agents WHERE task_id = ? ORDER BY window_index')
+    .prepare('SELECT * FROM workers WHERE task_id = ? ORDER BY window_index')
     .all(taskId) as Agent[];
 }
 
@@ -135,7 +139,7 @@ export function getChatAgentTmuxSession(
   chatId: string,
 ): { tmux_session: string | null } | undefined {
   return getDb()
-    .prepare(`SELECT tmux_session FROM agents WHERE id = ? AND task_id IS NULL`)
+    .prepare(`SELECT tmux_session FROM workers WHERE id = ? AND task_id IS NULL`)
     .get(chatId) as { tmux_session: string | null } | undefined;
 }
 
@@ -158,7 +162,7 @@ export function insertAgent(input: InsertAgentInput): string {
   const id = input.id ?? nanoid(12);
   getDb()
     .prepare(
-      `INSERT INTO agents
+      `INSERT INTO workers
          (id, task_id, window_index, label, harness_id, harness_session_id, hook_token, agent)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     )
@@ -181,7 +185,7 @@ export function insertAgentWithNotify(input: InsertAgentInput): string {
   const id = input.id ?? nanoid(12);
   getDb()
     .prepare(
-      `INSERT INTO agents
+      `INSERT INTO workers
          (id, task_id, window_index, label, harness_id, harness_session_id, hook_token, agent, notify_agent_id)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
@@ -205,12 +209,12 @@ export function insertAgentWithNotify(input: InsertAgentInput): string {
 
 /** Set the hook_token for an agent (used by ensureHookToken backfill). */
 export function setAgentHookToken(agentId: string, token: string): void {
-  getDb().prepare(`UPDATE agents SET hook_token = ? WHERE id = ?`).run(token, agentId);
+  getDb().prepare(`UPDATE workers SET hook_token = ? WHERE id = ?`).run(token, agentId);
 }
 
 /** Update the harness_session_id for an agent (called when a new session id is minted on resume/hop). */
 export function setAgentHarnessSessionId(agentId: string, sessionId: string): void {
-  getDb().prepare(`UPDATE agents SET harness_session_id = ? WHERE id = ?`).run(sessionId, agentId);
+  getDb().prepare(`UPDATE workers SET harness_session_id = ? WHERE id = ?`).run(sessionId, agentId);
   logger.info(
     { agent_id: agentId, operation: 'setAgentHarnessSessionId' },
     'agent harness_session_id updated',
@@ -234,7 +238,7 @@ export interface InsertChatAgentInput {
 export function insertChatAgent(input: InsertChatAgentInput): void {
   getDb()
     .prepare(
-      `INSERT INTO agents
+      `INSERT INTO workers
          (id, task_id, window_index, label, status, harness_id, harness_session_id,
           hook_token, hook_activity, tmux_session, agent, created_at)
        VALUES (?, NULL, 0, ?, 'running', ?, ?, ?, 'active', ?, ?, datetime('now'))`,
@@ -254,7 +258,7 @@ export function insertChatAgent(input: InsertChatAgentInput): void {
 export function listChatAgents(): Agent[] {
   return getDb()
     .prepare(
-      `SELECT * FROM agents
+      `SELECT * FROM workers
          WHERE task_id IS NULL
          ORDER BY created_at ASC`,
     )
@@ -263,14 +267,14 @@ export function listChatAgents(): Agent[] {
 
 /** Fetch a single standalone chat agent by id (task_id IS NULL). */
 export function getChatAgent(id: string): Agent | undefined {
-  return getDb().prepare(`SELECT * FROM agents WHERE id = ? AND task_id IS NULL`).get(id) as
+  return getDb().prepare(`SELECT * FROM workers WHERE id = ? AND task_id IS NULL`).get(id) as
     | Agent
     | undefined;
 }
 
 /** Mark a single agent's status='stopped' (used by createChat failure path). */
 export function setAgentStopped(agentId: string): void {
-  getDb().prepare(`UPDATE agents SET status = 'stopped' WHERE id = ?`).run(agentId);
+  getDb().prepare(`UPDATE workers SET status = 'stopped' WHERE id = ?`).run(agentId);
 }
 
 /**
@@ -279,7 +283,7 @@ export function setAgentStopped(agentId: string): void {
 export function stopChatAgent(agentId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents SET status = 'stopped', hook_activity = 'idle',
+      `UPDATE workers SET status = 'stopped', hook_activity = 'idle',
          hook_activity_updated_at = datetime('now')
        WHERE id = ?`,
     )
@@ -288,13 +292,13 @@ export function stopChatAgent(agentId: string): void {
 
 /** Hard-delete a single agent row (used by deleteChat). */
 export function deleteAgentRow(agentId: string): void {
-  getDb().prepare('DELETE FROM agents WHERE id = ?').run(agentId);
+  getDb().prepare('DELETE FROM workers WHERE id = ?').run(agentId);
 }
 
 /** Update window_index and status='running' for an agent (called per agent on resumeTask). */
 export function setAgentWindowRunning(agentId: string, windowIndex: number): void {
   getDb()
-    .prepare(`UPDATE agents SET window_index = ?, status = 'running' WHERE id = ?`)
+    .prepare(`UPDATE workers SET window_index = ?, status = 'running' WHERE id = ?`)
     .run(windowIndex, agentId);
   logger.info(
     { agent_id: agentId, window_index: windowIndex, operation: 'setAgentWindowRunning' },
@@ -306,7 +310,7 @@ export function setAgentWindowRunning(agentId: string, windowIndex: number): voi
 export function stopAllAgents(taskId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ?`,
+      `UPDATE workers SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ?`,
     )
     .run(taskId);
   logger.info({ task_id: taskId, operation: 'stopAllAgents' }, 'all agents stopped');
@@ -320,7 +324,7 @@ export function stopAllAgents(taskId: string): void {
 export function stopRunningAgents(taskId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ? AND status != 'stopped'`,
+      `UPDATE workers SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE task_id = ? AND status != 'stopped'`,
     )
     .run(taskId);
   logger.info({ task_id: taskId, operation: 'stopRunningAgents' }, 'running agents stopped');
@@ -334,7 +338,7 @@ export function stopRunningAgents(taskId: string): void {
 export function stopRunningAgentsForTask(taskId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents
+      `UPDATE workers
           SET status = 'stopped',
               hook_activity = 'idle',
               hook_activity_updated_at = datetime('now')
@@ -348,7 +352,7 @@ export function stopRunningAgentsForTask(taskId: string): void {
 export function stopAgent(agentId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE id = ?`,
+      `UPDATE workers SET status = 'stopped', hook_activity = 'idle', hook_activity_updated_at = datetime('now') WHERE id = ?`,
     )
     .run(agentId);
   logger.info({ agent_id: agentId, operation: 'stopAgent' }, 'agent stopped');
@@ -366,7 +370,7 @@ export function hopAgentToTask(
 ): void {
   getDb()
     .prepare(
-      `UPDATE agents
+      `UPDATE workers
           SET task_id = ?, window_index = ?, tmux_session = ?, status = 'running',
               hook_activity = 'active', hook_activity_updated_at = datetime('now')
         WHERE id = ?`,
@@ -467,7 +471,7 @@ export function findAgentByHarnessSession(
 ): { id: string; task_id: string } | undefined {
   return getDb()
     .prepare(
-      `SELECT a.id, a.task_id FROM agents a
+      `SELECT a.id, a.task_id FROM workers a
        WHERE a.harness_session_id = ? AND a.status != 'stopped'
        LIMIT 1`,
     )
@@ -480,7 +484,7 @@ export function findAgentByHarnessSession(
  */
 export function checkAgentTokenExists(token: string): boolean {
   const row = getDb()
-    .prepare(`SELECT 1 AS ok FROM agents WHERE hook_token = ? AND hook_token != '' LIMIT 1`)
+    .prepare(`SELECT 1 AS ok FROM workers WHERE hook_token = ? AND hook_token != '' LIMIT 1`)
     .get(token) as { ok: number } | undefined;
   return row !== undefined;
 }
@@ -495,7 +499,7 @@ export function findAgentByTokenAndExactSession(
 ): { id: string; task_id: string } | undefined {
   return getDb()
     .prepare(
-      `SELECT id, task_id FROM agents
+      `SELECT id, task_id FROM workers
        WHERE hook_token = ? AND harness_session_id = ?
        LIMIT 1`,
     )
@@ -511,7 +515,7 @@ export function findAgentByTokenWithNullSession(
 ): { id: string; task_id: string } | undefined {
   return getDb()
     .prepare(
-      `SELECT id, task_id FROM agents
+      `SELECT id, task_id FROM workers
        WHERE hook_token = ? AND harness_session_id IS NULL
        ORDER BY created_at DESC
        LIMIT 1`,
@@ -526,7 +530,7 @@ export function findAgentByTokenWithNullSession(
 export function findActiveAgentsByToken(token: string): Array<{ id: string; task_id: string }> {
   return getDb()
     .prepare(
-      `SELECT id, task_id FROM agents
+      `SELECT id, task_id FROM workers
        WHERE hook_token = ? AND hook_token != '' AND status != 'stopped'`,
     )
     .all(token) as Array<{ id: string; task_id: string }>;
@@ -539,7 +543,7 @@ export function setAgentHookActivity(
 ): void {
   getDb()
     .prepare(
-      `UPDATE agents SET hook_activity = ?, hook_activity_updated_at = datetime('now') WHERE id = ?`,
+      `UPDATE workers SET hook_activity = ?, hook_activity_updated_at = datetime('now') WHERE id = ?`,
     )
     .run(activity, agentId);
 }
@@ -551,7 +555,7 @@ export function setAgentHookActivity(
 export function setAgentHookActivityIfNotIdle(agentId: string): void {
   getDb()
     .prepare(
-      `UPDATE agents SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
+      `UPDATE workers SET hook_activity = 'active', hook_activity_updated_at = datetime('now')
        WHERE id = ? AND hook_activity != 'idle'`,
     )
     .run(agentId);
@@ -561,7 +565,7 @@ export function setAgentHookActivityIfNotIdle(agentId: string): void {
 export function countRunningAgentsExcept(taskId: string, excludeAgentId: string): number {
   const row = getDb()
     .prepare(
-      `SELECT COUNT(*) AS n FROM agents WHERE task_id = ? AND status = 'running' AND id != ?`,
+      `SELECT COUNT(*) AS n FROM workers WHERE task_id = ? AND status = 'running' AND id != ?`,
     )
     .get(taskId, excludeAgentId) as { n: number };
   return row.n;
@@ -584,7 +588,7 @@ export function listWatchedAgents(): Array<{
     .prepare(
       `SELECT a.id, a.task_id, a.window_index, a.label,
               t.tmux_session, a.notify_agent_id
-       FROM agents a
+       FROM workers a
        INNER JOIN tasks t ON a.task_id = t.id
        WHERE a.status = 'running'
          AND a.notify_agent_id IS NOT NULL
@@ -612,7 +616,7 @@ export function getNotifyAgentTarget(
   return getDb()
     .prepare(
       `SELECT a.window_index, t.tmux_session
-       FROM agents a
+       FROM workers a
        INNER JOIN tasks t ON a.task_id = t.id
        WHERE a.id = ? AND a.status != 'stopped' AND t.runtime_state = 'running'`,
     )

--- a/server/repositories/workers.ts
+++ b/server/repositories/workers.ts
@@ -9,31 +9,31 @@
 import { nanoid } from 'nanoid';
 import { getDb } from '../db.js';
 import { childLogger } from '../logger.js';
-import type { Agent, UserTerminal } from '../types.js';
+import type { Worker, UserTerminal } from '../types.js';
 
 const logger = childLogger('repositories/workers');
 
 // ─── Agent reads ──────────────────────────────────────────────────────────────
 
 /** Fetch a single worker by id. */
-export function getWorker(id: string): Agent | undefined {
-  return getDb().prepare('SELECT * FROM workers WHERE id = ?').get(id) as Agent | undefined;
+export function getWorker(id: string): Worker | undefined {
+  return getDb().prepare('SELECT * FROM workers WHERE id = ?').get(id) as Worker | undefined;
 }
 
 /** List all non-stopped agents for a task, ordered by window_index. */
-export function listActiveAgents(taskId: string): Agent[] {
+export function listActiveAgents(taskId: string): Worker[] {
   return getDb()
     .prepare(
       `SELECT * FROM workers WHERE task_id = ? AND status != 'stopped' ORDER BY window_index`,
     )
-    .all(taskId) as Agent[];
+    .all(taskId) as Worker[];
 }
 
 /** List all stopped agents for a task, ordered by window_index. */
-export function listStoppedAgents(taskId: string): Agent[] {
+export function listStoppedAgents(taskId: string): Worker[] {
   return getDb()
     .prepare(`SELECT * FROM workers WHERE task_id = ? AND status = 'stopped' ORDER BY window_index`)
-    .all(taskId) as Agent[];
+    .all(taskId) as Worker[];
 }
 
 /**
@@ -47,10 +47,10 @@ export function getTaskHookToken(taskId: string): { hook_token: string } | undef
 }
 
 /** Fetch a single agent by id and task_id (returns undefined if not found or wrong task). */
-export function getAgentByIdAndTask(agentId: string, taskId: string): Agent | undefined {
+export function getAgentByIdAndTask(agentId: string, taskId: string): Worker | undefined {
   return getDb()
     .prepare('SELECT * FROM workers WHERE id = ? AND task_id = ?')
-    .get(agentId, taskId) as Agent | undefined;
+    .get(agentId, taskId) as Worker | undefined;
 }
 
 /** Fetch the first non-stopped agent for a task, ordered by window_index. */
@@ -70,12 +70,12 @@ export function findFirstActiveAgent(
  * Bulk-fetch all agents for a set of task ids, ordered by window_index.
  * Used by the GET /api/tasks list endpoint.
  */
-export function listAgentsByTasks(taskIds: string[]): Agent[] {
+export function listAgentsByTasks(taskIds: string[]): Worker[] {
   if (taskIds.length === 0) return [];
   const placeholders = taskIds.map(() => '?').join(',');
   return getDb()
     .prepare(`SELECT * FROM workers WHERE task_id IN (${placeholders}) ORDER BY window_index`)
-    .all(...taskIds) as Agent[];
+    .all(...taskIds) as Worker[];
 }
 
 /**
@@ -118,10 +118,10 @@ export function countAgentsForTask(taskId: string): number {
 }
 
 /** List all agents for a task (all statuses), ordered by window_index. */
-export function listAllAgents(taskId: string): Agent[] {
+export function listAllAgents(taskId: string): Worker[] {
   return getDb()
     .prepare('SELECT * FROM workers WHERE task_id = ? ORDER BY window_index')
-    .all(taskId) as Agent[];
+    .all(taskId) as Worker[];
 }
 
 /** List all user_terminals for a task, ordered by window_index. */
@@ -255,20 +255,20 @@ export function insertChatAgent(input: InsertChatAgentInput): void {
 }
 
 /** List all standalone chat agents (task_id IS NULL), oldest first. */
-export function listChatAgents(): Agent[] {
+export function listChatAgents(): Worker[] {
   return getDb()
     .prepare(
       `SELECT * FROM workers
          WHERE task_id IS NULL
          ORDER BY created_at ASC`,
     )
-    .all() as Agent[];
+    .all() as Worker[];
 }
 
 /** Fetch a single standalone chat agent by id (task_id IS NULL). */
-export function getChatAgent(id: string): Agent | undefined {
+export function getChatAgent(id: string): Worker | undefined {
   return getDb().prepare(`SELECT * FROM workers WHERE id = ? AND task_id IS NULL`).get(id) as
-    | Agent
+    | Worker
     | undefined;
 }
 

--- a/server/routes/_shared.ts
+++ b/server/routes/_shared.ts
@@ -16,7 +16,7 @@ import { nanoid } from 'nanoid';
 import fs from 'fs';
 import type {
   Task,
-  Agent,
+  Worker,
   UserTerminal,
   Worktree,
   DerivedTaskStatus,
@@ -98,7 +98,7 @@ export function deepMerge(
 }
 
 export interface TaskRelations {
-  agents: Agent[];
+  workers: Worker[];
   user_terminals: UserTerminal[];
   pending_prompts: PermissionPromptRow[];
 }
@@ -108,13 +108,13 @@ export interface TaskResponseExtras {
   existing_review_id?: string | null;
 }
 
-/** Load a task plus agents, terminals, and pending permission prompts. */
+/** Load a task plus workers, terminals, and pending permission prompts. */
 export function fetchTaskWithRelations(taskId: string): { task: Task; relations: TaskRelations } {
   const task = getTaskRepo(taskId) as Task;
   return {
     task,
     relations: {
-      agents: listAllAgents(taskId),
+      workers: listAllAgents(taskId),
       user_terminals: listUserTerminals(taskId),
       pending_prompts: listPendingPromptsByTask(taskId),
     },
@@ -129,9 +129,12 @@ export function formatTaskResponse(
 ) {
   return {
     ...task,
-    agents: relations.agents,
+    workers: relations.workers,
     pending_prompts: relations.pending_prompts,
-    derived_status: derivedStatus({ runtime_state: task.runtime_state, agents: relations.agents }),
+    derived_status: derivedStatus({
+      runtime_state: task.runtime_state,
+      workers: relations.workers,
+    }),
     user_terminals: relations.user_terminals,
     ...(extras?.worktree_row !== undefined ? { worktree_row: extras.worktree_row } : {}),
     ...(extras?.existing_review_id !== undefined
@@ -140,20 +143,20 @@ export function formatTaskResponse(
   };
 }
 
-/** Reload a task with its related agents and user_terminals (mutation-style, no prompts). */
+/** Reload a task with its related workers and user_terminals (mutation-style, no prompts). */
 export function fetchTaskBundle(taskId: string): Task {
   const { task, relations } = fetchTaskWithRelations(taskId);
-  task.agents = relations.agents;
+  task.workers = relations.workers;
   task.user_terminals = relations.user_terminals;
   return task;
 }
 
 export function derivedStatus(task: {
   runtime_state: string;
-  agents: Array<{ status: string; hook_activity: string }>;
+  workers: Array<{ status: string; hook_activity: string }>;
 }): DerivedTaskStatus | null {
   if (task.runtime_state !== 'running') return null;
-  const activities = task.agents.filter((a) => a.status !== 'stopped').map((a) => a.hook_activity);
+  const activities = task.workers.filter((a) => a.status !== 'stopped').map((a) => a.hook_activity);
   if (activities.length === 0) return 'done';
   if (activities.includes('active')) return 'working';
   if (activities.includes('waiting')) return 'needs_attention';

--- a/server/routes/agent-defs.ts
+++ b/server/routes/agent-defs.ts
@@ -5,14 +5,14 @@ import { toDomainServiceError } from '../services/errors.js';
 
 export const router = express.Router();
 
-// ─── Agents ──────────────────────────────────────────────────────────────────
+// ─── Agent role definitions (orchestrator/planner/reviewer plugin skeletons) ──
 
-router.get('/api/agents', async (_req: Request, res: Response) => {
+router.get('/api/agent-roles', async (_req: Request, res: Response) => {
   const agents = await listAgents();
   res.json(agents);
 });
 
-router.get('/api/agents/:name', async (req: Request, res: Response) => {
+router.get('/api/agent-roles/:name', async (req: Request, res: Response) => {
   try {
     const agent = await getAgent(req.params.name as string);
     res.json(agent);

--- a/server/routes/agents-crud.ts
+++ b/server/routes/agents-crud.ts
@@ -1,16 +1,12 @@
 /**
- * `/api/agent-configs` — CRUD for the Agents-feature `agent_configs` table,
+ * `/api/agents` — CRUD for the `agents` table (persistent conductor agents),
  * plus derived live status and the endpoint that ensures/opens an agent's
  * persistent conductor session.
  *
- * NAMING CORRECTION (mirrors the `agents` → `agent_configs` table rename from
- * Task 1): `/api/agents` was NOT available for this feature — it's already
- * `GET /api/agents` + `GET /api/agents/:name` in `routes/agent-defs.ts` (agent
- * *role* definitions: orchestrator/planner/reviewer) and
- * `PATCH /api/agents/:id/task` in `routes/chats.ts` (moving a per-task
- * tmux-window worker between tasks — the pre-existing `agents` table). Reusing
- * that path would have silently shadowed those routes. `/api/agent-configs`
- * matches the already-adopted `agent_configs` table/repository naming.
+ * The three-way "agent" naming collision this used to route around is gone:
+ * the per-task tmux worker now lives at `/api/workers` (`routes/task-agents.ts`,
+ * `routes/chats.ts`), and agent *role* definitions (orchestrator/planner/
+ * reviewer) live at `/api/agent-roles` (`routes/agent-defs.ts`).
  */
 import express from 'express';
 import type { Request, Response } from 'express';
@@ -22,7 +18,7 @@ import {
   deleteAgent,
   type AgentConfig,
   type UpdateAgentInput,
-} from '../repositories/agents-config.js';
+} from '../repositories/agents.js';
 import { createConversation, getPrimaryAgentConversation } from '../repositories/orchestrator.js';
 import {
   startConversation,
@@ -50,7 +46,7 @@ export interface AgentWithStatus extends AgentConfig {
  * 'idle' (v1 does not attempt to detect "actively generating" — that needs a
  * pane-content heuristic that isn't cheap/reliable enough yet; 'working' is
  * reserved for a later pass). Never throws: a tmux probe failure is treated as
- * 'stopped' so `GET /api/agent-configs` can't be taken down by a flaky tmux call.
+ * 'stopped' so `GET /api/agents` can't be taken down by a flaky tmux call.
  */
 export async function deriveAgentStatus(
   agentId: string,
@@ -83,14 +79,14 @@ function normalizeChannelConfig(value: unknown): string | null {
   return JSON.stringify(value);
 }
 
-// GET /api/agent-configs — list all agents with derived status + session_id
-router.get('/api/agent-configs', async (_req: Request, res: Response) => {
+// GET /api/agents — list all agents with derived status + session_id
+router.get('/api/agents', async (_req: Request, res: Response) => {
   const agents = listAgents();
   res.json(await Promise.all(agents.map(withStatus)));
 });
 
-// POST /api/agent-configs — create an agent config
-router.post('/api/agent-configs', async (req: Request, res: Response) => {
+// POST /api/agents — create an agent config
+router.post('/api/agents', async (req: Request, res: Response) => {
   const body = req.body as {
     name?: unknown;
     system_prompt?: unknown;
@@ -118,16 +114,16 @@ router.post('/api/agent-configs', async (req: Request, res: Response) => {
   res.status(201).json(await withStatus(getAgent(id)!));
 });
 
-// GET /api/agent-configs/:id — a single agent with derived status + session_id
-router.get('/api/agent-configs/:id', async (req: Request, res: Response) => {
+// GET /api/agents/:id — a single agent with derived status + session_id
+router.get('/api/agents/:id', async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   const agent = getAgent(id);
   if (!agent) throw notFound('Agent not found');
   res.json(await withStatus(agent));
 });
 
-// PATCH /api/agent-configs/:id — update name/system_prompt/channel/channel_config
-router.patch('/api/agent-configs/:id', async (req: Request, res: Response) => {
+// PATCH /api/agents/:id — update name/system_prompt/channel/channel_config
+router.patch('/api/agents/:id', async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   const agent = getAgent(id);
   if (!agent) throw notFound('Agent not found');
@@ -165,8 +161,8 @@ router.patch('/api/agent-configs/:id', async (req: Request, res: Response) => {
   res.json(await withStatus(getAgent(id)!));
 });
 
-// DELETE /api/agent-configs/:id — delete the agent, stopping its session first
-router.delete('/api/agent-configs/:id', async (req: Request, res: Response) => {
+// DELETE /api/agents/:id — delete the agent, stopping its session first
+router.delete('/api/agents/:id', async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   const agent = getAgent(id);
   if (!agent) throw notFound('Agent not found');
@@ -181,8 +177,8 @@ router.delete('/api/agent-configs/:id', async (req: Request, res: Response) => {
   res.status(204).end();
 });
 
-// POST /api/agent-configs/:id/session — ensure + return the agent's persistent conversation
-router.post('/api/agent-configs/:id/session', async (req: Request, res: Response) => {
+// POST /api/agents/:id/session — ensure + return the agent's persistent conversation
+router.post('/api/agents/:id/session', async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;
   const agent = getAgent(id);
   if (!agent) throw notFound('Agent not found');

--- a/server/routes/chats.ts
+++ b/server/routes/chats.ts
@@ -6,7 +6,7 @@ import { broadcast } from '../events.js';
 import { validateAgentName } from '../harnesses/types.js';
 import { getHarness } from '../harnesses/index.js';
 import { hopAgent } from '../task-engine/index.js';
-import { getAgent as getAgentRepo, getTask as getTaskRepo } from '../repositories/index.js';
+import { getWorker as getWorkerRepo, getTask as getTaskRepo } from '../repositories/index.js';
 import { finishDailyPlanRunForChat } from '../workflows/daily-plan/run.js';
 import type { CreateChatRequest, Task } from '../types.js';
 import { badRequest, conflict, notFound, ServiceError } from '../services/errors.js';
@@ -27,8 +27,8 @@ router.get('/api/chats/:id', (req: Request, res: Response) => {
   res.json(chat);
 });
 
-router.patch('/api/agents/:id/task', async (req: Request, res: Response) => {
-  const agent = getAgentRepo(req.params.id as string);
+router.patch('/api/workers/:id/task', async (req: Request, res: Response) => {
+  const agent = getWorkerRepo(req.params.id as string);
   if (!agent) {
     throw notFound('Agent not found');
   }

--- a/server/routes/hook-auth.ts
+++ b/server/routes/hook-auth.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { checkAgentTokenExists } from '../repositories/agent-runtime.js';
+import { checkAgentTokenExists } from '../repositories/workers.js';
 import { childLogger } from '../logger.js';
 
 const logger = childLogger('routes/hook-auth');

--- a/server/routes/task-agents.ts
+++ b/server/routes/task-agents.ts
@@ -17,7 +17,7 @@ import { badRequest, notFound } from '../services/errors.js';
 
 export const router = express.Router();
 
-router.post('/api/tasks/:id/agents', async (req: Request, res: Response) => {
+router.post('/api/tasks/:id/workers', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {
@@ -46,7 +46,7 @@ router.post('/api/tasks/:id/agents', async (req: Request, res: Response) => {
   res.status(201).json(agent);
 });
 
-router.delete('/api/tasks/:id/agents/:agentId', async (req: Request, res: Response) => {
+router.delete('/api/tasks/:id/workers/:agentId', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
   const agent = getAgentByIdAndTask(req.params.agentId as string, req.params.id as string);
 
@@ -59,7 +59,7 @@ router.delete('/api/tasks/:id/agents/:agentId', async (req: Request, res: Respon
   res.json({ success: true });
 });
 
-router.post('/api/tasks/:id/agents/:agentId/message', async (req: Request, res: Response) => {
+router.post('/api/tasks/:id/workers/:agentId/message', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
 
   if (task.runtime_state !== 'running') {

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -16,7 +16,7 @@ import type {
   CreateTaskRequest,
   UpdateTaskRequest,
   Task,
-  Agent,
+  Worker,
   UserTerminal,
   RunMode,
 } from '../types.js';
@@ -77,12 +77,12 @@ router.get('/api/tasks', (req: Request, res: Response) => {
   const allTerminals = listUserTerminalsByTasks(taskIds);
 
   // Group by task_id using Maps
-  const agentsByTask = new Map<string, Agent[]>();
+  const workersByTask = new Map<string, Worker[]>();
   for (const agent of allAgents) {
     if (!agent.task_id) continue; // standalone agents don't belong to a task
-    const list = agentsByTask.get(agent.task_id) || [];
+    const list = workersByTask.get(agent.task_id) || [];
     list.push(agent);
-    agentsByTask.set(agent.task_id, list);
+    workersByTask.set(agent.task_id, list);
   }
 
   const promptsByTask = new Map<string, PermissionPromptRow[]>();
@@ -102,7 +102,7 @@ router.get('/api/tasks', (req: Request, res: Response) => {
 
   const result = tasks.map((task) =>
     formatTaskResponse(task, {
-      agents: agentsByTask.get(task.id) || [],
+      workers: workersByTask.get(task.id) || [],
       pending_prompts: promptsByTask.get(task.id) || [],
       user_terminals: terminalsByTask.get(task.id) || [],
     }),
@@ -156,8 +156,8 @@ router.get('/api/tasks/:id', async (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
   const { relations } = fetchTaskWithRelations(task.id);
   // Backfill hook_token for pre-step-1 agents that have an empty token.
-  const agents = await Promise.all(
-    relations.agents.map(async (agent) => {
+  const workers = await Promise.all(
+    relations.workers.map(async (agent) => {
       if (agent.hook_token !== '') return agent;
       const token = await ensureHookToken(agent, task.worktree ?? null);
       return { ...agent, hook_token: token };
@@ -167,7 +167,7 @@ router.get('/api/tasks/:id', async (req: Request, res: Response) => {
   res.json(
     formatTaskResponse(
       task,
-      { ...relations, agents },
+      { ...relations, workers },
       {
         worktree_row: worktreeRow,
         existing_review_id: lookupExistingReviewId(task),

--- a/server/services/task-service.ts
+++ b/server/services/task-service.ts
@@ -147,7 +147,7 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
   }
 
   const created = getTask(id) as Task;
-  created.agents = [];
+  created.workers = [];
   created.user_terminals = [];
 
   broadcast({ type: 'task:created', payload: { taskId: id } });

--- a/server/task-engine.test.ts
+++ b/server/task-engine.test.ts
@@ -1267,7 +1267,7 @@ describe('addAgent opts', () => {
     await addAgent(task, { prompt: 'Go', notify_agent_id: 'parent-agent-01' });
     const row = db
       .prepare(
-        'SELECT notify_agent_id FROM agents WHERE task_id = ? ORDER BY window_index DESC LIMIT 1',
+        'SELECT notify_agent_id FROM workers WHERE task_id = ? ORDER BY window_index DESC LIMIT 1',
       )
       .get(task.id) as { notify_agent_id: string | null };
     expect(row.notify_agent_id).toBe('parent-agent-01');
@@ -1277,7 +1277,7 @@ describe('addAgent opts', () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     await addAgent(task, { prompt: 'Go', label: 'Researcher' });
     const row = db
-      .prepare('SELECT label FROM agents WHERE task_id = ? ORDER BY window_index DESC LIMIT 1')
+      .prepare('SELECT label FROM workers WHERE task_id = ? ORDER BY window_index DESC LIMIT 1')
       .get(task.id) as { label: string };
     expect(row.label).toBe('Researcher');
   });
@@ -2704,7 +2704,7 @@ describe('hopAgent', () => {
       worktree: '/tmp/wt-t',
     });
     const agent = insertAgent(db, { id: 'agChat', task_id: null });
-    db.prepare(`UPDATE agents SET tmux_session = 'octomux-chat-agChat' WHERE id = 'agChat'`).run();
+    db.prepare(`UPDATE workers SET tmux_session = 'octomux-chat-agChat' WHERE id = 'agChat'`).run();
     const reloaded = {
       ...agent,
       task_id: null,

--- a/server/task-engine.test.ts
+++ b/server/task-engine.test.ts
@@ -15,7 +15,7 @@ import {
   countExecCalls,
   DEFAULTS,
 } from './test-helpers.js';
-import type { Task, Agent } from './types.js';
+import type { Task, Worker } from './types.js';
 import { getSettings } from './settings.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -211,7 +211,7 @@ describe('startTask', () => {
 
   describe('on success', () => {
     let updated: Task;
-    let agents: Agent[];
+    let agents: Worker[];
 
     beforeEach(async () => {
       insertTask(db);
@@ -1515,7 +1515,7 @@ describe('stopAgent', () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db);
 
-    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
+    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Worker);
 
     const call = findExecCall(vi.mocked(execFile), { cmd: 'tmux', argsInclude: ['kill-window'] });
     expect(call).toBeDefined();
@@ -1528,7 +1528,7 @@ describe('stopAgent', () => {
     insertTask(db, { ...DEFAULTS.runningTask });
     insertAgent(db, { hook_activity: 'active' });
 
-    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
+    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Worker);
 
     const agents = getAgents(db, DEFAULTS.task.id);
     expect(agents[0].status).toBe('stopped');
@@ -1540,7 +1540,7 @@ describe('stopAgent', () => {
     insertAgent(db);
     insertAgent(db, { id: 'agent-02', window_index: 1, label: 'Agent 2' });
 
-    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
+    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Worker);
 
     const agents = getAgents(db, DEFAULTS.task.id);
     const other = agents.find((a) => a.id === 'agent-02')!;
@@ -2125,7 +2125,7 @@ describe('hook integration', () => {
       status: 'pending',
     });
 
-    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Agent);
+    await stopAgent({ ...DEFAULTS.runningTask } as Task, { ...DEFAULTS.agent } as Worker);
 
     const prompts = getPermissionPrompts(db, DEFAULTS.task.id);
     const agent1Prompt = prompts.find((p) => p.agent_id === DEFAULTS.agent.id)!;
@@ -2709,7 +2709,7 @@ describe('hopAgent', () => {
       ...agent,
       task_id: null,
       tmux_session: 'octomux-chat-agChat',
-    } as Agent;
+    } as Worker;
 
     const updated = await hopAgent(reloaded, 'tT');
     expect(updated.task_id).toBe('tT');

--- a/server/task-engine/cleanup.ts
+++ b/server/task-engine/cleanup.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import { childLogger } from '../logger.js';
 import { execTmux } from '../tmux-bin.js';
-import type { Task, Agent } from '../types.js';
+import type { Task, Worker } from '../types.js';
 import {
   setRuntimeState,
   stopAllAgents,
@@ -215,7 +215,7 @@ export async function deleteTask(task: Task): Promise<void> {
   logger.info({ task_id: task.id, operation: 'deleteTask' }, 'deleteTask: complete');
 }
 
-export async function stopAgent(task: Task, agent: Agent): Promise<void> {
+export async function stopAgent(task: Task, agent: Worker): Promise<void> {
   logger.info(
     {
       task_id: task.id,

--- a/server/task-engine/launch.test.ts
+++ b/server/task-engine/launch.test.ts
@@ -351,7 +351,7 @@ describe('prepareResumeLaunch', () => {
 
     // setAgentHarnessSessionId should have updated the DB
     const updatedAgent = db
-      .prepare('SELECT harness_session_id FROM agents WHERE id = ?')
+      .prepare('SELECT harness_session_id FROM workers WHERE id = ?')
       .get(DEFAULTS.agent.id) as { harness_session_id: string } | undefined;
     expect(updatedAgent?.harness_session_id).toBe('new-session-id-xyz');
   });
@@ -376,7 +376,7 @@ describe('prepareResumeLaunch', () => {
 
     // harness_session_id should remain null (not updated)
     const updatedAgent = db
-      .prepare('SELECT harness_session_id FROM agents WHERE id = ?')
+      .prepare('SELECT harness_session_id FROM workers WHERE id = ?')
       .get(DEFAULTS.agent.id) as { harness_session_id: string | null } | undefined;
     expect(updatedAgent?.harness_session_id).toBeNull();
   });
@@ -401,7 +401,7 @@ describe('prepareResumeLaunch', () => {
 
     // harness_session_id should remain the original value (resume path doesn't set it)
     const updatedAgent = db
-      .prepare('SELECT harness_session_id FROM agents WHERE id = ?')
+      .prepare('SELECT harness_session_id FROM workers WHERE id = ?')
       .get(DEFAULTS.agent.id) as { harness_session_id: string } | undefined;
     expect(updatedAgent?.harness_session_id).toBe('existing-session-id');
   });

--- a/server/task-engine/launch.ts
+++ b/server/task-engine/launch.ts
@@ -8,7 +8,7 @@ import { shellQuoteSingle } from '../shell-quote.js';
 import { tmuxWindowSubstrate } from '../agent-session/substrate-tmux-windowed.js';
 import { setAgentHarnessSessionId } from '../repositories/index.js';
 import type { Harness } from '../harnesses/index.js';
-import type { Agent } from '../types.js';
+import type { Worker } from '../types.js';
 
 const logger = childLogger('task-engine/launch');
 
@@ -219,7 +219,7 @@ export function applyOrchestratorMcpConfig(
  * writes (setAgentWindowRunning / hopAgentToTask).
  */
 export function prepareResumeLaunch(opts: {
-  agent: Agent;
+  agent: Worker;
   harness: Harness;
   flags: string;
   model: string | null;

--- a/server/task-engine/lifecycle/add-agent.ts
+++ b/server/task-engine/lifecycle/add-agent.ts
@@ -13,7 +13,7 @@ import {
   insertAgentWithNotify,
 } from '../../repositories/index.js';
 import { buildAgentStartupCommand, launchAgentWindow, computeFreshSessionIds } from '../launch.js';
-import type { Agent, Task } from '../../types.js';
+import type { Worker, Task } from '../../types.js';
 import type { AddAgentOpts } from './types.js';
 
 const logger = childLogger('task-engine/lifecycle');
@@ -114,7 +114,7 @@ export function persistAddAgentRow(
   resolved: ResolvedAddAgentOpts,
   prepared: PreparedAddAgentLaunch,
   windowIndex: number,
-): Agent {
+): Worker {
   const addTarget = `${task.tmux_session}:${windowIndex}`;
 
   insertAgentWithNotify({
@@ -149,7 +149,7 @@ export function persistAddAgentRow(
   };
 }
 
-export async function addAgent(task: Task, opts: AddAgentOpts = {}): Promise<Agent> {
+export async function addAgent(task: Task, opts: AddAgentOpts = {}): Promise<Worker> {
   logger.info(
     { task_id: task.id, operation: 'addAgent', agent: opts.agent ?? null },
     'addAgent: start',

--- a/server/task-engine/lifecycle/hop-agent.ts
+++ b/server/task-engine/lifecycle/hop-agent.ts
@@ -6,7 +6,7 @@ import { execTmux } from '../../tmux-bin.js';
 import { resolveHarnessFlags } from '../../harness-flags.js';
 import { skillContentOverridesForScheduleId } from '../../schedule-prompt.js';
 import { chatDirFor, chatSessionName } from '../../chats.js';
-import type { Agent, Worktree } from '../../types.js';
+import type { Worker, Worktree } from '../../types.js';
 import {
   getTask as getTaskRepo,
   getTaskTmuxSession,
@@ -19,7 +19,7 @@ import { isTmuxTargetMissing } from '../sessions.js';
 
 const logger = childLogger('task-engine/lifecycle');
 
-export async function hopAgent(agent: Agent, targetTaskId: string | null): Promise<Agent> {
+export async function hopAgent(agent: Worker, targetTaskId: string | null): Promise<Worker> {
   const fromTaskId = agent.task_id;
   logger.info(
     {
@@ -124,5 +124,5 @@ export async function hopAgent(agent: Agent, targetTaskId: string | null): Promi
     'task_hop: complete',
   );
 
-  return getWorker(agent.id) as Agent;
+  return getWorker(agent.id) as Worker;
 }

--- a/server/task-engine/lifecycle/hop-agent.ts
+++ b/server/task-engine/lifecycle/hop-agent.ts
@@ -12,7 +12,7 @@ import {
   getTaskTmuxSession,
   getWorktree,
   hopAgentToTask,
-  getAgent,
+  getWorker,
 } from '../../repositories/index.js';
 import { buildAgentStartupCommand, launchAgentWindow, prepareResumeLaunch } from '../launch.js';
 import { isTmuxTargetMissing } from '../sessions.js';
@@ -124,5 +124,5 @@ export async function hopAgent(agent: Agent, targetTaskId: string | null): Promi
     'task_hop: complete',
   );
 
-  return getAgent(agent.id) as Agent;
+  return getWorker(agent.id) as Agent;
 }

--- a/server/task-engine/lifecycle/respawn-agent.test.ts
+++ b/server/task-engine/lifecycle/respawn-agent.test.ts
@@ -204,7 +204,7 @@ describe('respawnAgentFresh', () => {
     expect(startupCmd).toContain('OCTOMUX_ACTION_TOKEN=');
     expect(startupCmd).toContain('real-hook-token-abc');
 
-    const { checkAgentTokenExists } = await import('../../repositories/agent-runtime.js');
+    const { checkAgentTokenExists } = await import('../../repositories/workers.js');
     expect(checkAgentTokenExists('real-hook-token-abc')).toBe(true);
   });
 

--- a/server/task-engine/lifecycle/respawn-agent.test.ts
+++ b/server/task-engine/lifecycle/respawn-agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { createTestDb, insertTask, insertAgent, DEFAULTS } from '../../test-helpers.js';
-import type { Task, Agent } from '../../types.js';
+import type { Task, Worker } from '../../types.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -90,7 +90,7 @@ beforeEach(() => {
   insertTask(db, { ...DEFAULTS.runningTask });
 });
 
-function makeAgentRow(overrides: Partial<Agent> = {}): Agent {
+function makeAgentRow(overrides: Partial<Worker> = {}): Worker {
   return insertAgent(db, {
     ...DEFAULTS.agent,
     window_index: 1,

--- a/server/task-engine/lifecycle/respawn-agent.ts
+++ b/server/task-engine/lifecycle/respawn-agent.ts
@@ -6,7 +6,7 @@ import { childLogger } from '../../logger.js';
 import { broadcast } from '../../events.js';
 import { execTmux } from '../../tmux-bin.js';
 import {
-  getAgent,
+  getWorker,
   setAgentWindowRunning,
   setAgentHarnessSessionId,
 } from '../../repositories/index.js';
@@ -95,7 +95,7 @@ export async function respawnAgentFresh(
     });
   }
 
-  const updated = getAgent(agent.id) as Agent;
+  const updated = getWorker(agent.id) as Agent;
   broadcast({ type: 'task:updated', payload: { taskId: task.id } });
 
   logger.info(

--- a/server/task-engine/lifecycle/respawn-agent.ts
+++ b/server/task-engine/lifecycle/respawn-agent.ts
@@ -12,7 +12,7 @@ import {
 } from '../../repositories/index.js';
 import { buildAgentStartupCommand, launchAgentWindow, computeFreshSessionIds } from '../launch.js';
 import { isTmuxTargetMissing } from '../sessions.js';
-import type { Agent, Task } from '../../types.js';
+import type { Worker, Task } from '../../types.js';
 
 const logger = childLogger('task-engine/lifecycle');
 
@@ -34,9 +34,9 @@ const logger = childLogger('task-engine/lifecycle');
  */
 export async function respawnAgentFresh(
   task: Task,
-  agent: Agent,
+  agent: Worker,
   opts?: { prompt?: string; env?: Record<string, string>; fresh?: boolean },
-): Promise<Agent> {
+): Promise<Worker> {
   logger.info(
     { task_id: task.id, agent_id: agent.id, operation: 'respawn_fresh' },
     'respawn_fresh: start',
@@ -95,7 +95,7 @@ export async function respawnAgentFresh(
     });
   }
 
-  const updated = getWorker(agent.id) as Agent;
+  const updated = getWorker(agent.id) as Worker;
   broadcast({ type: 'task:updated', payload: { taskId: task.id } });
 
   logger.info(

--- a/server/task-engine/loop/engine.test.ts
+++ b/server/task-engine/loop/engine.test.ts
@@ -186,7 +186,7 @@ describe('startLoop', () => {
   });
 
   it('throws when the task has no active agent', async () => {
-    db.prepare(`UPDATE agents SET status = 'stopped' WHERE id = 'a1'`).run();
+    db.prepare(`UPDATE workers SET status = 'stopped' WHERE id = 'a1'`).run();
     await expect(startLoop('t1', LOOP_SPEC)).rejects.toThrow(/no active agent/);
   });
 

--- a/server/task-engine/loop/engine.ts
+++ b/server/task-engine/loop/engine.ts
@@ -1,6 +1,6 @@
 import { childLogger } from '../../logger.js';
 import { getTask, setRuntimeState } from '../../repositories/tasks.js';
-import { getAgent, findFirstActiveAgent } from '../../repositories/agent-runtime.js';
+import { getWorker, findFirstActiveAgent } from '../../repositories/workers.js';
 import {
   createLoopRun,
   getActiveLoopRunForTask,
@@ -169,7 +169,7 @@ export async function startLoop(
 
   const agentRef = findFirstActiveAgent(taskId);
   if (!agentRef) throw new Error(`startLoop: no active agent for task ${taskId}`);
-  const agent = getAgent(agentRef.id);
+  const agent = getWorker(agentRef.id);
   if (!agent) throw new Error(`startLoop: agent not found: ${agentRef.id}`);
 
   const run = createLoopRun({
@@ -218,7 +218,7 @@ export async function handleLoopIterationBoundary(taskId: string, agentId: strin
     return;
   }
   const task = getTask(taskId);
-  const agent = getAgent(agentId);
+  const agent = getWorker(agentId);
   if (!task || !agent || !task.worktree) {
     logger.warn({ task_id: taskId, agent_id: agentId }, 'loop: task/agent/worktree missing');
     return;
@@ -346,7 +346,7 @@ export async function resumeLoopOnStartup(task: Task): Promise<void> {
   }
 
   const agentRef = findFirstActiveAgent(task.id);
-  const agent = agentRef ? getAgent(agentRef.id) : undefined;
+  const agent = agentRef ? getWorker(agentRef.id) : undefined;
   if (!agent) {
     logger.warn(
       { task_id: task.id, loop_run_id: run.id },

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -110,7 +110,7 @@ export function insertAgent(db: Database.Database, overrides: Partial<Agent> = {
   } as Agent;
 
   db.prepare(
-    'INSERT INTO agents (id, task_id, window_index, label, status, harness_session_id, hook_activity, hook_token, notify_agent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO workers (id, task_id, window_index, label, status, harness_session_id, hook_activity, hook_token, notify_agent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
   ).run(
     agent.id,
     agent.task_id,
@@ -139,7 +139,7 @@ export function getTask(db: Database.Database, id: string): Task | undefined {
 }
 
 export function getAgents(db: Database.Database, taskId: string): Agent[] {
-  return db.prepare('SELECT * FROM agents WHERE task_id = ?').all(taskId) as Agent[];
+  return db.prepare('SELECT * FROM workers WHERE task_id = ?').all(taskId) as Agent[];
 }
 
 export function insertPermissionPrompt(
@@ -261,7 +261,7 @@ export function getAgentActivity(
   db: Database.Database,
   agentId: string,
 ): { hook_activity: string } {
-  return db.prepare('SELECT hook_activity FROM agents WHERE id = ?').get(agentId) as {
+  return db.prepare('SELECT hook_activity FROM workers WHERE id = ?').get(agentId) as {
     hook_activity: string;
   };
 }

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -12,7 +12,7 @@ import {
 } from '@octomux/test-fixtures';
 import { getDb, initDb, setDb } from './db.js';
 import { SELECT_TASK_SQL } from './task-select.js';
-import type { Task, Agent, UserTerminal } from './types.js';
+import type { Task, Worker, UserTerminal } from './types.js';
 
 // ─── Default Fixtures ────────────────────────────────────────────────────────
 
@@ -38,7 +38,7 @@ export function createTestDb(): Database.Database {
 export function insertTask(db: Database.Database, overrides: Partial<Task> = {}): Task {
   const task: Task = {
     ...DEFAULTS.task,
-    agents: undefined,
+    workers: undefined,
     ...overrides,
   } as Task;
 
@@ -103,11 +103,11 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
   return task;
 }
 
-export function insertAgent(db: Database.Database, overrides: Partial<Agent> = {}): Agent {
-  const agent: Agent = {
+export function insertAgent(db: Database.Database, overrides: Partial<Worker> = {}): Worker {
+  const agent: Worker = {
     ...DEFAULTS.agent,
     ...overrides,
-  } as Agent;
+  } as Worker;
 
   db.prepare(
     'INSERT INTO workers (id, task_id, window_index, label, status, harness_session_id, hook_activity, hook_token, notify_agent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -138,8 +138,8 @@ export function getTask(db: Database.Database, id: string): Task | undefined {
   return db.prepare(`${SELECT_TASK_SQL} WHERE t.id = ?`).get(id) as Task | undefined;
 }
 
-export function getAgents(db: Database.Database, taskId: string): Agent[] {
-  return db.prepare('SELECT * FROM workers WHERE task_id = ?').all(taskId) as Agent[];
+export function getAgents(db: Database.Database, taskId: string): Worker[] {
+  return db.prepare('SELECT * FROM workers WHERE task_id = ?').all(taskId) as Worker[];
 }
 
 export function insertPermissionPrompt(

--- a/server/workflows/doc-drift.e2e.test.ts
+++ b/server/workflows/doc-drift.e2e.test.ts
@@ -28,7 +28,7 @@ import './doc-drift/index.js';
 function insertActiveAgent(taskId: string): void {
   getDb()
     .prepare(
-      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+      `INSERT INTO workers (id, task_id, window_index, label, status, harness_id, hook_token)
        VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
     )
     .run(`${taskId}-agent`, taskId);

--- a/server/workflows/doc-drift/run.test.ts
+++ b/server/workflows/doc-drift/run.test.ts
@@ -27,7 +27,7 @@ import type { RunResult } from '../../types.js';
 function insertActiveAgent(taskId: string): void {
   getDb()
     .prepare(
-      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+      `INSERT INTO workers (id, task_id, window_index, label, status, harness_id, hook_token)
        VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
     )
     .run(`${taskId}-agent`, taskId);

--- a/server/workflows/doc-drift/run.ts
+++ b/server/workflows/doc-drift/run.ts
@@ -66,7 +66,7 @@ export async function createDocDriftTaskFromSchedule(
   broadcast({ type: 'task:created', payload: { taskId: id } });
 
   const fresh = getTask(id) as Task;
-  fresh.agents = [];
+  fresh.workers = [];
   fresh.user_terminals = [];
 
   await startTask(fresh);

--- a/server/workflows/pr-extract/run.ts
+++ b/server/workflows/pr-extract/run.ts
@@ -65,7 +65,7 @@ export async function createExtractTaskFromMergedPr(
   insertRun({ workflowKind: 'pr-extract', trigger: 'github', taskId: id });
 
   const fresh = getTask(id) as Task;
-  fresh.agents = [];
+  fresh.workers = [];
   fresh.user_terminals = [];
 
   startTask(fresh)

--- a/server/workflows/prod-log-triage.e2e.test.ts
+++ b/server/workflows/prod-log-triage.e2e.test.ts
@@ -28,7 +28,7 @@ import './prod-log-triage/index.js';
 function insertActiveAgent(taskId: string): void {
   getDb()
     .prepare(
-      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+      `INSERT INTO workers (id, task_id, window_index, label, status, harness_id, hook_token)
        VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
     )
     .run(`${taskId}-agent`, taskId);

--- a/server/workflows/prod-log-triage/run.test.ts
+++ b/server/workflows/prod-log-triage/run.test.ts
@@ -27,7 +27,7 @@ import type { RunResult } from '../../types.js';
 function insertActiveAgent(taskId: string): void {
   getDb()
     .prepare(
-      `INSERT INTO agents (id, task_id, window_index, label, status, harness_id, hook_token)
+      `INSERT INTO workers (id, task_id, window_index, label, status, harness_id, hook_token)
        VALUES (?, ?, 0, 'Agent 1', 'running', 'claude-code', 'tok')`,
     )
     .run(`${taskId}-agent`, taskId);

--- a/server/workflows/prod-log-triage/run.ts
+++ b/server/workflows/prod-log-triage/run.ts
@@ -68,7 +68,7 @@ export async function createTriageTaskFromSchedule(
   broadcast({ type: 'task:created', payload: { taskId: id } });
 
   const fresh = getTask(id) as Task;
-  fresh.agents = [];
+  fresh.workers = [];
   fresh.user_terminals = [];
 
   await startTask(fresh);

--- a/server/workflows/reviewer/run.ts
+++ b/server/workflows/reviewer/run.ts
@@ -220,7 +220,7 @@ function readbackAndKick(id: string): Task {
   broadcast({ type: 'task:created', payload: { taskId: id } });
 
   const fresh = getTask(id) as Task;
-  fresh.agents = [];
+  fresh.workers = [];
   fresh.user_terminals = [];
 
   // Fire-and-forget: the response shouldn't block on worktree setup.

--- a/server/workflows/reviewer/run.ts
+++ b/server/workflows/reviewer/run.ts
@@ -18,7 +18,7 @@ import {
 import { getTask, insertRun } from '../../repositories/index.js';
 import { startTask } from '../../task-engine/index.js';
 import { sendMessageToAgent } from '../../tmux-input.js';
-import { findFirstActiveAgent } from '../../repositories/agent-runtime.js';
+import { findFirstActiveAgent } from '../../repositories/workers.js';
 import { broadcast } from '../../events.js';
 import { childLogger } from '../../logger.js';
 import type { Task } from '../../types.js';

--- a/src/components/AgentActivitySummary.tsx
+++ b/src/components/AgentActivitySummary.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react';
-import type { Agent, PermissionPrompt } from '@octomux/types';
+import type { Worker, PermissionPrompt } from '@octomux/types';
 import { timeAgo, timeSince } from '@/lib/time';
 
 interface AgentActivitySummaryProps {
-  agents: Agent[];
+  workers: Worker[];
   pendingPrompts?: PermissionPrompt[];
   /** Compact mode for table rows — single line, no wrapping */
   compact?: boolean;
@@ -15,7 +15,7 @@ const ACTIVITY_DOT: Record<string, string> = {
   waiting: 'bg-[#FFB800]',
 };
 
-function agentStatusText(agent: Agent): string {
+function agentStatusText(agent: Worker): string {
   if (agent.hook_activity === 'active') return 'Active';
   if (agent.hook_activity === 'waiting') return 'Waiting for input';
   // idle — show duration
@@ -25,9 +25,9 @@ function agentStatusText(agent: Agent): string {
   return 'Idle';
 }
 
-function mostRecentActivity(agents: Agent[]): string | null {
+function mostRecentActivity(workers: Worker[]): string | null {
   let latest: string | null = null;
-  for (const a of agents) {
+  for (const a of workers) {
     if (a.hook_activity_updated_at && (!latest || a.hook_activity_updated_at > latest)) {
       latest = a.hook_activity_updated_at;
     }
@@ -36,11 +36,11 @@ function mostRecentActivity(agents: Agent[]): string | null {
 }
 
 export const AgentActivitySummary = memo(function AgentActivitySummary({
-  agents,
+  workers,
   pendingPrompts,
   compact,
 }: AgentActivitySummaryProps) {
-  const activeAgents = agents.filter((a) => a.status !== 'stopped');
+  const activeAgents = workers.filter((a) => a.status !== 'stopped');
   const hasPendingPrompts = pendingPrompts && pendingPrompts.length > 0;
   const lastActivity = mostRecentActivity(activeAgents);
 

--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -10,7 +10,7 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import type { Agent, UserTerminal } from '@octomux/types';
+import type { Worker, UserTerminal } from '@octomux/types';
 import { CloseIcon } from '@/components/icons';
 import { StatusGlyph } from '@/components/ui/status-glyph';
 
@@ -23,7 +23,7 @@ import { StatusGlyph } from '@/components/ui/status-glyph';
  * - status=waiting              → awaiting (▲ amber)
  * - status=idle                 → closed (○ grey)
  */
-function agentDisplayStatus(agent: Agent): string {
+function agentDisplayStatus(agent: Worker): string {
   if (agent.status === 'stopped') return 'closed';
   if (agent.status === 'waiting') return 'awaiting';
   if (agent.status === 'idle') return 'closed';
@@ -33,7 +33,7 @@ function agentDisplayStatus(agent: Agent): string {
 }
 
 interface AgentTabsProps {
-  agents: Agent[];
+  agents: Worker[];
   activeIndex: number;
   onSelect: (windowIndex: number) => void;
   onAddAgent: (prompt?: string) => void;
@@ -169,7 +169,7 @@ function AgentTabMenu({
   onDetach,
   onStop,
 }: {
-  agent: Agent;
+  agent: Worker;
   onMove?: (id: string) => void;
   onDetach?: (id: string) => void;
   onStop: (id: string) => void;

--- a/src/components/BoardCard.tsx
+++ b/src/components/BoardCard.tsx
@@ -184,9 +184,9 @@ export const BoardCard = memo(function BoardCard({
         <div className="mt-1.5 flex items-center justify-between gap-2">
           <div className="flex items-center gap-1.5 text-[11px]">
             <RuntimeDot state={task.runtime_state} />
-            {task.runtime_state === 'running' && task.agents && task.agents.length > 0 && (
+            {task.runtime_state === 'running' && task.workers && task.workers.length > 0 && (
               <span className="text-muted-soft">
-                {task.agents.length} agent{task.agents.length !== 1 ? 's' : ''}
+                {task.workers.length} agent{task.workers.length !== 1 ? 's' : ''}
               </span>
             )}
             <TaskDuration task={task} />

--- a/src/components/CommentsSidePanel.tsx
+++ b/src/components/CommentsSidePanel.tsx
@@ -7,14 +7,14 @@ import { timeAgo } from '@/lib/time';
 import { authorLabel } from '@/lib/comment-format';
 import { useCommentsContext } from '@/hooks/useTaskComments';
 import type { InlineCommentWithOutdated } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 
 const ROW_CAP = 500;
 
 type FilterMode = 'all' | 'unresolved' | 'outdated';
 
 export interface CommentsSidePanelProps {
-  agents: Agent[];
+  agents: Worker[];
   /** Files currently in the diff — used to mark "no longer in diff" comments. */
   filesInDiff: Set<string>;
   rangeIsBase: boolean;

--- a/src/components/Composer.test.tsx
+++ b/src/components/Composer.test.tsx
@@ -222,7 +222,7 @@ describe('Composer / submit', () => {
     });
   });
 
-  it('add-agent mode → POST /tasks/:id/agents with prompt, navigates to parent detail', async () => {
+  it('add-agent mode → POST /tasks/:id/workers with prompt, navigates to parent detail', async () => {
     apiMock.addAgent.mockResolvedValueOnce({
       id: 'a1',
       task_id: 't1',

--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -23,7 +23,7 @@ import { cn } from '@/lib/utils';
 import { taskApi } from '@/lib/api/taskApi';
 import type { PreflightResult } from '@/lib/api/taskApi';
 import { useTasksContext } from '@/lib/tasks-context';
-import type { Task, Agent } from '@octomux/types';
+import type { Task, Worker } from '@octomux/types';
 import { NoneModeConflictDialog } from './NoneModeConflictDialog';
 import { NoneModeDirtyDialog } from './NoneModeDirtyDialog';
 import { NoneModeSharedBranchDialog } from './NoneModeSharedBranchDialog';
@@ -34,14 +34,14 @@ async function createChatRequest(body: {
   agent?: string | null;
   prompt?: string;
   harness_id?: string;
-}): Promise<Agent> {
+}): Promise<Worker> {
   const res = await fetch('/api/chats', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`POST /api/chats: ${res.status}`);
-  return (await res.json()) as Agent;
+  return (await res.json()) as Worker;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/components/DiffFileList.tsx
+++ b/src/components/DiffFileList.tsx
@@ -15,7 +15,7 @@ import {
   type DiffRange,
   type FileDiffResponse,
 } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import { getDiffExpanded, setDiffExpanded } from '@/lib/diff-state';
 import { findHunkLine } from '@/lib/diff-hunks';
 import { useScrollSpy } from '@/hooks/useScrollSpy';
@@ -43,7 +43,7 @@ interface Props {
   onToggleReviewed: (path: string) => void;
   onActiveChange?: (path: string | null) => void;
   range?: DiffRange;
-  agents?: Agent[];
+  agents?: Worker[];
   rangeIsBase?: boolean;
   enableComments?: boolean;
   /** When provided, render sticky group-name dividers above each group's files. */

--- a/src/components/DiffFileRow.tsx
+++ b/src/components/DiffFileRow.tsx
@@ -3,7 +3,7 @@ import { Suspense, forwardRef, lazy, useCallback, useMemo, useRef, useState } fr
 import type { DiffOnMount } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import type { DiffFileEntry, FileDiffResponse } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ClampedExplainer } from '@/components/review/ClampedExplainer';
@@ -61,7 +61,7 @@ export interface DiffFileRowProps {
   onToggleExpanded: () => void;
   onEditorMount?: (path: string, ed: editor.IStandaloneDiffEditor) => void;
   /** Agents on the task — used to attribute non-user comments. */
-  agents?: Agent[];
+  agents?: Worker[];
   /** Whether the surrounding diff is showing the base range (controls outdated chip). */
   rangeIsBase?: boolean;
   /** When true, inline comment threads render. Defaults to true if a comments
@@ -302,7 +302,7 @@ function CommentZonePortals({
 }: {
   editor: editor.IStandaloneDiffEditor | null;
   filePath: string;
-  agents: Agent[];
+  agents: Worker[];
   rangeIsBase: boolean;
 }) {
   const ctx = useCommentsContext();

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { taskApi, type DiffFileEntry, type DiffRange } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import {
   getReviewed,
   setReviewed as persistReviewed,
@@ -33,7 +33,7 @@ interface Props {
   /** Opt-in to inline comment threads (uses CommentsContext). When true,
    *  callers must wrap with <CommentsContext.Provider>. */
   enableComments?: boolean;
-  agents?: Agent[];
+  agents?: Worker[];
   /** Notifier fired whenever the list of files in the diff changes. The host
    *  uses this to mark "no longer in diff" comments in the side panel. */
   onFilesChange?: (paths: string[]) => void;

--- a/src/components/InlineCommentThread.tsx
+++ b/src/components/InlineCommentThread.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { InlineCommentWithOutdated } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { timeAgo } from '@/lib/time';
@@ -8,7 +8,7 @@ import { linkify, authorLabel } from '@/lib/comment-format';
 
 export interface InlineCommentThreadProps {
   comments: InlineCommentWithOutdated[];
-  agents: Agent[];
+  agents: Worker[];
   /** Whether the parent surface is showing a non-base diff range. When true, we hide
    *  the outdated chip in favor of a "Posted on commit X" pill. */
   rangeIsBase: boolean;

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -131,11 +131,11 @@ export const TaskCard = memo(function TaskCard({
                 <span className="font-mono text-[#3B82F6]">{task.branch}</span>
               </>
             )}
-            {task.agents && task.agents.length > 0 && (
+            {task.workers && task.workers.length > 0 && (
               <>
                 <span className="text-[#2f2f2f]">|</span>
                 <span className="text-[#6a6a6a]">
-                  {task.agents.length} agent{task.agents.length !== 1 ? 's' : ''}
+                  {task.workers.length} agent{task.workers.length !== 1 ? 's' : ''}
                 </span>
               </>
             )}
@@ -170,9 +170,9 @@ export const TaskCard = memo(function TaskCard({
             </div>
           )}
 
-          {task.agents && task.agents.length > 0 && task.runtime_state === 'running' && (
+          {task.workers && task.workers.length > 0 && task.runtime_state === 'running' && (
             <div className="mt-2">
-              <AgentActivitySummary agents={task.agents} pendingPrompts={task.pending_prompts} />
+              <AgentActivitySummary workers={task.workers} pendingPrompts={task.pending_prompts} />
             </div>
           )}
           {task.pending_prompts && task.pending_prompts.length > 0 && (

--- a/src/components/TaskSettingUpView.tsx
+++ b/src/components/TaskSettingUpView.tsx
@@ -14,7 +14,7 @@ interface Step {
 function buildSteps(task: Task): Step[] {
   const hasWorktree = !!(task.worktree || task.worktree_id);
   const hasTmux = !!task.tmux_session;
-  const firstAgent = task.agents?.[0];
+  const firstAgent = task.workers?.[0];
   const hasAgent = !!firstAgent;
   const hasOutput = firstAgent?.hook_activity === 'active';
 

--- a/src/components/sidebar/chats-section.tsx
+++ b/src/components/sidebar/chats-section.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { taskApi } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import {
   ACTIVE_ACCENT,
   ACTIVE_FILL,
@@ -30,7 +30,7 @@ export function ChatsSection({
   collapsed: boolean;
   activePath: string;
 }) {
-  const [chats, setChats] = useState<Agent[]>([]);
+  const [chats, setChats] = useState<Worker[]>([]);
   const [movingAgentId, setMovingAgentId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -39,7 +39,7 @@ export function ChatsSection({
     try {
       const res = await fetch('/api/chats');
       if (!res.ok) return;
-      const rows = (await res.json()) as Agent[];
+      const rows = (await res.json()) as Worker[];
       setChats(rows);
     } catch {
       // silent

--- a/src/components/task-detail/TaskDetailAgentView.tsx
+++ b/src/components/task-detail/TaskDetailAgentView.tsx
@@ -46,14 +46,14 @@ export function TaskDetailAgentView({
   onMoveDialogClose,
   onMoved,
 }: TaskDetailAgentViewProps) {
-  const agents = task.agents || [];
+  const workers = task.workers || [];
 
   return (
     <div className={mode === 'agents' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}>
       <div className="flex shrink-0 items-center gap-1">
         <div className="min-w-0 flex-1">
           <AgentTabs
-            agents={agents}
+            agents={workers}
             activeIndex={activeWindow ?? 0}
             onSelect={onSelectWindow}
             onAddAgent={onAddAgent}
@@ -66,7 +66,7 @@ export function TaskDetailAgentView({
             onDetachAgent={isRunning ? onDetachAgent : undefined}
           />
         </div>
-        {agents.filter((a) => a.status !== 'stopped').length > 1 && (
+        {workers.filter((a) => a.status !== 'stopped').length > 1 && (
           <Button
             type="button"
             size="xs"
@@ -86,14 +86,14 @@ export function TaskDetailAgentView({
           onOpenChange={(open) => !open && onMoveDialogClose()}
           agentId={movingAgentId}
           currentTaskId={task.id}
-          agentLabel={task.agents?.find((a) => a.id === movingAgentId)?.label}
+          agentLabel={task.workers?.find((a) => a.id === movingAgentId)?.label}
           onMoved={onMoved}
         />
       )}
       {gridView ? (
         <div data-testid="task-agent-grid" className="min-h-0 flex-1 overflow-auto p-2">
           {(() => {
-            const running = agents.filter((a) => a.status !== 'stopped');
+            const running = workers.filter((a) => a.status !== 'stopped');
             const cols = gridColumns(running.length);
             return (
               <div

--- a/src/components/task-detail/TaskDetailDiffView.tsx
+++ b/src/components/task-detail/TaskDetailDiffView.tsx
@@ -7,7 +7,7 @@ import { CommentsSidePanel } from '@/components/CommentsSidePanel';
 import { DiffKeybindCheatSheet } from '@/components/task-detail/DiffKeybindCheatSheet';
 import { CommentsContext } from '@/hooks/useTaskComments';
 import type { DiffRange, DiffSummaryResponse } from '@/lib/api/taskApi';
-import type { Agent, Task } from '@octomux/types';
+import type { Worker, Task } from '@octomux/types';
 import type { DiffFileListHandle } from '@/components/DiffFileList';
 import type { QueuedComment } from '@/hooks/useReviewQueue';
 
@@ -64,7 +64,7 @@ export function TaskDetailDiffView({
   onQueueJumpTo,
   onSendBatch,
 }: TaskDetailDiffViewProps) {
-  const agents: Agent[] = task.agents ?? [];
+  const workers: Worker[] = task.workers ?? [];
 
   return (
     <CommentsContext.Provider value={taskComments}>
@@ -114,13 +114,13 @@ export function TaskDetailDiffView({
               range={range}
               listRef={diffListRef}
               enableComments={true}
-              agents={agents}
+              agents={workers}
               onFilesChange={onFilesChange}
             />
           </div>
           {showCommentsPanel ? (
             <CommentsSidePanel
-              agents={agents}
+              agents={workers}
               filesInDiff={filesInDiffSet}
               rangeIsBase={range.kind === 'base'}
               onJumpTo={onJumpToComment}

--- a/src/hooks/useInlineCommentZones.tsx
+++ b/src/hooks/useInlineCommentZones.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import type { InlineCommentWithOutdated, PostCommentInput } from '@/lib/api/taskApi';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 import { Button } from '@/components/ui/button';
 import { InlineCommentThread } from '@/components/InlineCommentThread';
 
@@ -24,7 +24,7 @@ export interface UseInlineCommentZonesParams {
   editor: MonacoEditor.IStandaloneDiffEditor | null;
   filePath: string;
   comments: InlineCommentWithOutdated[];
-  agents: Agent[];
+  agents: Worker[];
   rangeIsBase: boolean;
   outdatedUnavailable: boolean;
   openComposer: OpenComposer | null;

--- a/src/hooks/useTaskViewMode.ts
+++ b/src/hooks/useTaskViewMode.ts
@@ -66,10 +66,10 @@ export function useTaskViewMode({
     }
   }, [taskId, activeWindow, mode]);
 
-  const firstAgentWindow = task?.agents?.[0]?.window_index ?? null;
+  const firstAgentWindow = task?.workers?.[0]?.window_index ?? null;
   useEffect(() => {
-    if (agentParam && task?.agents) {
-      const agent = task.agents.find((a) => a.id === agentParam);
+    if (agentParam && task?.workers) {
+      const agent = task.workers.find((a) => a.id === agentParam);
       if (agent) {
         setActiveWindow(agent.window_index);
         return;
@@ -78,7 +78,7 @@ export function useTaskViewMode({
     if (activeWindow === null && firstAgentWindow !== null) {
       setActiveWindow(firstAgentWindow);
     }
-  }, [firstAgentWindow, activeWindow, agentParam, task?.agents]);
+  }, [firstAgentWindow, activeWindow, agentParam, task?.workers]);
 
   useEffect(() => {
     if (task && task.runtime_state !== 'running') {

--- a/src/lib/api.test.tsx
+++ b/src/lib/api.test.tsx
@@ -74,7 +74,7 @@ const apiCases = [
   {
     name: 'addAgent with prompt',
     call: () => taskApi.addAgent('t1', { prompt: 'Write tests' }),
-    expectedUrl: '/api/tasks/t1/agents',
+    expectedUrl: '/api/tasks/t1/workers',
     expectedMethod: 'POST',
     expectedBody: JSON.stringify({ prompt: 'Write tests' }),
     response: { id: 'a1' },
@@ -82,7 +82,7 @@ const apiCases = [
   {
     name: 'addAgent without data',
     call: () => taskApi.addAgent('t1'),
-    expectedUrl: '/api/tasks/t1/agents',
+    expectedUrl: '/api/tasks/t1/workers',
     expectedMethod: 'POST',
     expectedBody: JSON.stringify({}),
     response: { id: 'a1' },
@@ -90,7 +90,7 @@ const apiCases = [
   {
     name: 'stopAgent',
     call: () => taskApi.stopAgent('t1', 'a1'),
-    expectedUrl: '/api/tasks/t1/agents/a1',
+    expectedUrl: '/api/tasks/t1/workers/a1',
     expectedMethod: 'DELETE',
     expectedBody: undefined,
     response: undefined,

--- a/src/lib/api/agentsApi.ts
+++ b/src/lib/api/agentsApi.ts
@@ -1,14 +1,14 @@
 /**
  * src/lib/api/agentsApi.ts
  *
- * Agents-feature API surface: CRUD for long-running agent configs plus the
+ * Agents-feature API surface: CRUD for long-running conductor agents plus the
  * derived live status and the endpoint that ensures/opens an agent's
  * persistent conductor session. Mirrors `server/routes/agents-crud.ts`.
  *
- * NAMING: the REST base is `/api/agent-configs`, not `/api/agents` — that path
- * is already taken by agent *role* definitions (`routes/agent-defs.ts`) and the
- * per-task tmux-window worker hop (`routes/chats.ts`). See
- * `plans/2026-07-24-agents-feature.md` ("Naming correction").
+ * The REST base is `/api/agents`. Agent *role* definitions
+ * (orchestrator/planner/reviewer) live at `/api/agent-roles`
+ * (`routes/agent-defs.ts`); the per-task tmux-window worker hop lives at
+ * `/api/workers/:id/task` (`routes/chats.ts`).
  */
 
 import type { OrchestratorConversation } from '../orchestrator-api';
@@ -51,16 +51,15 @@ export interface AgentSession extends OrchestratorConversation {
 }
 
 export const agentsApi = {
-  list: () => request<AgentWithStatus[]>('/agent-configs'),
+  list: () => request<AgentWithStatus[]>('/agents'),
   create: (data: CreateAgentInput) =>
-    request<AgentWithStatus>('/agent-configs', { method: 'POST', body: JSON.stringify(data) }),
-  get: (id: string) => request<AgentWithStatus>(`/agent-configs/${id}`),
+    request<AgentWithStatus>('/agents', { method: 'POST', body: JSON.stringify(data) }),
+  get: (id: string) => request<AgentWithStatus>(`/agents/${id}`),
   update: (id: string, data: UpdateAgentInput) =>
-    request<AgentWithStatus>(`/agent-configs/${id}`, {
+    request<AgentWithStatus>(`/agents/${id}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
-  remove: (id: string) => request<void>(`/agent-configs/${id}`, { method: 'DELETE' }),
-  ensureSession: (id: string) =>
-    request<AgentSession>(`/agent-configs/${id}/session`, { method: 'POST' }),
+  remove: (id: string) => request<void>(`/agents/${id}`, { method: 'DELETE' }),
+  ensureSession: (id: string) => request<AgentSession>(`/agents/${id}/session`, { method: 'POST' }),
 };

--- a/src/lib/api/configApi.ts
+++ b/src/lib/api/configApi.ts
@@ -161,9 +161,10 @@ export const configApi = {
   listSkills: () => request<Skill[]>('/skills'),
   getSkill: (name: string) => request<SkillDetail>(`/skills/${encodeURIComponent(name)}`),
 
-  // Agents
-  listAgents: () => request<AgentDefinition[]>('/agents'),
-  getAgent: (name: string) => request<AgentDetail>(`/agents/${encodeURIComponent(name)}`),
+  // Agent role definitions (orchestrator/planner/reviewer plugin skeletons) —
+  // not to be confused with `agentsApi` (persistent conductor agents, `/api/agents`).
+  listAgents: () => request<AgentDefinition[]>('/agent-roles'),
+  getAgent: (name: string) => request<AgentDetail>(`/agent-roles/${encodeURIComponent(name)}`),
 
   // Repo Config
   listRepoConfigs: () => request<RepoConfig[]>('/repo-configs'),

--- a/src/lib/api/taskApi.ts
+++ b/src/lib/api/taskApi.ts
@@ -263,14 +263,17 @@ export const taskApi = {
   deleteComment: (taskId: string, commentId: string) =>
     request<void>(`/tasks/${taskId}/comments/${commentId}`, { method: 'DELETE' }),
   sendAgentMessage: (taskId: string, agentId: string, message: string) =>
-    request<{ ok: boolean }>(`/tasks/${taskId}/agents/${agentId}/message`, {
+    request<{ ok: boolean }>(`/tasks/${taskId}/workers/${agentId}/message`, {
       method: 'POST',
       body: JSON.stringify({ message }),
     }),
   addAgent: (taskId: string, data?: AddAgentRequest) =>
-    request<Agent>(`/tasks/${taskId}/agents`, { method: 'POST', body: JSON.stringify(data || {}) }),
+    request<Agent>(`/tasks/${taskId}/workers`, {
+      method: 'POST',
+      body: JSON.stringify(data || {}),
+    }),
   stopAgent: (taskId: string, agentId: string) =>
-    request<void>(`/tasks/${taskId}/agents/${agentId}`, { method: 'DELETE' }),
+    request<void>(`/tasks/${taskId}/workers/${agentId}`, { method: 'DELETE' }),
   createUserTerminal: (taskId: string) =>
     request<{ editor: string; windowIndex: number | null }>(`/tasks/${taskId}/user-terminal`, {
       method: 'POST',
@@ -302,9 +305,9 @@ export const taskApi = {
   getTaskHookExecutions: (id: string, limit?: number) =>
     request<HookExecution[]>(`/tasks/${id}/hooks${limit ? `?limit=${limit}` : ''}`),
 
-  // Agent task hopping (runtime agent row ← tasks table)
+  // Worker task hopping (per-task tmux worker row ← tasks table)
   moveAgentToTask: (agentId: string, taskId: string | null) =>
-    request<Agent>(`/agents/${encodeURIComponent(agentId)}/task`, {
+    request<Agent>(`/workers/${encodeURIComponent(agentId)}/task`, {
       method: 'PATCH',
       body: JSON.stringify({ task_id: taskId }),
     }),

--- a/src/lib/api/taskApi.ts
+++ b/src/lib/api/taskApi.ts
@@ -13,7 +13,7 @@ import type {
   CreateTaskRequest,
   UpdateTaskRequest,
   AddAgentRequest,
-  Agent,
+  Worker,
   UserTerminal,
   Worktree,
   WorktreeSummary,
@@ -268,7 +268,7 @@ export const taskApi = {
       body: JSON.stringify({ message }),
     }),
   addAgent: (taskId: string, data?: AddAgentRequest) =>
-    request<Agent>(`/tasks/${taskId}/workers`, {
+    request<Worker>(`/tasks/${taskId}/workers`, {
       method: 'POST',
       body: JSON.stringify(data || {}),
     }),
@@ -307,15 +307,15 @@ export const taskApi = {
 
   // Worker task hopping (per-task tmux worker row ← tasks table)
   moveAgentToTask: (agentId: string, taskId: string | null) =>
-    request<Agent>(`/workers/${encodeURIComponent(agentId)}/task`, {
+    request<Worker>(`/workers/${encodeURIComponent(agentId)}/task`, {
       method: 'PATCH',
       body: JSON.stringify({ task_id: taskId }),
     }),
 
   // Chats (standalone runtime agents)
-  listChats: () => request<Agent[]>('/chats'),
+  listChats: () => request<Worker[]>('/chats'),
   closeChat: (id: string) =>
-    request<Agent>(`/chats/${encodeURIComponent(id)}`, {
+    request<Worker>(`/chats/${encodeURIComponent(id)}`, {
       method: 'PATCH',
       body: JSON.stringify({ status: 'stopped' }),
     }),

--- a/src/lib/comment-format.ts
+++ b/src/lib/comment-format.ts
@@ -1,5 +1,5 @@
 import { createElement, type ReactNode } from 'react';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 
 const URL_RE = /\bhttps?:\/\/[^\s<>"']+/g;
 
@@ -7,7 +7,7 @@ const URL_RE = /\bhttps?:\/\/[^\s<>"']+/g;
  * Display name for a comment author: "You" for the local user (no agent id),
  * otherwise the agent's label (falling back to "agent" if it's gone).
  */
-export function authorLabel(c: { agent_id: string | null }, agents: Agent[]): string {
+export function authorLabel(c: { agent_id: string | null }, agents: Worker[]): string {
   if (c.agent_id == null) return 'You';
   return agents.find((a) => a.id === c.agent_id)?.label ?? 'agent';
 }

--- a/src/lib/use-notifications.test.tsx
+++ b/src/lib/use-notifications.test.tsx
@@ -31,7 +31,7 @@ describe('useNotifications', () => {
         id: 't1',
         title: 'Task one',
         runtime_state: 'running',
-        agents: [
+        workers: [
           makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' }),
         ],
       }),
@@ -49,13 +49,13 @@ describe('useNotifications', () => {
         id: 't1',
         title: 'Task one',
         runtime_state: 'idle',
-        agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
+        workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
       }),
       makeTask({
         id: 't2',
         title: 'Task two',
         runtime_state: 'idle',
-        agents: [makeAgent({ id: 'a2', task_id: 't2', status: 'stopped', hook_activity: 'idle' })],
+        workers: [makeAgent({ id: 'a2', task_id: 't2', status: 'stopped', hook_activity: 'idle' })],
       }),
     ];
     const { rerender } = renderHook(({ t }) => useNotifications(t, navigate), {
@@ -74,13 +74,13 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
     });
     const closed = makeTask({
       id: 't1',
       title: 'Task one',
       runtime_state: 'idle',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
     });
     const { rerender } = renderHook(({ t }) => useNotifications(t, navigate), {
       initialProps: { t: [running] },
@@ -105,14 +105,14 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
     });
     const errored = makeTask({
       id: 't1',
       title: 'Task one',
       runtime_state: 'error',
       error: 'boom',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'stopped', hook_activity: 'idle' })],
     });
     const { rerender } = renderHook(({ t }) => useNotifications(t, navigate), {
       initialProps: { t: [running] },
@@ -131,7 +131,7 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Multi agent',
       runtime_state: 'running',
-      agents: [
+      workers: [
         makeAgent({
           id: 'a1',
           task_id: 't1',
@@ -159,7 +159,7 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Multi agent',
       runtime_state: 'idle',
-      agents: [
+      workers: [
         makeAgent({
           id: 'a1',
           task_id: 't1',
@@ -201,7 +201,7 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [
+      workers: [
         makeAgent({
           id: 'a1',
           task_id: 't1',
@@ -222,7 +222,7 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [
+      workers: [
         makeAgent({
           id: 'a1',
           task_id: 't1',
@@ -256,14 +256,16 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'active' })],
       pending_prompts: [],
     });
     const withPrompt = makeTask({
       id: 't1',
       title: 'Task one',
       runtime_state: 'running',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'waiting' })],
+      workers: [
+        makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'waiting' }),
+      ],
       pending_prompts: [
         {
           id: 'p1',
@@ -303,7 +305,7 @@ describe('useNotifications', () => {
       id: 't1',
       title: 'Stuck task',
       runtime_state: 'idle',
-      agents: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'idle' })],
+      workers: [makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'idle' })],
     });
     const { rerender } = renderHook(({ t }) => useNotifications(t, navigate), {
       initialProps: { t: [stale] },
@@ -324,7 +326,7 @@ describe('useNotifications', () => {
         id: 't1',
         title: 'Task one',
         runtime_state: 'running',
-        agents: [
+        workers: [
           makeAgent({ id: 'a1', task_id: 't1', status: 'running', hook_activity: 'waiting' }),
         ],
         pending_prompts: [

--- a/src/lib/use-notifications.ts
+++ b/src/lib/use-notifications.ts
@@ -1,16 +1,16 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import type { Task, Agent } from '@octomux/types';
+import type { Task, Worker } from '@octomux/types';
 import { showToast } from '../components/CustomToast';
 import { getNotificationsEnabled } from './notification-settings';
 
 interface AgentSnapshot {
-  status: Agent['status'];
-  hookActivity: Agent['hook_activity'];
+  status: Worker['status'];
+  hookActivity: Worker['hook_activity'];
 }
 
 /** Format: "Task Title #1" — extracts number from agent label like "Agent 1". */
-function agentTag(task: Task, agent: Agent): string {
+function agentTag(task: Task, agent: Worker): string {
   const num = agent.label.match(/\d+/)?.[0] ?? '1';
   return `${task.title} #${num}`;
 }
@@ -61,12 +61,12 @@ export function useNotifications(tasks: Task[], navigate: (path: string) => void
 
     for (const task of tasks) {
       currentTaskStates.set(task.id, task.runtime_state);
-      if (!task.agents) continue;
+      if (!task.workers) continue;
 
       const isViewing = task.id === viewingTaskId;
       const suppressAgentToasts = taskTransitioning.has(task.id);
 
-      for (const agent of task.agents) {
+      for (const agent of task.workers) {
         currentAgents.set(agent.id, {
           status: agent.status,
           hookActivity: agent.hook_activity,
@@ -110,7 +110,7 @@ export function useNotifications(tasks: Task[], navigate: (path: string) => void
             notifiedPrompts.current.add(prompt.id);
             const taskId = task.id;
             const agentId = prompt.agent_id;
-            const promptAgent = task.agents?.find((a) => a.id === prompt.agent_id);
+            const promptAgent = task.workers?.find((a) => a.id === prompt.agent_id);
             const promptTag = promptAgent ? agentTag(task, promptAgent) : `${task.title} #?`;
             showToast('warning', promptTag, `Needs permission: ${prompt.tool_name}`, {
               label: 'View',

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import type { Agent } from '@octomux/types';
+import type { Worker } from '@octomux/types';
 
 const TerminalView = lazy(() =>
   import('@/components/TerminalView').then((m) => ({ default: m.TerminalView })),
@@ -8,7 +8,7 @@ const TerminalView = lazy(() =>
 
 export default function ChatPage() {
   const { id } = useParams<{ id: string }>();
-  const [chat, setChat] = useState<Agent | null>(null);
+  const [chat, setChat] = useState<Worker | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -16,7 +16,7 @@ export default function ChatPage() {
     let cancelled = false;
     fetch(`/api/chats/${id}`)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
-      .then((data: Agent) => {
+      .then((data: Worker) => {
         if (!cancelled) setChat(data);
       })
       .catch((e: Error) => {

--- a/src/pages/GridMonitor.test.tsx
+++ b/src/pages/GridMonitor.test.tsx
@@ -55,7 +55,7 @@ describe('flattenRunningAgents', () => {
       makeTask({
         id: 't1',
         runtime_state: 'running',
-        agents: [
+        workers: [
           makeAgent({ id: 'a1', task_id: 't1', window_index: 0, label: 'Agent A' }),
           makeAgent({
             id: 'a2',
@@ -69,7 +69,7 @@ describe('flattenRunningAgents', () => {
       makeTask({
         id: 't2',
         runtime_state: 'idle',
-        agents: [makeAgent({ id: 'a3', task_id: 't2', window_index: 0 })],
+        workers: [makeAgent({ id: 'a3', task_id: 't2', window_index: 0 })],
       }),
     ]);
     expect(flat).toHaveLength(1);
@@ -82,7 +82,7 @@ describe('flattenRunningAgents', () => {
       makeTask({
         id: 't1',
         runtime_state: 'setting_up',
-        agents: [makeAgent({ id: 'a1', task_id: 't1', window_index: 0 })],
+        workers: [makeAgent({ id: 'a1', task_id: 't1', window_index: 0 })],
       }),
     ]);
     expect(flat).toHaveLength(1);
@@ -106,7 +106,7 @@ describe('GridMonitor page', () => {
         id: 't-a',
         title: 'Task A',
         runtime_state: 'running',
-        agents: [
+        workers: [
           makeAgent({ id: 'a-0', task_id: 't-a', window_index: 0, label: 'A0' }),
           makeAgent({ id: 'a-1', task_id: 't-a', window_index: 1, label: 'A1' }),
         ],
@@ -115,7 +115,7 @@ describe('GridMonitor page', () => {
         id: 't-b',
         title: 'Task B',
         runtime_state: 'running',
-        agents: [makeAgent({ id: 'b-0', task_id: 't-b', window_index: 0, label: 'B0' })],
+        workers: [makeAgent({ id: 'b-0', task_id: 't-b', window_index: 0, label: 'B0' })],
       }),
     ]);
     renderWithRouter(<GridMonitor />);
@@ -134,14 +134,14 @@ describe('GridMonitor page', () => {
         makeTask({
           id: 't1',
           runtime_state: 'running',
-          agents: [makeAgent({ id: 'a1', task_id: 't1', window_index: 0 })],
+          workers: [makeAgent({ id: 'a1', task_id: 't1', window_index: 0 })],
         }),
       ])
       .mockResolvedValue([
         makeTask({
           id: 't1',
           runtime_state: 'running',
-          agents: [
+          workers: [
             makeAgent({ id: 'a1', task_id: 't1', window_index: 0 }),
             makeAgent({ id: 'a2', task_id: 't1', window_index: 1, label: 'Agent B' }),
           ],

--- a/src/pages/GridMonitor.tsx
+++ b/src/pages/GridMonitor.tsx
@@ -31,7 +31,7 @@ export function flattenRunningAgents(tasks: Task[]): FlatAgent[] {
   const out: FlatAgent[] = [];
   for (const task of tasks) {
     if (task.runtime_state !== 'running' && task.runtime_state !== 'setting_up') continue;
-    for (const agent of task.agents ?? []) {
+    for (const agent of task.workers ?? []) {
       if (agent.status === 'stopped') continue;
       out.push({
         key: `${task.id}:${agent.window_index}`,

--- a/src/pages/LoopDetailPage.tsx
+++ b/src/pages/LoopDetailPage.tsx
@@ -51,7 +51,7 @@ export default function LoopDetailPage() {
     }
   };
 
-  const activeAgent = task?.agents?.find((a) => a.status !== 'stopped') ?? null;
+  const activeAgent = task?.workers?.find((a) => a.status !== 'stopped') ?? null;
 
   return (
     <div className="flex h-full min-h-0 flex-col p-6">

--- a/src/pages/TaskDetail.terminal-cache.test.tsx
+++ b/src/pages/TaskDetail.terminal-cache.test.tsx
@@ -57,13 +57,13 @@ const taskA = makeTask({
   id: 'task-A',
   title: 'Task A',
   tmux_session: 'octomux-agent-task-A',
-  agents: [makeAgent({ id: 'a-A', task_id: 'task-A', window_index: 0 })],
+  workers: [makeAgent({ id: 'a-A', task_id: 'task-A', window_index: 0 })],
 });
 const taskB = makeTask({
   id: 'task-B',
   title: 'Task B',
   tmux_session: 'octomux-agent-task-B',
-  agents: [makeAgent({ id: 'a-B', task_id: 'task-B', window_index: 0 })],
+  workers: [makeAgent({ id: 'a-B', task_id: 'task-B', window_index: 0 })],
 });
 
 // Helper child that captures the real router-bound navigate so the test can

--- a/src/pages/TaskDetail.test.tsx
+++ b/src/pages/TaskDetail.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@monaco-editor/react', () => ({
 const runningTask: Task = makeTask({
   runtime_state: 'running',
   tmux_session: 'octomux-agent-test-task-01',
-  agents: [makeAgent({ id: 'a1' })],
+  workers: [makeAgent({ id: 'a1' })],
 });
 
 describe('TaskDetail', () => {
@@ -202,7 +202,7 @@ describe('TaskDetail', () => {
   // ─── Draft task controls ────────────────────────────────────────────────
 
   it('shows Start button for draft task', async () => {
-    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', agents: [] }));
+    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', workers: [] }));
     renderDetail();
     await waitFor(() => {
       // Header has a Start button, edit form also has one
@@ -213,7 +213,7 @@ describe('TaskDetail', () => {
 
   it('clicking Start calls startTask', async () => {
     const user = userEvent.setup();
-    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', agents: [] }));
+    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', workers: [] }));
     renderDetail();
     await waitFor(() => {
       expect(screen.getAllByText('Start').length).toBeGreaterThanOrEqual(1);
@@ -230,7 +230,7 @@ describe('TaskDetail', () => {
   const nonRunningStates = ['idle', 'error'] as const;
 
   it.each(nonRunningStates)('hides Close button when runtime_state is "%s"', async (state) => {
-    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: state, agents: [] }));
+    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: state, workers: [] }));
     renderDetail();
     await waitFor(() => {
       expect(screen.getByText('Fix order validation')).toBeInTheDocument();
@@ -257,7 +257,7 @@ describe('TaskDetail', () => {
   });
 
   it('shows edit form when task is draft', async () => {
-    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', agents: [] }));
+    apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'idle', workers: [] }));
     renderDetail();
     await waitFor(() => {
       expect(screen.getByLabelText('Title')).toBeInTheDocument();
@@ -268,7 +268,7 @@ describe('TaskDetail', () => {
   it('shows "Terminal session ended" message for closed task without agents', async () => {
     apiMock.getTask.mockResolvedValue(
       // initial_prompt set → not a draft, just a closed task with no active terminal
-      makeTask({ runtime_state: 'idle', tmux_session: null, agents: [], initial_prompt: 'do it' }),
+      makeTask({ runtime_state: 'idle', tmux_session: null, workers: [], initial_prompt: 'do it' }),
     );
     renderDetail();
     await waitFor(() => {
@@ -337,7 +337,7 @@ describe('TaskDetail', () => {
         runtime_state: 'idle',
         branch: null,
         worktree: null,
-        agents: [],
+        workers: [],
       }),
     );
     renderDetail();
@@ -388,7 +388,7 @@ describe('TaskDetail', () => {
 
   it('renders setting_up checklist when status=setting_up and no terminal yet', async () => {
     apiMock.getTask.mockResolvedValue(
-      makeTask({ runtime_state: 'setting_up', agents: [], tmux_session: null }),
+      makeTask({ runtime_state: 'setting_up', workers: [], tmux_session: null }),
     );
     renderDetail();
     await waitFor(() => {
@@ -411,7 +411,7 @@ describe('TaskDetail', () => {
     const noEditorStates = ['idle', 'setting_up', 'error'] as const;
 
     it.each(noEditorStates)('hides Editor button when runtime_state is "%s"', async (state) => {
-      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: state, agents: [] }));
+      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: state, workers: [] }));
       renderDetail();
       await waitFor(() => {
         expect(screen.getByText('Fix order validation')).toBeInTheDocument();
@@ -463,7 +463,7 @@ describe('TaskDetail', () => {
         expect(apiMock.createUserTerminal).toHaveBeenCalledTimes(1);
       });
 
-      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'setting_up', agents: [] }));
+      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'setting_up', workers: [] }));
       simulateEvent();
       await waitFor(() => {
         expect(screen.getByTestId('task-setting-up')).toBeInTheDocument();
@@ -592,7 +592,7 @@ describe('TaskDetail', () => {
         expect(apiMock.createUserTerminal).toHaveBeenCalled();
       });
 
-      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'setting_up', agents: [] }));
+      apiMock.getTask.mockResolvedValue(makeTask({ runtime_state: 'setting_up', workers: [] }));
       simulateEvent();
       await waitFor(() => {
         expect(screen.getByTestId('task-setting-up')).toBeInTheDocument();
@@ -606,7 +606,7 @@ describe('TaskDetail', () => {
     const taskWithTerminals = makeTask({
       runtime_state: 'running',
       tmux_session: 'octomux-agent-test-task-01',
-      agents: [makeAgent({ id: 'a1' })],
+      workers: [makeAgent({ id: 'a1' })],
       user_terminals: [
         {
           id: 'term-1',
@@ -698,7 +698,7 @@ describe('TaskDetail', () => {
           makeTask({
             run_mode: mode,
             runtime_state: 'running',
-            agents: [makeAgent({ id: 'a1' })],
+            workers: [makeAgent({ id: 'a1' })],
             branch: mode === 'scratch' ? null : 'agents/test-task-01',
             repo_path: mode === 'scratch' ? '' : '/Users/dev/projects/my-repo',
           }),
@@ -726,7 +726,7 @@ describe('TaskDetail', () => {
           run_mode: 'none',
           runtime_state: 'running',
           branch: 'feat/inplace',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       renderDetail();
@@ -741,7 +741,7 @@ describe('TaskDetail', () => {
           run_mode: 'existing',
           runtime_state: 'running',
           branch: 'feat/existing',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       renderDetail();
@@ -755,7 +755,7 @@ describe('TaskDetail', () => {
         makeTask({
           run_mode: 'scratch',
           runtime_state: 'running',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
           pr_url: 'https://github.com/org/repo/pull/99',
           pr_number: 99,
         }),
@@ -772,7 +772,7 @@ describe('TaskDetail', () => {
         makeTask({
           run_mode: undefined as unknown as 'new',
           runtime_state: 'running',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       renderDetail();
@@ -843,7 +843,7 @@ describe('TaskDetail', () => {
           runtime_state: 'running',
           worktree: '/tmp/wt',
           base_branch: 'main',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       apiMock.getTaskDiffSummary.mockResolvedValue(makeDiffSummary());
@@ -867,7 +867,7 @@ describe('TaskDetail', () => {
           runtime_state: 'running',
           worktree: '/tmp/wt',
           base_branch: 'main',
-          agents: [makeAgent({ id: 'agent-99', window_index: 0, status: 'running' })],
+          workers: [makeAgent({ id: 'agent-99', window_index: 0, status: 'running' })],
         }),
       );
       apiMock.getTaskDiffSummary.mockResolvedValue(makeDiffSummary());
@@ -927,7 +927,7 @@ describe('TaskDetail', () => {
           runtime_state: 'running',
           worktree: '/tmp/wt',
           base_branch: 'main',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       apiMock.getTaskDiffSummary.mockResolvedValue(makeDiffSummary({ base_is_stale: true }));
@@ -947,7 +947,7 @@ describe('TaskDetail', () => {
           runtime_state: 'running',
           worktree: '/tmp/wt',
           base_branch: 'main',
-          agents: [makeAgent({ id: 'a1' })],
+          workers: [makeAgent({ id: 'a1' })],
         }),
       );
       apiMock.getTaskDiffSummary.mockResolvedValue(makeDiffSummary());

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -50,10 +50,10 @@ export default function TaskDetail() {
 
   const validWindowIndexes = useMemo(() => {
     const s = new Set<number>();
-    for (const a of task?.agents || []) s.add(a.window_index);
+    for (const a of task?.workers || []) s.add(a.window_index);
     for (const t of task?.user_terminals || []) s.add(t.window_index);
     return s;
-  }, [task?.agents, task?.user_terminals]);
+  }, [task?.workers, task?.user_terminals]);
 
   const { terminalLRU } = useTerminalCache({ taskId, activeWindow, validWindowIndexes });
 
@@ -65,13 +65,13 @@ export default function TaskDetail() {
   const { reviewQueue, taskComments } = useTaskDetailComments({ taskId });
 
   const activeAgentId = useMemo(() => {
-    const ags = task?.agents ?? [];
+    const ags = task?.workers ?? [];
     if (activeWindow !== null) {
       const a = ags.find((x) => x.window_index === activeWindow && x.status !== 'stopped');
       if (a) return a.id;
     }
     return ags.find((x) => x.status !== 'stopped')?.id ?? null;
-  }, [task?.agents, activeWindow]);
+  }, [task?.workers, activeWindow]);
 
   const isDiffMode = mode === 'diff';
   const diffState = useDiffState({
@@ -135,7 +135,7 @@ export default function TaskDetail() {
     async (agentId: string) => {
       if (!taskId) return;
       try {
-        const taskAgents = task?.agents || [];
+        const taskAgents = task?.workers || [];
         const stoppedAgent = taskAgents.find((a) => a.id === agentId);
         await taskApi.stopAgent(taskId, agentId);
         if (stoppedAgent && stoppedAgent.window_index === activeWindow) {
@@ -214,7 +214,7 @@ export default function TaskDetail() {
         const closedTerminal = terminals.find((t) => t.id === terminalId);
         await taskApi.closeTerminal(taskId, terminalId);
         if (closedTerminal && closedTerminal.window_index === activeWindow) {
-          const agents = task?.agents || [];
+          const agents = task?.workers || [];
           const runningAgent = agents.find((a) => a.status !== 'stopped');
           const otherTerminal = terminals.find((t) => t.id !== terminalId);
           setActiveWindow(runningAgent?.window_index ?? otherTerminal?.window_index ?? null);
@@ -246,7 +246,7 @@ export default function TaskDetail() {
     );
   }
 
-  const agents = task.agents || [];
+  const agents = task.workers || [];
   const isRunning = task.runtime_state === 'running';
   const isDraft = task.runtime_state === 'idle' && !task.initial_prompt;
   const canResume =

--- a/src/test-helpers.tsx
+++ b/src/test-helpers.tsx
@@ -1,7 +1,7 @@
 import { render, type RenderOptions } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import type { ReactElement } from 'react';
-import type { Task, Agent } from '@octomux/types';
+import type { Task, Worker } from '@octomux/types';
 import {
   FRONTEND_AGENT_DEFAULTS,
   FRONTEND_TASK_DEFAULTS,
@@ -14,7 +14,7 @@ import {
 export const AGENT_DEFAULTS = FRONTEND_AGENT_DEFAULTS;
 export const TASK_DEFAULTS = FRONTEND_TASK_DEFAULTS;
 
-export function makeAgent(overrides: Partial<Agent> = {}): Agent {
+export function makeAgent(overrides: Partial<Worker> = {}): Worker {
   return makeAgentFixture(overrides);
 }
 


### PR DESCRIPTION
Follows #231 (merged). Renames the two overloaded tables and the routes that collided.
## Why

"Agent" meant three different things, and `server/routes/agents-crud.ts` opened with a
14-line comment apologising for the resulting route collision.

| Concept | Table | Route (before) | Route (after) |
| --- | --- | --- | --- |
| per-task tmux worker | `agents` -> `workers` | `/api/tasks/:id/agents` | `/api/workers`, `/api/tasks/:id/workers` |
| persistent conductor agent | `agent_configs` -> `agents` | `/api/agent-configs` | `/api/agents` |
| agent *role* definition | none (plugin files) | `/api/agents` | `/api/agent-roles` |

## ⚠️ Breaking: REST paths change

`/api/agent-configs` becomes `/api/agents`, and the role-definitions endpoint moves from
`/api/agents` to `/api/agent-roles`. Everything inside this repo is updated; **anything
outside it — scripts, bookmarks, external tooling — must be updated by hand.**

## Migration safety

Rename order is **mandatory**: `agents` -> `workers` first, then `agent_configs` -> `agents`.
Reversed, step 2 collides with the still-existing table and errors loudly rather than
corrupting silently.

SQLite 3.53.1 with `legacy_alter_table = 0` rewrites dependent `REFERENCES` clauses
automatically — verified empirically in a scratch script before relying on it:

| FK | Follows | Lands on |
| --- | --- | --- |
| `task_updates.agent_id` | the worker table | `workers(id)` |
| `permission_prompts.agent_id` | the worker table | `workers(id)` |
| `orchestrator_conversations.agent_id` | `agent_configs` | `agents(id)` |

**Ordering trap (the subtle one):** `renameAgentWorkerTables()` runs in `initDb()` *before*
`SCHEMA` executes. `SCHEMA` declares `workers` directly, so running the rename only inside
`runMigrations` would let `CREATE TABLE IF NOT EXISTS workers` create an empty placeholder
ahead of the rename on any un-migrated install — silently orphaning every worker row. Step 2
is additionally conditional on `agent_configs` existing, for databases old enough to predate it.

**Verified against a copy of a production database** (the original was never written to):

```
BEFORE  tables: agent_configs, agents   agents: 21   agent_configs: 2
AFTER   tables: agents, workers         workers: 21  agents: 2
        worker ids identical:           true
        task_updates.agent_id            -> workers
        permission_prompts.agent_id      -> workers
        orchestrator_conversations.agent_id -> agents
        foreign_key_check:              []
2nd boot: no-op, counts and FKs unchanged
```

## Deliberately not renamed

User-facing contracts, left alone on purpose: the `octomux add-agent` CLI command, the
`/octomux:add-agent` and `send-agent-message` skills, `plugin/agents/*.md`, and MCP tool
names such as `add_agent`.

The `Agent` TypeScript type and the `task.agents` wire field also stay — renaming them
cascades through `packages/api-client` and every frontend component for no functional gain.
**This does leave a residual inconsistency**: `/api/workers` returns objects that still
appear under a `task.agents` field. Worth a follow-up if it bothers you; it is cosmetic.

## Also included

- **Test-determinism fix.** Two assertions in `api.test.ts` read `mock.calls[0]` — the first
  call *ever* recorded on the mock — while `beforeEach` runs `restoreAllMocks` (spies) rather
  than `clearAllMocks`, so history can carry over from an earlier test in the file. Switched
  to `mock.lastCall`.
- **`CLAUDE.md` refresh** covering the three meanings of "agent", the mandatory rename order,
  the `initDb` ordering constraint, plus the kinds-as-presets model and single-source skills
  delivery from #231.

## Verification

```
tsc -b        clean
vitest        359 files, 4210 tests, 0 failures (7 consecutive full runs)
eslint        0 errors
prettier      clean
```

## Known issue, not introduced here

Three *different* intermittent test failures surfaced during this work, each passing in
isolation and in repeated runs. Two had identifiable determinism bugs and are fixed (the
learnings `ORDER BY` in #231, and `mock.calls[0]` here). A third — `api.comments.test.ts`
"captures learning when rejection_why provided" — failed once and did not reproduce across
seven subsequent full runs. The capture path is a synchronous better-sqlite3 call, so it is
not a write race; I could not isolate it. Flagging rather than burying it: it may bite CI.
