### PR TITLE
docs: fix doc drift 2026-07-27

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
   - `schedules/cron.ts` — `isCronDue()`, the 5-field cron evaluator (`croner`, UTC) behind
     scheduled runs. Rows live in the `schedules` table; `poller/schedule-cron.ts` fires them.
 - `src/` — React SPA (pages, components, lib/api.ts)
+  - `workflows/` — front-end workflow-UI registry mirroring `server/workflows/`.
+    `registerWorkflowUI(kind, { navLabel, icon, ListView, DetailView })` (`loops/register.tsx`)
+    backs the generic `/w/:kind/:id` route; a kind that registers `getItem` + `outputSchema`
+    instead of a `DetailView` falls back to the schema-driven `DefaultDetailView`.
 - `cli/` — CLI tool; one file per subcommand in `cli/src/commands/` (create-task, list-tasks,
   get-task, close-task, resume-task, delete-task, add-agent, send-message, stop-agent, init,
   emit, loop-start, loop-start-group, learn/recall/unlearn, post-review,
@@ -134,7 +138,8 @@ octomux emit --run <loop-run-id> --status done|blocked|needs_human --reason "<wh
   `max_iterations`, `budget` (tokens/time), `no_progress` (`--stall-after` N no-op iterations).
 - Each iteration appends to a curated playbook in the worktree so the next fresh context sees
   what earlier ones tried.
-- UI at `/loops`, `/loops/:id`; REST in `server/routes/loops.ts`.
+- UI at `/loops` (list) and `/w/loops/:id` (detail, via the workflow-UI registry); `/loops/:id`
+  is a legacy redirect. REST in `server/routes/loops.ts`.
 - Spec: `spec/workflow-framework.md`; plans: `plans/2026-07-12-loop-harness-*.md`.
 
 ### Learnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,14 @@ server/           Express backend (API, terminal streaming, task lifecycle, DB)
   routes/         one module per REST surface (tasks, diffs, reviews, loops, …)
   task-engine/    worktree + tmux + harness lifecycle (cleanup.ts: closeTask, deleteTask)
   harnesses/      pluggable agent backends (claude-code.ts, cursor.ts)
+  workflows/      workflow kinds (loops, reviewer, doc-drift, …) + kind presets
+  schedules/      cron.ts — isCronDue(), the 5-field cron evaluator behind schedules
   poller/         background pollers (PR detection, merged-PR close, hooks, schedules)
   db.ts           SQLite singleton with getDb() / setDb() / initDb()
   db/             schema.ts + forward-only migrations.ts
   types.ts        re-exports @octomux/types + review-orchestrator types
 src/              React SPA (pages, components, lib/api.ts)
+  workflows/      front-end workflow-UI registry behind the /w/:kind/:id route
 cli/              CLI tool for task management
 packages/         bun workspaces: types, diff-engine, api-client, test-fixtures
 electron/         macOS desktop shell

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -52,7 +52,7 @@ octomux create-task -t "Spike UI" -r . --harness cursor  # Cursor CLI
 
 **Per-agent mix:** on a running task, **Add agent** can attach a second window under either harness (e.g. Claude plans, Cursor implements).
 
-Custom agent personas live under **Settings → Agents** (`.md` files). Claude uses them via `--agent`; Cursor gets matching rules under each worktree’s `.cursor/rules/`.
+Agent role definitions (orchestrator, planner, reviewer) ship in octomux's bundled plugin and reach both harnesses via `--plugin-dir` — there is no repo or home tier to edit. Your own skills and subagents go in Claude Code's native `~/.claude/skills/`, `~/.claude/agents/`, or `<repo>/.claude/`, which the harness reads directly and octomux does not manage.
 
 ## 4. GitHub CLI (optional)
 
@@ -108,11 +108,10 @@ Draft first if you want to edit title, prompt, and branch before agents start �
 | `./data/tasks.db`             | Task state (development)                                |
 | `~/.octomux/logs/`            | Server + hook logs                                      |
 | `~/.octomux/hooks/<event>.d/` | Lifecycle hooks                                         |
-| `~/.octomux/agents/`          | Custom agent definitions (Claude + Cursor)              |
-| `~/.claude/skills/`           | Skills installed for Claude Code                        |
+| `~/.claude/skills/`           | Your own Claude Code skills (read by the harness)       |
+| `~/.claude/workflows/`        | Review workflow scripts installed by `octomux init`     |
 | `<repo>/.worktrees/<task-id>` | Per-task git worktree                                   |
 | `<worktree>/.octomux-hooks/`  | Cursor hook bridge (Cursor tasks)                       |
-| `<worktree>/.cursor/rules/`   | Cursor rules synced from agent definitions              |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each screen is a lens over one managed agent backend:
 - **Monitor grid** — every running agent's terminal tiled into one live wall; spot the stuck one instantly.
 - **Orchestrator view** — watch an agent that dispatches agents: the parent planning, its children coding, who's blocked — the whole tree at once.
 - **Review workstation** — an agent drafts a walkthrough + inline comments (grounded against the real diff, no invented line numbers); nothing hits GitHub until you accept it, then it posts as one batched review. Reject a comment with a reason and it remembers for next time.
-- **Chats, Workspaces, skill & agent editing** — detach a quick spike as its own session, manage the reusable worktrees behind your tasks, and author your Claude Code skills and subagents from **Settings** in the browser.
+- **Chats, Workspaces, persistent agents** — detach a quick spike as its own session, manage the reusable worktrees behind your tasks, and keep long-lived agents (own system prompt, optional Telegram/Slack channel) on **Agents**.
 - **Loops** — hand a task a prompt plus a verify command and it re-runs itself in fresh context until verify passes; `/loops` shows the iteration ledger, what each pass changed, and the stop controls. Fan out N competing candidates from one prompt when you want options.
 - **Schedules** — run a task on a cron from `/schedules` (nightly triage, a weekly digest) instead of remembering to kick it off.
 - **Worktrees keep agents off each other** — five agents can edit `auth.ts` at once without conflicts on your main tree.


### PR DESCRIPTION
Scheduled doc-drift pass. Branch was cut from `main` (165 commits behind `next`) — merged `origin/next` first so nothing here re-fixes drift `next` already fixed.

## Drift found and fixed

| Doc | Claim | Reality |
| --- | --- | --- |
| README.md:50 | "author your Claude Code skills and subagents from **Settings**" | `server/routes/skills.ts` is GET-only and `src/pages/SkillEditor.tsx` is deleted — no skill authoring UI. `/agents` is a top-level nav item for persistent conductor agents (name + system_prompt + optional Telegram/Slack channel), not Settings. |
| ONBOARDING.md:55 | agent personas under Settings → Agents as `.md`, Claude uses `--agent`, Cursor gets `.cursor/rules/` | No `--agent` flag in `server/harnesses/claude-code.ts`; roles ship via `--plugin-dir`. `.cursor/rules` is written nowhere. |
| ONBOARDING.md:111 | `~/.octomux/agents/` — custom agent definitions | Tier removed; `server/octomux-paths.ts:17-29` documents why (`syncAgents()` is a no-op in both harnesses, so the tier was REST-visible but invisible to every agent). |
| ONBOARDING.md:112 | `~/.claude/skills/` — "Skills installed for Claude Code" | `installSkills()` in `bin/octomux.js:240` copies from `<pkg>/skills`, which does not exist and is not in `package.json` `files` — it always returns early. That path only holds *your own* skills. Added the `~/.claude/workflows/` row, which `octomux init` really does populate. |
| ONBOARDING.md:115 | `<worktree>/.cursor/rules/` synced from agent definitions | Never written — `cursor.ts:153 syncAgents()` is a no-op. |
| CLAUDE.md:137 | "UI at `/loops`, `/loops/:id`" | `src/App.tsx:37-40,129` — `/loops/:id` now redirects to `/w/loops/:id`. |
| CLAUDE.md / CONTRIBUTING.md | — | `src/workflows/` (front-end workflow-UI registry behind `/w/:kind/:id`) and `server/workflows/` were undocumented top-level surface. Added a line each. |

## Noted, not fixed (code, not docs)

- `installSkills()` in `bin/octomux.js:239-270` is dead — its source dir `<pkg>/skills` does not exist and is not shipped. Worth deleting, but out of scope for a docs PR.
- `src/pages/SettingsPage.tsx:628` still tells users octomux "mirrors Settings → Agents into .cursor/rules". Same stale claim as ONBOARDING.md:115, but it is UI copy rather than a doc file.

## Verified clean

`prettier --check` passes on all four files. Every other documented path, npm script, CLI subcommand (checked against the `register*(program)` list in `cli/src/index.ts`, not `cli/dist`), SPA route, env var (`OCTOMUX_DATA_DIR`, `OCTOMUX_BIND`, `OCTOMUX_REMOTE_TOKEN`, `OCTOMUX_GITHUB_LOGIN`), spec, and plan file referenced in README/CLAUDE.md/CONTRIBUTING.md/ONBOARDING.md still resolves.