### PR TITLE
fix(harness): remove hook config on teardown of user-owned paths

### DIFF
--- a/server/agent-session/session.test.ts
+++ b/server/agent-session/session.test.ts
@@ -79,6 +79,7 @@ function makeStubHarness(): Harness {
     buildResumeCommand: vi.fn().mockReturnValue('stub-resume'),
     buildContinueCommand: vi.fn().mockReturnValue(null),
     installHooks: vi.fn().mockResolvedValue(undefined),
+    uninstallHooks: vi.fn().mockResolvedValue(undefined),
     syncAgents: vi.fn().mockResolvedValue(undefined),
     resolveFlags: vi.fn().mockReturnValue(''),
     validateSettings: vi.fn().mockReturnValue({}),

--- a/server/harnesses/claude-code.test.ts
+++ b/server/harnesses/claude-code.test.ts
@@ -132,6 +132,44 @@ describe('claudeCodeHarness.installHooks', () => {
     expect(written.permissions.allow).toContain('Bash(git diff:*)');
   });
 
+  it("uninstallHooks strips our hooks but keeps the user's hooks and permissions", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
+    await claudeCodeHarness.installHooks(tmp, 'http://127.0.0.1:7777', 'tok-abc');
+
+    const settingsPath = path.join(tmp, '.claude', 'settings.local.json');
+    const withUserHook = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    withUserHook.hooks.Stop.push({ hooks: [{ type: 'command', command: 'say done' }] });
+    withUserHook.hooks.PreToolUse = [{ hooks: [{ type: 'command', command: 'lint' }] }];
+    fs.writeFileSync(settingsPath, JSON.stringify(withUserHook), 'utf-8');
+
+    await claudeCodeHarness.uninstallHooks(tmp);
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    expect(JSON.stringify(after)).not.toContain('/api/hooks/');
+    expect(after.hooks.Stop).toEqual([{ hooks: [{ type: 'command', command: 'say done' }] }]);
+    expect(after.hooks.PreToolUse).toHaveLength(1);
+    expect(after.hooks.UserPromptSubmit).toBeUndefined();
+    expect(after.permissions.allow).toContain('Bash(git diff:*)');
+  });
+
+  it('uninstallHooks drops the hooks key entirely when only ours were there', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
+    await claudeCodeHarness.installHooks(tmp, 'http://127.0.0.1:7777', 'tok-abc');
+    await claudeCodeHarness.uninstallHooks(tmp);
+
+    const after = JSON.parse(
+      fs.readFileSync(path.join(tmp, '.claude', 'settings.local.json'), 'utf-8'),
+    );
+    expect(after.hooks).toBeUndefined();
+    expect(after.permissions.deny).toContain('Bash(rm -rf:*)');
+  });
+
+  it('uninstallHooks is a no-op when there is no settings file', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
+    await expect(claudeCodeHarness.uninstallHooks(tmp)).resolves.toBeUndefined();
+    expect(fs.existsSync(path.join(tmp, '.claude', 'settings.local.json'))).toBe(false);
+  });
+
   it('uri-encodes the token', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-harness-'));
     await claudeCodeHarness.installHooks(tmp, 'http://127.0.0.1:7777', 'tok&special=value');

--- a/server/harnesses/claude-code.ts
+++ b/server/harnesses/claude-code.ts
@@ -88,6 +88,54 @@ export const claudeCodeHarness: Harness = {
     writeJsonConfig(settingsPath, merged);
   },
 
+  async uninstallHooks(dirPath: string) {
+    const settingsPath = path.join(dirPath, '.claude', 'settings.local.json');
+
+    let existing: Record<string, unknown>;
+    try {
+      existing = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    } catch {
+      return; // no config (or unparseable) — nothing to clean
+    }
+    if (typeof existing !== 'object' || existing === null || Array.isArray(existing)) return;
+    if (
+      typeof existing.hooks !== 'object' ||
+      existing.hooks === null ||
+      Array.isArray(existing.hooks)
+    ) {
+      return;
+    }
+
+    // Strip only OUR entries (url contains /api/hooks/); the user's own hooks,
+    // and their permissions, stay untouched.
+    const hooks: Record<string, unknown> = {};
+    for (const [event, matchers] of Object.entries(existing.hooks as Record<string, unknown>)) {
+      if (!Array.isArray(matchers)) {
+        hooks[event] = matchers;
+        continue;
+      }
+      const kept = matchers
+        .map((m) => {
+          const inner = (m as { hooks?: unknown })?.hooks;
+          if (!Array.isArray(inner)) return m;
+          const keptInner = inner.filter(
+            (h) => !String((h as { url?: unknown })?.url ?? '').includes('/api/hooks/'),
+          );
+          return keptInner.length === inner.length ? m : { ...(m as object), hooks: keptInner };
+        })
+        .filter((m) => {
+          const inner = (m as { hooks?: unknown })?.hooks;
+          return !Array.isArray(inner) || inner.length > 0;
+        });
+      if (kept.length > 0) hooks[event] = kept;
+    }
+
+    const next: Record<string, unknown> = { ...existing };
+    if (Object.keys(hooks).length > 0) next.hooks = hooks;
+    else delete next.hooks;
+    writeJsonConfig(settingsPath, next);
+  },
+
   async syncAgents(_worktreePath: string) {
     // Vendored agents ship in the bundled octomux plugin (`--plugin-dir`).
   },

--- a/server/harnesses/cursor.test.ts
+++ b/server/harnesses/cursor.test.ts
@@ -255,4 +255,33 @@ describe('cursorHarness.installHooks', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('uninstallHooks removes the bridge dir and our hooks.json', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-cursor-hooks-rm-'));
+    try {
+      await cursorHarness.installHooks(tmpDir, 'http://127.0.0.1:7777', 'tok-abc');
+      await cursorHarness.uninstallHooks(tmpDir);
+      expect(fs.existsSync(path.join(tmpDir, '.octomux-hooks'))).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, '.cursor', 'hooks.json'))).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uninstallHooks keeps a hooks.json that is not ours, and no-ops on a bare dir', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-cursor-hooks-keep-'));
+    try {
+      const hooksPath = path.join(tmpDir, '.cursor', 'hooks.json');
+      fs.mkdirSync(path.dirname(hooksPath), { recursive: true });
+      fs.writeFileSync(hooksPath, '{"version":1,"hooks":{"sessionStart":[]}}', 'utf-8');
+      await cursorHarness.uninstallHooks(tmpDir);
+      expect(fs.existsSync(hooksPath)).toBe(true);
+
+      const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-cursor-hooks-bare-'));
+      await expect(cursorHarness.uninstallHooks(bare)).resolves.toBeUndefined();
+      fs.rmSync(bare, { recursive: true, force: true });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/server/harnesses/cursor.ts
+++ b/server/harnesses/cursor.ts
@@ -150,6 +150,20 @@ export const cursorHarness: Harness = {
     }
   },
 
+  async uninstallHooks(dirPath: string): Promise<void> {
+    // `.cursor/hooks.json` is written wholesale by installHooks and every entry
+    // points at our bridge — drop it only when that still holds, so a
+    // hand-edited file survives.
+    const hooksJsonPath = path.join(dirPath, '.cursor', 'hooks.json');
+    try {
+      const raw = fs.readFileSync(hooksJsonPath, 'utf-8');
+      if (raw.includes('.octomux-hooks')) fs.rmSync(hooksJsonPath, { force: true });
+    } catch {
+      /* absent or unreadable — nothing to clean */
+    }
+    fs.rmSync(path.join(dirPath, '.octomux-hooks'), { recursive: true, force: true });
+  },
+
   async syncAgents(_worktreePath: string): Promise<void> {
     // Vendored agents ship in the bundled octomux plugin (`--plugin-dir`).
   },

--- a/server/harnesses/types.ts
+++ b/server/harnesses/types.ts
@@ -68,6 +68,14 @@ export interface Harness {
   buildResumeCommand(opts: HarnessResumeOpts): string;
   buildContinueCommand(opts: HarnessResumeOpts): string | null;
   installHooks(worktreePath: string, baseUrl: string, hookToken: string): Promise<void>;
+  /**
+   * Remove octomux's hook wiring from a directory. Called on teardown for paths
+   * octomux does NOT own (run_mode `existing`/`none`), which survive deleteTask
+   * — otherwise the config outlives the worker row whose token it carries and
+   * every later session in that directory 401s on every hook. Must leave the
+   * user's own hooks and permissions intact, and no-op when nothing is there.
+   */
+  uninstallHooks(dirPath: string): Promise<void>;
   syncAgents(worktreePath: string): Promise<void>;
   /**
    * Optional post-launch hook called after the launch command is sent to the

--- a/server/task-engine.test.ts
+++ b/server/task-engine.test.ts
@@ -1480,6 +1480,35 @@ describe('deleteTask', () => {
         findExecCall(vi.mocked(execFile), { cmd: 'git', argsInclude: ['branch', '-D'] }),
       ).toBeUndefined();
     });
+
+    // The repo survives deleteTask, so our hook config must not — a config
+    // whose token outlives the agent row 401s in every later session there.
+    it('strips our hook config from the user-owned repo', async () => {
+      insertTask(db, noneRunningTask);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          permissions: { allow: ['Bash(ls:*)'] },
+          hooks: {
+            Stop: [
+              { hooks: [{ type: 'http', url: 'http://127.0.0.1:7777/api/hooks/stop?token=t' }] },
+            ],
+            PreToolUse: [{ hooks: [{ type: 'command', command: 'mine' }] }],
+          },
+        }),
+      );
+
+      await deleteTask(noneRunningTask);
+
+      const write = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find(([p]) => String(p).endsWith('settings.local.json'));
+      expect(write).toBeDefined();
+      expect(String(write![0])).toContain(noneRunningTask.repo_path);
+      const written = JSON.parse(String(write![1]));
+      expect(written.hooks.Stop).toBeUndefined();
+      expect(written.hooks.PreToolUse).toHaveLength(1);
+      expect(written.permissions.allow).toEqual(['Bash(ls:*)']);
+    });
   });
 
   describe('run_mode=existing (safety)', () => {

--- a/server/task-engine/cleanup.ts
+++ b/server/task-engine/cleanup.ts
@@ -19,6 +19,7 @@ import {
   resolveTaskPermissionPrompts,
   resolveAgentPermissionPrompts,
 } from '../repositories/permission-prompts.js';
+import { getHarness } from '../harnesses/index.js';
 import { isTmuxTargetMissing } from './sessions.js';
 import { scratchDirFor } from './reconcile.js';
 import { cleanupLinkedSessions } from './sessions.js';
@@ -171,13 +172,27 @@ export async function deleteTask(task: Task): Promise<void> {
       break;
     }
     case 'existing':
-    case 'none':
-      // Intentionally do nothing — user's worktree/repo must never be touched.
-      logger.info(
-        { task_id: task.id, operation: 'deleteTask', run_mode: task.run_mode },
-        'deleteTask: skipped filesystem cleanup (user-owned path)',
-      );
+    case 'none': {
+      // The user's worktree/repo is never removed — but our hook wiring must
+      // be, or it outlives the worker rows holding its token and every later
+      // session in that directory 401s on every hook. (Two live tasks sharing
+      // one path already clobber each other's token at install time, so there
+      // is nothing extra to guard here.)
+      const dir = task.worktree || task.repo_path;
+      try {
+        await getHarness(task.harness_id).uninstallHooks(dir);
+        logger.info(
+          { task_id: task.id, operation: 'deleteTask', run_mode: task.run_mode, dir },
+          'deleteTask: hook config removed from user-owned path',
+        );
+      } catch (err) {
+        logger.warn(
+          { task_id: task.id, operation: 'deleteTask', run_mode: task.run_mode, dir, err },
+          'deleteTask: hook config removal failed',
+        );
+      }
       break;
+    }
     case 'scratch': {
       const dir = task.worktree || scratchDirFor(task.id);
       try {


### PR DESCRIPTION
## Problem

`deleteTask` deliberately never touches the filesystem for `run_mode` `existing`/`none` — the user's repo/worktree is theirs. But `setup/none.ts` installs hooks at `task.repo_path` and `setup/existing.ts` at the user's worktree, and nothing ever removed them. The agent rows carrying the `hook_token` go away with the task; the config outlives them.

Result: every Claude Code session later started in that directory — including the human's own — fires four HTTP hooks per turn, all rejected with 401. Four repo roots on my machine had accumulated dead configs this way, worth ~6,000 `hook token not recognized` warnings across the last three log files.

## Fix

- `Harness.uninstallHooks(dirPath)` — new interface method.
  - **claude-code**: strips only entries whose url contains `/api/hooks/` from `.claude/settings.local.json`, drops emptied event arrays, drops the `hooks` key when nothing of ours remains. The user's own hooks and the entire `permissions` block are preserved. No-op on a missing or unparseable file.
  - **cursor**: removes `.octomux-hooks/`, and `.cursor/hooks.json` only when it still points at our bridge (a hand-edited file survives).
- Called from `deleteTask` for `existing`/`none`. Failure is logged, not thrown. `softDeleteTask` routes through the purge poller into the same `deleteTask`, so trash-then-purge is covered.

`closeTask` intentionally keeps hooks — the agent rows survive for resume. `new`/`scratch` need nothing, the directory itself is removed.

## Tests

Four harness tests (user hooks + permissions preserved, `hooks` key dropped when only ours were present, no-op on a bare dir, cursor keeps a foreign `hooks.json`) and one `deleteTask` test asserting the repo's settings file is rewritten without our `Stop` hook but with the user's `PreToolUse` intact. The `deleteTask` test was verified non-vacuous — it fails when the `uninstallHooks` call is removed.

Typecheck, lint, and the full suite pass.

## Not covered

Chats accept a custom `cwd` and would leak the same way, but no caller passes one today and `agents` has no `cwd` column to clean up from — fixing it means a migration for an unused path.