### PR TITLE
docs: fix doc drift 2026-07-28

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ branch `agents/<id>`. Each **worker** = tmux window within the session.
 `tasks.model TEXT` column. Propagated through:
 
 - `POST /api/tasks` body: `{ model: "claude-opus-4-8" }` → stored in DB
-- `POST /api/tasks/:id/agents` body: `{ model: ... }` → stored on agent launch
+- `POST /api/tasks/:id/workers` body: `{ model: ... }` → stored on worker launch
 - `octomux create-task --model <id>` and `octomux add-agent --model <id>`
 - Harness: `applyModel(flags, model)` strips any existing `--model` then appends the per-task one
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ src/              React SPA (pages, components, lib/api.ts)
   workflows/      front-end workflow-UI registry behind the /w/:kind/:id route
 cli/              CLI tool for task management
 packages/         bun workspaces: types, diff-engine, api-client, test-fixtures
+plugin/           bundled Claude Code plugin (skills/, agents/) — the only tier agents see
+kinds/            built-in schedule-kind presets (*.json), read by server/workflows/presets.ts
 electron/         macOS desktop shell
 e2e/              Playwright E2E tests
 ```

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -108,10 +108,13 @@ Draft first if you want to edit title, prompt, and branch before agents start �
 | `./data/tasks.db`             | Task state (development)                                |
 | `~/.octomux/logs/`            | Server + hook logs                                      |
 | `~/.octomux/hooks/<event>.d/` | Lifecycle hooks                                         |
+| `~/.octomux/kinds/`           | Your own schedule-kind presets (Settings → Kinds)       |
 | `~/.claude/skills/`           | Your own Claude Code skills (read by the harness)       |
 | `~/.claude/workflows/`        | Review workflow scripts installed by `octomux init`     |
 | `<repo>/.worktrees/<task-id>` | Per-task git worktree                                   |
 | `<worktree>/.octomux-hooks/`  | Cursor hook bridge (Cursor tasks)                       |
+
+Set `OCTOMUX_DATA_DIR` to move the `~/.octomux` root elsewhere — the desktop app does this so it never shares the CLI's data directory.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Scheduled doc-drift pass. Branch was 167 commits behind `origin/next`; fast-forwarded first so findings are against current `next`, then audited README / CLAUDE.md / CONTRIBUTING.md / ONBOARDING.md against the code (there is no `docs/`).

### Drift found and fixed

| Doc | Claim | Reality |
| --- | --- | --- |
| `CLAUDE.md` | Per-task model override propagates via `POST /api/tasks/:id/agents` | Route is `POST /api/tasks/:id/workers` (`server/routes/task-agents.ts:20`) after the `agents`→`workers` rename — CLAUDE.md's own concept table already says `workers`, so the file contradicted itself |
| `CONTRIBUTING.md` | Architecture tree lists top-level dirs | Omitted `plugin/` and `kinds/`, both shipped in `package.json` `files` and the only delivery path for skills/agent roles (`--plugin-dir`) and built-in schedule-kind presets (`server/workflows/presets.ts`) |
| `ONBOARDING.md` | §7 "Where things live" | Omitted `~/.octomux/kinds/` — user-authored kind presets, writable via `/api/kinds` (`homeKindsDir()`, `server/routes/kinds.ts`) |
| `ONBOARDING.md` | §7 presents `~/.octomux` as the fixed state root | `OCTOMUX_DATA_DIR` overrides it (`server/octomux-root.ts`); the desktop app relies on this |

### Verified clean (no change)

- README CLI reference table — every command still registered in `cli/src/index.ts`, and `create-task --harness/--model/--mode/--fork-from`, `add-agent --model/--notify-agent`, `loop-start --budget-tokens/--stall-after`, `loop-start-group --n` all exist.
- README env/paths — `OCTOMUX_BIND`, `OCTOMUX_REMOTE_TOKEN`, `~/.octomux/data/remote-token`, `~/.octomux/hooks/<event>.d/`, `/ws/events`, `/ws/terminal/*`, Node `>=20`.
- ONBOARDING — every referenced SPA route (`/setup`, `/tasks`, `/workspaces`, `/schedules`) exists in `src/App.tsx`; `~/.claude/workflows/` really is installed by `octomux init` (`cli/src/commands/init.ts:96`); `octomux hooks-install jira-status` template present.
- CLAUDE.md — every referenced source/spec/plan path resolves; the removed `<repo>/.octomux/{skills,agents}` and `~/.octomux/agents` tiers appear in no doc except the CLAUDE.md note explaining they are gone.

### Noted, not changed

- README says the REST API is "~110 endpoints"; actual count is ~129. Left alone — the figure is explicitly approximate.