### PR TITLE
fix(reviews): eliminate stuck 'reviewing' runs and misleading inbox states

### DIFF
--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -933,6 +933,20 @@ describe('pollReviewerRequests', () => {
     expect((calledWith as { id: string }).id).toBe(created.id);
   });
 
+  it('does not resurrect a soft-deleted review task for the same PR', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, { id: 'trashed', repo_path: REPO, pr_number: 42, source: 'auto_review' });
+    db.prepare(`UPDATE tasks SET deleted_at = datetime('now') WHERE id = 'trashed'`).run();
+    mockPrList([makePR()]);
+
+    await pollReviewerRequests();
+
+    const created = db
+      .prepare(`SELECT id FROM tasks WHERE source = 'auto_review' AND deleted_at IS NULL`)
+      .all();
+    expect(created).toHaveLength(0);
+  });
+
   it('skips when owner is not in reviewRequests (e.g. already reviewed)', async () => {
     insertTask(db, { id: 'seed', repo_path: REPO });
     mockPrList([makePR({ reviewRequests: [{ login: 'someone-else' }] })]);
@@ -1320,6 +1334,64 @@ describe('sweepStuckReviewRuns', () => {
     };
     expect(row.status).toBe('failed');
     expect(row.error).toMatch(/timeout/);
+  });
+
+  it('fails a post-walkthrough run whose task is no longer running', async () => {
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, source)
+       VALUES ('t1', 'x', '', 'idle', 'backlog', 'auto_review')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO review_runs (id, task_id, pr_head_sha, walkthrough, status, started_at)
+       VALUES ('r1', 't1', 'sha', '{"global":{}}', 'running', datetime('now', '-16 minutes'))`,
+    ).run();
+
+    const { sweepStuckReviewRuns } = await import('./poller.js');
+    await sweepStuckReviewRuns();
+    const row = db.prepare(`SELECT status, error FROM review_runs WHERE id = 'r1'`).get() as {
+      status: string;
+      error: string | null;
+    };
+    expect(row.status).toBe('failed');
+    expect(row.error).toMatch(/no longer running/);
+  });
+
+  it('fails a stale run whose PR head advanced past its sha', async () => {
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, source, pr_head_sha)
+       VALUES ('t1', 'x', '', 'running', 'backlog', 'auto_review', 'sha-new')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO review_runs (id, task_id, pr_head_sha, walkthrough, status, started_at)
+       VALUES ('r1', 't1', 'sha-old', '{"global":{}}', 'running', datetime('now', '-16 minutes'))`,
+    ).run();
+
+    const { sweepStuckReviewRuns } = await import('./poller.js');
+    await sweepStuckReviewRuns();
+    const row = db.prepare(`SELECT status, error FROM review_runs WHERE id = 'r1'`).get() as {
+      status: string;
+      error: string | null;
+    };
+    expect(row.status).toBe('failed');
+    expect(row.error).toMatch(/superseded/);
+  });
+
+  it('leaves an old post-walkthrough run alone while its task still runs on the same head', async () => {
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, source, pr_head_sha)
+       VALUES ('t1', 'x', '', 'running', 'backlog', 'auto_review', 'sha')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO review_runs (id, task_id, pr_head_sha, walkthrough, status, started_at)
+       VALUES ('r1', 't1', 'sha', '{"global":{}}', 'running', datetime('now', '-16 minutes'))`,
+    ).run();
+
+    const { sweepStuckReviewRuns } = await import('./poller.js');
+    await sweepStuckReviewRuns();
+    const row = db.prepare(`SELECT status FROM review_runs WHERE id = 'r1'`).get() as {
+      status: string;
+    };
+    expect(row.status).toBe('running');
   });
 
   it('leaves a fresh review_run alone', async () => {

--- a/server/poller/pr-and-reviewers.ts
+++ b/server/poller/pr-and-reviewers.ts
@@ -2,6 +2,7 @@ import { childLogger } from '../logger.js';
 import { pollPRs } from './pr-detection.js';
 import { pollReviewerRequests } from './reviewer-requests.js';
 import { sweepStuckReviewRuns } from './review-runs.js';
+import { reconcileReviewerRuns } from '../workflows/reviewer/finish-run.js';
 
 const logger = childLogger('poller');
 
@@ -21,5 +22,10 @@ export async function pollPRsAndReviewers(): Promise<void> {
     await sweepStuckReviewRuns();
   } catch (err) {
     logger.error({ err, operation: 'sweepStuckReviewRuns' }, 'sweepStuckReviewRuns failed');
+  }
+  try {
+    reconcileReviewerRuns();
+  } catch (err) {
+    logger.error({ err, operation: 'reconcileReviewerRuns' }, 'reconcileReviewerRuns failed');
   }
 }

--- a/server/poller/review-runs.ts
+++ b/server/poller/review-runs.ts
@@ -5,16 +5,26 @@ import { findStuckReviewRuns, failReviewRunById } from '../repositories/review-r
 const logger = childLogger('poller');
 const REVIEW_RUN_TIMEOUT_MIN = 15;
 
+const STUCK_ERRORS: Record<string, string> = {
+  'no-progress': `timeout: no progress for ${REVIEW_RUN_TIMEOUT_MIN} minutes`,
+  'task-not-running': `timeout: task no longer running after ${REVIEW_RUN_TIMEOUT_MIN} minutes`,
+  'head-advanced': 'superseded: PR head advanced without a new review run',
+};
+
 /**
- * Fail review_runs that have been 'running' for longer than the timeout window
- * without producing a walkthrough or any inline comments. Idempotent.
+ * Fail review_runs that have been 'running' past the timeout window and can
+ * never complete on their own (no progress, task's agents gone, or the PR head
+ * advanced without a replacement run). Idempotent.
  */
 export async function sweepStuckReviewRuns(): Promise<void> {
   const stuck = findStuckReviewRuns(REVIEW_RUN_TIMEOUT_MIN);
 
   for (const row of stuck) {
-    failReviewRunById(row.id, `timeout: no progress for ${REVIEW_RUN_TIMEOUT_MIN} minutes`);
-    logger.warn({ task_id: row.task_id, review_run_id: row.id }, 'review_run timed out');
+    failReviewRunById(row.id, STUCK_ERRORS[row.reason] ?? STUCK_ERRORS['no-progress']);
+    logger.warn(
+      { task_id: row.task_id, review_run_id: row.id, reason: row.reason },
+      'review_run swept as stuck',
+    );
     broadcast({ type: 'review:run-failed', payload: { taskId: row.task_id, reviewRunId: row.id } });
   }
 }

--- a/server/poller/reviewer-requests.ts
+++ b/server/poller/reviewer-requests.ts
@@ -9,6 +9,7 @@ import { sendMessageToAgent } from '../tmux-input.js';
 import {
   listTaskRepoPaths,
   findExistingPrTask,
+  hasTrashedPrReviewTask,
   listAutoReviewDrafts,
   hardDeleteTask,
   updateTaskPromptAndSha,
@@ -232,6 +233,13 @@ async function upsertReviewTask(
       return { action: 'nudged', taskId: existing.id };
     }
 
+    return { action: 'skipped' };
+  }
+
+  // The user deleted this PR's review — don't resurrect it while the trashed
+  // task exists (its worktree is only removed when the trash purges, so an
+  // early recreate would error on the leftover worktree anyway).
+  if (hasTrashedPrReviewTask(repoPath, pr.number)) {
     return { action: 'skipped' };
   }
 

--- a/server/repositories/review-runs.test.ts
+++ b/server/repositories/review-runs.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestDb } from '../test-helpers.js';
-import { createReviewRun, getReviewRun, getCurrentRun, completeRun } from './review-runs.js';
+import {
+  createReviewRun,
+  getReviewRun,
+  getCurrentRun,
+  getLatestRun,
+  completeRun,
+} from './review-runs.js';
 
 vi.mock('../events.js', () => ({ broadcast: vi.fn() }));
 
@@ -73,5 +79,53 @@ describe('review-runs', () => {
     ).run();
     const run = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
     expect(run.deep_review_attached).toBe(0);
+  });
+
+  it('createReviewRun supersedes an older running run on a different head sha', () => {
+    const old = createReviewRun({ task_id: TASK_ID, pr_head_sha: 'sha-old' });
+    const fresh = createReviewRun({ task_id: TASK_ID, pr_head_sha: 'sha-new' });
+
+    const oldRow = db
+      .prepare(`SELECT status, error, completed_at FROM review_runs WHERE id = ?`)
+      .get(old.id) as { status: string; error: string | null; completed_at: string | null };
+    expect(oldRow.status).toBe('failed');
+    expect(oldRow.error).toMatch(/superseded/);
+    expect(oldRow.completed_at).not.toBeNull();
+    expect(fresh.status).toBe('running');
+  });
+
+  it('createReviewRun leaves completed runs and other tasks untouched', () => {
+    const done = createReviewRun({ task_id: TASK_ID, pr_head_sha: 'sha-done' });
+    db.prepare(`UPDATE review_runs SET status = 'completed' WHERE id = ?`).run(done.id);
+    db.prepare(
+      `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, source)
+       VALUES ('t_other', 'x', '', 'idle', 'backlog', 'auto_review')`,
+    ).run();
+    const other = createReviewRun({ task_id: 't_other', pr_head_sha: 'sha-x' });
+
+    createReviewRun({ task_id: TASK_ID, pr_head_sha: 'sha-new' });
+
+    const doneRow = db.prepare(`SELECT status FROM review_runs WHERE id = ?`).get(done.id) as {
+      status: string;
+    };
+    expect(doneRow.status).toBe('completed');
+    const otherRow = db.prepare(`SELECT status FROM review_runs WHERE id = ?`).get(other.id) as {
+      status: string;
+    };
+    expect(otherRow.status).toBe('running');
+  });
+
+  it('getLatestRun returns the latest run including failed ones', () => {
+    db.prepare(
+      `INSERT INTO review_runs (id, task_id, pr_head_sha, status, started_at)
+       VALUES ('r-old', ?, 'sha-1', 'completed', datetime('now', '-10 minutes')),
+              ('r-new', ?, 'sha-2', 'failed', datetime('now'))`,
+    ).run(TASK_ID, TASK_ID);
+
+    expect(getLatestRun(TASK_ID)?.id).toBe('r-new');
+  });
+
+  it('getLatestRun returns null when the task has no runs', () => {
+    expect(getLatestRun(TASK_ID)).toBeNull();
   });
 });

--- a/server/repositories/review-runs.ts
+++ b/server/repositories/review-runs.ts
@@ -13,10 +13,30 @@ export interface CreateReviewRunInput {
 
 export function createReviewRun(input: CreateReviewRunInput): ReviewRun {
   const id = nanoid(12);
-  getDb()
-    .prepare(`INSERT INTO review_runs (id, task_id, pr_head_sha) VALUES (?, ?, ?)`)
-    .run(id, input.task_id, input.pr_head_sha);
-  const row = getReviewRun(id);
+  const row = getDb().transaction(() => {
+    // A run for a new head replaces any run still chasing an older head —
+    // without this, the old row stays 'running' forever (nothing else ever
+    // completes it) and the inbox shows a permanent "reviewing".
+    const superseded = getDb()
+      .prepare(
+        `UPDATE review_runs
+            SET status = 'failed',
+                error = 'superseded by review run for head ' || ?,
+                completed_at = datetime('now')
+          WHERE task_id = ? AND status = 'running' AND pr_head_sha != ?`,
+      )
+      .run(input.pr_head_sha, input.task_id, input.pr_head_sha);
+    if (superseded.changes > 0) {
+      logger.info(
+        { task_id: input.task_id, superseded_count: superseded.changes },
+        'superseded older running review_runs',
+      );
+    }
+    getDb()
+      .prepare(`INSERT INTO review_runs (id, task_id, pr_head_sha) VALUES (?, ?, ?)`)
+      .run(id, input.task_id, input.pr_head_sha);
+    return getReviewRun(id);
+  })();
   if (!row) throw new Error('failed to read review_run after insert');
   logger.info(
     { task_id: input.task_id, review_run_id: id, pr_head_sha: input.pr_head_sha },
@@ -59,6 +79,19 @@ export function getCurrentRun(taskId: string): ReviewRun | null {
       .prepare(
         `SELECT * FROM review_runs
            WHERE task_id = ? AND status != 'failed'
+           ORDER BY started_at DESC, rowid DESC LIMIT 1`,
+      )
+      .get(taskId) as ReviewRun | undefined) ?? null
+  );
+}
+
+/** True latest run for the task, including failed ones. */
+export function getLatestRun(taskId: string): ReviewRun | null {
+  return (
+    (getDb()
+      .prepare(
+        `SELECT * FROM review_runs
+           WHERE task_id = ?
            ORDER BY started_at DESC, rowid DESC LIMIT 1`,
       )
       .get(taskId) as ReviewRun | undefined) ?? null
@@ -116,24 +149,47 @@ export function getReviewRunHeadSha(id: string): string | undefined {
 export interface StuckReviewRun {
   id: string;
   task_id: string;
+  reason: 'no-progress' | 'task-not-running' | 'head-advanced';
 }
 
 /**
- * Find review_runs that have been 'running' longer than timeoutMinutes without
- * producing a walkthrough or any inline comments since they started.
+ * Find review_runs that have been 'running' longer than timeoutMinutes and can
+ * never complete on their own:
+ * - 'no-progress': no walkthrough and no inline comments since they started
+ * - 'task-not-running': the task has no live agents left to call `review complete`
+ * - 'head-advanced': the PR head moved past the run's sha (a re-review was
+ *   requested but a run for the new head never started)
  * Used by poller.sweepStuckReviewRuns.
  */
 export function findStuckReviewRuns(timeoutMinutes: number): StuckReviewRun[] {
   return getDb()
     .prepare(
-      `SELECT rr.id, rr.task_id FROM review_runs rr
+      `SELECT rr.id, rr.task_id,
+              CASE
+                WHEN rr.walkthrough IS NULL
+                     AND NOT EXISTS (
+                       SELECT 1 FROM inline_comments ic
+                        WHERE ic.review_run_id = rr.id
+                          AND ic.created_at > rr.started_at
+                     )
+                  THEN 'no-progress'
+                WHEN t.runtime_state NOT IN ('running', 'setting_up')
+                  THEN 'task-not-running'
+                ELSE 'head-advanced'
+              END AS reason
+         FROM review_runs rr
+         JOIN tasks t ON t.id = rr.task_id
         WHERE rr.status = 'running'
           AND rr.started_at < datetime('now', ?)
-          AND rr.walkthrough IS NULL
-          AND NOT EXISTS (
-            SELECT 1 FROM inline_comments ic
-             WHERE ic.review_run_id = rr.id
-               AND ic.created_at > rr.started_at
+          AND (
+            (rr.walkthrough IS NULL
+             AND NOT EXISTS (
+               SELECT 1 FROM inline_comments ic
+                WHERE ic.review_run_id = rr.id
+                  AND ic.created_at > rr.started_at
+             ))
+            OR t.runtime_state NOT IN ('running', 'setting_up')
+            OR (t.pr_head_sha IS NOT NULL AND rr.pr_head_sha != t.pr_head_sha)
           )`,
     )
     .all(`-${timeoutMinutes} minutes`) as StuckReviewRun[];

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -742,6 +742,25 @@ export function findExistingPrTask(
 }
 
 /**
+ * True when a soft-deleted (trashed) auto-review task still exists for the
+ * repo+PR. Used by the reviewer poller to avoid resurrecting a review the user
+ * just deleted — the trashed task's worktree is only removed when the trash
+ * purges, so recreating early would also collide with the leftover worktree.
+ */
+export function hasTrashedPrReviewTask(repoPath: string, prNumber: number): boolean {
+  const row = getDb()
+    .prepare(
+      `SELECT 1 FROM tasks t
+         INNER JOIN worktrees w ON t.worktree_id = w.id
+        WHERE w.repo_path = ? AND t.pr_number = ?
+          AND t.source = 'auto_review' AND t.deleted_at IS NOT NULL
+        LIMIT 1`,
+    )
+    .get(repoPath, prNumber);
+  return row !== undefined;
+}
+
+/**
  * List idle auto-review draft tasks for a given repo_path.
  * Used by cleanupResolvedReviewDrafts to find and purge drafts whose PR is no
  * longer awaiting review.

--- a/server/workflows/reviewer/finish-run.test.ts
+++ b/server/workflows/reviewer/finish-run.test.ts
@@ -4,7 +4,7 @@ import { getDb } from '../../db.js';
 import { insertRun, getRun } from '../../repositories/runs.js';
 import { createReviewRun, completeRun } from '../../repositories/review-runs.js';
 import { broadcast } from '../../events.js';
-import { finishReviewerRun, wireReviewerRunFinisher } from './finish-run.js';
+import { finishReviewerRun, reconcileReviewerRuns, wireReviewerRunFinisher } from './finish-run.js';
 import type { RunResult } from '../../types.js';
 
 describe('finishReviewerRun', () => {
@@ -63,6 +63,73 @@ describe('finishReviewerRun', () => {
     const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
     expect(() => finishReviewerRun('t1', reviewRun.id, false)).not.toThrow();
     expect(getDb().prepare(`SELECT COUNT(*) AS c FROM runs`).get()).toEqual({ c: 0 });
+  });
+});
+
+describe('reconcileReviewerRuns', () => {
+  beforeEach(() => {
+    createTestDb();
+  });
+
+  it('finishes a running run whose latest review_run completed without an in-process event', () => {
+    insertTestTask({ id: 't1', pr_number: 7, pr_url: 'https://github.com/o/r/pull/7' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    // Simulate the CLI completing the run in another process: direct DB update,
+    // no broadcast reaches this process's listeners.
+    getDb()
+      .prepare(
+        `UPDATE review_runs SET status = 'completed', completed_at = datetime('now') WHERE id = ?`,
+      )
+      .run(reviewRun.id);
+
+    reconcileReviewerRuns();
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('done');
+    const result = JSON.parse(finished.result_json!) as RunResult;
+    expect(result.outcome).toBe('done');
+  });
+
+  it('fails a running run whose latest review_run failed', () => {
+    insertTestTask({ id: 't1' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    const reviewRun = createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+    getDb()
+      .prepare(`UPDATE review_runs SET status = 'failed', error = ? WHERE id = ?`)
+      .run('timeout: no progress for 15 minutes', reviewRun.id);
+
+    reconcileReviewerRuns();
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('failed');
+    const result = JSON.parse(finished.result_json!) as RunResult;
+    expect(result.summary).toBe('timeout: no progress for 15 minutes');
+  });
+
+  it('fails a running run whose task errored before any review_run started', () => {
+    insertTestTask({ id: 't1', runtime_state: 'error', error: 'worktree add failed' });
+    const runRow = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+
+    reconcileReviewerRuns();
+
+    const finished = getRun(runRow.id)!;
+    expect(finished.status).toBe('failed');
+    expect(finished.error).toBe('worktree add failed');
+  });
+
+  it('leaves runs alone while the review_run is still running or not yet created', () => {
+    insertTestTask({ id: 't1' });
+    const active = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't1' });
+    createReviewRun({ task_id: 't1', pr_head_sha: 'sha1' });
+
+    insertTestTask({ id: 't2' });
+    const pending = insertRun({ workflowKind: 'reviewer', trigger: 'github', taskId: 't2' });
+
+    reconcileReviewerRuns();
+
+    expect(getRun(active.id)?.status).toBe('running');
+    expect(getRun(pending.id)?.status).toBe('running');
   });
 });
 

--- a/server/workflows/reviewer/finish-run.ts
+++ b/server/workflows/reviewer/finish-run.ts
@@ -5,7 +5,7 @@
  */
 import { subscribeServerEvents } from '../../events.js';
 import { getTask } from '../../repositories/index.js';
-import { getReviewRun } from '../../repositories/review-runs.js';
+import { getReviewRun, getLatestRun } from '../../repositories/review-runs.js';
 import { countCommentsForRun } from '../../repositories/inline-comments.js';
 import { finishRun, listRunsForWorkflow } from '../../repositories/runs.js';
 import { childLogger } from '../../logger.js';
@@ -57,6 +57,45 @@ export function finishReviewerRun(taskId: string, reviewRunId: string, failed: b
     { task_id: taskId, run_id: run.id, review_run_id: reviewRunId, comment_count: commentCount },
     'reviewer: run finished on drafts ready',
   );
+}
+
+/**
+ * Reconcile running reviewer `runs` rows against review_runs state in the DB.
+ *
+ * `octomux review complete` runs in the agent's CLI process, so its
+ * `review:drafts-ready` broadcast never reaches this process's in-process
+ * listeners — without this sweep every github-triggered reviewer run would sit
+ * at 'running' forever. Called from the poller; idempotent.
+ */
+export function reconcileReviewerRuns(): void {
+  const running = listRunsForWorkflow('reviewer').filter(
+    (r) => r.status === 'running' && r.task_id,
+  );
+
+  for (const run of running) {
+    const taskId = run.task_id as string;
+    const latest = getLatestRun(taskId);
+
+    if (latest?.status === 'completed') {
+      finishReviewerRun(taskId, latest.id, false);
+    } else if (latest?.status === 'failed') {
+      finishReviewerRun(taskId, latest.id, true);
+    } else if (!latest) {
+      const task = getTask(taskId);
+      if (task?.runtime_state === 'error') {
+        const summary = task.error ?? 'task errored before the review started';
+        finishRun(run.id, {
+          status: 'failed',
+          error: summary,
+          result: { outcome: 'failed', summary } satisfies RunResult,
+        });
+        logger.info(
+          { task_id: taskId, run_id: run.id },
+          'reviewer: run finished on task error (no review_run)',
+        );
+      }
+    }
+  }
 }
 
 /** Subscribe to review lifecycle events. Returns unsubscribe — call from server startup only. */

--- a/server/workflows/reviewer/reviews-inbox.test.ts
+++ b/server/workflows/reviewer/reviews-inbox.test.ts
@@ -46,6 +46,31 @@ describe('reviews-inbox', () => {
     expect(row.status).toBe('drafts-ready'); // accepted > 0 OR drafts > 0 AND latest run completed
   });
 
+  it('shows failed when the latest run failed, even with older completed runs', () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO review_runs (id, task_id, pr_head_sha, status, error, started_at, completed_at)
+       VALUES ('r2', 't1', 'sha-h2', 'failed', 'timeout: no progress for 15 minutes',
+               datetime('now'), datetime('now'))`,
+    ).run();
+
+    const row = listReviewsInbox()[0];
+    expect(row.status).toBe('failed');
+  });
+
+  it('shows error for an errored task with no review runs instead of published', () => {
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO tasks
+         (id, title, description, runtime_state, workflow_status, source, worktree_id, pr_number, error)
+       VALUES ('t-err', 'PR review', '', 'error', 'backlog', 'auto_review', 'wt1', 9,
+               'worktree add failed')`,
+    ).run();
+
+    const row = listReviewsInbox().find((r) => r.task_id === 't-err')!;
+    expect(row.status).toBe('error');
+  });
+
   it('getReviewDetail returns task + latest run + all comments (active + history) + published history', () => {
     const detail = getReviewDetail('t1');
     expect(detail).not.toBeNull();

--- a/server/workflows/reviewer/reviews-inbox.ts
+++ b/server/workflows/reviewer/reviews-inbox.ts
@@ -1,5 +1,5 @@
 import { listPublishedReviews } from '../../repositories/published-reviews.js';
-import { getCurrentRun, listRunsForTask } from '../../repositories/review-runs.js';
+import { getLatestRun, listRunsForTask } from '../../repositories/review-runs.js';
 import { listComments, countCommentsByStatus } from '../../repositories/inline-comments.js';
 import { listReviewTasks, getReviewTask } from '../../repositories/index.js';
 import { childLogger } from '../../logger.js';
@@ -13,7 +13,8 @@ export type ReviewInboxStatus =
   | 'drafts-ready' // latest run completed, drafts await user action
   | 'head-advanced' // PR head SHA differs from latest review_run's SHA
   | 'published' // a published_review exists for the current head SHA and no drafts left
-  | 'failed'; // latest run failed
+  | 'failed' // latest run failed
+  | 'error'; // the task errored before any review_run started
 
 export interface ReviewInboxRow {
   task_id: string;
@@ -48,6 +49,10 @@ function deriveStatus(
   if (latestRun?.status === 'running') return 'reviewing';
   if (latestRun?.status === 'failed') return 'failed';
 
+  // The task died before a review_run ever started (e.g. worktree setup
+  // failure) — without this it would fall through to 'published'.
+  if (!latestRun && task.runtime_state === 'error') return 'error';
+
   // Head has advanced past the last reviewed SHA
   if (latestRun && task.pr_head_sha && latestRun.pr_head_sha !== task.pr_head_sha) {
     return 'head-advanced';
@@ -61,7 +66,9 @@ export function listReviewsInbox(): ReviewInboxRow[] {
   const tasks = listReviewTasks();
 
   return tasks.map((task) => {
-    const latestRun = getCurrentRun(task.id);
+    // True latest run (including failed) — a failed latest run must surface as
+    // 'failed', not be skipped in favour of an older completed run.
+    const latestRun = getLatestRun(task.id);
 
     const counts = countCommentsByStatus(task.id);
 

--- a/src/lib/api/reviewApi.ts
+++ b/src/lib/api/reviewApi.ts
@@ -16,7 +16,8 @@ export type ReviewInboxStatus =
   | 'drafts-ready'
   | 'head-advanced'
   | 'published'
-  | 'failed';
+  | 'failed'
+  | 'error';
 
 export type PublishedReviewVerdict = 'COMMENT' | 'APPROVE' | 'REQUEST_CHANGES';
 

--- a/src/pages/ReviewsPage.tsx
+++ b/src/pages/ReviewsPage.tsx
@@ -21,6 +21,7 @@ const STATUS_PILL: Record<
   'head-advanced': { label: 'head advanced', variant: 'secondary' },
   published: { label: 'published', variant: 'outline' },
   failed: { label: 'failed', variant: 'destructive' },
+  error: { label: 'error', variant: 'destructive' },
 };
 
 function formatActivityAt(iso: string): string {


### PR DESCRIPTION
## What

Fixes five related bugs that left reviews permanently stuck at "reviewing" and made the reviews inbox lie about state:

- **Supersede on new run**: `createReviewRun` now fails any still-running run for the same task on a different head sha (same transaction). Previously the old row stayed `running` forever.
- **Wider stuck sweep**: `sweepStuckReviewRuns` now also fails runs whose task has no live agents left (agent died after the walkthrough, so nothing would ever call `octomux review complete`) and runs whose PR head advanced without a replacement run ever starting.
- **Workflow runs reconciler**: new `reconcileReviewerRuns()` in the poller finishes reviewer `runs` rows from DB state. `octomux review complete` executes in the agent's CLI process, so its `review:drafts-ready` broadcast never reaches the server's in-process listeners — every github-triggered reviewer run sat at `running` forever. Also retroactively cleans existing stuck rows.
- **Honest inbox status**: the inbox derives status from the true latest run (including failed), so a failed run shows `failed` instead of being masked by an older completed run; errored tasks with no runs get a new `error` status instead of falling through to `published`.
- **No resurrection from trash**: `pollReviewerRequests` skips PRs whose auto-review task is soft-deleted. Recreating early also collided with the leftover worktree (`git worktree add: already exists`) and produced errored tasks that displayed as `published`.

## Why

Observed in production: 3 orphaned `running` review_runs (each superseded by a mid-review push), all reviewer workflow `runs` rows stuck at `running` despite completed reviews, and deleted reviews resurrected within a minute as errored tasks labelled "published". The review-run lifecycle relied entirely on the agent explicitly signalling completion, with no janitor for agents that die and no supersession when the PR head advances.

## Testing

- TDD: each fix has a failing test written first — `server/repositories/review-runs.test.ts`, `server/poller.test.ts` (sweep + resurrection), `server/workflows/reviewer/finish-run.test.ts` (reconciler), `server/workflows/reviewer/reviews-inbox.test.ts` (failed/error derivation).
- Full suite: 4244/4245 pass; the one failure (`HomePage > hydrates composer from URL`) also fails on clean `next` (pre-existing).
- `bun run typecheck` clean; `bun run lint` only pre-existing warnings.