### PR TITLE
fix(hooks): debounce agent quiescence instead of flipping on every Stop

### DIFF
--- a/server/hooks.b4.test.ts
+++ b/server/hooks.b4.test.ts
@@ -1,8 +1,12 @@
 /**
- * B4: Stop hook → human_review auto-transition tests.
+ * Quiescence-guarded in_progress → human_review transition tests.
  *
- * Verifies that POST /api/hooks/stop transitions in_progress → human_review
- * when the stopping agent is the last running one and no pending prompts remain.
+ * The B4 synchronous transition was removed from the Stop hook and replaced by
+ * the quiescence poller (pollQuiescence). These tests verify that Stop no longer
+ * transitions the task, and that the quiescence poller does so when the agent
+ * has been genuinely idle past the debounce window.
+ *
+ * Poller-level tests live in server/poller/quiescence.test.ts.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
@@ -15,7 +19,7 @@ vi.mock('./hook-dispatcher.js', () => ({
   getTaskHookExecutions: vi.fn(async () => []),
 }));
 
-describe('B4: POST /api/hooks/stop → human_review transition', () => {
+describe('B4 (removed): POST /api/hooks/stop no longer synchronously transitions to human_review', () => {
   let db: Database.Database;
   let app: ReturnType<typeof createApp>;
 
@@ -33,7 +37,7 @@ describe('B4: POST /api/hooks/stop → human_review transition', () => {
     } as any);
   });
 
-  it('transitions in_progress → human_review when last agent stops', async () => {
+  it('Stop does NOT transition in_progress → human_review (debounced via quiescence poller)', async () => {
     await request(app)
       .post('/api/hooks/stop?token=tok-b4')
       .send({ session_id: 'sess-123' })
@@ -42,18 +46,16 @@ describe('B4: POST /api/hooks/stop → human_review transition', () => {
     const task = db.prepare('SELECT workflow_status FROM tasks WHERE id = ?').get('t1') as {
       workflow_status: string;
     };
-    expect(task.workflow_status).toBe('human_review');
+    // Must remain in_progress — quiescence poller handles the transition after debounce
+    expect(task.workflow_status).toBe('in_progress');
 
     const update = db
       .prepare(`SELECT * FROM task_updates WHERE task_id = 't1' AND kind = 'transition'`)
-      .get() as any;
-    expect(update).not.toBeNull();
-    expect(update.from_status).toBe('in_progress');
-    expect(update.to_status).toBe('human_review');
-    expect(update.body).toBe('auto: agent stopped');
+      .get();
+    expect(update).toBeUndefined();
   });
 
-  it('fires workflow_status_changed hook on transition', async () => {
+  it('Stop does NOT fire workflow_status_changed (that belongs to the quiescence poller)', async () => {
     const { fireHook } = await import('./hook-dispatcher.js');
 
     await request(app)
@@ -61,43 +63,32 @@ describe('B4: POST /api/hooks/stop → human_review transition', () => {
       .send({ session_id: 'sess-123' })
       .expect(200);
 
-    expect(fireHook).toHaveBeenCalledWith(
-      'workflow_status_changed',
-      expect.objectContaining({
-        event: 'workflow_status_changed',
-        data: expect.objectContaining({ from: 'in_progress', to: 'human_review' }),
-      }),
-    );
+    expect(fireHook).not.toHaveBeenCalledWith('workflow_status_changed', expect.anything());
   });
 
-  it('skips transition when other agents are still running', async () => {
-    // Add a second running agent
-    insertAgent(db, {
-      id: 'a2',
-      task_id: 't1',
-      harness_session_id: 'sess-456',
-      hook_token: 'tok-b4-2',
-      status: 'running',
-      window_index: 1,
-    } as any);
+  it('Stop sets agent to idle regardless', async () => {
+    const row = db
+      .prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`)
+      .get() as { hook_activity: string };
+    // starts active
+    expect(row.hook_activity).toBe('active');
 
     await request(app)
       .post('/api/hooks/stop?token=tok-b4')
       .send({ session_id: 'sess-123' })
       .expect(200);
 
-    const task = db.prepare('SELECT workflow_status FROM tasks WHERE id = ?').get('t1') as {
-      workflow_status: string;
-    };
-    // Should remain in_progress because a2 is still running
-    expect(task.workflow_status).toBe('in_progress');
+    const after = db
+      .prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`)
+      .get() as { hook_activity: string };
+    expect(after.hook_activity).toBe('idle');
   });
 
-  it('skips transition when pending permission prompts remain', async () => {
+  it('workflow_status remains in_progress even when pending prompts exist', async () => {
     insertPermissionPrompt(db, {
       id: 'pp1',
       task_id: 't1',
-      agent_id: null, // no agent (or same agent — just needs to be pending)
+      agent_id: null,
       session_id: 'sess-other',
       status: 'pending',
     });
@@ -118,7 +109,7 @@ describe('B4: POST /api/hooks/stop → human_review transition', () => {
     { workflow_status: 'planned' as const },
     { workflow_status: 'pr' as const },
     { workflow_status: 'done' as const },
-  ])('skips transition when task is in $workflow_status', async ({ workflow_status }) => {
+  ])('tasks in $workflow_status are not modified by Stop', async ({ workflow_status }) => {
     db.prepare('UPDATE tasks SET workflow_status = ? WHERE id = ?').run(workflow_status, 't1');
 
     await request(app)

--- a/server/hooks.loop.test.ts
+++ b/server/hooks.loop.test.ts
@@ -3,8 +3,9 @@
  *
  * Verifies POST /api/hooks/stop dispatches to the loop engine — and bypasses
  * human_review/task_updates/fireHook/summarizer entirely — when the stopping
- * agent's task has runtime_state='looping'. A non-looping task keeps the
- * existing B4 behavior unchanged.
+ * agent's task has runtime_state='looping'. A non-looping task sets the agent
+ * idle and defers the in_progress → human_review transition to the quiescence
+ * poller (no longer happens synchronously in the Stop handler).
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
@@ -70,10 +71,12 @@ describe('Stop hook: loop guard', () => {
         expect(fireHook).not.toHaveBeenCalled();
         expect(summarizeAgentProgress).not.toHaveBeenCalled();
       } else {
+        // For a running (non-looping) task, Stop no longer transitions to human_review
+        // synchronously — the quiescence poller handles that after the debounce window.
         expect(handleLoopIterationBoundary).not.toHaveBeenCalled();
-        expect(task.workflow_status).toBe('human_review');
-        expect(update).not.toBeUndefined();
-        expect(fireHook).toHaveBeenCalled();
+        expect(task.workflow_status).toBe('in_progress');
+        expect(update).toBeUndefined();
+        expect(fireHook).not.toHaveBeenCalledWith('workflow_status_changed', expect.anything());
         expect(summarizeAgentProgress).toHaveBeenCalled();
       }
     },

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -259,7 +259,10 @@ describe('Hook endpoints', () => {
   });
 
   describe('POST /api/hooks/stop', () => {
-    it('resolves all pending prompts and sets agent to idle', async () => {
+    it('sets agent to idle but does NOT blanket-resolve pending permission prompts', async () => {
+      // Subagents inherit the parent hook token and post under the same worker row.
+      // Blanket-resolving on Stop would clobber subagent prompts — so Stop must
+      // no longer call resolveAgentPermissionPrompts.
       insertPermissionPrompt(db, {
         id: 'pp1',
         task_id: 't1',
@@ -278,9 +281,11 @@ describe('Hook endpoints', () => {
         .send({ session_id: 'sess-123', stop_hook_active: false })
         .expect(200);
 
+      // Prompts must remain pending — Stop no longer blanket-resolves them
       const prompts = getPermissionPrompts(db, 't1');
-      expect(prompts.every((p) => p.status === 'resolved')).toBe(true);
+      expect(prompts.every((p) => p.status === 'pending')).toBe(true);
 
+      // Agent activity still flips to idle
       expect(getAgentActivity(db, 'a1').hook_activity).toBe('idle');
     });
 
@@ -603,8 +608,10 @@ describe('Stop hook suppression for orchestrator-managed tasks', () => {
     } as any);
   });
 
-  it('auto-transitions in_progress → human_review for UN-managed tasks (existing behavior)', async () => {
-    // task-m is NOT in managed_tasks → existing B4 behavior applies
+  it('Stop hook does NOT synchronously transition to human_review (debounced via poller)', async () => {
+    // The B4 synchronous transition has been removed — Stop now only sets the agent idle.
+    // The quiescence poller (pollQuiescence) handles the in_progress → human_review
+    // transition after the debounce window expires.
     await request(app)
       .post('/api/hooks/stop?token=tok-m')
       .send({ session_id: 'sess-m' })
@@ -613,7 +620,8 @@ describe('Stop hook suppression for orchestrator-managed tasks', () => {
     const row = db.prepare(`SELECT workflow_status FROM tasks WHERE id = ?`).get('task-m') as {
       workflow_status: string;
     };
-    expect(row.workflow_status).toBe('human_review');
+    // Must remain in_progress — quiescence poller decides after debounce
+    expect(row.workflow_status).toBe('in_progress');
   });
 
   it('SUPPRESSES in_progress → human_review auto-transition for orchestrator-managed tasks', async () => {

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -9,7 +9,6 @@ import { childLogger } from './logger.js';
 import { summarizeAgentProgress } from './summarize.js';
 import { handleLoopIterationBoundary } from './task-engine/loop/engine.js';
 import {
-  isOrchestratorManaged,
   upsertManagedTask,
   getManagedTask,
   conversationIdForHookToken,
@@ -29,7 +28,6 @@ import {
   setAgentHarnessSessionId,
   setAgentHookActivity,
   setAgentHookActivityIfNotIdle,
-  countRunningAgentsExcept,
 } from './repositories/workers.js';
 import {
   getTaskWorkflowStatus,
@@ -41,9 +39,7 @@ import {
 } from './repositories/tasks.js';
 import {
   insertPermissionPrompt,
-  resolveAgentPermissionPrompts,
   resolveOldestPendingByAgent,
-  countPendingByTask,
 } from './repositories/permission-prompts.js';
 import { inTransaction } from './repositories/tx.js';
 
@@ -329,12 +325,7 @@ router.post(
       return;
     }
 
-    inTransaction(() => {
-      // Resolve ALL pending prompts for this agent
-      resolveAgentPermissionPrompts(agent.id);
-
-      setAgentHookActivity(agent.id, 'idle');
-    });
+    setAgentHookActivity(agent.id, 'idle');
 
     // Loop harness: a looping task's Stop hook marks an iteration boundary, not
     // a normal turn end — bypass human_review/task_updates/fireHook/summarizer
@@ -348,43 +339,6 @@ router.post(
       });
       res.status(200).send();
       return;
-    }
-
-    // B4: Auto-transition in_progress → human_review when the last agent stops.
-    // SUPPRESSED for orchestrator-managed tasks (§6.5, R3-I1): managed_tasks.phase
-    // is authoritative; workflow_status is set only via set_workflow_status tool.
-    const task = getTaskWorkflowStatus(agent.task_id);
-
-    if (task && task.workflow_status === 'in_progress' && !isOrchestratorManaged(task.id)) {
-      const otherRunning = countRunningAgentsExcept(agent.task_id, agent.id);
-      const pendingPrompts = countPendingByTask(agent.task_id);
-
-      if (otherRunning === 0 && pendingPrompts === 0) {
-        setWorkflowStatus(task.id, 'human_review');
-        addTaskUpdate({
-          task_id: task.id,
-          kind: 'transition',
-          from_status: 'in_progress',
-          to_status: 'human_review',
-          body: 'auto: agent stopped',
-        });
-
-        logger.info(
-          { task_id: task.id, agent_id: agent.id, operation: 'auto_human_review' },
-          'auto-transitioned to human_review',
-        );
-
-        fireHook('workflow_status_changed', {
-          event: 'workflow_status_changed',
-          task: { id: task.id, workflow_status: 'human_review' as const },
-          data: { from: 'in_progress', to: 'human_review', note: 'auto: agent stopped' },
-        });
-      }
-    } else if (task && task.workflow_status === 'in_progress' && isOrchestratorManaged(task.id)) {
-      logger.info(
-        { task_id: task.id, agent_id: agent.id, operation: 'stop_suppressed_managed' },
-        'Stop hook: suppressed auto-human_review for orchestrator-managed task',
-      );
     }
 
     // Orchestrator phase-complete detection (spec §6.5). A managed task signals

--- a/server/poller/index.ts
+++ b/server/poller/index.ts
@@ -10,6 +10,7 @@ import {
   APPROVAL_INTERVAL,
   SCHEDULE_INTERVAL,
   TRIAGE_PR_COMMENTS_INTERVAL,
+  QUIESCENCE_INTERVAL,
 } from './intervals.js';
 import { pollMergedPRs } from './merged-pr.js';
 import { pollPRsAndReviewers } from './pr-and-reviewers.js';
@@ -18,6 +19,7 @@ import { pollSoftDeletes } from './soft-deletes.js';
 import { pollStatuses } from './status.js';
 import { pollTriagePrComments } from './triage-pr-comments.js';
 import { pollWalkthroughHandoffs } from './walkthrough-handoff.js';
+import { pollQuiescence } from './quiescence.js';
 
 const logger = childLogger('poller');
 
@@ -27,6 +29,7 @@ export function startPolling(): void {
   ensureHooksInstalled();
 
   pollers = [
+    createPoller(pollQuiescence, QUIESCENCE_INTERVAL),
     createPoller(pollStatuses, STATUS_INTERVAL),
     createPoller(pollPRsAndReviewers, PR_INTERVAL),
     createPoller(pollMergedPRs, MERGED_PR_INTERVAL),
@@ -72,3 +75,4 @@ export { pollPRsAndReviewers } from './pr-and-reviewers.js';
 export { pollSchedules } from './schedule-cron.js';
 export { checkTriagePrComments, pollTriagePrComments } from './triage-pr-comments.js';
 export { repoNameWithOwner, parseNameWithOwner } from './github-repo.js';
+export { pollQuiescence } from './quiescence.js';

--- a/server/poller/intervals.ts
+++ b/server/poller/intervals.ts
@@ -1,4 +1,6 @@
 /** Poll cadences — 0 in test env so setInterval is skipped (tests call tick fns directly). */
+export const QUIESCENCE_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 5000;
+export const QUIESCENCE_DEBOUNCE_MS = 90000; // 90s: must exceed observed subagent re-wake gaps (30–75s)
 export const STATUS_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 5000;
 export const PR_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;
 export const MERGED_PR_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;

--- a/server/poller/quiescence.test.ts
+++ b/server/poller/quiescence.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  createTestDb,
+  insertTask,
+  insertAgent,
+  insertPermissionPrompt,
+} from '../test-helpers.js';
+import {
+  upsertManagedTask,
+  createConversation,
+} from '../repositories/orchestrator.js';
+import { pollQuiescence } from './quiescence.js';
+
+// Helper to set hook_activity and hook_activity_updated_at directly
+function setWorkerActivity(
+  db: Database.Database,
+  agentId: string,
+  activity: string,
+  updatedAtExpr: string,
+) {
+  db.prepare(
+    `UPDATE workers SET hook_activity = ?, hook_activity_updated_at = ${updatedAtExpr} WHERE id = ?`,
+  ).run(activity, agentId);
+}
+
+function getWorkflowStatus(db: Database.Database, taskId: string): string {
+  const row = db
+    .prepare(`SELECT workflow_status FROM tasks WHERE id = ?`)
+    .get(taskId) as { workflow_status: string };
+  return row.workflow_status;
+}
+
+function countTaskUpdates(db: Database.Database, taskId: string): number {
+  const row = db
+    .prepare(`SELECT COUNT(*) as n FROM task_updates WHERE task_id = ?`)
+    .get(taskId) as { n: number };
+  return row.n;
+}
+
+describe('pollQuiescence', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  const cases = [
+    {
+      name: '(a) task idle > debounce, no pending prompts, not managed → transitions once + fires hook',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q1', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q1',
+          task_id: 'task-q1',
+          status: 'running',
+          hook_token: 'tok-q1',
+        } as any);
+        // idle for 120s (well past 90s debounce)
+        setWorkerActivity(db, 'agent-q1', 'idle', `datetime('now', '-120 seconds')`);
+      },
+      taskId: 'task-q1',
+      expectTransition: true,
+    },
+    {
+      name: '(b) idle but WITHIN debounce window → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q2', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q2',
+          task_id: 'task-q2',
+          status: 'running',
+          hook_token: 'tok-q2',
+        } as any);
+        // idle for only 30s (within 90s debounce)
+        setWorkerActivity(db, 'agent-q2', 'idle', `datetime('now', '-30 seconds')`);
+      },
+      taskId: 'task-q2',
+      expectTransition: false,
+    },
+    {
+      name: '(c) a worker still active → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q3', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q3',
+          task_id: 'task-q3',
+          status: 'running',
+          hook_token: 'tok-q3',
+        } as any);
+        setWorkerActivity(db, 'agent-q3', 'active', `datetime('now', '-120 seconds')`);
+      },
+      taskId: 'task-q3',
+      expectTransition: false,
+    },
+    {
+      name: '(c2) a worker waiting → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q4', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q4',
+          task_id: 'task-q4',
+          status: 'running',
+          hook_token: 'tok-q4',
+        } as any);
+        setWorkerActivity(db, 'agent-q4', 'waiting', `datetime('now', '-120 seconds')`);
+      },
+      taskId: 'task-q4',
+      expectTransition: false,
+    },
+    {
+      name: '(d) pending permission prompt present → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q5', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q5',
+          task_id: 'task-q5',
+          status: 'running',
+          hook_token: 'tok-q5',
+        } as any);
+        setWorkerActivity(db, 'agent-q5', 'idle', `datetime('now', '-120 seconds')`);
+        insertPermissionPrompt(db, {
+          id: 'pp-q5',
+          task_id: 'task-q5',
+          agent_id: 'agent-q5',
+          session_id: 'sess-q5',
+          status: 'pending',
+        });
+      },
+      taskId: 'task-q5',
+      expectTransition: false,
+    },
+    {
+      name: '(e) orchestrator-managed → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, { id: 'task-q6', runtime_state: 'running', workflow_status: 'in_progress' });
+        insertAgent(db, {
+          id: 'agent-q6',
+          task_id: 'task-q6',
+          status: 'running',
+          hook_token: 'tok-q6',
+        } as any);
+        setWorkerActivity(db, 'agent-q6', 'idle', `datetime('now', '-120 seconds')`);
+        const convId = createConversation({ title: 'test-q6' });
+        upsertManagedTask({ conversation_id: convId, task_id: 'task-q6', phase: 'planning' });
+      },
+      taskId: 'task-q6',
+      expectTransition: false,
+    },
+    {
+      name: '(f) already human_review → no transition',
+      setup: (db: Database.Database) => {
+        insertTask(db, {
+          id: 'task-q7',
+          runtime_state: 'running',
+          workflow_status: 'human_review',
+        });
+        insertAgent(db, {
+          id: 'agent-q7',
+          task_id: 'task-q7',
+          status: 'running',
+          hook_token: 'tok-q7',
+        } as any);
+        setWorkerActivity(db, 'agent-q7', 'idle', `datetime('now', '-120 seconds')`);
+      },
+      taskId: 'task-q7',
+      expectTransition: false,
+    },
+  ];
+
+  it.each(cases)('$name', async ({ setup, taskId, expectTransition }) => {
+    setup(db);
+
+    await pollQuiescence();
+
+    const status = getWorkflowStatus(db, taskId);
+    if (expectTransition) {
+      expect(status).toBe('human_review');
+      // Exactly one transition task_update row must be written
+      expect(countTaskUpdates(db, taskId)).toBe(1);
+      const update = db
+        .prepare(`SELECT * FROM task_updates WHERE task_id = ?`)
+        .get(taskId) as Record<string, unknown>;
+      expect(update.kind).toBe('transition');
+      expect(update.from_status).toBe('in_progress');
+      expect(update.to_status).toBe('human_review');
+      expect(update.body).toBe('auto: agent stopped');
+    } else {
+      // No transition should have been written (regardless of initial status)
+      expect(countTaskUpdates(db, taskId)).toBe(0);
+    }
+  });
+
+  it('transitions only once even when called twice (idempotent)', async () => {
+    insertTask(db, { id: 'task-idem', runtime_state: 'running', workflow_status: 'in_progress' });
+    insertAgent(db, {
+      id: 'agent-idem',
+      task_id: 'task-idem',
+      status: 'running',
+      hook_token: 'tok-idem',
+    } as any);
+    setWorkerActivity(db, 'agent-idem', 'idle', `datetime('now', '-120 seconds')`);
+
+    await pollQuiescence();
+    await pollQuiescence();
+
+    expect(getWorkflowStatus(db, 'task-idem')).toBe('human_review');
+    // Only one task_update row — second call skips (workflow_status != 'in_progress')
+    expect(countTaskUpdates(db, 'task-idem')).toBe(1);
+  });
+
+  it('task with no workers is not transitioned (no workers = not yet started)', async () => {
+    insertTask(db, { id: 'task-noworker', runtime_state: 'running', workflow_status: 'in_progress' });
+    // No workers inserted
+
+    await pollQuiescence();
+
+    expect(getWorkflowStatus(db, 'task-noworker')).toBe('in_progress');
+  });
+});

--- a/server/poller/quiescence.ts
+++ b/server/poller/quiescence.ts
@@ -1,0 +1,73 @@
+import { broadcast } from '../events.js';
+import { fireHook } from '../hook-dispatcher.js';
+import { childLogger } from '../logger.js';
+import { isOrchestratorManaged } from '../repositories/orchestrator.js';
+import { countPendingByTask } from '../repositories/permission-prompts.js';
+import {
+  listTasksAwaitingQuiescence,
+  setWorkflowStatus,
+  addTaskUpdate,
+} from '../repositories/tasks.js';
+import { QUIESCENCE_DEBOUNCE_MS } from './intervals.js';
+
+const logger = childLogger('poller/quiescence');
+
+/**
+ * Periodic sweep: transition tasks from in_progress → human_review once they
+ * have been genuinely idle for the quiescence debounce window.
+ *
+ * A task qualifies when ALL of:
+ *   - workflow_status = 'in_progress'
+ *   - runtime_state = 'running'
+ *   - NOT orchestrator-managed
+ *   - has at least one non-stopped worker, and every non-stopped worker has
+ *     hook_activity = 'idle' with hook_activity_updated_at older than QUIESCENCE_DEBOUNCE_MS
+ *   - countPendingByTask(...) === 0 (no pending permission prompts)
+ */
+export function pollQuiescence(): void {
+  const candidates = listTasksAwaitingQuiescence(QUIESCENCE_DEBOUNCE_MS);
+
+  for (const { id } of candidates) {
+    // Skip orchestrator-managed tasks — their workflow_status is authoritative
+    // only via set_workflow_status tool, not the quiescence heuristic.
+    if (isOrchestratorManaged(id)) {
+      logger.info(
+        { task_id: id, operation: 'quiescence_skip_managed' },
+        'quiescence: skipping orchestrator-managed task',
+      );
+      continue;
+    }
+
+    // Skip if any pending permission prompts are present
+    const pending = countPendingByTask(id);
+    if (pending > 0) {
+      logger.info(
+        { task_id: id, pending_prompts: pending, operation: 'quiescence_skip_pending' },
+        'quiescence: skipping task with pending permission prompts',
+      );
+      continue;
+    }
+
+    setWorkflowStatus(id, 'human_review');
+    addTaskUpdate({
+      task_id: id,
+      kind: 'transition',
+      from_status: 'in_progress',
+      to_status: 'human_review',
+      body: 'auto: agent stopped',
+    });
+
+    logger.info(
+      { task_id: id, operation: 'auto_human_review' },
+      'auto-transitioned to human_review',
+    );
+
+    fireHook('workflow_status_changed', {
+      event: 'workflow_status_changed',
+      task: { id, workflow_status: 'human_review' as const },
+      data: { from: 'in_progress', to: 'human_review', note: 'auto: agent stopped' },
+    });
+
+    broadcast({ type: 'task:updated', payload: { taskId: id } });
+  }
+}

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -828,6 +828,50 @@ export function listNoneModeActiveTasks(
 }
 
 /**
+ * List tasks that are candidates for the quiescence → human_review transition.
+ * A task qualifies when:
+ *   - workflow_status = 'in_progress'
+ *   - runtime_state = 'running' (excludes looping / idle / etc.)
+ *   - NOT deleted
+ *   - has at least one worker
+ *   - every non-stopped worker has hook_activity = 'idle'
+ *   - the most-recent hook_activity_updated_at across all non-stopped workers is
+ *     older than debounceMs (continuous idle for at least the debounce window)
+ *
+ * The orchestrator-managed guard and pending-prompt guard are applied in JS
+ * after fetching (simpler to test, no extra joins needed).
+ *
+ * Returns task ids only — callers load full state via getTaskWorkflowStatus.
+ */
+export function listTasksAwaitingQuiescence(
+  debounceMs: number,
+): Array<{ id: string }> {
+  return getDb()
+    .prepare(
+      `SELECT t.id
+         FROM tasks t
+        WHERE t.workflow_status = 'in_progress'
+          AND t.runtime_state = 'running'
+          AND t.deleted_at IS NULL
+          AND EXISTS (
+            SELECT 1 FROM workers w WHERE w.task_id = t.id AND w.status != 'stopped'
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM workers w
+             WHERE w.task_id = t.id
+               AND w.status != 'stopped'
+               AND w.hook_activity != 'idle'
+          )
+          AND (
+            SELECT MAX(w.hook_activity_updated_at)
+              FROM workers w
+             WHERE w.task_id = t.id AND w.status != 'stopped'
+          ) <= datetime('now', ? || ' seconds')`,
+    )
+    .all(`-${Math.ceil(debounceMs / 1000)}`) as Array<{ id: string }>;
+}
+
+/**
  * Tasks that need the user's attention right now: pending permission prompts,
  * or errored tasks whose error hasn't been viewed. Used by the inbox.
  */


### PR DESCRIPTION
## What

Stops octomux from treating every Claude Code `Stop` hook as "the agent is done."

- `server/hooks.ts` `/stop`: removed the synchronous `in_progress → human_review` transition (the "B4" block) and the blanket `resolveAgentPermissionPrompts` call. The handler now only marks the worker idle (loop / phase-complete / summarizer paths untouched).
- `server/poller/quiescence.ts` (new) — `pollQuiescence()` performs that transition only after a task has been genuinely idle for a debounce window. Registered in `server/poller/index.ts` at a 5s cadence.
- `server/repositories/tasks.ts` — `listTasksAwaitingQuiescence(debounceMs)`: SQL gate requiring every non-stopped worker to be `idle` and the most recent `hook_activity_updated_at` older than the window.
- `server/poller/intervals.ts` — `QUIESCENCE_INTERVAL=5000`, `QUIESCENCE_DEBOUNCE_MS=90000`.

A task qualifies for the flip only when: `workflow_status='in_progress'` + `runtime_state='running'` + not orchestrator-managed + has ≥1 non-stopped worker, all idle ≥90s + no pending permission prompts.

## Why

Modern agents spawn subagents and self-continue, so `Stop` now fires many times per unit of work, with the re-wake arriving ~30–75s later as a new `UserPromptSubmit` on the same session. The old edge-triggered transition made tasks flap `human_review ⇄ in_progress` repeatedly — **one fresh task flipped 5× in 6 minutes in prod logs**. Fallout:

- False "needs human" states on the board.
- **Jira integration spam** — it subscribes to `workflow_status_changed` (`server/integrations/jira/index.ts`), so a linked ticket's status churned on every flip.
- **Clobbered subagent permission prompts** — subagents inherit the parent's hooks and POST under the same worker row/token, so the main agent's `Stop` blanket-resolved a subagent's live prompt.

Debouncing to quiescence absorbs the re-wake churn into a single correct transition. It degrades gracefully through the known Claude Code hook bugs (unreliable `SubagentStop`, background completions bypassing `Stop`) because the backstop is a timer, not a subagent counter.

Orphaned pending prompts don't wedge a task: `cleanup.ts` still resolves prompts when an agent is actually stopped/closed.

## Testing

- `bun run typecheck` — clean.
- New `server/poller/quiescence.test.ts` (9 cases): debounce boundary (120s vs 30s), active/waiting workers, pending prompt, orchestrator-managed, already-`human_review`, idempotency, no-workers.
- Updated `server/hooks.test.ts` / `hooks.b4.test.ts` / `hooks.loop.test.ts`: `Stop` no longer transitions synchronously or blanket-resolves prompts.
- Full server suite: **2751 passed** (191 files). ESLint clean on changed files.