### PR TITLE
ci(publish): OIDC trusted publishing + release 1.3.0

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -73,8 +73,12 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; the bundled npm is older.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -110,8 +114,7 @@ jobs:
       - name: Publish @octomux/tmux-${{ matrix.platform }}-${{ matrix.arch }}
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         working-directory: packages/tmux-${{ matrix.platform }}-${{ matrix.arch }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        # No token: OIDC trusted publishing, configured per package on npmjs.com.
         run: |
           set -euo pipefail
           PKG="@octomux/tmux-${{ matrix.platform }}-${{ matrix.arch }}"
@@ -127,5 +130,5 @@ jobs:
           if npm view "$PKG@$VER" version >/dev/null 2>&1; then
             echo "$PKG@$VER already on npm — skipping publish"
           else
-            npm publish --access public
+            npm publish --provenance --access public
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; the bundled npm is older.
+      - run: npm install -g npm@latest
 
       - run: bun install
 
@@ -41,9 +44,9 @@ jobs:
 
       - run: bun run build
 
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      # No token: authenticated via OIDC trusted publishing configured on
+      # npmjs.com (package settings -> Publishing access -> GitHub Actions).
+      - run: npm publish --provenance --access public
 
       # electron-release.yml runs on the same v* tag and its
       # `electron-builder --publish always` (releaseType: release) creates the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octomux",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/tmux-darwin-arm64/package.json
+++ b/packages/tmux-darwin-arm64/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.30",
   "description": "Prebuilt static tmux for octomux (darwin arm64)",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShreyPaharia/octomux.git",
+    "directory": "packages/tmux-darwin-arm64"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/tmux-darwin-x64/package.json
+++ b/packages/tmux-darwin-x64/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.30",
   "description": "Prebuilt static tmux for octomux (darwin x64)",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShreyPaharia/octomux.git",
+    "directory": "packages/tmux-darwin-x64"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/tmux-linux-arm64/package.json
+++ b/packages/tmux-linux-arm64/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.30",
   "description": "Prebuilt static tmux for octomux (linux arm64)",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShreyPaharia/octomux.git",
+    "directory": "packages/tmux-linux-arm64"
+  },
   "os": [
     "linux"
   ],

--- a/packages/tmux-linux-x64/package.json
+++ b/packages/tmux-linux-x64/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.30",
   "description": "Prebuilt static tmux for octomux (linux x64)",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShreyPaharia/octomux.git",
+    "directory": "packages/tmux-linux-x64"
+  },
   "os": [
     "linux"
   ],


### PR DESCRIPTION
## Why

The npm automation tokens were decommissioned as insecure, so `publish.yml` and
`build-binaries.yml` can no longer authenticate. Replaces them with npm
**trusted publishing** — GitHub Actions mints a short-lived OIDC token that npm
exchanges against a trusted publisher registered on each package. Nothing
long-lived is stored in repo secrets.

## What changed

- `NODE_AUTH_TOKEN` removed from both publish steps.
- `node-version: 24` + `npm install -g npm@latest` — trusted publishing needs npm >= 11.5.1.
- `--provenance` on both `npm publish` calls, which requires a `repository`
  field, so one is added to each `packages/tmux-*/package.json`.
- `id-token: write` was already present in both workflows; unchanged.
- Version bumped to 1.3.0 for the `next` -> `main` release.

## Manual step required before tagging v1.3.0

Trusted publishers are configured **per package** on npmjs.com
(package -> Settings -> Publishing access -> GitHub Actions), with:

| field | value |
| --- | --- |
| Organization or user | `ShreyPaharia` |
| Repository | `octomux` |
| Workflow filename | `publish.yml` (root package) / `build-binaries.yml` (tmux packages) |

Packages needing this: `octomux`, `@octomux/tmux-linux-x64`, `@octomux/tmux-darwin-arm64`.

`@octomux/tmux-linux-arm64` and `@octomux/tmux-darwin-x64` have never been
published, so they have no settings page — they already fail to publish today
(runner unavailable at tag time). Use `npm trust` (npm >= 11.10.0) to register
a publisher without a placeholder publish if we want them.

Without this configuration the publish job 401s.