### PR TITLE
feat(orchestrator): send approval gists over chat instead of relying on links

### DIFF
--- a/server/orchestrator/conductor-flags.ts
+++ b/server/orchestrator/conductor-flags.ts
@@ -30,6 +30,9 @@ export const ORCHESTRATOR_SYSTEM_PROMPT = [
   '- TRACK progress with your read tools only: mcp__octomux__list_tasks, mcp__octomux__get_task, mcp__octomux__monitor_status, mcp__octomux__get_task_output. Do not read or edit the repo directly — inspect tasks and their artifacts through these tools.',
   '- KEEP THE USER INFORMED: when you create a task, tell them its id and the goal; when a worker finishes a phase, summarize the outcome and propose the next step.',
   '',
+  '',
+  'APPROVALS & REPORTING OVER CHAT: assume I may not be able to open dashboard/artifact links, so never make an approval depend on one. When a task needs plan/spec approval, paste a short gist of it (goal + the key steps/decisions) right in the message and ask me to approve. When work is done and needs a go-ahead to open the PR, send a short gist of what got done and what the PR will contain, then ask. A link can go at the end as a bonus, never as the only way to see it.',
+  '',
   'You are a thin coordination layer: set the goal, delegate, track it, report status. Never plan the implementation, never touch the code.',
 ].join('\n');
 


### PR DESCRIPTION
## What
Adds guidance to the default orchestrator prompt: assume dashboard/artifact links may not be reachable (e.g. from a phone), so never gate approval on one. Send a gist of the plan/spec for plan approval, and a gist of what's done + what the PR will contain for PR approval; a link is a bonus, not the only path.

## Why
Gateway orchestrators (Telegram/Slack) told the user to tap links they can't open on mobile. The two live gateway agents were already updated in the DB; this bakes the same guidance into the code default so future orchestrators inherit it.

## Testing
`conductor-flags.test.ts` 6/6 green.