### PR TITLE
style: format 3 files that landed unformatted from #239

### DIFF
--- a/server/hooks.b4.test.ts
+++ b/server/hooks.b4.test.ts
@@ -67,9 +67,9 @@ describe('B4 (removed): POST /api/hooks/stop no longer synchronously transitions
   });
 
   it('Stop sets agent to idle regardless', async () => {
-    const row = db
-      .prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`)
-      .get() as { hook_activity: string };
+    const row = db.prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`).get() as {
+      hook_activity: string;
+    };
     // starts active
     expect(row.hook_activity).toBe('active');
 
@@ -78,9 +78,9 @@ describe('B4 (removed): POST /api/hooks/stop no longer synchronously transitions
       .send({ session_id: 'sess-123' })
       .expect(200);
 
-    const after = db
-      .prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`)
-      .get() as { hook_activity: string };
+    const after = db.prepare(`SELECT hook_activity FROM workers WHERE id = 'a1'`).get() as {
+      hook_activity: string;
+    };
     expect(after.hook_activity).toBe('idle');
   });
 

--- a/server/poller/quiescence.test.ts
+++ b/server/poller/quiescence.test.ts
@@ -1,15 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
-import {
-  createTestDb,
-  insertTask,
-  insertAgent,
-  insertPermissionPrompt,
-} from '../test-helpers.js';
-import {
-  upsertManagedTask,
-  createConversation,
-} from '../repositories/orchestrator.js';
+import { createTestDb, insertTask, insertAgent, insertPermissionPrompt } from '../test-helpers.js';
+import { upsertManagedTask, createConversation } from '../repositories/orchestrator.js';
 import { pollQuiescence } from './quiescence.js';
 
 // Helper to set hook_activity and hook_activity_updated_at directly
@@ -25,9 +17,9 @@ function setWorkerActivity(
 }
 
 function getWorkflowStatus(db: Database.Database, taskId: string): string {
-  const row = db
-    .prepare(`SELECT workflow_status FROM tasks WHERE id = ?`)
-    .get(taskId) as { workflow_status: string };
+  const row = db.prepare(`SELECT workflow_status FROM tasks WHERE id = ?`).get(taskId) as {
+    workflow_status: string;
+  };
   return row.workflow_status;
 }
 
@@ -210,7 +202,11 @@ describe('pollQuiescence', () => {
   });
 
   it('task with no workers is not transitioned (no workers = not yet started)', async () => {
-    insertTask(db, { id: 'task-noworker', runtime_state: 'running', workflow_status: 'in_progress' });
+    insertTask(db, {
+      id: 'task-noworker',
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+    });
     // No workers inserted
 
     await pollQuiescence();

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -862,9 +862,7 @@ export function listNoneModeActiveTasks(
  *
  * Returns task ids only — callers load full state via getTaskWorkflowStatus.
  */
-export function listTasksAwaitingQuiescence(
-  debounceMs: number,
-): Array<{ id: string }> {
+export function listTasksAwaitingQuiescence(debounceMs: number): Array<{ id: string }> {
   return getDb()
     .prepare(
       `SELECT t.id


### PR DESCRIPTION
Pure `prettier --write` on the 3 files that merged unformatted in #239 (`hooks.b4.test.ts`, `quiescence.test.ts`, `tasks.ts`), so `bun run format:check` (and the pre-push hook) passes again. No logic change.