### PR TITLE
fix(agent-session): retry truncated result-file reads instead of failing

### DIFF
--- a/server/agent-session/session.test.ts
+++ b/server/agent-session/session.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import { nanoid } from 'nanoid';
-import { runAgentSession, mcpSubmitResultCapture } from './session.js';
+import { runAgentSession, mcpSubmitResultCapture, readResultFileIfReady } from './session.js';
 import type { CaptureStrategy, RunAgentSessionOptions } from './session.js';
 import type { ProcessHandle, ProcessSubstrate } from './substrate.js';
 import type { Harness } from '../harnesses/types.js';
@@ -404,5 +404,63 @@ describe('mcpSubmitResultCapture — default capture round-trip', () => {
       capture.dispose();
       fs.rmSync(resultDir, { recursive: true, force: true });
     }
+  });
+
+  // Regression: the watcher fires the instant the file is created, before the
+  // MCP server has flushed the JSON. A truncated read must be treated as
+  // "not ready, retry" — NOT a fatal "Failed to parse result file" reject
+  // (which was breaking the slack-watcher schedule).
+  it('does not reject on a transient truncated/empty file — polls until complete', async () => {
+    const resultDir = path.join(os.tmpdir(), `octomux-test-cap3-${nanoid(8)}`);
+    const schema = {
+      type: 'object',
+      properties: { reply: { type: 'string' } },
+      required: ['reply'],
+    };
+    const capture = mcpSubmitResultCapture<{ reply: string }>(schema, { resultDir });
+
+    try {
+      await capture.setup({ workspaceDir: resultDir });
+      const resultPath = path.join(resultDir, 'result.json');
+
+      const waitPromise = capture.waitForResult();
+      await new Promise<void>((resolve) => setImmediate(resolve)); // let watcher attach
+
+      fs.writeFileSync(resultPath, ''); // half-written: exists but empty
+      // Give the watcher + a poll cycle (100ms) time to (wrongly) reject.
+      await new Promise<void>((resolve) => setTimeout(resolve, 150));
+      fs.writeFileSync(resultPath, JSON.stringify({ reply: 'done' })); // now complete
+
+      await expect(waitPromise).resolves.toEqual({ reply: 'done' });
+    } finally {
+      capture.dispose();
+      fs.rmSync(resultDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});
+
+describe('readResultFileIfReady', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-rfr-'));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('returns null when the file is absent', () => {
+    expect(readResultFileIfReady(path.join(dir, 'nope.json'))).toBeNull();
+  });
+
+  it('returns null for an empty/truncated file (not ready)', () => {
+    const p = path.join(dir, 'r.json');
+    fs.writeFileSync(p, '');
+    expect(readResultFileIfReady(p)).toBeNull();
+    fs.writeFileSync(p, '{"reply": "par'); // truncated mid-write
+    expect(readResultFileIfReady(p)).toBeNull();
+  });
+
+  it('parses a complete file', () => {
+    const p = path.join(dir, 'r.json');
+    fs.writeFileSync(p, JSON.stringify({ reply: 'ok' }));
+    expect(readResultFileIfReady(p)).toEqual({ reply: 'ok' });
   });
 });

--- a/server/agent-session/session.ts
+++ b/server/agent-session/session.ts
@@ -83,6 +83,24 @@ export interface McpSubmitResultCaptureOpts {
 }
 
 /**
+ * Read + parse the result file if it's fully written. Returns the parsed value,
+ * or `null` when the file is absent OR present-but-not-yet-complete. The watcher
+ * fires the instant the file is created — before the MCP server has flushed the
+ * JSON — so a parse failure means "not ready, retry", NOT a fatal error. A
+ * genuinely malformed file just never parses and the caller times out.
+ * (Results are schema-validated objects, so a bare `null` is never written.)
+ */
+export function readResultFileIfReady<T = unknown>(rPath: string): T | null {
+  if (!fs.existsSync(rPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(rPath, 'utf8')) as T;
+  } catch (err) {
+    logger.debug({ rPath, err }, 'result file not yet parseable; will retry');
+    return null;
+  }
+}
+
+/**
  * Create the default CaptureStrategy backed by the submit_result MCP server.
  * The agent CLI is told to load the generated mcp-config.json; the MCP server
  * subprocess writes captured results to a JSON file which we watch for.
@@ -155,19 +173,17 @@ export function mcpSubmitResultCapture<T = unknown>(
           reject(err);
         };
 
-        // Read + parse the result file; returns true once handled (resolved or
-        // rejected). Returns false if the file isn't there yet.
+        // Read + parse the result file; returns true once handled (resolved).
+        // Returns false if the file isn't there yet OR is present but not fully
+        // written — the 100ms poll retries until it parses or we time out.
         const tryRead = (): boolean => {
           if (disposed) {
             settleReject(new Error('capture disposed before result'));
             return true;
           }
-          if (!fs.existsSync(rPath)) return false;
-          try {
-            settleResolve(JSON.parse(fs.readFileSync(rPath, 'utf8')) as T);
-          } catch (err) {
-            settleReject(new Error(`Failed to parse result file: ${err}`));
-          }
+          const value = readResultFileIfReady<T>(rPath);
+          if (value === null) return false;
+          settleResolve(value);
           return true;
         };
 


### PR DESCRIPTION
## What
`readResultFileIfReady()` — a parse failure on the captured result file now means "not fully written yet, the 100ms poll will retry" instead of a fatal reject.

## Why
The result-file watcher fires the instant the file is created, before the submit_result MCP server flushes its JSON. A transient truncated read made `waitForResult` reject with *'Failed to parse result file: Unexpected end of JSON input'*, which was intermittently failing the `slack-watcher` schedule (seen daily in prod). A genuinely malformed file still never parses and the run times out as before.

## Testing
`session.test.ts` 12/12, incl. a regression test that writes an empty file then the complete JSON and asserts `waitForResult` resolves (not rejects), plus direct `readResultFileIfReady` unit tests. typecheck clean.