### PR TITLE
feat(prs): pull_requests table + multi-branch PR detection (foundation)

### DIFF
--- a/server/api.pull-requests.test.ts
+++ b/server/api.pull-requests.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests: GET /api/tasks/:id returns pull_requests array and legacy pr_url field.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import type Database from 'better-sqlite3';
+import { createTestDb, insertTask } from './test-helpers.js';
+import { upsertPullRequest } from './repositories/pull-requests.js';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('./task-engine/index.js', () => ({
+  startTask: vi.fn(),
+  closeTask: vi.fn(),
+  softDeleteTask: vi.fn(),
+  deleteTask: vi.fn(),
+  resumeTask: vi.fn(),
+  addAgent: vi.fn(),
+  stopAgent: vi.fn(),
+  createUserTerminal: vi.fn(),
+  createShellTerminal: vi.fn(),
+  closeShellTerminal: vi.fn(),
+  hopAgent: vi.fn(),
+}));
+
+vi.mock('./hook-dispatcher.js', () => ({
+  fireHook: vi.fn(),
+  getTaskHookExecutions: vi.fn(async () => []),
+}));
+
+vi.mock('./events.js', () => ({
+  broadcast: vi.fn(),
+}));
+
+vi.mock('./hook-token.js', () => ({
+  ensureHookToken: vi.fn(async () => 'tok'),
+}));
+
+// Note: do NOT mock 'fs' globally — migrations.ts uses fs.readFileSync to read kind presets
+// (catches ENOENT gracefully), and mocking it without that function causes 500s.
+
+const { createApp } = await import('./app.js');
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/tasks/:id — pull_requests field', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    vi.clearAllMocks();
+  });
+
+  it('returns empty pull_requests array when the task has no PRs', async () => {
+    insertTask(db, { id: 't1', branch: 'agents/t1', runtime_state: 'idle' });
+
+    const res = await request(app).get('/api/tasks/t1').expect(200);
+    expect(res.body.pull_requests).toEqual([]);
+  });
+
+  it('returns pull_requests array with upserted rows', async () => {
+    insertTask(db, { id: 't2', branch: 'agents/t2', runtime_state: 'idle' });
+
+    upsertPullRequest({
+      task_id: 't2',
+      branch: 'agents/t2',
+      number: 7,
+      url: 'https://github.com/o/r/pull/7',
+      state: 'open',
+    });
+    upsertPullRequest({
+      task_id: 't2',
+      branch: 'agents/t2-slice1',
+      number: 8,
+      url: 'https://github.com/o/r/pull/8',
+      state: 'merged',
+    });
+
+    const res = await request(app).get('/api/tasks/t2').expect(200);
+    expect(res.body.pull_requests).toHaveLength(2);
+    const urls = res.body.pull_requests.map((p: { url: string }) => p.url);
+    expect(urls).toContain('https://github.com/o/r/pull/7');
+    expect(urls).toContain('https://github.com/o/r/pull/8');
+  });
+
+  it('still returns legacy pr_url on the task when a derived primary exists', async () => {
+    insertTask(db, {
+      id: 't3',
+      branch: 'agents/t3',
+      runtime_state: 'idle',
+      pr_url: 'https://github.com/o/r/pull/5',
+      pr_number: 5,
+    });
+
+    const res = await request(app).get('/api/tasks/t3').expect(200);
+    expect(res.body.pr_url).toBe('https://github.com/o/r/pull/5');
+    expect(res.body.pr_number).toBe(5);
+    // pull_requests array is populated by the backfill migration
+    // (which runs inside createTestDb via initDb + runMigrations);
+    // however, since the task was inserted AFTER initDb ran, the array is empty here.
+    expect(Array.isArray(res.body.pull_requests)).toBe(true);
+  });
+
+  it('returns 404 for unknown task id', async () => {
+    await request(app).get('/api/tasks/nonexistent').expect(404);
+  });
+});

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -927,6 +927,48 @@ export function runMigrations(instance: Database.Database): void {
   );
   instance.exec(`CREATE INDEX IF NOT EXISTS idx_loop_runs_group ON loop_runs(group_id);`);
 
+  // ── Multiple PRs per task — pull_requests table (2026-07-31) ────────────────
+  // Forward-only. CREATE TABLE IF NOT EXISTS is idempotent for fresh DBs (already
+  // in SCHEMA). For old DBs that ran an earlier SCHEMA without this table, the
+  // CREATE ensures the table exists before we backfill from tasks.pr_url.
+  instance.exec(`
+    CREATE TABLE IF NOT EXISTS pull_requests (
+      id          TEXT PRIMARY KEY,
+      task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+      branch      TEXT NOT NULL,
+      base_branch TEXT,
+      number      INTEGER,
+      url         TEXT,
+      head_sha    TEXT,
+      title       TEXT,
+      state       TEXT NOT NULL DEFAULT 'open',
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(task_id, branch)
+    );
+    CREATE INDEX IF NOT EXISTS idx_pull_requests_task_id ON pull_requests(task_id);
+    CREATE INDEX IF NOT EXISTS idx_pull_requests_state ON pull_requests(state);
+  `);
+
+  // Backfill: for every task that has a non-null pr_url, insert one pull_requests
+  // row using the task's branch (from the joined worktrees table). Idempotent via
+  // INSERT OR IGNORE (guarded by the UNIQUE(task_id, branch) constraint).
+  instance.exec(`
+    INSERT OR IGNORE INTO pull_requests (id, task_id, branch, base_branch, number, url, state)
+    SELECT
+      lower(hex(randomblob(6))) || lower(hex(randomblob(6))),
+      t.id,
+      w.branch,
+      w.base_branch,
+      t.pr_number,
+      t.pr_url,
+      'open'
+    FROM tasks t
+    INNER JOIN worktrees w ON t.worktree_id = w.id
+    WHERE t.pr_url IS NOT NULL
+      AND w.branch IS NOT NULL
+  `);
+
   // ── Remove the Teams feature (2026-07-18, P0) ────────────────────────────
   // Forward-only drop: team_schedules/team_runs are no longer read or written.
   instance.exec('DROP TABLE IF EXISTS team_runs;');

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -203,6 +203,23 @@ CREATE TABLE IF NOT EXISTS runs (
 CREATE INDEX IF NOT EXISTS idx_runs_workflow_kind ON runs(workflow_kind);
 CREATE INDEX IF NOT EXISTS idx_runs_schedule_id ON runs(schedule_id);
 
+CREATE TABLE IF NOT EXISTS pull_requests (
+    id          TEXT PRIMARY KEY,
+    task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    branch      TEXT NOT NULL,
+    base_branch TEXT,
+    number      INTEGER,
+    url         TEXT,
+    head_sha    TEXT,
+    title       TEXT,
+    state       TEXT NOT NULL DEFAULT 'open',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(task_id, branch)
+);
+CREATE INDEX IF NOT EXISTS idx_pull_requests_task_id ON pull_requests(task_id);
+CREATE INDEX IF NOT EXISTS idx_pull_requests_state ON pull_requests(state);
+
 `;
 
 /** Apply SQLite pragmas required for octomux (WAL + foreign keys). */

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -498,13 +498,11 @@ describe('pollPRs', () => {
     expect(task.pr_number).toBe(99);
   });
 
-  const pollPRSkipCases = [
-    {
-      name: 'already has a PR',
-      overrides: { pr_url: 'https://github.com/org/repo/pull/1', pr_number: 1 },
-    },
-    { name: 'has no branch', overrides: { branch: null } },
-  ];
+  // Note: a task that "already has a PR" is intentionally NOT skipped anymore —
+  // the poller keeps looking so it can discover additional slice-branch PRs on a
+  // long-running task. The null→'pr' workflow flip is still guarded (see
+  // pr-detection.test.ts). Only a missing branch skips detection.
+  const pollPRSkipCases = [{ name: 'has no branch', overrides: { branch: null } }];
 
   it.each(pollPRSkipCases)('skips tasks that $name', async ({ overrides }) => {
     insertTask(db, { ...DEFAULTS.runningTask, ...overrides });

--- a/server/poller/pr-detection.test.ts
+++ b/server/poller/pr-detection.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDb, insertTask, insertAgent, findCallback } from '../test-helpers.js';
+import { listPullRequestsByTask } from '../repositories/pull-requests.js';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('../events.js', () => ({
+  broadcast: vi.fn(),
+}));
+
+vi.mock('../hook-dispatcher.js', () => ({
+  fireHook: vi.fn(),
+}));
+
+const { execFile } = await import('child_process');
+const { broadcast } = await import('../events.js');
+const { fireHook } = await import('../hook-dispatcher.js');
+const { pollPRs } = await import('./pr-detection.js');
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build the mock execFile implementation for a PR-detection scenario. */
+function mockExecFile(options: {
+  /** git remote get-url returns this (determines owner/repo). */
+  remoteUrl?: string;
+  /** Branches returned by `git branch --list '...*'`. */
+  sliceBranches?: string[];
+  /** GraphQL response data keyed by alias `pr0`, `pr1`, etc. */
+  graphqlData?: Record<
+    string,
+    { pullRequests: { nodes: Array<{ number: number; url: string; state: string }> } } | null
+  >;
+}) {
+  vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], ...rest: any[]) => {
+    const cb = findCallback(...rest);
+    if (!cb) return undefined as any;
+
+    if (cmd === 'git' && args?.includes('remote') && args?.includes('get-url')) {
+      cb(null, { stdout: `${options.remoteUrl ?? 'git@github.com:org/repo.git'}\n`, stderr: '' });
+    } else if (cmd === 'git' && args?.includes('branch') && args?.includes('--list')) {
+      const out = (options.sliceBranches ?? []).map((b) => `  ${b}`).join('\n');
+      cb(null, { stdout: out ? `${out}\n` : '', stderr: '' });
+    } else if (cmd === 'gh' && args?.[0] === 'api' && args?.[1] === 'graphql') {
+      cb(null, {
+        stdout: JSON.stringify({ data: options.graphqlData ?? {} }),
+        stderr: '',
+      });
+    } else {
+      cb(null, { stdout: '', stderr: '' });
+    }
+    return undefined as any;
+  }) as unknown as typeof execFile);
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('pollPRs (pr-detection)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    vi.clearAllMocks();
+  });
+
+  it('upserts two pull_request rows when a task has a main + slice branch with PRs', async () => {
+    const taskId = 'task-pd-1';
+    const mainBranch = 'agents/task-pd-1';
+    const sliceBranch = 'agents/task-pd-1-slice1';
+
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      branch: mainBranch,
+      repo_path: '/repo',
+    });
+
+    mockExecFile({
+      sliceBranches: [sliceBranch],
+      graphqlData: {
+        pr0: {
+          pullRequests: { nodes: [{ number: 10, url: 'https://gh/pull/10', state: 'OPEN' }] },
+        },
+        pr1: {
+          pullRequests: { nodes: [{ number: 11, url: 'https://gh/pull/11', state: 'OPEN' }] },
+        },
+      },
+    });
+
+    await pollPRs();
+
+    const prs = listPullRequestsByTask(taskId);
+    expect(prs).toHaveLength(2);
+    const numbers = prs.map((p) => p.number).sort((a, b) => (a ?? 0) - (b ?? 0));
+    expect(numbers).toEqual([10, 11]);
+  });
+
+  it('maps GitHub MERGED state to merged', async () => {
+    const taskId = 'task-pd-2';
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      branch: 'agents/task-pd-2',
+      repo_path: '/repo',
+    });
+
+    mockExecFile({
+      graphqlData: {
+        pr0: { pullRequests: { nodes: [{ number: 5, url: 'u5', state: 'MERGED' }] } },
+      },
+    });
+
+    await pollPRs();
+
+    const prs = listPullRequestsByTask(taskId);
+    expect(prs).toHaveLength(1);
+    expect(prs[0].state).toBe('merged');
+  });
+
+  it('maps GitHub CLOSED state to closed', async () => {
+    const taskId = 'task-pd-3';
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      branch: 'agents/task-pd-3',
+      repo_path: '/repo',
+    });
+
+    mockExecFile({
+      graphqlData: {
+        pr0: { pullRequests: { nodes: [{ number: 6, url: 'u6', state: 'CLOSED' }] } },
+      },
+    });
+
+    await pollPRs();
+
+    const prs = listPullRequestsByTask(taskId);
+    expect(prs[0].state).toBe('closed');
+  });
+
+  it('sets derived primary on tasks.pr_url after first PR', async () => {
+    const taskId = 'task-pd-4';
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      branch: 'agents/task-pd-4',
+      repo_path: '/repo',
+    });
+
+    mockExecFile({
+      graphqlData: {
+        pr0: {
+          pullRequests: { nodes: [{ number: 42, url: 'https://gh/pull/42', state: 'OPEN' }] },
+        },
+      },
+    });
+
+    await pollPRs();
+
+    const row = db.prepare(`SELECT pr_url, pr_number FROM tasks WHERE id = ?`).get(taskId) as {
+      pr_url: string | null;
+      pr_number: number | null;
+    };
+
+    expect(row.pr_url).toBe('https://gh/pull/42');
+    expect(row.pr_number).toBe(42);
+  });
+
+  it('fires workflow transition + broadcast on first PR detection when in_progress', async () => {
+    const taskId = 'task-pd-5';
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      branch: 'agents/task-pd-5',
+      repo_path: '/repo',
+    });
+    // Add an agent so insertAgent can exist; not required by pollPRs itself.
+    insertAgent(db, {
+      id: 'agent-pd-5',
+      task_id: taskId,
+      hook_token: 'tok',
+      status: 'running',
+    } as any);
+
+    mockExecFile({
+      graphqlData: {
+        pr0: {
+          pullRequests: { nodes: [{ number: 99, url: 'https://gh/pull/99', state: 'OPEN' }] },
+        },
+      },
+    });
+
+    await pollPRs();
+
+    expect(broadcast).toHaveBeenCalledWith({ type: 'task:updated', payload: { taskId } });
+    expect(fireHook).toHaveBeenCalledWith(
+      'workflow_status_changed',
+      expect.objectContaining({
+        data: expect.objectContaining({ to: 'pr' }),
+      }),
+    );
+  });
+
+  it('does NOT fire workflow transition when task has no prior PR but workflow_status is not in_progress/human_review', async () => {
+    const taskId = 'task-pd-6';
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'idle',
+      workflow_status: 'backlog',
+      branch: 'agents/task-pd-6',
+      repo_path: '/repo',
+    });
+
+    mockExecFile({
+      graphqlData: {
+        pr0: { pullRequests: { nodes: [{ number: 77, url: 'u77', state: 'OPEN' }] } },
+      },
+    });
+
+    await pollPRs();
+
+    expect(fireHook).not.toHaveBeenCalled();
+    // broadcast IS called (the task got a new PR)
+    expect(broadcast).toHaveBeenCalledWith({ type: 'task:updated', payload: { taskId } });
+  });
+});

--- a/server/poller/pr-detection.ts
+++ b/server/poller/pr-detection.ts
@@ -3,11 +3,8 @@ import { promisify } from 'util';
 import { broadcast } from '../events.js';
 import { fireHook } from '../hook-dispatcher.js';
 import { childLogger } from '../logger.js';
-import {
-  setTaskPrDetected,
-  addTaskUpdate,
-  listTasksNeedingPrDetection,
-} from '../repositories/tasks.js';
+import { addTaskUpdate, listTasksNeedingPrDetection, getTask } from '../repositories/tasks.js';
+import { upsertPullRequest, syncDerivedPrimaryPr } from '../repositories/pull-requests.js';
 import type { Task } from '../types.js';
 import { repoNameWithOwner } from './github-repo.js';
 
@@ -32,25 +29,73 @@ export async function detectPR(task: Task): Promise<{ url: string; number: numbe
   }
 }
 
+/**
+ * Enumerate candidate branches for a task: the task's own branch plus any
+ * git branches whose name starts with the `agents/<taskid>` prefix (slice branches).
+ * Returns deduplicated list; task.branch is always first.
+ */
+async function candidateBranches(task: Task): Promise<string[]> {
+  if (!task.branch || !task.repo_path) return [];
+  const branches = [task.branch];
+
+  // Slice branches follow `agents/<id>-<slice>`; the base prefix is task.branch
+  // (which itself is `agents/<id>`).
+  const prefix = task.branch; // e.g. "agents/abc123def456"
+  try {
+    const { stdout } = await execFile('git', [
+      '-C',
+      task.repo_path,
+      'branch',
+      '--list',
+      `${prefix}-*`,
+    ]);
+    for (const line of stdout.split('\n')) {
+      const b = line.replace(/^\*?\s+/, '').trim();
+      if (b && b !== prefix && !branches.includes(b)) {
+        branches.push(b);
+      }
+    }
+  } catch {
+    // Not a fatal error — fall back to just the task's own branch.
+  }
+  return branches;
+}
+
 export async function pollPRs(): Promise<void> {
   const tasks = listTasksNeedingPrDetection();
   if (tasks.length === 0) return;
 
-  const eligible: Array<{ task: Task; owner: string; name: string; branch: string }> = [];
+  // For each task, enumerate candidate branches (main + slice branches).
+  // Build one flat list of (task, branch) entries to query in bulk.
+  const entries: Array<{
+    task: Task;
+    owner: string;
+    name: string;
+    branch: string;
+    baseBranch: string | null;
+  }> = [];
+
   for (const task of tasks) {
     if (!task.repo_path || !task.branch) continue;
     const nwo = await repoNameWithOwner(task.repo_path);
     if (!nwo) continue;
     const [owner, name] = nwo.split('/');
     if (!owner || !name) continue;
-    eligible.push({ task, owner, name, branch: task.branch });
-  }
-  if (eligible.length === 0) return;
 
-  const aliasFragments = eligible
+    const branches = await candidateBranches(task);
+    for (const branch of branches) {
+      entries.push({ task, owner, name, branch, baseBranch: task.base_branch ?? null });
+    }
+  }
+
+  if (entries.length === 0) return;
+
+  // Build a single batched GraphQL query; one alias per (task, branch) entry.
+  // Each alias requests: number, url, state.
+  const aliasFragments = entries
     .map(
       ({ owner, name, branch }, i) =>
-        `pr${i}: repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) { pullRequests(headRefName: ${JSON.stringify(branch)}, first: 1, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number url } } }`,
+        `pr${i}: repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) { pullRequests(headRefName: ${JSON.stringify(branch)}, first: 1, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { number url state } } }`,
     )
     .join('\n  ');
   const query = `query { ${aliasFragments} }`;
@@ -58,7 +103,7 @@ export async function pollPRs(): Promise<void> {
   let parsed: {
     data?: Record<
       string,
-      { pullRequests: { nodes: Array<{ number: number; url: string }> } } | null
+      { pullRequests: { nodes: Array<{ number: number; url: string; state: string }> } } | null
     >;
   } = {};
   try {
@@ -74,17 +119,46 @@ export async function pollPRs(): Promise<void> {
     return;
   }
 
-  for (const [i, { task }] of eligible.entries()) {
-    const node = parsed.data?.[`pr${i}`]?.pullRequests?.nodes?.[0];
-    const pr = node ? { url: node.url, number: node.number } : null;
-    if (pr) {
-      const prevWorkflow = task.workflow_status;
-      const shouldFlipToPr = prevWorkflow === 'in_progress' || prevWorkflow === 'human_review';
-      setTaskPrDetected(task.id, pr.url, pr.number);
+  // Group results back by task_id so we can run syncDerivedPrimaryPr once per task.
+  const taskIds = new Set(entries.map((e) => e.task.id));
 
+  for (const [i, { task, branch, baseBranch }] of entries.entries()) {
+    const node = parsed.data?.[`pr${i}`]?.pullRequests?.nodes?.[0];
+    if (!node) continue;
+
+    // Map GitHub's OPEN / MERGED / CLOSED to our lowercase values.
+    const ghState = node.state?.toUpperCase();
+    const state = ghState === 'MERGED' ? 'merged' : ghState === 'CLOSED' ? 'closed' : 'open';
+
+    upsertPullRequest({
+      task_id: task.id,
+      branch,
+      base_branch: baseBranch,
+      number: node.number,
+      url: node.url,
+      state,
+    });
+  }
+
+  // Sync derived primary and fire workflow transitions for each affected task.
+  for (const taskId of taskIds) {
+    const taskBefore = entries.find((e) => e.task.id === taskId)!.task;
+    const hadPrBefore = taskBefore.pr_url != null;
+
+    syncDerivedPrimaryPr(taskId);
+
+    // Re-read to get the updated pr_url (syncDerivedPrimaryPr writes tasks).
+    const taskAfter = getTask(taskId);
+    if (!taskAfter) continue;
+
+    const prevWorkflow = taskBefore.workflow_status;
+    const shouldFlipToPr = prevWorkflow === 'in_progress' || prevWorkflow === 'human_review';
+
+    if (!hadPrBefore && taskAfter.pr_url) {
+      // First PR detected for this task.
       if (shouldFlipToPr) {
         addTaskUpdate({
-          task_id: task.id,
+          task_id: taskId,
           kind: 'transition',
           from_status: prevWorkflow,
           to_status: 'pr',
@@ -93,15 +167,16 @@ export async function pollPRs(): Promise<void> {
         fireHook('workflow_status_changed', {
           event: 'workflow_status_changed',
           task: {
-            ...task,
-            pr_url: pr.url,
-            pr_number: pr.number,
+            ...taskAfter,
             workflow_status: 'pr' as import('../types.js').WorkflowStatus,
           },
           data: { from: prevWorkflow, to: 'pr', note: 'auto: PR opened' },
         });
       }
-      broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+      broadcast({ type: 'task:updated', payload: { taskId } });
+    } else if (hadPrBefore) {
+      // PR state may have changed — broadcast update anyway.
+      broadcast({ type: 'task:updated', payload: { taskId } });
     }
   }
 }

--- a/server/repositories/pull-requests.test.ts
+++ b/server/repositories/pull-requests.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDb, insertTask } from '../test-helpers.js';
+import {
+  upsertPullRequest,
+  listPullRequestsByTask,
+  syncDerivedPrimaryPr,
+} from './pull-requests.js';
+
+describe('pull-requests repository', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  // ── migration + backfill ─────────────────────────────────────────────────
+
+  describe('migration backfill', () => {
+    it('seeds a pull_requests row from tasks.pr_url on initDb', () => {
+      // Insert a task that already has a pr_url (simulates an existing production row).
+      insertTask(db, {
+        id: 'task-mig-1',
+        pr_url: 'https://github.com/org/repo/pull/7',
+        pr_number: 7,
+        branch: 'agents/task-mig-1',
+      });
+
+      // Manually run the backfill SQL as the migration does (createTestDb already ran it
+      // via initDb, but here the task was inserted AFTER initDb — so run it explicitly to
+      // test the migration logic in isolation).
+      db.exec(`
+        INSERT OR IGNORE INTO pull_requests (id, task_id, branch, base_branch, number, url, state)
+        SELECT
+          lower(hex(randomblob(6))) || lower(hex(randomblob(6))),
+          t.id, w.branch, w.base_branch, t.pr_number, t.pr_url, 'open'
+        FROM tasks t
+        INNER JOIN worktrees w ON t.worktree_id = w.id
+        WHERE t.pr_url IS NOT NULL AND w.branch IS NOT NULL
+      `);
+
+      const rows = db
+        .prepare(`SELECT * FROM pull_requests WHERE task_id = 'task-mig-1'`)
+        .all() as Array<Record<string, unknown>>;
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].url).toBe('https://github.com/org/repo/pull/7');
+      expect(rows[0].number).toBe(7);
+      expect(rows[0].branch).toBe('agents/task-mig-1');
+      expect(rows[0].state).toBe('open');
+    });
+
+    it('is idempotent — running the backfill twice produces one row', () => {
+      insertTask(db, {
+        id: 'task-mig-2',
+        pr_url: 'https://github.com/org/repo/pull/8',
+        pr_number: 8,
+        branch: 'agents/task-mig-2',
+      });
+
+      const sql = `
+        INSERT OR IGNORE INTO pull_requests (id, task_id, branch, base_branch, number, url, state)
+        SELECT
+          lower(hex(randomblob(6))) || lower(hex(randomblob(6))),
+          t.id, w.branch, w.base_branch, t.pr_number, t.pr_url, 'open'
+        FROM tasks t
+        INNER JOIN worktrees w ON t.worktree_id = w.id
+        WHERE t.pr_url IS NOT NULL AND w.branch IS NOT NULL
+      `;
+      db.exec(sql);
+      db.exec(sql); // second run — must no-op
+
+      const count = (
+        db
+          .prepare(`SELECT COUNT(*) AS n FROM pull_requests WHERE task_id = 'task-mig-2'`)
+          .get() as { n: number }
+      ).n;
+      expect(count).toBe(1);
+    });
+  });
+
+  // ── upsertPullRequest ────────────────────────────────────────────────────
+
+  describe('upsertPullRequest', () => {
+    it('inserts a new row on first call', () => {
+      insertTask(db, { id: 'task-up-1', branch: 'agents/task-up-1' });
+      const pr = upsertPullRequest({
+        task_id: 'task-up-1',
+        branch: 'agents/task-up-1',
+        number: 10,
+        url: 'https://github.com/o/r/pull/10',
+        state: 'open',
+      });
+      expect(pr.id).toBeTruthy();
+      expect(pr.task_id).toBe('task-up-1');
+      expect(pr.branch).toBe('agents/task-up-1');
+      expect(pr.number).toBe(10);
+      expect(pr.state).toBe('open');
+    });
+
+    it('updates an existing row on second call for same (task_id, branch)', () => {
+      insertTask(db, { id: 'task-up-2', branch: 'agents/task-up-2' });
+      upsertPullRequest({
+        task_id: 'task-up-2',
+        branch: 'agents/task-up-2',
+        number: 11,
+        url: 'https://github.com/o/r/pull/11',
+        state: 'open',
+      });
+      const updated = upsertPullRequest({
+        task_id: 'task-up-2',
+        branch: 'agents/task-up-2',
+        state: 'merged',
+      });
+      expect(updated.state).toBe('merged');
+      expect(updated.number).toBe(11); // preserved from first insert (COALESCE)
+    });
+
+    it('two calls with different branches produce two rows', () => {
+      insertTask(db, { id: 'task-up-3', branch: 'agents/task-up-3' });
+      upsertPullRequest({
+        task_id: 'task-up-3',
+        branch: 'agents/task-up-3',
+        number: 20,
+        url: 'https://github.com/o/r/pull/20',
+        state: 'open',
+      });
+      upsertPullRequest({
+        task_id: 'task-up-3',
+        branch: 'agents/task-up-3-slice1',
+        number: 21,
+        url: 'https://github.com/o/r/pull/21',
+        state: 'open',
+      });
+      const rows = listPullRequestsByTask('task-up-3');
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  // ── listPullRequestsByTask ────────────────────────────────────────────────
+
+  describe('listPullRequestsByTask', () => {
+    it('returns rows newest-first', () => {
+      insertTask(db, { id: 'task-list-1', branch: 'agents/task-list-1' });
+      const a = upsertPullRequest({
+        task_id: 'task-list-1',
+        branch: 'agents/task-list-1',
+        number: 1,
+        url: 'u1',
+        state: 'open',
+      });
+      const b = upsertPullRequest({
+        task_id: 'task-list-1',
+        branch: 'agents/task-list-1-s2',
+        number: 2,
+        url: 'u2',
+        state: 'open',
+      });
+      const rows = listPullRequestsByTask('task-list-1');
+      // b was inserted after a — should come first (DESC created_at).
+      expect(rows[0].id).toBe(b.id);
+      expect(rows[1].id).toBe(a.id);
+    });
+
+    it('returns empty array for task with no PRs', () => {
+      insertTask(db, { id: 'task-list-2', branch: 'agents/task-list-2' });
+      expect(listPullRequestsByTask('task-list-2')).toEqual([]);
+    });
+  });
+
+  // ── syncDerivedPrimaryPr ──────────────────────────────────────────────────
+
+  describe('syncDerivedPrimaryPr', () => {
+    const cases = [
+      {
+        name: '0 PRs → nulls on tasks',
+        prs: [] as Array<{
+          branch: string;
+          number: number;
+          url: string;
+          state: 'open' | 'merged' | 'closed';
+        }>,
+        expected: { pr_url: null, pr_number: null, pr_head_sha: null },
+      },
+      {
+        name: '1 open PR → that PR is primary',
+        prs: [{ branch: 'b1', number: 5, url: 'https://gh/pr/5', state: 'open' as const }],
+        expected: { pr_url: 'https://gh/pr/5', pr_number: 5, pr_head_sha: null },
+      },
+      {
+        name: 'open + merged → open wins',
+        prs: [
+          { branch: 'b1', number: 5, url: 'u5', state: 'open' as const },
+          { branch: 'b2', number: 6, url: 'u6', state: 'merged' as const },
+        ],
+        expected: { pr_url: 'u5', pr_number: 5, pr_head_sha: null },
+      },
+      {
+        name: 'all merged → newest row is primary',
+        prs: [
+          { branch: 'b1', number: 3, url: 'u3', state: 'merged' as const },
+          { branch: 'b2', number: 4, url: 'u4', state: 'merged' as const },
+        ],
+        // b2 inserted last → newest created_at → primary
+        expected: { pr_url: 'u4', pr_number: 4, pr_head_sha: null },
+      },
+    ] as const;
+
+    it.each(cases)('$name', ({ prs, expected }) => {
+      const taskId = `task-sync-${Math.random().toString(36).slice(2, 8)}`;
+      insertTask(db, { id: taskId, branch: 'agents/' + taskId });
+
+      for (const pr of prs) {
+        upsertPullRequest({ task_id: taskId, ...pr });
+      }
+
+      syncDerivedPrimaryPr(taskId);
+
+      const row = db
+        .prepare(`SELECT pr_url, pr_number, pr_head_sha FROM tasks WHERE id = ?`)
+        .get(taskId) as {
+        pr_url: string | null;
+        pr_number: number | null;
+        pr_head_sha: string | null;
+      };
+
+      expect(row.pr_url).toBe(expected.pr_url);
+      expect(row.pr_number).toBe(expected.pr_number);
+      expect(row.pr_head_sha).toBe(expected.pr_head_sha);
+    });
+  });
+});

--- a/server/repositories/pull-requests.ts
+++ b/server/repositories/pull-requests.ts
@@ -1,0 +1,153 @@
+/**
+ * Repository layer for the `pull_requests` table.
+ * Stores one row per (task_id, branch) pair; upserts on conflict.
+ */
+import { nanoid } from 'nanoid';
+import { getDb } from '../db.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('repositories/pull-requests');
+
+export type PullRequestState = 'open' | 'merged' | 'closed';
+
+export interface PullRequest {
+  id: string;
+  task_id: string;
+  branch: string;
+  base_branch: string | null;
+  number: number | null;
+  url: string | null;
+  head_sha: string | null;
+  title: string | null;
+  state: PullRequestState;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpsertPullRequestInput {
+  task_id: string;
+  branch: string;
+  base_branch?: string | null;
+  number?: number | null;
+  url?: string | null;
+  head_sha?: string | null;
+  title?: string | null;
+  state?: PullRequestState;
+}
+
+/**
+ * Insert or update a pull_requests row keyed on (task_id, branch).
+ * On conflict, updates all supplied fields and bumps updated_at.
+ */
+export function upsertPullRequest(input: UpsertPullRequestInput): PullRequest {
+  const db = getDb();
+  const existing = db
+    .prepare(`SELECT id FROM pull_requests WHERE task_id = ? AND branch = ?`)
+    .get(input.task_id, input.branch) as { id: string } | undefined;
+
+  if (existing) {
+    db.prepare(
+      `UPDATE pull_requests
+          SET base_branch = COALESCE(?, base_branch),
+              number      = COALESCE(?, number),
+              url         = COALESCE(?, url),
+              head_sha    = COALESCE(?, head_sha),
+              title       = COALESCE(?, title),
+              state       = ?,
+              updated_at  = datetime('now')
+        WHERE task_id = ? AND branch = ?`,
+    ).run(
+      input.base_branch ?? null,
+      input.number ?? null,
+      input.url ?? null,
+      input.head_sha ?? null,
+      input.title ?? null,
+      input.state ?? 'open',
+      input.task_id,
+      input.branch,
+    );
+    logger.info(
+      { task_id: input.task_id, branch: input.branch, operation: 'upsertPullRequest' },
+      'pull_request updated',
+    );
+  } else {
+    const id = nanoid(12);
+    db.prepare(
+      `INSERT INTO pull_requests (id, task_id, branch, base_branch, number, url, head_sha, title, state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      input.task_id,
+      input.branch,
+      input.base_branch ?? null,
+      input.number ?? null,
+      input.url ?? null,
+      input.head_sha ?? null,
+      input.title ?? null,
+      input.state ?? 'open',
+    );
+    logger.info(
+      { task_id: input.task_id, branch: input.branch, pr_id: id, operation: 'upsertPullRequest' },
+      'pull_request inserted',
+    );
+  }
+
+  return getDb()
+    .prepare(`SELECT * FROM pull_requests WHERE task_id = ? AND branch = ?`)
+    .get(input.task_id, input.branch) as PullRequest;
+}
+
+/** List all pull_requests for a task, newest first (rowid breaks ties within the same second). */
+export function listPullRequestsByTask(taskId: string): PullRequest[] {
+  return getDb()
+    .prepare(`SELECT * FROM pull_requests WHERE task_id = ? ORDER BY created_at DESC, rowid DESC`)
+    .all(taskId) as PullRequest[];
+}
+
+/**
+ * Recompute tasks.pr_url / pr_number / pr_head_sha from the task's pull_requests rows.
+ * Rule: prefer the most-recently-created `open` PR; fall back to the newest row overall;
+ * set all three to NULL if there are no rows.
+ * Keeps every existing reader of tasks.pr_* working without changes.
+ */
+export function syncDerivedPrimaryPr(taskId: string): void {
+  const db = getDb();
+
+  // Prefer open, newest first (rowid breaks same-second ties); fall back to any state.
+  const primary = db
+    .prepare(
+      `SELECT url, number, head_sha
+         FROM pull_requests
+        WHERE task_id = ?
+        ORDER BY
+          CASE WHEN state = 'open' THEN 0 ELSE 1 END,
+          created_at DESC,
+          rowid DESC
+        LIMIT 1`,
+    )
+    .get(taskId) as
+    | { url: string | null; number: number | null; head_sha: string | null }
+    | undefined;
+
+  if (primary) {
+    db.prepare(
+      `UPDATE tasks
+          SET pr_url      = ?,
+              pr_number   = ?,
+              pr_head_sha = ?,
+              updated_at  = datetime('now')
+        WHERE id = ?`,
+    ).run(primary.url, primary.number, primary.head_sha, taskId);
+  } else {
+    db.prepare(
+      `UPDATE tasks
+          SET pr_url      = NULL,
+              pr_number   = NULL,
+              pr_head_sha = NULL,
+              updated_at  = datetime('now')
+        WHERE id = ?`,
+    ).run(taskId);
+  }
+
+  logger.info({ task_id: taskId, operation: 'syncDerivedPrimaryPr' }, 'derived primary PR synced');
+}

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -791,13 +791,17 @@ export function listRunningTasksWithPr(): Task[] {
 }
 
 /**
- * List tasks that are running or idle with no PR url yet and a branch set.
- * Used by pollPRs to find tasks that need PR detection.
+ * List running/idle tasks with a branch set. Used by pollPRs to detect PRs.
+ * We intentionally keep polling AFTER the first PR is found (no `pr_url IS NULL`
+ * gate): a long-running task can open several slice PRs over its life, and the
+ * poller discovers each `agents/<id>*` branch's PR. The workflow → 'pr'
+ * transition is guarded on the null→non-null flip in pollPRs, so re-polling an
+ * already-PR'd task is idempotent.
  */
 export function listTasksNeedingPrDetection(): Task[] {
   return getDb()
     .prepare(
-      `${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'idle') AND t.pr_url IS NULL AND w.branch IS NOT NULL`,
+      `${SELECT_TASK_SQL} WHERE t.runtime_state IN ('running', 'idle') AND w.branch IS NOT NULL`,
     )
     .all() as Task[];
 }

--- a/server/routes/_shared.ts
+++ b/server/routes/_shared.ts
@@ -10,6 +10,8 @@ import {
   listUserTerminals,
   listPendingPromptsByTask,
 } from '../repositories/index.js';
+import { listPullRequestsByTask } from '../repositories/pull-requests.js';
+import type { PullRequest } from '../repositories/pull-requests.js';
 import type { PermissionPromptRow } from '../repositories/permission-prompts.js';
 import { findReviewTaskByPrNumber, findReviewTaskBySource } from '../repositories/index.js';
 import { nanoid } from 'nanoid';
@@ -101,6 +103,7 @@ export interface TaskRelations {
   workers: Worker[];
   user_terminals: UserTerminal[];
   pending_prompts: PermissionPromptRow[];
+  pull_requests: PullRequest[];
 }
 
 export interface TaskResponseExtras {
@@ -108,7 +111,7 @@ export interface TaskResponseExtras {
   existing_review_id?: string | null;
 }
 
-/** Load a task plus workers, terminals, and pending permission prompts. */
+/** Load a task plus workers, terminals, pending permission prompts, and pull_requests. */
 export function fetchTaskWithRelations(taskId: string): { task: Task; relations: TaskRelations } {
   const task = getTaskRepo(taskId) as Task;
   return {
@@ -117,6 +120,7 @@ export function fetchTaskWithRelations(taskId: string): { task: Task; relations:
       workers: listAllAgents(taskId),
       user_terminals: listUserTerminals(taskId),
       pending_prompts: listPendingPromptsByTask(taskId),
+      pull_requests: listPullRequestsByTask(taskId),
     },
   };
 }
@@ -136,6 +140,7 @@ export function formatTaskResponse(
       workers: relations.workers,
     }),
     user_terminals: relations.user_terminals,
+    pull_requests: relations.pull_requests,
     ...(extras?.worktree_row !== undefined ? { worktree_row: extras.worktree_row } : {}),
     ...(extras?.existing_review_id !== undefined
       ? { existing_review_id: extras.existing_review_id }
@@ -143,7 +148,7 @@ export function formatTaskResponse(
   };
 }
 
-/** Reload a task with its related workers and user_terminals (mutation-style, no prompts). */
+/** Reload a task with its related workers, user_terminals, and pull_requests (mutation-style, no prompts). */
 export function fetchTaskBundle(taskId: string): Task {
   const { task, relations } = fetchTaskWithRelations(taskId);
   task.workers = relations.workers;

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -105,6 +105,9 @@ router.get('/api/tasks', (req: Request, res: Response) => {
       workers: workersByTask.get(task.id) || [],
       pending_prompts: promptsByTask.get(task.id) || [],
       user_terminals: terminalsByTask.get(task.id) || [],
+      // ponytail: list endpoint omits pull_requests to avoid N+1 DB queries;
+      // add bulk fetch here if the dashboard ever needs per-task PR lists in the board view.
+      pull_requests: [],
     }),
   );
 


### PR DESCRIPTION
First slice of multiple-PRs-per-task (spec/multiple-prs-per-task.md).

## What
- **`pull_requests` table** (many-per-task): forward-only migration in `db/migrations.ts` + `SCHEMA`, with idempotent backfill from `tasks.pr_url`.
- **`repositories/pull-requests.ts`**: `upsertPullRequest`, `listPullRequestsByTask`, `syncDerivedPrimaryPr` (keeps `tasks.pr_*` as the derived primary = most-recent open PR, newest fallback) + `PullRequest` type.
- **Widened poller** (`pr-detection.ts`): enumerates each task's `agents/<id>*` branches, queries each branch's PR (incl. state) via the batched GraphQL, upserts a row per PR, then syncs the derived primary. The `in_progress|human_review → pr` workflow flip is guarded on the null→non-null transition, so re-polling is idempotent.
- **Polling gate**: dropped the `pr_url IS NULL` condition in `listTasksNeedingPrDetection` so a long-running task keeps getting polled and discovers *additional* slice PRs (this is what makes many-PRs-per-task actually work).
- **API**: task detail returns a `pull_requests` array; legacy `pr_url`/`pr_number` still populated.

## Testing
New `pull-requests.test.ts` (11), `pr-detection.test.ts` (6), `api.pull-requests.test.ts` (4); `poller.test.ts` updated (removed the now-invalid 'skips task that already has a PR' case). typecheck clean. Targeted suites green deterministically; the box's full-suite flakiness under load is pre-existing (identical count on plain next).

## Deferred to follow-up PRs
- PostToolUse hook fast-path parsing `gh pr create`/`git push`.
- Web UI (PR list + workflow-status rollup in the info tab).
- Multi-ticket: relax `task_external_refs` PK for N Linear/Jira refs per task.