### PR TITLE
fix(orchestrator): send artifact summaries over chat, not bare links

### DIFF
--- a/server/gateway/gateway.test.ts
+++ b/server/gateway/gateway.test.ts
@@ -274,6 +274,47 @@ describe('gateway glue', () => {
     ]);
   });
 
+  it('a card with args.summary sends the summary as payload — link only a trailing ref', async () => {
+    createAgent({
+      name: 'Ops Agent',
+      system_prompt: 'You watch prod.',
+      channel: 'telegram',
+      channel_config: JSON.stringify({ threadKey: 'chat-1' }),
+    });
+
+    const { adapter, sent } = fakeAdapter();
+    const { conductor, sendTurn } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+    await gw.handleInbound(inbound());
+    const convId = sendTurn.mock.calls[0]![0] as string;
+
+    pushToConversation(
+      convId,
+      JSON.stringify({
+        type: 'card',
+        id: 'card-1',
+        command: 'approve-plan',
+        args: {
+          task_id: 't1',
+          plan_path: 'plan.json',
+          artifact_url: '/api/orchestrator/artifact?task=t1&path=plan.json',
+          summary: 'Add a widget.\n\nFiles:\n• src/widget.ts — create',
+        },
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sent).toHaveLength(1);
+    const text = sent[0]!.text;
+    // Summary is the payload; the URL is a trailing secondary ref, never alone.
+    expect(text).toContain('Add a widget.');
+    expect(text).toContain('src/widget.ts — create');
+    expect(text).toContain('(ref: /api/orchestrator/artifact?task=t1&path=plan.json)');
+    expect(text).not.toBe(
+      '[t1] plan ready for review: /api/orchestrator/artifact?task=t1&path=plan.json',
+    );
+  });
+
   it('start() pre-registers the proactive relay for a bound agent — a supervisor push reaches the channel with NO prior inbound (survives restart)', async () => {
     const agentId = createAgent({
       name: 'Ops Agent',

--- a/server/gateway/gateway.ts
+++ b/server/gateway/gateway.ts
@@ -117,6 +117,7 @@ export function createGateway(
     const args = event.args;
     const taskId = typeof args.task_id === 'string' ? args.task_id : undefined;
     const artifactUrl = typeof args.artifact_url === 'string' ? args.artifact_url : undefined;
+    const summary = typeof args.summary === 'string' ? args.summary.trim() : '';
     const label =
       event.command === 'approve-plan'
         ? 'plan ready for review'
@@ -124,6 +125,13 @@ export function createGateway(
           ? 'spec ready for review'
           : event.command;
     const prefix = taskId ? `[${taskId}] ` : '';
+    // Summary is the payload; the link (when present) is a trailing secondary
+    // reference only — a user on mobile/SSH can't open it, so it must never be
+    // the whole message.
+    if (summary) {
+      const ref = artifactUrl ? `\n\n(ref: ${artifactUrl})` : '';
+      return `${prefix}${label}\n\n${summary}${ref}`;
+    }
     return artifactUrl ? `${prefix}${label}: ${artifactUrl}` : `${prefix}${label}`;
   }
 

--- a/server/orchestrator/artifact-endpoint.ts
+++ b/server/orchestrator/artifact-endpoint.ts
@@ -131,6 +131,39 @@ function resolveArtifactPath(
   return { resolved };
 }
 
+/**
+ * Read a task artifact's contents server-side, reusing the same symlink-safe
+ * resolution as the GET endpoint. Returns null (never throws) on missing
+ * task/worktree, a rejected/traversing path, or a missing file — so callers
+ * (e.g. the supervisor summary path) can fall back gracefully.
+ *
+ * This is the single server-side artifact reader: the browser goes through the
+ * GET endpoint, the supervisor goes through here, both via `resolveArtifactPath`.
+ */
+export function readTaskArtifact(taskId: string, relPath: string): string | null {
+  const found = getWorktreePath(taskId);
+  if (!found) return null;
+
+  const resolution = resolveArtifactPath(found.worktreePath, relPath);
+  if ('rejected' in resolution) {
+    logger.debug(
+      { task_id: taskId, path: relPath, reason: resolution.rejected },
+      'readTaskArtifact rejected',
+    );
+    return null;
+  }
+
+  try {
+    return fs.readFileSync(resolution.resolved, 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      logger.warn({ task_id: taskId, path: relPath, err }, 'readTaskArtifact read error');
+    }
+    return null;
+  }
+}
+
 // ─── Route handlers ───────────────────────────────────────────────────────────
 
 function handleGet(req: Request, res: Response): void {

--- a/server/orchestrator/artifact-summary.test.ts
+++ b/server/orchestrator/artifact-summary.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for buildArtifactSummary — the pure gist builder that makes gateway
+ * chat replies self-contained instead of bare links.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildArtifactSummary } from './artifact-summary.js';
+
+const PLAN = JSON.stringify({
+  schema_version: '1.0.0',
+  summary: 'Add a widget and wire it up.',
+  files: [
+    { path: 'src/widget.ts', action: 'create' },
+    { path: 'src/app.ts', action: 'modify' },
+  ],
+  open_questions: ['Should the widget be lazy-loaded?'],
+});
+
+describe('buildArtifactSummary', () => {
+  it('renders plan.json summary + file list + open questions', () => {
+    const out = buildArtifactSummary('plan.json', PLAN);
+    expect(out).toContain('Add a widget and wire it up.');
+    expect(out).toContain('src/widget.ts — create');
+    expect(out).toContain('src/app.ts — modify');
+    expect(out).toContain('Should the widget be lazy-loaded?');
+    // Payload is content, not a URL.
+    expect(out).not.toMatch(/https?:\/\//);
+  });
+
+  it('returns the head of markdown content for spec.md', () => {
+    const spec = '# Spec\n\nGoal: make it work.\n\nDetails follow.';
+    const out = buildArtifactSummary('spec.md', spec);
+    expect(out).toContain('Goal: make it work.');
+  });
+
+  it('falls back to raw head when plan.json is malformed', () => {
+    const out = buildArtifactSummary('plan.json', '{not valid json');
+    expect(out).toContain('{not valid json');
+  });
+
+  it('falls back to raw head when plan.json has no recognizable fields', () => {
+    const out = buildArtifactSummary('plan.json', JSON.stringify({ nope: 1 }));
+    expect(out).toContain('"nope"');
+  });
+
+  it('bounds output to maxChars with an ellipsis', () => {
+    const long = 'x'.repeat(5000);
+    const out = buildArtifactSummary('spec.md', long, 100);
+    expect(out.length).toBeLessThanOrEqual(102); // 100 + '\n…'
+    expect(out.endsWith('…')).toBe(true);
+  });
+});

--- a/server/orchestrator/artifact-summary.ts
+++ b/server/orchestrator/artifact-summary.ts
@@ -1,0 +1,114 @@
+/**
+ * server/orchestrator/artifact-summary.ts
+ *
+ * Build a self-contained, plain-text gist of a task artifact so gateway chat
+ * replies (Telegram/Slack) carry the actual content — not a bare link the user
+ * can't open from a phone/SSH session.
+ *
+ * `buildArtifactSummary` is pure (path + content in, bounded string out) so it's
+ * trivially testable. `summarizeArtifact` wires it to the shared symlink-safe
+ * reader; it returns null when the artifact can't be read so callers fall back
+ * to their plain note.
+ */
+
+import path from 'path';
+import { readTaskArtifact } from './artifact-endpoint.js';
+import { childLogger } from '../logger.js';
+
+const logger = childLogger('orchestrator/artifact-summary');
+
+const DEFAULT_MAX_CHARS = 1200;
+
+/** Truncate to `maxChars`, appending an ellipsis when cut. */
+function clamp(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars).trimEnd()}\n…`;
+}
+
+/**
+ * Render a plan.json object as a readable gist: summary, file list, and any
+ * open questions. Falls back to raw content when the shape is unexpected.
+ */
+function summarizePlanJson(content: string, maxChars: number): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    // Malformed JSON — surface the raw head so the user still sees something.
+    return clamp(content, maxChars);
+  }
+
+  const plan = parsed as {
+    summary?: unknown;
+    files?: unknown;
+    open_questions?: unknown;
+  };
+  const parts: string[] = [];
+
+  if (typeof plan.summary === 'string' && plan.summary.trim()) {
+    parts.push(plan.summary.trim());
+  }
+
+  if (Array.isArray(plan.files) && plan.files.length > 0) {
+    const lines = plan.files
+      .map((f) => {
+        const file = f as { path?: unknown; action?: unknown };
+        const p = typeof file.path === 'string' ? file.path : null;
+        if (!p) return null;
+        const action = typeof file.action === 'string' ? file.action : 'change';
+        return `• ${p} — ${action}`;
+      })
+      .filter((l): l is string => l !== null);
+    if (lines.length > 0) parts.push(`Files:\n${lines.join('\n')}`);
+  }
+
+  if (Array.isArray(plan.open_questions) && plan.open_questions.length > 0) {
+    const qs = plan.open_questions
+      .filter((q): q is string => typeof q === 'string' && q.trim() !== '')
+      .map((q) => `• ${q}`);
+    if (qs.length > 0) parts.push(`Open questions:\n${qs.join('\n')}`);
+  }
+
+  // Nothing recognizable — fall back to the raw head rather than an empty gist.
+  if (parts.length === 0) return clamp(content, maxChars);
+
+  return clamp(parts.join('\n\n'), maxChars);
+}
+
+/**
+ * Build a bounded, self-contained plain-text summary of an artifact.
+ *
+ * - plan.json (or any .json)  → summary + file list + open questions
+ * - .md / .html / anything else → head of the raw content
+ *
+ * Always bounded to `maxChars` (ellipsis when cut).
+ */
+export function buildArtifactSummary(
+  relPath: string,
+  content: string,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): string {
+  const ext = path.extname(relPath).toLowerCase();
+  if (ext === '.json') {
+    return summarizePlanJson(content, maxChars);
+  }
+  return clamp(content, maxChars);
+}
+
+/**
+ * Read a task artifact and render its gist. Returns null when the artifact can't
+ * be read (missing task/worktree/file or empty) so the caller keeps its plain note.
+ */
+export function summarizeArtifact(
+  taskId: string,
+  relPath: string,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): string | null {
+  const content = readTaskArtifact(taskId, relPath);
+  if (content === null || content.trim() === '') {
+    logger.debug({ task_id: taskId, path: relPath }, 'summarizeArtifact: no readable artifact');
+    return null;
+  }
+  return buildArtifactSummary(relPath, content, maxChars);
+}

--- a/server/orchestrator/mcp/read.test.ts
+++ b/server/orchestrator/mcp/read.test.ts
@@ -227,6 +227,41 @@ describe('orchestrator mcp read tools', () => {
     });
   });
 
+  // ─── regression: post-rename schema (no `no such column: task_id`) ───────────
+  //
+  // get_task and get_agent_output both count agents via `countAgentsForTask`.
+  // A stale build queried `FROM agents WHERE task_id` — after the agents→workers
+  // rename `agents` is the conductor table (no task_id), so the live conductor
+  // saw `no such column: task_id` on exactly these two tools while list_tasks etc.
+  // (which never count agents) kept working. This pins the count to `workers`
+  // against the real migrated schema so that regression can't silently return.
+  describe('post-rename agent-count regression (SHR: no such column task_id)', () => {
+    it('get_task counts workers rows without throwing on the post-rename schema', () => {
+      const db = getDb();
+      insertTask(db, { id: 'task-reg-01', title: 'Regression task' });
+      insertAgent(db, { id: 'w-reg-01', task_id: 'task-reg-01' });
+      insertAgent(db, { id: 'w-reg-02', task_id: 'task-reg-01', window_index: 1 });
+
+      expect(() => handleGetTask({ task_id: 'task-reg-01' })).not.toThrow();
+      expect(handleGetTask({ task_id: 'task-reg-01' })!.agent_count).toBe(2);
+    });
+
+    it('get_agent_output counts workers rows without throwing on the post-rename schema', async () => {
+      const db = getDb();
+      insertTask(db, {
+        id: 'task-reg-02',
+        title: 'Regression task 2',
+        tmux_session: 'octomux-agent-task-reg-02',
+      });
+      insertAgent(db, { id: 'w-reg-03', task_id: 'task-reg-02' });
+      tmuxState.hasSession = true;
+      tmuxState.capture = 'working\n';
+
+      const result = await handleGetAgentOutput({ task_id: 'task-reg-02' });
+      expect(result.agent_count).toBe(1);
+    });
+  });
+
   // ─── monitor_status ────────────────────────────────────────────────────────
 
   describe('handleMonitorStatus', () => {

--- a/server/orchestrator/supervisor.test.ts
+++ b/server/orchestrator/supervisor.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { createTestDb, insertTask } from '../test-helpers.js';
 import { getDb } from '../db.js';
 import {
@@ -707,5 +710,63 @@ describe('supervisor spec branch — phase:spec relay', () => {
       .prepare(`SELECT * FROM action_cards WHERE conversation_id = ?`)
       .all(convId) as Array<{ tool_name: string }>;
     expect(cards.some((c) => c.tool_name === 'approve-plan')).toBe(true);
+  });
+
+  it('phase=plan → relay message + card embed the plan summary (not a bare link)', async () => {
+    // Real worktree with a plan.json so summarizeArtifact returns content.
+    const worktree = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-plan-'));
+    fs.writeFileSync(
+      path.join(worktree, 'plan.json'),
+      JSON.stringify({
+        schema_version: '1.0.0',
+        summary: 'Wire up the frobnicator end to end.',
+        files: [{ path: 'src/frob.ts', action: 'create' }],
+        open_questions: [],
+      }),
+      'utf8',
+    );
+
+    const convId = createConversation({ title: 'Plan summary conv' });
+    const task = insertTask(getDb(), { id: 'task-plan-summary-01', worktree });
+    upsertManagedTask({ conversation_id: convId, task_id: task.id, phase: 'planning' });
+
+    const seq = appendEvent({
+      task_id: task.id,
+      type: 'task:phase_complete',
+      payload: JSON.stringify({ phase: 'plan', artifacts: ['plan.json'] }),
+    });
+    await supervisor.processEvent({
+      seq,
+      task_id: task.id,
+      type: 'task:phase_complete',
+      payload: JSON.stringify({ phase: 'plan', artifacts: ['plan.json'] }),
+    });
+
+    const pushed = mockPush.mock.calls.map((c) => {
+      try {
+        return JSON.parse(String(c[0])) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    });
+
+    // The card carries the summary in args.
+    const planCard = pushed.find((p) => p && p['command'] === 'approve-plan');
+    expect((planCard!['args'] as Record<string, unknown>)['summary']).toContain(
+      'Wire up the frobnicator',
+    );
+
+    // The relay message leads with the summary and is not a bare-link-only payload.
+    const note = pushed.find(
+      (p) =>
+        p &&
+        p['type'] === 'message' &&
+        typeof p['text'] === 'string' &&
+        (p['text'] as string).includes('Wire up the frobnicator'),
+    );
+    expect(note).toBeDefined();
+    expect(note!['text'] as string).toContain('src/frob.ts — create');
+
+    fs.rmSync(worktree, { recursive: true, force: true });
   });
 });

--- a/server/orchestrator/supervisor.ts
+++ b/server/orchestrator/supervisor.ts
@@ -48,6 +48,7 @@ import {
 import { pushToConversation } from './stream.js';
 import { runSendMessage } from './exec.js';
 import { getTask } from '../repositories/index.js';
+import { summarizeArtifact } from './artifact-summary.js';
 
 const logger = childLogger('orchestrator/supervisor');
 
@@ -240,6 +241,10 @@ export function createSupervisor(): Supervisor {
         const specPath = (artifacts[0] as string | undefined) ?? 'spec.md';
         const artifactUrl = `/api/orchestrator/artifact?task=${encodeURIComponent(event.task_id)}&path=${encodeURIComponent(specPath)}`;
 
+        // Self-contained gist of the spec so a channel reader (mobile/SSH) can
+        // review without opening the link. Falls back to null → plain note.
+        const specSummary = summarizeArtifact(event.task_id, specPath);
+
         // Push a read-only spec card event (no action_cards row — it's informational only).
         const specCardId = nanoid(12);
         const specCardEvent = {
@@ -250,17 +255,21 @@ export function createSupervisor(): Supervisor {
             task_id: event.task_id,
             spec_path: specPath,
             artifact_url: artifactUrl,
+            ...(specSummary ? { summary: specSummary } : {}),
           },
         };
         pushToConversation(convId, JSON.stringify(specCardEvent));
 
-        // Concise assistant note so the ws history shows what happened.
+        // Assistant note carrying the spec gist as its payload (link secondary).
+        const specNote = specSummary
+          ? `📋 spec ready — planning is underway. Review:\n\n${specSummary}\n\n(ref: ${artifactUrl})`
+          : `📋 spec ready — open to review; planning is underway.`;
         pushToConversation(
           convId,
           JSON.stringify({
             type: 'message',
             role: 'assistant',
-            text: `📋 spec ready — open to review; planning is underway.`,
+            text: specNote,
           }),
         );
 
@@ -333,6 +342,11 @@ export function createSupervisor(): Supervisor {
         // path can resolve it on approval (without a row, approve is a silent
         // no-op). tool_name 'approve-plan' routes executeCard to the relay branch.
         const artifactUrl = `/api/orchestrator/artifact?task=${encodeURIComponent(event.task_id)}&path=${encodeURIComponent(planPath)}`;
+
+        // Self-contained gist of the plan so the user can approve from chat
+        // (mobile/SSH) without opening the artifact link.
+        const planSummary = summarizeArtifact(event.task_id, planPath);
+
         const cardId = createCard({
           conversation_id: convId,
           tool_use_id: `relay-${nanoid(8)}`,
@@ -348,17 +362,21 @@ export function createSupervisor(): Supervisor {
             plan_path: planPath,
             // artifact_url is the REST endpoint the UI calls to render the plan
             artifact_url: artifactUrl,
+            ...(planSummary ? { summary: planSummary } : {}),
           },
         };
         pushToConversation(convId, JSON.stringify(cardEvent));
 
-        // Also push a concise text note so the ws history shows what happened
+        // Text note carrying the plan gist as its payload (link secondary).
+        const planNote = planSummary
+          ? `📋 task \`${event.task_id}\` plan ready to approve:\n\n${planSummary}\n\nReply approve to begin implementation.\n\n(ref: ${artifactUrl})`
+          : `[supervisor] task \`${event.task_id}\` plan ready — review at \`${planPath}\` and approve to begin implementation.`;
         pushToConversation(
           convId,
           JSON.stringify({
             type: 'message',
             role: 'assistant',
-            text: `[supervisor] task \`${event.task_id}\` plan ready — review at \`${planPath}\` and approve to begin implementation.`,
+            text: planNote,
           }),
         );
 
@@ -387,12 +405,18 @@ export function createSupervisor(): Supervisor {
 
         // Diff-view URL is a pointer to the diff viewer for this task — not code contents
         const diffUrl = `/tasks/${event.task_id}?view=diff`;
+        // Lead with the agent's own last-reported summary so the message stands
+        // on its own; the diff link is a trailing secondary reference.
+        const doneSummary = getTask(event.task_id)?.current_summary?.trim();
+        const doneNote = doneSummary
+          ? `✅ task \`${event.task_id}\` implementation complete:\n\n${doneSummary}\n\n(diff: ${diffUrl})`
+          : `✅ task \`${event.task_id}\` implementation complete. (diff: ${diffUrl})`;
         pushToConversation(
           convId,
           JSON.stringify({
             type: 'message',
             role: 'assistant',
-            text: `[supervisor] task \`${event.task_id}\` implementation complete — diff view: ${diffUrl}`,
+            text: doneNote,
           }),
         );
 


### PR DESCRIPTION
## What & why

Two related orchestrator/gateway defects, root-caused before touching code.

### Bug 1 — chat replies were bare links, not summaries
The supervisor's `task:phase_complete` relay pushed **bare pointers** to the gateway: a `card` event that `formatCardEvent` flattened to `[task] label: <url>`, plus notes referencing a path or diff URL. Nothing embedded the artifact's content, so Telegram/Slack users (mobile/SSH, can't open links) received only a link.

`be1f316` ("send approval gists over chat") only tweaked the **conductor LLM system prompt** — but these messages come from **supervisor CODE**, not the LLM, so it never took.

**Fix (shared path, once):**
- `readTaskArtifact()` — server-side reader reusing the existing symlink-safe path resolution (no new path logic).
- `buildArtifactSummary` / `summarizeArtifact` — bounded plain-text gist (plan.json → `summary` + file list + open questions; `.md` → content head).
- Supervisor spec / plan / done relays embed the gist as the payload; the link is demoted to a trailing `(ref: …)`.
- `formatCardEvent` renders `args.summary` as the payload, URL only as a secondary ref.

### Bug 2 — `get_task` / `get_agent_output` threw `no such column: task_id`
Both tools count agents via `countAgentsForTask`. A stale prod build ran `FROM agents WHERE task_id` — after the `agents`→`workers` rename, `agents` is the conductor table (no `task_id`), so the migrated live DB threw. Tools that don't count agents kept working.

The query is **already correct on `next`** (`FROM workers`, fixed in `f1c356a`); the live failure is a stale deploy (that build isn't even an ancestor of `next`). This adds an **explicit regression guard** pinning both tools to the post-rename `workers` schema so it can't silently return. Live prod DB confirmed via readonly repro. **The live instance needs a redeploy of the current build.**

## Tests
- `artifact-summary.test.ts` (new) — gist builder table tests.
- `gateway.test.ts` — card with `args.summary` sends summary-as-payload, link as trailing ref.
- `supervisor.test.ts` — plan relay embeds the plan summary into message + card (real worktree artifact).
- `mcp/read.test.ts` — named regression guard for the `no such column: task_id` bug.

All affected suites green (orchestrator + gateway: 485 passing); typecheck, lint, and `bun run build` green.