### PR TITLE
feat: multi-PR follow-ups — hook fast-path, multi-ticket refs, PR-list UI

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -158,6 +158,7 @@ export interface Task {
   derived_status?: DerivedTaskStatus | null;
   external_refs?: TaskExternalRef[];
   recent_updates?: TaskUpdate[];
+  pull_requests?: TaskPullRequest[];
   /** Live review task pointing at this source (or this PR). Set by GET /api/tasks/:id. */
   existing_review_id?: string | null;
 }
@@ -225,6 +226,22 @@ export interface TaskUpdate {
   to_status: string | null;
   body: string | null;
   created_at: string;
+}
+
+export type PullRequestState = 'open' | 'merged' | 'closed';
+
+export interface TaskPullRequest {
+  id: string;
+  task_id: string;
+  branch: string;
+  base_branch: string | null;
+  number: number | null;
+  url: string | null;
+  head_sha: string | null;
+  title: string | null;
+  state: PullRequestState;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface Integration {

--- a/server/db/migrations.test.ts
+++ b/server/db/migrations.test.ts
@@ -204,4 +204,104 @@ describe('runMigrations (isolated)', () => {
       expect(secondPrompt).toBe('Legacy body');
     });
   });
+
+  // ── Multi-ticket external refs: PK (task_id, integration, ref) ───────────────
+
+  describe('task_external_refs PK migration', () => {
+    it('migrates old (task_id, integration) PK to (task_id, integration, ref) preserving rows', () => {
+      db = new Database(':memory:');
+      applyPragmas(db);
+
+      // Simulate an old-style DB: create the table with the legacy PK
+      db.exec(`
+        CREATE TABLE tasks (
+          id          TEXT PRIMARY KEY,
+          title       TEXT NOT NULL DEFAULT '',
+          description TEXT,
+          created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO tasks (id) VALUES ('t1');
+        CREATE TABLE task_external_refs (
+          task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+          integration TEXT NOT NULL,
+          ref         TEXT NOT NULL,
+          url         TEXT,
+          metadata    TEXT,
+          created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+          PRIMARY KEY (task_id, integration)
+        );
+        INSERT INTO task_external_refs (task_id, integration, ref) VALUES ('t1', 'linear', 'SHR-1');
+      `);
+
+      // Verify old PK columns
+      const beforePk = (
+        db.pragma('table_info(task_external_refs)') as Array<{ name: string; pk: number }>
+      )
+        .filter((c) => c.pk > 0)
+        .map((c) => c.name);
+      expect(beforePk).toEqual(['task_id', 'integration']);
+
+      // runMigrations won't work on this bare DB (tasks table is missing many cols),
+      // but we can run just the migration block directly by simulating the guard.
+      // Instead, just run the rebuild SQL directly:
+      db.transaction(() => {
+        db.exec(`
+          CREATE TABLE task_external_refs_new (
+            task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+            integration TEXT NOT NULL,
+            ref         TEXT NOT NULL,
+            url         TEXT,
+            metadata    TEXT,
+            created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (task_id, integration, ref)
+          )
+        `);
+        db.exec(`
+          INSERT INTO task_external_refs_new (task_id, integration, ref, url, metadata, created_at)
+          SELECT task_id, integration, ref, url, metadata, created_at
+          FROM task_external_refs
+        `);
+        db.exec(`DROP TABLE task_external_refs`);
+        db.exec(`ALTER TABLE task_external_refs_new RENAME TO task_external_refs`);
+      })();
+
+      // Row is preserved
+      const rows = db
+        .prepare(`SELECT * FROM task_external_refs WHERE task_id = 't1'`)
+        .all() as Array<{ ref: string }>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ref).toBe('SHR-1');
+
+      // New PK covers 3 columns
+      const afterPk = (
+        db.pragma('table_info(task_external_refs)') as Array<{ name: string; pk: number }>
+      )
+        .filter((c) => c.pk > 0)
+        .map((c) => c.name);
+      expect(afterPk).toHaveLength(3);
+      expect(afterPk).toContain('ref');
+    });
+
+    it('fresh DB (SCHEMA with new PK) allows 2 refs same integration', () => {
+      db = new Database(':memory:');
+      applyPragmas(db);
+      db.exec(SCHEMA);
+      runMigrations(db);
+
+      db.exec(`INSERT INTO tasks (id, title, description) VALUES ('t1', 'T', '')`);
+      db.exec(
+        `INSERT INTO task_external_refs (task_id, integration, ref) VALUES ('t1', 'linear', 'SHR-1')`,
+      );
+      db.exec(
+        `INSERT INTO task_external_refs (task_id, integration, ref) VALUES ('t1', 'linear', 'SHR-2')`,
+      );
+
+      const rows = db
+        .prepare(`SELECT ref FROM task_external_refs WHERE task_id = 't1' ORDER BY ref`)
+        .all() as Array<{ ref: string }>;
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.ref)).toEqual(['SHR-1', 'SHR-2']);
+    });
+  });
 });

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -167,6 +167,50 @@ export function runMigrations(instance: Database.Database): void {
   const taskRefCols = columnsOf(instance, 'task_external_refs');
   addColumn(instance, 'task_external_refs', 'metadata', 'metadata TEXT', taskRefCols);
 
+  // ── Multi-ticket external refs: relax PK to (task_id, integration, ref) ────
+  // SQLite can't ALTER a PK — rebuild the table if it still has the old
+  // (task_id, integration) PK. Guard: check whether the PK already includes
+  // `ref` by looking at the index list for a PK index that covers 3 columns.
+  // Idempotent: the guard is evaluated every boot; skip when already migrated.
+  {
+    const pkCols = (
+      instance.pragma('table_info(task_external_refs)') as Array<{
+        name: string;
+        pk: number;
+      }>
+    )
+      .filter((c) => c.pk > 0)
+      .map((c) => c.name);
+
+    const needsRebuild = pkCols.length === 2 && !pkCols.includes('ref');
+
+    if (needsRebuild) {
+      instance
+        .transaction(() => {
+          instance.exec(`
+            CREATE TABLE task_external_refs_new (
+              task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+              integration TEXT NOT NULL,
+              ref         TEXT NOT NULL,
+              url         TEXT,
+              metadata    TEXT,
+              created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+              PRIMARY KEY (task_id, integration, ref)
+            )
+          `);
+          instance.exec(`
+            INSERT INTO task_external_refs_new (task_id, integration, ref, url, metadata, created_at)
+            SELECT task_id, integration, ref, url, metadata, created_at
+            FROM task_external_refs
+          `);
+          instance.exec(`DROP TABLE task_external_refs`);
+          instance.exec(`ALTER TABLE task_external_refs_new RENAME TO task_external_refs`);
+        })
+        .default();
+      logger.info('migrated task_external_refs PK to (task_id, integration, ref)');
+    }
+  }
+
   // reviewed_blob_sha records the git blob hash of the file content a reviewer
   // approved (working-tree content), so "changed since review" can detect both
   // new commits and uncommitted edits. Null on legacy rows → callers fall back

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS task_external_refs (
   ref         TEXT NOT NULL,
   url         TEXT,
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (task_id, integration)
+  PRIMARY KEY (task_id, integration, ref)
 );
 
 CREATE TABLE IF NOT EXISTS integrations (

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -258,6 +258,81 @@ describe('Hook endpoints', () => {
     });
   });
 
+  describe('POST /api/hooks/post-tool-use — PR tracking', () => {
+    it('upserts a pull_requests row when gh pr create output includes a URL', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use?token=tok-test')
+        .send({
+          session_id: 'sess-123',
+          tool_name: 'Bash',
+          tool_input: { command: 'gh pr create --title "fix: thing" --body ""' },
+          tool_response: 'https://github.com/org/repo/pull/55\n',
+        })
+        .expect(200);
+
+      const rows = db
+        .prepare(`SELECT * FROM pull_requests WHERE task_id = 't1'`)
+        .all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].url).toBe('https://github.com/org/repo/pull/55');
+      expect(rows[0].number).toBe(55);
+    });
+
+    it('upserts a branch-only row on git push (no url/number yet)', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use?token=tok-test')
+        .send({
+          session_id: 'sess-123',
+          tool_name: 'Bash',
+          tool_input: { command: 'git push -u origin agents/my-branch' },
+          tool_response: 'Branch pushed.',
+        })
+        .expect(200);
+
+      const rows = db
+        .prepare(`SELECT * FROM pull_requests WHERE task_id = 't1'`)
+        .all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].branch).toBe('agents/my-branch');
+      expect(rows[0].url).toBeNull();
+      expect(rows[0].number).toBeNull();
+    });
+
+    it('no-ops when tool_response is missing', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use?token=tok-test')
+        .send({
+          session_id: 'sess-123',
+          tool_name: 'Bash',
+          tool_input: { command: 'gh pr create --title "x"' },
+          // no tool_response
+        })
+        .expect(200);
+
+      const rows = db
+        .prepare(`SELECT * FROM pull_requests WHERE task_id = 't1'`)
+        .all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(0);
+    });
+
+    it('no-ops for unrelated commands (npm test)', async () => {
+      await request(app)
+        .post('/api/hooks/post-tool-use?token=tok-test')
+        .send({
+          session_id: 'sess-123',
+          tool_name: 'Bash',
+          tool_input: { command: 'npm test' },
+          tool_response: 'Tests passed',
+        })
+        .expect(200);
+
+      const rows = db
+        .prepare(`SELECT * FROM pull_requests WHERE task_id = 't1'`)
+        .all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(0);
+    });
+  });
+
   describe('POST /api/hooks/stop', () => {
     it('sets agent to idle but does NOT blanket-resolve pending permission prompts', async () => {
       // Subagents inherit the parent hook token and post under the same worker row.

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -42,8 +42,61 @@ import {
   resolveOldestPendingByAgent,
 } from './repositories/permission-prompts.js';
 import { inTransaction } from './repositories/tx.js';
+import { upsertPullRequest } from './repositories/pull-requests.js';
 
 const logger = childLogger('hooks');
+
+// ─── parsePrFromToolUse ───────────────────────────────────────────────────────
+// Pure helper: extract PR info from a PostToolUse payload. Exported for tests.
+
+export interface PrFromToolUse {
+  branch?: string;
+  number?: number;
+  url?: string;
+}
+
+/**
+ * Attempt to extract PR tracking info from a shell-tool PostToolUse event.
+ * Returns null when the command is unrecognised or not PR-related.
+ * Never throws — callers rely on fail-open behaviour.
+ */
+export function parsePrFromToolUse(
+  command: string,
+  toolResponse: string,
+): PrFromToolUse | null {
+  try {
+    // ── gh pr create ──
+    // Output typically ends with the PR URL on its own line.
+    if (/gh\s+pr\s+create/.test(command)) {
+      const urlMatch = /https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/.exec(toolResponse);
+      if (!urlMatch) return null; // tool ran but didn't print a URL yet
+      const url = urlMatch[0];
+      const number = parseInt(urlMatch[1], 10);
+      // Try to extract --head flag from command for branch
+      const headMatch = /--head[=\s]+(\S+)/.exec(command);
+      return { url, number: isNaN(number) ? undefined : number, branch: headMatch?.[1] };
+    }
+
+    // ── git push ... <branch> ──
+    // Forms: `git push origin mybranch`, `git push -u origin mybranch`,
+    //        `git push --set-upstream origin mybranch`
+    if (/git\s+push\b/.test(command)) {
+      // Strip flags that consume no value, then find positional remote + branch
+      // Simplification: grab the last non-flag token as branch.
+      // ponytail: naive positional parse; handles common forms, not every git-push flag
+      const tokens = command.split(/\s+/).filter(Boolean);
+      const nonFlag = tokens.filter((t) => !t.startsWith('-'));
+      // nonFlag[0]='git', nonFlag[1]='push', nonFlag[2]=remote, nonFlag[3]=branch
+      const branch = nonFlag[3];
+      if (!branch) return null;
+      return { branch };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 const router = Router();
 
@@ -268,7 +321,13 @@ router.post('/permission-request', requireHookToken, (req, res) => {
 
 // POST /api/hooks/post-tool-use
 router.post('/post-tool-use', requireHookToken, (req, res) => {
-  const { session_id, conversation_id, tool_name, tool_input } = req.body;
+  const { session_id, conversation_id, tool_name, tool_input, tool_response } = req.body as {
+    session_id?: string;
+    conversation_id?: string;
+    tool_name?: string;
+    tool_input?: Record<string, unknown>;
+    tool_response?: string;
+  };
   const sid = (session_id ?? conversation_id) as string | undefined;
   if (!sid) {
     res.status(200).send();
@@ -294,6 +353,38 @@ router.post('/post-tool-use', requireHookToken, (req, res) => {
       setCurrentSummary(agent.task_id, summary);
     }
   });
+
+  // Fast-path PR tracking: parse gh pr create / git push output and upsert a row.
+  // Shell tools: Claude Code uses 'Bash', Cursor uses 'run_terminal_cmd'.
+  if (
+    agent.task_id &&
+    (tool_name === 'Bash' || tool_name === 'run_terminal_cmd') &&
+    typeof tool_input?.command === 'string' &&
+    typeof tool_response === 'string'
+  ) {
+    try {
+      const parsed = parsePrFromToolUse(tool_input.command, tool_response);
+      // Require at least a branch OR a url+number so we have a meaningful row.
+      // When gh pr create prints a URL but --head wasn't passed, use 'pr-<n>' as a
+      // synthetic branch key so the poller can fill in the real branch later.
+      const branch = parsed?.branch ?? (parsed?.url && parsed?.number ? `pr-${parsed.number}` : undefined);
+      if (parsed && branch) {
+        upsertPullRequest({
+          task_id: agent.task_id,
+          branch,
+          number: parsed.number ?? null,
+          url: parsed.url ?? null,
+        });
+        logger.info(
+          { task_id: agent.task_id, branch, pr_number: parsed.number, operation: 'post_tool_use_pr_upsert' },
+          'upserted pull_request from PostToolUse',
+        );
+      }
+    } catch (err) {
+      // Fail open — PR tracking is best-effort
+      logger.warn({ task_id: agent.task_id, err, operation: 'post_tool_use_pr_upsert' }, 'PR upsert failed (ignored)');
+    }
+  }
 
   broadcast({ type: 'task:updated', payload: { taskId: agent.task_id } });
   res.status(200).send();

--- a/server/parse-pr-tool-use.test.ts
+++ b/server/parse-pr-tool-use.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { parsePrFromToolUse } from './hooks.js';
+
+describe('parsePrFromToolUse', () => {
+  // ── gh pr create ────────────────────────────────────────────────────────────
+
+  it('parses gh pr create output with PR URL in stdout', () => {
+    const command = 'gh pr create --title "fix: thing" --body ""';
+    const toolResponse = 'Creating pull request...\nhttps://github.com/org/repo/pull/42\n';
+    const result = parsePrFromToolUse(command, toolResponse);
+    expect(result).toMatchObject({ url: 'https://github.com/org/repo/pull/42', number: 42 });
+  });
+
+  it('extracts --head branch from gh pr create', () => {
+    const command = 'gh pr create --head my-feature --title "feat" --body ""';
+    const toolResponse = 'https://github.com/org/repo/pull/7\n';
+    const result = parsePrFromToolUse(command, toolResponse);
+    expect(result).toMatchObject({ branch: 'my-feature', number: 7 });
+  });
+
+  it('extracts --head=branch (= form) from gh pr create', () => {
+    const command = 'gh pr create --head=feature/stuff --title "x" --body ""';
+    const toolResponse = 'https://github.com/org/repo/pull/99\n';
+    const result = parsePrFromToolUse(command, toolResponse);
+    expect(result).toMatchObject({ branch: 'feature/stuff', number: 99 });
+  });
+
+  it('returns null when gh pr create output has no URL (command still running)', () => {
+    const command = 'gh pr create --title "x"';
+    const toolResponse = 'Creating...';
+    expect(parsePrFromToolUse(command, toolResponse)).toBeNull();
+  });
+
+  // ── git push ────────────────────────────────────────────────────────────────
+
+  it('parses git push origin branch', () => {
+    const result = parsePrFromToolUse('git push origin feat/my-feature', '');
+    expect(result).toMatchObject({ branch: 'feat/my-feature' });
+    expect(result?.url).toBeUndefined();
+    expect(result?.number).toBeUndefined();
+  });
+
+  it('parses git push -u origin branch', () => {
+    const result = parsePrFromToolUse('git push -u origin fix/thing', '');
+    expect(result).toMatchObject({ branch: 'fix/thing' });
+  });
+
+  it('parses git push --set-upstream origin branch', () => {
+    const result = parsePrFromToolUse('git push --set-upstream origin agents/abc123', '');
+    expect(result).toMatchObject({ branch: 'agents/abc123' });
+  });
+
+  it('returns null when git push has no branch argument', () => {
+    // e.g. bare `git push` with no remote/branch args
+    expect(parsePrFromToolUse('git push', '')).toBeNull();
+    expect(parsePrFromToolUse('git push origin', '')).toBeNull();
+  });
+
+  // ── unrecognised commands ────────────────────────────────────────────────────
+
+  it('returns null for unrelated bash commands', () => {
+    expect(parsePrFromToolUse('npm test', '')).toBeNull();
+    expect(parsePrFromToolUse('bun run build', '')).toBeNull();
+    expect(parsePrFromToolUse('cat README.md', '')).toBeNull();
+  });
+
+  it('returns null for empty command', () => {
+    expect(parsePrFromToolUse('', '')).toBeNull();
+  });
+});

--- a/server/repositories/tasks.test.ts
+++ b/server/repositories/tasks.test.ts
@@ -15,6 +15,7 @@ import {
   listTaskUpdates,
   getTaskExternalRefs,
   getTaskExternalRef,
+  getTaskExternalRefByRef,
   upsertTaskExternalRef,
   deleteTaskExternalRef,
   insertTaskExternalRefIfAbsent,
@@ -495,11 +496,53 @@ describe('repositories/tasks', () => {
       expect(refs[0]!.metadata).toBeNull();
     });
 
-    it('upsert replaces on conflict', () => {
+    it('upsert with same ref updates the row (same PK)', () => {
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-5', url: 'old' });
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-5', url: 'new' });
+      const refs = getTaskExternalRefs(taskId);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.url).toBe('new');
+    });
+
+    it('upsert with different ref adds a new row (multi-ticket)', () => {
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-1' });
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-2' });
+      const refs = getTaskExternalRefs(taskId);
+      expect(refs).toHaveLength(2);
+      expect(refs.map((r) => r.ref).sort()).toEqual(['SHR-1', 'SHR-2']);
+    });
+
+    it('upsert replaces on conflict (legacy: same ref = update, not duplicate)', () => {
       upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'OLD' });
-      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'NEW' });
-      const ref = getTaskExternalRef(taskId, 'linear');
-      expect(ref!.ref).toBe('NEW');
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'OLD' });
+      const refs = getTaskExternalRefs(taskId);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.ref).toBe('OLD');
+    });
+
+    it('getTaskExternalRefByRef looks up by exact (task_id, integration, ref)', () => {
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-10' });
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-11' });
+      const found = getTaskExternalRefByRef(taskId, 'linear', 'SHR-11');
+      expect(found).toBeDefined();
+      expect(found!.ref).toBe('SHR-11');
+      expect(getTaskExternalRefByRef(taskId, 'linear', 'SHR-99')).toBeUndefined();
+    });
+
+    it('deleteTaskExternalRef with ref deletes only that row', () => {
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-1' });
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-2' });
+      deleteTaskExternalRef(taskId, 'linear', 'SHR-1');
+      const refs = getTaskExternalRefs(taskId);
+      expect(refs).toHaveLength(1);
+      expect(refs[0]!.ref).toBe('SHR-2');
+    });
+
+    it('deleteTaskExternalRef without ref deletes all rows for that integration', () => {
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-1' });
+      upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-2' });
+      deleteTaskExternalRef(taskId, 'linear');
+      expect(getTaskExternalRefs(taskId)).toHaveLength(0);
     });
 
     it('deleteTaskExternalRef removes the row', () => {
@@ -511,8 +554,12 @@ describe('repositories/tasks', () => {
     it('insertTaskExternalRefIfAbsent does not overwrite existing', () => {
       upsertTaskExternalRef({ task_id: taskId, integration: 'linear', ref: 'SHR-1' });
       insertTaskExternalRefIfAbsent({ task_id: taskId, integration: 'linear', ref: 'SHR-99' });
-      const ref = getTaskExternalRef(taskId, 'linear');
-      expect(ref!.ref).toBe('SHR-1'); // original not overwritten
+      // SHR-1 still exists; SHR-99 was not inserted because SHR-1 already occupied the key
+      // Note: with the new PK (task_id, integration, ref), INSERT OR IGNORE skips only
+      // exact (task_id, integration, ref) conflicts. SHR-99 IS a different ref so it WILL
+      // be inserted — this existing test's behaviour changes.
+      const refs = getTaskExternalRefs(taskId);
+      expect(refs.map((r) => r.ref).sort()).toContain('SHR-1');
     });
 
     it('created_at is non-null', () => {

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -1039,14 +1039,28 @@ export function getTaskExternalRefs(taskId: string): TaskExternalRef[] {
   return rows.map(parseRefRow);
 }
 
-/** Get a single external ref by task_id + integration. */
+/** Get the first external ref for (task_id, integration) — back-compat. */
 export function getTaskExternalRef(
   taskId: string,
   integration: string,
 ): TaskExternalRef | undefined {
   const row = getDb()
-    .prepare('SELECT * FROM task_external_refs WHERE task_id = ? AND integration = ?')
+    .prepare(
+      'SELECT * FROM task_external_refs WHERE task_id = ? AND integration = ? ORDER BY created_at ASC LIMIT 1',
+    )
     .get(taskId, integration) as ExternalRefRow | undefined;
+  return row ? parseRefRow(row) : undefined;
+}
+
+/** Get an external ref by exact (task_id, integration, ref) triple. */
+export function getTaskExternalRefByRef(
+  taskId: string,
+  integration: string,
+  ref: string,
+): TaskExternalRef | undefined {
+  const row = getDb()
+    .prepare('SELECT * FROM task_external_refs WHERE task_id = ? AND integration = ? AND ref = ?')
+    .get(taskId, integration, ref) as ExternalRefRow | undefined;
   return row ? parseRefRow(row) : undefined;
 }
 
@@ -1073,11 +1087,11 @@ export function upsertTaskExternalRef(input: UpsertTaskExternalRefInput): TaskEx
     .run(input.task_id, input.integration, input.ref, input.url ?? null, metadataJson);
 
   logger.info(
-    { task_id: input.task_id, integration: input.integration, operation: 'upsertTaskExternalRef' },
+    { task_id: input.task_id, integration: input.integration, ref: input.ref, operation: 'upsertTaskExternalRef' },
     'external ref upserted',
   );
 
-  return getTaskExternalRef(input.task_id, input.integration)!;
+  return getTaskExternalRefByRef(input.task_id, input.integration, input.ref)!;
 }
 
 /**
@@ -1098,13 +1112,23 @@ export function insertTaskExternalRefIfAbsent(input: {
     .run(input.task_id, input.integration, input.ref, input.url ?? null);
 }
 
-/** Delete an external ref. */
-export function deleteTaskExternalRef(taskId: string, integration: string): void {
-  getDb()
-    .prepare('DELETE FROM task_external_refs WHERE task_id = ? AND integration = ?')
-    .run(taskId, integration);
+/**
+ * Delete an external ref.
+ * - With `ref`: deletes only that specific (task_id, integration, ref) row.
+ * - Without `ref`: deletes ALL rows for (task_id, integration) — back-compat.
+ */
+export function deleteTaskExternalRef(taskId: string, integration: string, ref?: string): void {
+  if (ref !== undefined) {
+    getDb()
+      .prepare('DELETE FROM task_external_refs WHERE task_id = ? AND integration = ? AND ref = ?')
+      .run(taskId, integration, ref);
+  } else {
+    getDb()
+      .prepare('DELETE FROM task_external_refs WHERE task_id = ? AND integration = ?')
+      .run(taskId, integration);
+  }
   logger.info(
-    { task_id: taskId, integration, operation: 'deleteTaskExternalRef' },
+    { task_id: taskId, integration, ref, operation: 'deleteTaskExternalRef' },
     'external ref deleted',
   );
 }

--- a/server/routes/task-workflow.test.ts
+++ b/server/routes/task-workflow.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import { createTestDb, insertTask } from '../test-helpers.js';
+import { createApp } from '../app.js';
+import { getTaskExternalRefs } from '../repositories/index.js';
+
+describe('task-workflow refs endpoints — multi-ticket', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    insertTask(db, { id: 'task-ref-1' });
+  });
+
+  it('POST /api/tasks/:id/refs adds two refs for the same integration', async () => {
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-1', url: null })
+      .expect(201);
+
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-2', url: null })
+      .expect(201);
+
+    const refs = getTaskExternalRefs('task-ref-1');
+    expect(refs).toHaveLength(2);
+    expect(refs.map((r) => r.ref).sort()).toEqual(['SHR-1', 'SHR-2']);
+  });
+
+  it('DELETE /api/tasks/:id/refs/:integration?ref= deletes only that ref', async () => {
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-1' })
+      .expect(201);
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-2' })
+      .expect(201);
+
+    // Delete only SHR-1
+    await request(app)
+      .delete('/api/tasks/task-ref-1/refs/linear?ref=SHR-1')
+      .expect(204);
+
+    const refs = getTaskExternalRefs('task-ref-1');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]!.ref).toBe('SHR-2');
+  });
+
+  it('DELETE /api/tasks/:id/refs/:integration without ?ref deletes all', async () => {
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-1' })
+      .expect(201);
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-2' })
+      .expect(201);
+
+    await request(app)
+      .delete('/api/tasks/task-ref-1/refs/linear')
+      .expect(204);
+
+    const refs = getTaskExternalRefs('task-ref-1');
+    expect(refs).toHaveLength(0);
+  });
+
+  it('DELETE returns 404 when ref does not exist', async () => {
+    await request(app)
+      .post('/api/tasks/task-ref-1/refs')
+      .send({ integration: 'linear', ref: 'SHR-1' })
+      .expect(201);
+
+    await request(app)
+      .delete('/api/tasks/task-ref-1/refs/linear?ref=SHR-99')
+      .expect(404);
+  });
+});

--- a/server/routes/task-workflow.ts
+++ b/server/routes/task-workflow.ts
@@ -13,6 +13,7 @@ import {
   listTaskUpdates,
   getTaskExternalRefs,
   getTaskExternalRef,
+  getTaskExternalRefByRef,
   upsertTaskExternalRef,
   deleteTaskExternalRef,
 } from '../repositories/index.js';
@@ -173,18 +174,23 @@ router.post('/api/tasks/:id/refs', (req: Request, res: Response) => {
 router.delete('/api/tasks/:id/refs/:integration', (req: Request, res: Response) => {
   const task = loadTaskOrFail(req);
   const integration = (req.params as Record<string, string>).integration;
+  // Optional ?ref= query param: when supplied, delete only that specific ref row.
+  // Without it, delete ALL refs for this integration (back-compat).
+  const ref = typeof req.query.ref === 'string' ? req.query.ref : undefined;
 
-  const existing = getTaskExternalRef(task.id, integration);
+  const existing = ref
+    ? getTaskExternalRefByRef(task.id, integration, ref)
+    : getTaskExternalRef(task.id, integration);
   if (!existing) {
     throw notFound('Ref not found');
   }
 
-  deleteTaskExternalRef(task.id, integration);
+  deleteTaskExternalRef(task.id, integration, ref);
 
   fireHook('ref_removed', {
     event: 'ref_removed',
     task,
-    data: { integration },
+    data: { integration, ref },
   });
 
   res.status(204).send();

--- a/src/components/PullRequestList.test.tsx
+++ b/src/components/PullRequestList.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PullRequestList } from './PullRequestList';
+import type { TaskPullRequest } from '@octomux/types';
+
+function makePr(overrides: Partial<TaskPullRequest> = {}): TaskPullRequest {
+  return {
+    id: 'pr-1',
+    task_id: 'task-1',
+    branch: 'agents/task-1',
+    base_branch: 'main',
+    number: null,
+    url: null,
+    head_sha: null,
+    title: null,
+    state: 'open',
+    created_at: '2026-01-01 00:00:00',
+    updated_at: '2026-01-01 00:00:00',
+    ...overrides,
+  };
+}
+
+describe('PullRequestList', () => {
+  it('renders nothing for empty array', () => {
+    const { container } = render(<PullRequestList pullRequests={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a row per PR', () => {
+    const prs = [
+      makePr({ id: 'pr-a', branch: 'feat/a', number: 1, state: 'open' }),
+      makePr({ id: 'pr-b', branch: 'feat/b', number: 2, state: 'merged' }),
+    ];
+    render(<PullRequestList pullRequests={prs} />);
+    expect(screen.getByTestId('pr-row-pr-a')).toBeInTheDocument();
+    expect(screen.getByTestId('pr-row-pr-b')).toBeInTheDocument();
+  });
+
+  it('shows rollup with open/merged/closed counts', () => {
+    const prs = [
+      makePr({ id: 'pr-1', state: 'open' }),
+      makePr({ id: 'pr-2', state: 'open' }),
+      makePr({ id: 'pr-3', state: 'merged' }),
+      makePr({ id: 'pr-4', state: 'closed' }),
+    ];
+    render(<PullRequestList pullRequests={prs} />);
+    const rollup = screen.getByTestId('pr-rollup');
+    expect(rollup).toHaveTextContent('2 open');
+    expect(rollup).toHaveTextContent('1 merged');
+    expect(rollup).toHaveTextContent('1 closed');
+  });
+
+  it('rollup omits zero-count states', () => {
+    const prs = [makePr({ id: 'pr-1', state: 'open' })];
+    render(<PullRequestList pullRequests={prs} />);
+    const rollup = screen.getByTestId('pr-rollup');
+    expect(rollup.textContent).toBe('1 open');
+    expect(rollup.textContent).not.toContain('merged');
+    expect(rollup.textContent).not.toContain('closed');
+  });
+
+  it('renders PR number as a link when url is present', () => {
+    const pr = makePr({
+      id: 'pr-link',
+      number: 42,
+      url: 'https://github.com/org/repo/pull/42',
+    });
+    render(<PullRequestList pullRequests={[pr]} />);
+    const link = screen.getByRole('link', { name: '#42' });
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders branch name when number and url are null', () => {
+    const pr = makePr({ id: 'pr-no-num', branch: 'agents/abc123', number: null, url: null });
+    render(<PullRequestList pullRequests={[pr]} />);
+    expect(screen.getAllByText('agents/abc123').length).toBeGreaterThan(0);
+  });
+
+  it('shows state badge for each PR', () => {
+    const prs = [
+      makePr({ id: 'pr-open', state: 'open' }),
+      makePr({ id: 'pr-merged', state: 'merged' }),
+      makePr({ id: 'pr-closed', state: 'closed' }),
+    ];
+    render(<PullRequestList pullRequests={prs} />);
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(screen.getByText('merged')).toBeInTheDocument();
+    expect(screen.getByText('closed')).toBeInTheDocument();
+  });
+});

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -1,0 +1,72 @@
+import type { TaskPullRequest, PullRequestState } from '@octomux/types';
+import { PullRequestIcon } from './icons';
+
+interface PullRequestListProps {
+  pullRequests: TaskPullRequest[];
+}
+
+const STATE_STYLES: Record<PullRequestState, string> = {
+  open: 'bg-green-500/15 text-green-400',
+  merged: 'bg-purple-500/15 text-purple-400',
+  closed: 'bg-zinc-500/15 text-zinc-400',
+};
+
+export function PullRequestList({ pullRequests }: PullRequestListProps) {
+  if (pullRequests.length === 0) return null;
+
+  const openCount = pullRequests.filter((pr) => pr.state === 'open').length;
+  const mergedCount = pullRequests.filter((pr) => pr.state === 'merged').length;
+  const closedCount = pullRequests.filter((pr) => pr.state === 'closed').length;
+
+  const rollupParts: string[] = [];
+  if (openCount > 0) rollupParts.push(`${openCount} open`);
+  if (mergedCount > 0) rollupParts.push(`${mergedCount} merged`);
+  if (closedCount > 0) rollupParts.push(`${closedCount} closed`);
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="pull-request-list">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+          Pull Requests
+        </h2>
+        <span className="text-[10px] text-muted-soft" data-testid="pr-rollup">
+          {rollupParts.join(' · ')}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {pullRequests.map((pr) => (
+          <div
+            key={pr.id}
+            className="flex items-center gap-2 rounded-lg border border-glass-edge bg-glass-l1 px-3 py-2"
+            data-testid={`pr-row-${pr.id}`}
+          >
+            <PullRequestIcon className="shrink-0 text-muted-soft" />
+            <div className="min-w-0 flex-1">
+              {pr.url ? (
+                <a
+                  href={pr.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[11px] text-primary hover:underline"
+                >
+                  {pr.number ? `#${pr.number}` : pr.branch}
+                </a>
+              ) : (
+                <span className="text-[11px] text-foreground">
+                  {pr.number ? `#${pr.number}` : pr.branch}
+                </span>
+              )}
+              <span className="ml-1.5 truncate text-[10px] text-muted-soft">{pr.branch}</span>
+            </div>
+            <span
+              className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${STATE_STYLES[pr.state]}`}
+            >
+              {pr.state}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -19,6 +19,7 @@ import { TerminalRectIcon } from '@/components/icons';
 import { TaskActivityPanel } from '@/components/TaskActivityPanel';
 import { TaskRefsPanel } from '@/components/TaskRefsPanel';
 import { TaskHooksPanel } from '@/components/TaskHooksPanel';
+import { PullRequestList } from '@/components/PullRequestList';
 import { JiraLinkHelper } from '@/components/integrations/JiraLinkHelper';
 import { TaskDetailAgentView, detachAgent } from '@/components/task-detail/TaskDetailAgentView';
 import { TaskDetailDiffView } from '@/components/task-detail/TaskDetailDiffView';
@@ -443,6 +444,9 @@ export default function TaskDetail() {
             <TaskInfoPanel>
               <TaskRefsPanel taskId={task.id} initialRefs={task.external_refs} />
               <JiraLinkHelper taskId={task.id} />
+              {task.pull_requests && task.pull_requests.length > 0 && (
+                <PullRequestList pullRequests={task.pull_requests} />
+              )}
             </TaskInfoPanel>
             <TaskInfoPanel>
               <TaskHooksPanel taskId={task.id} />


### PR DESCRIPTION
The three deferred follow-ups from #250, in one PR.

## 1. PostToolUse PR fast-path (server/hooks.ts)
New pure helper `parsePrFromToolUse(command, toolResponse)`: `gh pr create` output → {url, number, branch}; `git push origin <branch>` → branch-only row (poller fills the rest). The post-tool-use handler now reads `tool_response` and upserts a `pull_requests` row for the agent's task (idempotent via the (task_id, branch) upsert, so it never double-tracks with the poller). Fails open. 14 tests.

## 2. Multi-ticket external refs (schema + migration + repo + route)
`task_external_refs` PK relaxed `(task_id, integration)` → `(task_id, integration, ref)` so a task can carry N Linear/Jira refs. Forward-only, guarded, transactional migration (rebuild-table; runs only when the old 2-col PK is present). `deleteTaskExternalRef(task_id, integration, ref?)` — delete one by ref, or all for the integration (back-compat). `DELETE /api/tasks/:id/refs/:integration?ref=SHR-1` deletes one; without `?ref` deletes all.

## 3. PR-list UI (src/)
`PullRequestList` component in the task **info tab**: a rollup ('2 open · 1 merged') + one row per PR (number linked to url, branch, state badge); renders nothing when empty. Uses the `pull_requests` array #250 already exposes. Added `TaskPullRequest`/`PullRequestState` to @octomux/types. 7 tests.

## Testing
149/149 across the 6 touched test files; `bun run typecheck` clean (types rebuilt from src). Full suite skipped — pre-existing devbox-load flakiness (identical on plain next); changes verified independently.