### PR TITLE
docs: merge stranded doc-drift fixes (#241 + #246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,10 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
 
 - `server/` — Express backend (API, terminal streaming, task lifecycle, DB)
   - `api.ts` — mounts the routers from `routes/` onto the Express app
-  - `routes/` — one router per surface (tasks, task-agents, task-workflow, diffs, reviews,
-    review-runs, comments, chats, loops, skills, schedules, settings, orchestrator, …)
+  - `routes/` — one router per surface (tasks, task-agents, task-workflow, diffs, comments,
+    chats, loops, skills, schedules, kinds, settings, orchestrator, …). Workflow-owned
+    routers (`loops`, plus `reviews` and `pr-extracts` under `server/workflows/*/routes.ts`)
+    are mounted via each workflow's `apiRouter`, not imported by `api.ts` directly.
   - `app.ts` — extracted `createApp()` for testability
   - `task-engine/` — worktree + tmux + harness lifecycle. `cleanup.ts` holds `closeTask` /
     `deleteTask`; also `launch.ts`, `git.ts`, `sessions.ts`, `terminals.ts`, `reconcile.ts`,
@@ -49,6 +51,11 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
   - `hook-base-url.ts` — `hookBaseUrl()` returns `http://127.0.0.1:<port>` for harness callbacks.
   - `schedules/cron.ts` — `isCronDue()`, the 5-field cron evaluator (`croner`, UTC) behind
     scheduled runs. Rows live in the `schedules` table; `poller/schedule-cron.ts` fires them.
+  - `orchestrator/` — the conductor: command gate/schemas, MCP server, approval timeouts.
+  - `gateway/` — chat-DM front end onto the conductor (Telegram + Slack), default-deny
+    owner allowlist, opt-in per channel. Setup and security model in `server/gateway/README.md`.
+  - `integrations/` — provider registry + credential store (`jira`, `linear`,
+    `slack-gateway`, `telegram-gateway`); env vars win over DB-stored values.
 - `src/` — React SPA (pages, components, lib/api.ts)
   - `workflows/` — front-end workflow-UI registry mirroring `server/workflows/`.
     `registerWorkflowUI(kind, { navLabel, icon, ListView, DetailView })` (`loops/register.tsx`)
@@ -181,12 +188,17 @@ revisions had `<repo>/.octomux/{skills,agents}` and `~/.octomux/agents`; nothing
 delivered them (`syncAgents()` is a no-op in both harnesses), so they were listed over
 REST and invisible to every running agent. They are gone; don't reintroduce them.
 
+One narrow exception survives: `octomux add-agent --skeleton <name>` reads
+`<worktree>/.octomux/agents/<name>.md` and prepends it to the prompt
+(`task-engine/lifecycle/add-agent.ts`). That is a per-worktree file read at launch, not a
+discovery tier — nothing lists or serves it.
+
 Users' own skills/subagents live in Claude Code's native `~/.claude/skills/`,
 `~/.claude/agents/`, and `<repo>/.claude/` — the harness reads those directly and octomux
 neither manages nor lists them. Repo-specific customization goes there.
 
 The skills are also installable into a user's own sessions via the plugin marketplace
-(`.claude-plugin/marketplace.json`): `/plugin marketplace add ShreyPaharia/octomux-agents`
+(`.claude-plugin/marketplace.json`): `/plugin marketplace add ShreyPaharia/octomux`
 then `/plugin install octomux@octomux`.
 
 `workflows/review-deep.js` is a Claude Code _workflow_ script, which plugins cannot ship —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ server/           Express backend (API, terminal streaming, task lifecycle, DB)
   workflows/      workflow kinds (loops, reviewer, doc-drift, …) + kind presets
   schedules/      cron.ts — isCronDue(), the 5-field cron evaluator behind schedules
   poller/         background pollers (PR detection, merged-PR close, hooks, schedules)
+  orchestrator/   the conductor — command gate/schemas, MCP server, approvals
+  gateway/        Telegram + Slack chat front end onto the conductor (see its README.md)
+  integrations/   provider registry + credential store (jira, linear, *-gateway)
   db.ts           SQLite singleton with getDb() / setDb() / initDb()
   db/             schema.ts + forward-only migrations.ts
   types.ts        re-exports @octomux/types + review-orchestrator types
@@ -37,6 +40,8 @@ cli/              CLI tool for task management
 packages/         bun workspaces: types, diff-engine, api-client, test-fixtures
 plugin/           bundled Claude Code plugin (skills/, agents/) — the only tier agents see
 kinds/            built-in schedule-kind presets (*.json), read by server/workflows/presets.ts
+workflows/        Claude Code workflow scripts (review-deep.js) — `octomux init` copies these
+                  to ~/.claude/workflows/, since plugins cannot ship them
 electron/         macOS desktop shell
 e2e/              Playwright E2E tests
 ```

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -101,18 +101,19 @@ Draft first if you want to edit title, prompt, and branch before agents start �
 
 ## 7. Where things live
 
-| Path                          | Purpose                                                 |
-| ----------------------------- | ------------------------------------------------------- |
-| `~/.octomux/settings.json`    | Defaults (editor, Jira, harness flags, default harness) |
-| `~/.octomux/data/tasks.db`    | Task state (production)                                 |
-| `./data/tasks.db`             | Task state (development)                                |
-| `~/.octomux/logs/`            | Server + hook logs                                      |
-| `~/.octomux/hooks/<event>.d/` | Lifecycle hooks                                         |
-| `~/.octomux/kinds/`           | Your own schedule-kind presets (Settings → Kinds)       |
-| `~/.claude/skills/`           | Your own Claude Code skills (read by the harness)       |
-| `~/.claude/workflows/`        | Review workflow scripts installed by `octomux init`     |
-| `<repo>/.worktrees/<task-id>` | Per-task git worktree                                   |
-| `<worktree>/.octomux-hooks/`  | Cursor hook bridge (Cursor tasks)                       |
+| Path                               | Purpose                                                 |
+| ---------------------------------- | ------------------------------------------------------- |
+| `~/.octomux/settings.json`         | Defaults (editor, Jira, harness flags, default harness) |
+| `~/.octomux/data/tasks.db`         | Task state (production)                                 |
+| `./data/tasks.db`                  | Task state (development)                                |
+| `~/.octomux/logs/`                 | Server + hook logs                                      |
+| `~/.octomux/hooks/<event>.d/`      | Lifecycle hooks (global)                                |
+| `<repo>/.octomux/hooks/<event>.d/` | Lifecycle hooks (repo-local; run after the global ones) |
+| `~/.octomux/kinds/`                | Your own schedule-kind presets (Settings → Kinds)       |
+| `~/.claude/skills/`                | Your own Claude Code skills (read by the harness)       |
+| `~/.claude/workflows/`             | Review workflow scripts installed by `octomux init`     |
+| `<repo>/.worktrees/<task-id>`      | Per-task git worktree                                   |
+| `<worktree>/.octomux-hooks/`       | Cursor hook bridge (Cursor tasks)                       |
 
 Set `OCTOMUX_DATA_DIR` to move the `~/.octomux` root elsewhere — the desktop app does this so it never shares the CLI's data directory.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ octomux is a bet on what that surface should look like: not a chat box bolted on
 | Command                              | Description                                                          |
 | ------------------------------------ | -------------------------------------------------------------------- |
 | `octomux start`                      | Dashboard at `:7777` (add `--bind 0.0.0.0` for remote)               |
-| `octomux init`                       | Defaults wizard (Jira/Linear, base branch, harness prefs)            |
+| `octomux init`                       | Defaults wizard (Jira URL/project, base branch) + workflow scripts   |
 | `octomux create-task`                | New task (`--harness`, `--model`, `--mode`, `--fork-from`)           |
 | `octomux list-tasks` / `get-task`    | Inspect tasks                                                        |
 | `octomux close-task` / `delete-task` | Stop or fully remove                                                 |
@@ -135,7 +135,7 @@ devices can reach the port; the token is a second factor. For HTTPS, front it wi
 octomux keeps a clean line between the **agent backend** (done for you) and the **views**
 (where the value is). Building blocks available today:
 
-- **REST API** (~110 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
+- **REST API** (~130 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
 - **Two live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux.
 - **A queryable SQLite schema** — tasks, agents, permission prompts, review runs, comments, learnings.
 - **A pluggable harness interface** — add a new agent backend by implementing one interface and registering it.


### PR DESCRIPTION
Supersedes #241 and #246. Both doc-drift branches were cut from `next`, and PR #243 squash-merged next→main, so their diffs against main carried the entire 1.3.0 delta (550+ files) and showed as CONFLICTING. This branch cherry-picks only the two doc commits onto main.

## Changes

- **CLAUDE.md** — document `server/orchestrator`, `server/gateway`, `server/integrations`; correct the `routes/` map (workflow-owned routers mount via each workflow's `apiRouter`, not `api.ts`); fix the plugin marketplace slug to `ShreyPaharia/octomux`; note the surviving `add-agent --skeleton` exception.
- **CONTRIBUTING.md** — add `orchestrator/`, `gateway/`, `integrations/`, and root `workflows/` to the tree.
- **ONBOARDING.md** — document repo-local `<repo>/.octomux/hooks/<event>.d/`.
- **README.md** — correct `octomux init` scope and the REST endpoint count (~110 → ~130).

## Verification

Every claim re-checked against current main, not against the branches' original bases:
- `server/{orchestrator,gateway,integrations}` and root `workflows/` exist; `server/gateway/README.md` exists.
- `server/api.ts:51` — `if (wf.apiRouter) app.use(wf.apiRouter)`; `server/workflows/{reviewer,pr-extract}/routes.ts` exist, no `routes/reviews.ts`.
- `server/task-engine/lifecycle/add-agent.ts:39` reads `<worktree>/.octomux/agents/<name>.md`.
- `server/hook-dispatcher.ts:82-95` — `resolveHookDirs()` pushes the global dir then the repo-local one, confirming the documented ordering.
- Endpoint count: 132 `router.<verb>(` handlers across `server/{routes,workflows,gateway,orchestrator}` (non-test).
- Prettier clean.

Two hunks conflicted (same correction, worded differently); kept one wording and re-applied the endpoint-count hunk by hand.

Close #241 and #246 once this lands.