### PR TITLE
docs: fix doc drift 2026-08-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![npm version](https://img.shields.io/npm/v/octomux)](https://www.npmjs.com/package/octomux)
 [![license](https://img.shields.io/github/license/ShreyPaharia/octomux)](LICENSE)
 [![npm downloads](https://img.shields.io/npm/dw/octomux)](https://www.npmjs.com/package/octomux)
-[![npm downloads](https://img.shields.io/npm/dw/octomux)](https://www.npmjs.com/package/octomux)
 [![GitHub stars](https://img.shields.io/github/stars/ShreyPaharia/octomux)](https://github.com/ShreyPaharia/octomux)
 
 # octomux
@@ -126,8 +125,6 @@ Three workflows octomux makes one-click:
 
 <sub>Verified 2 Aug 2026 against each project's own docs. Something out of date or unfair? [Open an issue](https://github.com/ShreyPaharia/octomux/issues/new) — corrections to this table are welcome and get merged.</sub>
 
-<sub>Verified 2 Aug 2026 against each project's own docs. Something out of date or unfair? [Open an issue](https://github.com/ShreyPaharia/octomux/issues/new) — corrections to this table are welcome and get merged.</sub>
-
 ## Why octomux
 
 The editor was built around a human typing one file at a time. That's not the job anymore. The job is directing a fleet — and the hard part moved from _writing_ code to _reviewing_ it, _unblocking_ it, and _knowing what's happening_ across ten sessions.
@@ -186,10 +183,10 @@ octomux keeps a clean line between the **agent backend** (done for you) and the 
 (where the value is). Building blocks available today:
 
 - **REST API** (~130 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
-- **Two live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux.
+- **Three live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux, and `/ws/orchestrator/:convId` for the conductor's conversation stream.
 - **A queryable SQLite schema** — tasks, agents, permission prompts, review runs, comments, learnings.
 - **A pluggable harness interface** — add a new agent backend by implementing one interface and registering it.
-- **User hook scripts** — drop executables in `~/.octomux/hooks` to fire on task-lifecycle events.
+- **User hook scripts** — drop executables in `~/.octomux/hooks/<event>.d/` (or `<repo>/.octomux/hooks/<event>.d/`) to fire on task-lifecycle events.
 
 There isn't a drop-in plugin API for custom UI views yet — adding one means building against
 these blocks in the codebase. A first-class way to author and share views is the direction


### PR DESCRIPTION
Scheduled doc-drift pass. Surveyed README.md, CLAUDE.md, CONTRIBUTING.md, ONBOARDING.md against the code on `main` (branch fast-forwarded to `origin/main` first — `next` no longer exists on the remote, it was deleted after the 1.3.0 release).

## Fixed

- **`README.md` — "Two live WebSocket channels" is wrong; there are three.** `server/index.ts:62-71` registers `handleTerminalUpgrade`, `handleEventUpgrade`, and `handleOrchestratorUpgrade`. `/ws/orchestrator/:convId` (`server/orchestrator/stream.ts:537`) was undocumented.
- **`README.md` — user hook scripts path was imprecise.** Executables must go in `~/.octomux/hooks/<event>.d/`, not `~/.octomux/hooks` (`server/hooks-install.ts:60`, `cli/src/commands/hooks-install.ts:48`), and the repo-local tier `<repo>/.octomux/hooks/<event>.d/` was missing — ONBOARDING.md:110-111 already documents both correctly.
- **`README.md` — two verbatim duplicated lines.** The npm-downloads badge appeared twice, and the "Verified 2 Aug 2026 against each project's own docs" `<sub>` note appeared twice around the comparison table.

## Checked, no drift

- CLI reference table — every command re-derived from the `register*(program)` list at `cli/src/index.ts:55-89`; `--harness` / `--fork-from` / `--notify-agent` / `--mode` all still declared.
- `~130 endpoints` — a count at the tree where that number was written (`0ddfced`, 4 days ago) matches today's, so it reflects a counting rule, not drift. Left alone.
- `CLAUDE.md` — routes list, the three-meanings-of-"agent" table (`/api/workers`, `/api/agents`, `/api/agent-roles`), schedules/kinds endpoint lists, "six cron-kind files folded into `kinds/*.json`" (6 cron kinds + `custom.json`), loop UI routes (`/loops`, `/w/loops/:id`, `/loops/:id` redirect), `packages/*`, build/typecheck script descriptions, `OCTOMUX_AI_TASK_NAMING` — all verified against code.
- `CONTRIBUTING.md` architecture tree and `ONBOARDING.md` "Where things live" table — verified row by row, clean.

## Skipped

- `README.md` tells contributors to open PRs against `next`, which does not currently exist on the remote and gets no CI (`ci.yml` triggers on `main` only). But 14 of the last 15 merged PRs targeted `next` — it is the real integration branch, recreated per release cycle. Left as-is rather than guessing.
- `bun run format:check` already fails on `README.md` on `main` (`*you*` vs Prettier's `_you_`, line 30) — pre-existing and unrelated to doc drift; CI does not run `format:check`.