### PR TITLE
fix(terminal): keep idle WebSockets alive so terminals survive idle gaps

### DIFF
--- a/server/events.ts
+++ b/server/events.ts
@@ -2,6 +2,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import type { IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import { appendEvent, eventsSince } from './repositories/orchestrator.js';
+import { installHeartbeat } from './ws-heartbeat.js';
 
 export type ServerEvent =
   | { type: 'task:updated' | 'task:created' | 'task:deleted'; payload: { taskId: string } }
@@ -68,6 +69,7 @@ export function subscribeServerEvents(listener: InProcessListener): () => void {
 
 export function setupEventWebSocket(): void {
   wss = new WebSocketServer({ noServer: true });
+  installHeartbeat(wss);
 }
 
 export function handleEventUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {

--- a/server/orchestrator/stream.ts
+++ b/server/orchestrator/stream.ts
@@ -42,6 +42,7 @@ import { tailTranscript } from './transcript.js';
 import type { ChatEvent } from './transcript.js';
 import type { StopFn } from './transcript.js';
 import { executeCard } from './gate.js';
+import { installHeartbeat } from '../ws-heartbeat.js';
 
 const logger = childLogger('orchestrator/stream');
 
@@ -530,6 +531,7 @@ let wss: WebSocketServer;
 /** Initialise the orchestrator WebSocket server (noServer mode). Call once at startup. */
 export function setupOrchestratorWebSocket(): void {
   wss = new WebSocketServer({ noServer: true });
+  installHeartbeat(wss);
   logger.debug({}, 'stream: orchestrator WebSocket server initialised');
 }
 

--- a/server/terminal.ts
+++ b/server/terminal.ts
@@ -5,6 +5,7 @@ import type { Duplex } from 'stream';
 import { nanoid } from 'nanoid';
 import { getTask, getChatAgentTmuxSession } from './repositories/index.js';
 import { execTmux, tmuxSpawnSpec } from './tmux-bin.js';
+import { installHeartbeat } from './ws-heartbeat.js';
 
 interface TerminalConnection {
   ws: WebSocket;
@@ -19,6 +20,7 @@ export function setupTerminalWebSocket(): void {
   // repetitive ANSI — compression cuts remote-viewing bandwidth ~10x. ws only
   // compresses frames above its 1KB threshold, so keystroke echo stays fast.
   wss = new WebSocketServer({ noServer: true, perMessageDeflate: true });
+  installHeartbeat(wss);
 }
 
 export function handleTerminalUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {

--- a/server/ws-heartbeat.test.ts
+++ b/server/ws-heartbeat.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import type { WebSocketServer, WebSocket } from 'ws';
+import { installHeartbeat } from './ws-heartbeat.js';
+
+class FakeWs extends EventEmitter {
+  ping = vi.fn();
+  terminate = vi.fn();
+}
+
+class FakeWss extends EventEmitter {
+  clients = new Set<FakeWs>();
+  connect(): FakeWs {
+    const ws = new FakeWs();
+    this.clients.add(ws);
+    this.emit('connection', ws);
+    return ws;
+  }
+}
+
+describe('installHeartbeat', () => {
+  let wss: FakeWss;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    wss = new FakeWss();
+    installHeartbeat(wss as unknown as WebSocketServer, 1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pings connected clients on each interval', () => {
+    const ws = wss.connect();
+    vi.advanceTimersByTime(1000);
+    expect(ws.ping).toHaveBeenCalledTimes(1);
+    expect(ws.terminate).not.toHaveBeenCalled();
+  });
+
+  it('keeps clients that answer pings alive', () => {
+    const ws = wss.connect();
+    vi.advanceTimersByTime(1000);
+    (ws as unknown as WebSocket).emit('pong');
+    vi.advanceTimersByTime(1000);
+    expect(ws.ping).toHaveBeenCalledTimes(2);
+    expect(ws.terminate).not.toHaveBeenCalled();
+  });
+
+  it('terminates clients that miss a pong', () => {
+    const ws = wss.connect();
+    vi.advanceTimersByTime(1000); // ping sent, no pong comes back
+    vi.advanceTimersByTime(1000); // missed pong detected
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
+    expect(ws.ping).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops pinging after the server closes', () => {
+    const ws = wss.connect();
+    wss.emit('close');
+    vi.advanceTimersByTime(5000);
+    expect(ws.ping).not.toHaveBeenCalled();
+  });
+});

--- a/server/ws-heartbeat.ts
+++ b/server/ws-heartbeat.ts
@@ -1,0 +1,37 @@
+import type { WebSocketServer, WebSocket } from 'ws';
+
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Ping every connected client on an interval and terminate ones that miss a pong.
+ *
+ * An idle terminal/event socket carries zero traffic, so NAT gateways and tunnel
+ * proxies silently drop the connection after a few minutes of silence. The browser
+ * never learns (its half-open socket still reports OPEN), so reconnect logic never
+ * fires and the user has to refresh. The ping traffic keeps intermediary connection
+ * state alive; the missed-pong terminate reaps server-side resources (viewer ptys)
+ * for peers that vanished without a FIN. Browsers answer protocol-level pings
+ * automatically — no client code involved.
+ */
+export function installHeartbeat(
+  wss: WebSocketServer,
+  intervalMs: number = HEARTBEAT_INTERVAL_MS,
+): void {
+  const alive = new WeakSet<WebSocket>();
+  wss.on('connection', (ws) => {
+    alive.add(ws);
+    ws.on('pong', () => alive.add(ws));
+  });
+  const timer = setInterval(() => {
+    for (const ws of wss.clients) {
+      if (!alive.has(ws)) {
+        ws.terminate();
+        continue;
+      }
+      alive.delete(ws);
+      ws.ping();
+    }
+  }, intervalMs);
+  timer.unref();
+  wss.on('close', () => clearInterval(timer));
+}

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -348,4 +348,33 @@ describe('TerminalView', () => {
     const stale = MockWebSocket.instances.find((ws, idx) => idx >= 2 && ws.url.endsWith('/0'));
     expect(stale).toBeUndefined();
   });
+
+  it('reconnects immediately on tab return when the socket is dead', async () => {
+    // Background tabs throttle the backoff timer, so a scheduled reconnect can
+    // sit for minutes. Returning to the tab must not wait for it.
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws1 = MockWebSocket.instances[0];
+    act(() => ws1._open());
+    act(() => ws1._close(1006)); // abnormal close → reconnect scheduled with backoff
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('does not open a duplicate socket on tab return while connected', async () => {
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    act(() => MockWebSocket.instances[0]._open());
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
 });

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -349,6 +349,22 @@ export function TerminalView({
     }
   }, [connectWs]);
 
+  // A reconnect scheduled while the tab is hidden gets throttled by the browser
+  // (background timers fire at most ~once a minute), so a dropped connection can
+  // stay down long after the user returns. Retry immediately on tab return if
+  // the socket is dead. CONNECTING/OPEN sockets are left alone — retrying then
+  // would leak a duplicate connection.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      const ws = wsRef.current;
+      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) return;
+      handleRetryNow();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, [handleRetryNow]);
+
   // Connect on mount and reconnect when taskId/windowIndex changes
   useEffect(() => {
     unmounted.current = false;


### PR DESCRIPTION
## What

- New `server/ws-heartbeat.ts` — `installHeartbeat(wss)` pings every connected client every 30s and terminates peers that miss a pong. Wired into all three WebSocket servers: terminal, events, orchestrator.
- `TerminalView` now reconnects immediately when the tab becomes visible and the socket is dead, instead of waiting out a background-throttled backoff timer. CONNECTING/OPEN sockets are left alone so no duplicate connections.

## Why

Idle terminal/event sockets carried zero traffic, so NAT gateways and tunnel proxies silently dropped the TCP connection after ~5 minutes of silence. Neither end got a FIN, so the browser's half-open socket still reported OPEN — the reconnect logic never fired and keystrokes went into a dead socket until a page refresh. The 30s ping traffic keeps intermediary connection state alive (browsers answer protocol pings automatically), and the missed-pong terminate reaps server-side viewer ptys for peers that vanished.

## Testing

- 4 new unit tests for `installHeartbeat` (ping cadence, pong keeps alive, missed pong terminates, stops on wss close)
- 2 new `TerminalView` tests (immediate reconnect on tab return with dead socket; no duplicate socket while connected)
- `bunx vitest run server/ws-heartbeat.test.ts src/components/TerminalView.test.tsx server/terminal.test.ts` — 37 passed
- `bun run typecheck`, eslint, and prettier clean