### PR TITLE
feat(gateway): condense raw artifact payloads in outbound chat messages

### DIFF
--- a/server/gateway/condense.test.ts
+++ b/server/gateway/condense.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { condenseForChat, CHAT_MAX_CHARS } from './condense.js';
+
+const PLAN = {
+  schema_version: '1.0.0',
+  summary: 'Add a condense guard to the gateway outbound path.',
+  files: [
+    { path: 'server/gateway/condense.ts', action: 'create', steps: ['write it'] },
+    { path: 'server/gateway/gateway.ts', action: 'modify', steps: ['wire it'] },
+  ],
+  open_questions: ['Should Slack get a higher cap?'],
+  detail: 'A very long prose body that must never reach chat. '.repeat(30),
+};
+const PLAN_JSON = JSON.stringify(PLAN, null, 2);
+
+describe('condenseForChat', () => {
+  it.each([
+    ['fenced json block', `plan ready — approve?\n\`\`\`json\n${PLAN_JSON}\n\`\`\`\nok?`],
+    ['bare fenced block', `plan ready — approve?\n\`\`\`\n${PLAN_JSON}\n\`\`\`\nok?`],
+    ['unfenced blob', `plan ready — approve?\n${PLAN_JSON}\nok?`],
+  ])('replaces a plan.json payload (%s) with a readable summary', (_name, message) => {
+    const out = condenseForChat(message);
+    expect(out).toContain('📋 Plan: Add a condense guard to the gateway outbound path.');
+    expect(out).toContain('• server/gateway/condense.ts (create)');
+    expect(out).toContain('• server/gateway/gateway.ts (modify)');
+    expect(out).toContain('Open questions:');
+    expect(out).toContain('• Should Slack get a higher cap?');
+    // No raw JSON survives: no schema_version key, no steps, no detail body.
+    expect(out).not.toContain('schema_version');
+    expect(out).not.toContain('"steps"');
+    expect(out).not.toContain('must never reach chat');
+    // Surrounding prose is preserved.
+    expect(out).toContain('plan ready — approve?');
+    expect(out).toContain('ok?');
+  });
+
+  it('collapses a large non-plan JSON blob to a condensed marker with keys and gist', () => {
+    const blob = JSON.stringify({
+      title: 'walkthrough of the change',
+      sections: Array.from({ length: 20 }, (_, i) => ({ heading: `h${i}`, body: 'x'.repeat(40) })),
+    });
+    const out = condenseForChat(`here it is:\n${blob}`);
+    expect(out).toContain('[structured payload condensed —');
+    expect(out).toContain('keys: title, sections');
+    expect(out).toContain('walkthrough of the change');
+    expect(out).not.toContain('"sections"');
+  });
+
+  it.each([
+    ['small inline JSON', 'set {"level":"debug"} in the config'],
+    ['plain prose', 'Two tasks running; both green. Want a third?'],
+    ['prose with braces', 'in TS use `type X = { a: string }` for that'],
+    ['unbalanced brace', 'an open { with no close and ' + 'filler '.repeat(80)],
+  ])('leaves %s untouched', (_name, message) => {
+    expect(condenseForChat(message)).toBe(message);
+  });
+
+  it('does not crash or mangle a large unparseable brace span', () => {
+    const notJson = `{ this is ${'definitely '.repeat(60)}not json }`;
+    expect(condenseForChat(notJson)).toBe(notJson);
+  });
+
+  it('truncates an over-long message (e.g. a pasted 19KB spec) with a clear marker', () => {
+    const spec = `# Spec\n${'All work and no play makes Jack a dull boy. '.repeat(450)}`;
+    expect(spec.length).toBeGreaterThan(19_000);
+    const out = condenseForChat(spec);
+    expect(out.length).toBeLessThan(CHAT_MAX_CHARS + 50);
+    expect(out).toContain(`… [truncated, ${spec.length - CHAT_MAX_CHARS} chars omitted]`);
+    expect(out.startsWith('# Spec')).toBe(true);
+  });
+
+  it('summarizes a plan even when the surrounding message is huge, then caps length', () => {
+    const message = `${PLAN_JSON}\n${'padding '.repeat(1000)}`;
+    const out = condenseForChat(message);
+    expect(out).toContain('📋 Plan:');
+    expect(out.length).toBeLessThan(CHAT_MAX_CHARS + 50);
+    expect(out).toContain('… [truncated,');
+  });
+});

--- a/server/gateway/condense.ts
+++ b/server/gateway/condense.ts
@@ -1,0 +1,172 @@
+/**
+ * server/gateway/condense.ts
+ *
+ * Guard for every outbound gateway chat message (Slack/Telegram): replace raw
+ * structured-artifact payloads with a readable summary before send. Applied at
+ * the single OutboundQueue seam in gateway.ts, so turn replies, supervisor
+ * pushes, and any future adapter are all covered.
+ *
+ *  - plan.json-shaped blobs (validated with the existing validatePlanJson) are
+ *    rendered from their own summary/files/open_questions fields — no LLM call.
+ *  - other large JSON blobs are collapsed to a one-line marker.
+ *  - anything still over CHAT_MAX_CHARS is truncated with a clear marker
+ *    (Telegram hard-fails above 4096 chars; the user reads on mobile anyway).
+ */
+
+import { childLogger } from '../logger.js';
+import { validatePlanJson } from '../orchestrator/exec.js';
+
+const logger = childLogger('gateway-condense');
+
+/** Under Telegram's 4096 hard limit; deliberately also applied to Slack. */
+export const CHAT_MAX_CHARS = 3900;
+
+/** Bare {...} spans shorter than this are never treated as artifact candidates. */
+const MIN_BARE_SPAN_CHARS = 400;
+
+/** Non-plan JSON blobs shorter than this pass through untouched. */
+const MIN_GENERIC_BLOB_CHARS = 500;
+
+const MAX_LISTED_KEYS = 8;
+
+interface PlanFileEntry {
+  path: string;
+  action: string;
+}
+
+/** Render a validated plan from its own fields; steps/detail are dropped. */
+function renderPlan(plan: Record<string, unknown>): string {
+  const lines = [`📋 Plan: ${(plan['summary'] as string).trim()}`];
+  const files = plan['files'] as PlanFileEntry[];
+  if (files.length > 0) {
+    lines.push('', 'Files:');
+    for (const f of files) lines.push(`• ${f.path} (${f.action})`);
+  }
+  const questions = plan['open_questions'] as string[] | undefined;
+  if (questions && questions.length > 0) {
+    lines.push('', 'Open questions:');
+    for (const q of questions) lines.push(`• ${q}`);
+  }
+  return lines.join('\n');
+}
+
+function renderGeneric(parsed: Record<string, unknown>, rawLength: number): string {
+  const keys = Object.keys(parsed);
+  const listed =
+    keys.slice(0, MAX_LISTED_KEYS).join(', ') + (keys.length > MAX_LISTED_KEYS ? ', …' : '');
+  const kb = (rawLength / 1024).toFixed(1);
+  const gist = ['summary', 'title'].map((k) => parsed[k]).find((v) => typeof v === 'string') as
+    | string
+    | undefined;
+  const marker = `[structured payload condensed — ${kb} KB, keys: ${listed}]`;
+  return gist ? `${marker}\n${gist}` : marker;
+}
+
+/**
+ * Condense one JSON candidate. Returns the replacement text, or null to leave
+ * the original untouched (not JSON, or too small to be worth collapsing).
+ */
+function condenseBlob(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    if (raw.length < MIN_GENERIC_BLOB_CHARS) return null;
+    return `[structured payload condensed — ${(raw.length / 1024).toFixed(1)} KB]`;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (validatePlanJson(obj).valid) return renderPlan(obj);
+  if (raw.length < MIN_GENERIC_BLOB_CHARS) return null;
+  return renderGeneric(obj, raw.length);
+}
+
+/**
+ * Replace fenced code blocks whose body is a condensable JSON payload.
+ * The closing fence must sit at the start of a line — a JSON string literal
+ * can't contain a real newline, so lazy matching can't stop early on a
+ * ``` embedded inside the payload's strings.
+ */
+function replaceFencedBlobs(text: string): string {
+  return text.replace(/```[a-zA-Z]*\r?\n([\s\S]*?)\r?\n```/g, (fence, body: string) => {
+    const replacement = condenseBlob(body.trim());
+    return replacement ?? fence;
+  });
+}
+
+/**
+ * Find the index of the `}` closing the `{` at `start`, honouring JSON string
+ * literals and escapes. Returns -1 when unbalanced.
+ */
+function matchBraces(text: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString) {
+      if (c === '\\') escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') inString = true;
+    else if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Replace bare (unfenced) {...} spans that are condensable JSON payloads. */
+function replaceBareBlobs(text: string): string {
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== '{') {
+      out += text[i];
+      i++;
+      continue;
+    }
+    const end = matchBraces(text, i);
+    if (end === -1) {
+      out += text.slice(i);
+      break;
+    }
+    const span = text.slice(i, end + 1);
+    const replacement = span.length >= MIN_BARE_SPAN_CHARS ? condenseBlob(span) : null;
+    out += replacement ?? span;
+    i = end + 1;
+  }
+  return out;
+}
+
+/**
+ * Condense structured-artifact payloads in an outbound chat message and cap
+ * its length. Idempotent on ordinary prose.
+ */
+export function condenseForChat(text: string): string {
+  let out = replaceBareBlobs(replaceFencedBlobs(text));
+  if (out !== text) {
+    logger.info(
+      { before_chars: text.length, after_chars: out.length },
+      'condensed structured payload in outbound chat message',
+    );
+  }
+  if (out.length > CHAT_MAX_CHARS) {
+    const omitted = out.length - CHAT_MAX_CHARS;
+    logger.info(
+      { message_chars: out.length, omitted_chars: omitted },
+      'truncated outbound chat message',
+    );
+    out = `${out.slice(0, CHAT_MAX_CHARS)}\n… [truncated, ${omitted} chars omitted]`;
+  }
+  return out;
+}

--- a/server/gateway/gateway.test.ts
+++ b/server/gateway/gateway.test.ts
@@ -125,6 +125,68 @@ describe('gateway glue', () => {
     expect(sent[0]!.text).not.toContain('ghp_ABCDEFGH12345678');
   });
 
+  it('delivers a raw plan.json reply as a readable summary, never the raw JSON', async () => {
+    const { adapter, sent } = fakeAdapter();
+    const { conductor, sendTurn, emit } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    await gw.handleInbound(inbound());
+    const convId = sendTurn.mock.calls[0]![0] as string;
+
+    // The conductor pastes the raw plan artifact into its reply (the observed
+    // live failure mode) — the gateway must condense it before send.
+    const planJson = JSON.stringify(
+      {
+        schema_version: '1.0.0',
+        summary: 'Wire the condense guard into the outbound path.',
+        files: [{ path: 'server/gateway/gateway.ts', action: 'modify', steps: ['wire'] }],
+        open_questions: ['ship behind a flag?'],
+        detail: 'long body '.repeat(100),
+      },
+      null,
+      2,
+    );
+    emit(convId, {
+      type: 'assistant',
+      text: `plan ready for task abc123 — approve?\n\`\`\`json\n${planJson}\n\`\`\``,
+      uuid: 'a1',
+      timestamp: 't',
+    });
+    emit(convId, { type: 'system', subtype: 'stop_hook_summary', uuid: 's1', timestamp: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sent).toHaveLength(1);
+    const text = sent[0]!.text;
+    expect(text).toContain('plan ready for task abc123 — approve?');
+    expect(text).toContain('📋 Plan: Wire the condense guard into the outbound path.');
+    expect(text).toContain('• server/gateway/gateway.ts (modify)');
+    expect(text).toContain('• ship behind a flag?');
+    expect(text).not.toContain('schema_version');
+    expect(text).not.toContain('long body');
+  });
+
+  it('truncates an over-long reply with a clear marker instead of dumping it', async () => {
+    const { adapter, sent } = fakeAdapter();
+    const { conductor, sendTurn, emit } = fakeConductor();
+    const gw = createGateway(adapter, conductor);
+
+    await gw.handleInbound(inbound());
+    const convId = sendTurn.mock.calls[0]![0] as string;
+
+    emit(convId, {
+      type: 'assistant',
+      text: `# Spec\n${'spec prose '.repeat(2000)}`, // ~22KB, like the observed spec dump
+      uuid: 'a1',
+      timestamp: 't',
+    });
+    emit(convId, { type: 'system', subtype: 'stop_hook_summary', uuid: 's1', timestamp: 't' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.text.length).toBeLessThan(4096); // Telegram hard limit
+    expect(sent[0]!.text).toContain('… [truncated,');
+  });
+
   it('reuses the same conversation for a second message on the same thread', async () => {
     const { adapter } = fakeAdapter();
     const { conductor, sendTurn, emit } = fakeConductor();

--- a/server/gateway/gateway.ts
+++ b/server/gateway/gateway.ts
@@ -17,6 +17,7 @@
 import { childLogger } from '../logger.js';
 import { isAllowed, type Channel } from './allowlist.js';
 import { redactSecrets } from './redact.js';
+import { condenseForChat } from './condense.js';
 import { OutboundQueue } from './outbound.js';
 import type { ChannelAdapter, InboundMessage } from './adapter.js';
 import { getThreadConv, setThreadConv, seenInbound, markInbound } from '../repositories/gateway.js';
@@ -89,7 +90,12 @@ export function createGateway(
   adapter: ChannelAdapter,
   conductor: GatewayConductor = realConductor,
 ): Gateway {
-  const outbound = new OutboundQueue((threadKey, text) => adapter.send(threadKey, text));
+  // Single choke point for every outbound chat message (turn replies AND
+  // supervisor pushes): condense raw artifact payloads and cap length here so
+  // no adapter ever receives a raw plan.json dump or an over-limit message.
+  const outbound = new OutboundQueue((threadKey, text) =>
+    adapter.send(threadKey, condenseForChat(text)),
+  );
   const threads = new Map<string, ThreadState>();
 
   const key = (channel: Channel, threadKey: string) => `${channel}:${threadKey}`;

--- a/server/orchestrator/conductor-flags.ts
+++ b/server/orchestrator/conductor-flags.ts
@@ -31,7 +31,7 @@ export const ORCHESTRATOR_SYSTEM_PROMPT = [
   '- KEEP THE USER INFORMED: when you create a task, tell them its id and the goal; when a worker finishes a phase, summarize the outcome and propose the next step.',
   '',
   '',
-  'APPROVALS & REPORTING OVER CHAT: assume I may not be able to open dashboard/artifact links, so never make an approval depend on one. When a task needs plan/spec approval, paste a short gist of it (goal + the key steps/decisions) right in the message and ask me to approve. When work is done and needs a go-ahead to open the PR, send a short gist of what got done and what the PR will contain, then ask. A link can go at the end as a bonus, never as the only way to see it.',
+  'APPROVALS & REPORTING OVER CHAT: assume I may not be able to open dashboard/artifact links, so never make an approval depend on one. When a task needs plan/spec approval, write a short PROSE gist — the goal, the files it touches, and any open questions — and ask me to approve. NEVER paste raw JSON (plan.json or otherwise), full spec markdown, or full file contents into chat; summarize in your own words and keep the whole message comfortably under ~1500 characters. When work is done and needs a go-ahead to open the PR, send a short gist of what got done and what the PR will contain, then ask. A link can go at the end as a bonus, never as the only way to see it.',
   '',
   'You are a thin coordination layer: set the goal, delegate, track it, report status. Never plan the implementation, never touch the code.',
 ].join('\n');


### PR DESCRIPTION
## What

Adds a `condenseForChat()` guard at the gateway's single outbound choke point (the `OutboundQueue` send seam in `server/gateway/gateway.ts`) so every message relayed to Slack/Telegram is readable and size-safe:

- **plan.json-shaped blobs** (fenced or bare, validated with the existing `validatePlanJson`) are rendered from the plan's own `summary`/`files`/`open_questions` fields — no LLM call, no re-summarizing
- **other large JSON payloads** collapse to a one-line marker with size, top-level keys, and any `summary`/`title` gist
- **over-long messages** are truncated at 3900 chars with a clear `… [truncated, N chars omitted]` marker (Telegram hard-fails above 4096)

Also tightens the orchestrator system prompt (the be1f316 approval-gist guidance): gist approvals in prose, never paste raw JSON, spec markdown, or full file contents.

## Why

Observed live: plan-approval messages arrived on Slack/TG as raw `plan.json` blobs and a 19KB spec markdown dump — unreadable on mobile/SSH. The supervisor and MCP read tools already relay pointers only; the raw content comes from the orchestrator LLM pasting artifacts into its reply, which the gateway relayed verbatim with no size handling in either adapter. Fixing at the shared OutboundQueue seam covers both relay ears (turn replies and supervisor pushes) and any future adapter with one guard.

Before/after with a real plan payload: 7,037 chars of raw JSON → 815-char readable summary (plan summary + file list + open questions, surrounding prose intact).

## Testing

- 11 new unit tests (`server/gateway/condense.test.ts`): plan rendering (fenced/bare/unfenced), generic JSON condensing, prose/small-JSON/unbalanced-brace passthrough, truncation marker
- 2 new gateway end-to-end tests: a turn reply embedding raw plan.json arrives at the fake adapter as a summary (no `schema_version`, no plan body); a ~22KB reply arrives under Telegram's 4096 limit with the truncation marker
- `vitest run` on gateway + conductor-flags suites: 30/30 pass; `typecheck`, `lint` (touched files clean), `format:check`, and full `build` green
- Pre-existing `api.*.test.ts` failures reproduce identically at base with this change stashed — unrelated