### PR TITLE
docs: fix doc drift 2026-08-06

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 
 # ─── Telegram gateway (opt-in) ───────────────────────────────────────────────
 # Talk to the octomux conductor over a Telegram DM. Leave the token unset to
-# keep the gateway disabled. See docs/gateway-setup.md.
+# keep the gateway disabled. See server/gateway/README.md.
 
 # Bot token from @BotFather (https://t.me/botfather → /newbot).
 OCTOMUX_GATEWAY_TELEGRAM_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ Users' own skills/subagents live in Claude Code's native `~/.claude/skills/`,
 neither manages nor lists them. Repo-specific customization goes there.
 
 The skills are also installable into a user's own sessions via the plugin marketplace
-(`.claude-plugin/marketplace.json`): `/plugin marketplace add ShreyPaharia/octomux-agents`
+(`.claude-plugin/marketplace.json`): `/plugin marketplace add ShreyPaharia/octomux`
 then `/plugin install octomux@octomux`.
 
 `workflows/review-deep.js` is a Claude Code _workflow_ script, which plugins cannot ship —

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ devices can reach the port; the token is a second factor. For HTTPS, front it wi
 octomux keeps a clean line between the **agent backend** (done for you) and the **views**
 (where the value is). Building blocks available today:
 
-- **REST API** (~110 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
-- **Two live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux.
+- **REST API** (~145 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
+- **Three live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux, `/ws/orchestrator/:convId` for the orchestrator stream.
 - **A queryable SQLite schema** — tasks, agents, permission prompts, review runs, comments, learnings.
 - **A pluggable harness interface** — add a new agent backend by implementing one interface and registering it.
-- **User hook scripts** — drop executables in `~/.octomux/hooks` to fire on task-lifecycle events.
+- **User hook scripts** — drop executables in `~/.octomux/hooks/<event>.d/` (or `<repo>/.octomux/hooks/<event>.d/` for repo-local ones) to fire on task-lifecycle events.
 
 There isn't a drop-in plugin API for custom UI views yet — adding one means building against
 these blocks in the codebase. A first-class way to author and share views is the direction


### PR DESCRIPTION
Scheduled doc-drift pass. Docs audited against code on `next`; five claims re-derived mechanically, three drifted.

### Fixed

- **README "Built to extend" — endpoint count.** Claimed `~110` REST endpoints; actual count is 147 (`router|app.(get|post|put|patch|delete)` across `server/**`, excluding tests). Updated to `~145`.
- **README "Built to extend" — WebSocket channels.** Claimed "Two live WebSocket channels". `server/index.ts:66-70` registers three upgrade handlers: `/ws/terminal/*`, `/ws/events`, and `/ws/orchestrator/:convId` (`server/orchestrator/stream.ts`). Added the third.
- **README "Built to extend" — hook script path.** Said "drop executables in `~/.octomux/hooks`". `server/hook-dispatcher.ts:87,92` reads `~/.octomux/hooks/<event>.d/` and `<repo>/.octomux/hooks/<event>.d/`. Corrected both the `.d` suffix and the repo-local tier.
- **CLAUDE.md — marketplace slug.** `/plugin marketplace add ShreyPaharia/octomux-agents`; the repo is `ShreyPaharia/octomux` (`package.json` `repository.url`, `git remote`). The old slug only resolves via GitHub's rename redirect.
- **`.env.example` — dead doc pointer.** Line 8 pointed at `docs/gateway-setup.md`, which was planned in `plans/2026-07-23-phase2-gateway.md` but never written (no `docs/` directory exists). Retargeted to `server/gateway/README.md`, which covers the full Telegram walkthrough — the same file the Slack section already points at.

### Checked, no drift

`CLAUDE.md` (routes list, agents/workers/agent-roles table, loops + schedules CLI and endpoints, "six cron kinds" vs `kinds/*.json`, `packages/*`, build/typecheck script text, `plugin/{skills,agents}`), `CONTRIBUTING.md` architecture tree and script list, `ONBOARDING.md` "Where things live" table and `octomux init` flags, README CLI reference table (every command against the `register*(program)` list in `cli/src/index.ts`, every flag against its command file), Node/platform requirements, screenshot paths, remote-token path.

### Note

This task's worktree was created from a commit ~50 behind `next`; it was fast-forwarded to `origin/next` before auditing, otherwise the edits would have reverted newer work.