### PR TITLE
docs: fix doc drift 2026-08-10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
     plus `lifecycle/`, `setup/`, `loop/` subdirs.
   - `db.ts` — SQLite singleton with `getDb()` / `setDb()` / `initDb()`
   - `logger.ts` — pino root + `childLogger('<module>')` helper
-  - `types.ts` — shared types (Task, Agent, TaskStatus, AgentStatus)
+  - `types.ts` — re-exports `@octomux/types` (Task, Worker, RuntimeState, WorkflowStatus,
+    WorkerStatus) plus the server-only review/orchestrator types
   - `harnesses/` — pluggable harness implementations (`claude-code.ts`, `cursor.ts`;
     `claude-code` is the default via `DEFAULT_HARNESS_ID`).
     Each `Harness` exports `id`, `displayName`, `sessionIdMode`, command builders,
@@ -93,8 +94,13 @@ DB migrations are forward-only. Back up `~/.octomux/data/tasks.db` (prod) or
 
 ## Task Lifecycle
 
-draft → setting_up → running → closed/error
-Error at any point → error state with message in `task.error`
+A task carries two orthogonal statuses (`packages/types/src/index.ts`):
+
+- `runtime_state: RuntimeState` — `idle | setting_up | running | error | looping`
+- `workflow_status: WorkflowStatus` — the board column, `backlog | planned | in_progress | human_review | pr | done`
+
+`setting_up → running → idle` is the usual runtime path (close sets `idle`). Error at any
+point → `error` with the message in `task.error`.
 
 Per task: git worktree at `<repo>/.worktrees/<id>`, tmux session `octomux-agent-<id>`,
 branch `agents/<id>`. Each **worker** = tmux window within the session.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ server/           Express backend (API, terminal streaming, task lifecycle, DB)
 src/              React SPA (pages, components, lib/api.ts)
   workflows/      front-end workflow-UI registry behind the /w/:kind/:id route
 cli/              CLI tool for task management
-packages/         bun workspaces: types, diff-engine, api-client, test-fixtures
+packages/         bun workspaces: types, diff-engine, api-client, test-fixtures,
+                  plus the prebuilt tmux-{darwin,linux}-{arm64,x64} binaries
 plugin/           bundled Claude Code plugin (skills/, agents/) — the only tier agents see
 kinds/            built-in schedule-kind presets (*.json), read by server/workflows/presets.ts
 electron/         macOS desktop shell
@@ -43,13 +44,19 @@ e2e/              Playwright E2E tests
 
 ## Task Lifecycle
 
+A task carries two orthogonal statuses (`packages/types/src/index.ts`):
+
 ```
-draft → setting_up → running → closed / error
+runtime_state:    idle | setting_up | running | error | looping
+workflow_status:  backlog | planned | in_progress | human_review | pr | done
 ```
 
-Each task gets a git worktree at `<repo>/.worktrees/<id>`, a tmux session `octomux-agent-<id>`, and a branch `agents/<id>`. Each agent runs in a tmux window within the session.
+`setting_up → running → idle` is the usual runtime path; errors land in `error` with the
+message in `task.error`.
 
-- **Close** — stops agents and kills the tmux session. Worktree and branch are preserved for resume.
+Each task gets a git worktree at `<repo>/.worktrees/<id>`, a tmux session `octomux-agent-<id>`, and a branch `agents/<id>`. Each worker runs in a tmux window within the session.
+
+- **Close** — stops workers and kills the tmux session. Worktree and branch are preserved for resume.
 - **Delete** — kills tmux session, removes worktree, deletes branch, removes DB rows. Full cleanup.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ devices can reach the port; the token is a second factor. For HTTPS, front it wi
 octomux keeps a clean line between the **agent backend** (done for you) and the **views**
 (where the value is). Building blocks available today:
 
-- **REST API** (~110 endpoints) over tasks, agents, diffs, reviews, chats, workspaces, skills.
-- **Two live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux.
-- **A queryable SQLite schema** — tasks, agents, permission prompts, review runs, comments, learnings.
+- **REST API** (~140 endpoints) over tasks, workers, diffs, reviews, chats, workspaces, skills, loops, schedules.
+- **Three live WebSocket channels** — `/ws/events` for task/chat/review events, `/ws/terminal/*` for bidirectional xterm ↔ tmux, `/ws/orchestrator/*` for the orchestrator conversation stream.
+- **A queryable SQLite schema** — tasks, workers, agents, permission prompts, review runs, comments, learnings, loop runs, schedules.
 - **A pluggable harness interface** — add a new agent backend by implementing one interface and registering it.
 - **User hook scripts** — drop executables in `~/.octomux/hooks` to fire on task-lifecycle events.
 


### PR DESCRIPTION
Scheduled doc-drift audit. Every claim below was mechanically re-derived from the code on `next`.

### Fixed

| Doc | Was | Now |
| --- | --- | --- |
| `README.md` | REST API "~110 endpoints" | ~140 (141 `router.<verb>('...')` handlers under `server/`, excluding tests) |
| `README.md` | "Two live WebSocket channels" | Three — `server/index.ts` also wires `handleOrchestratorUpgrade` for `/ws/orchestrator/:convId` (`server/orchestrator/stream.ts`) |
| `README.md` | SQLite schema list omitted post-rename tables | added `workers`, loop runs, schedules; `agents` now means the persistent conductor agent |
| `CLAUDE.md` | `types.ts` — shared types (Task, **Agent, TaskStatus, AgentStatus**) | `TaskStatus`/`AgentStatus`/`Agent` no longer exist; `server/types.ts` is `export * from '@octomux/types'` exposing `Task`, `Worker`, `RuntimeState`, `WorkflowStatus`, `WorkerStatus` |
| `CLAUDE.md` | Task Lifecycle "draft → setting_up → running → closed/error" | neither `draft` nor `closed` is a status. Two orthogonal columns: `runtime_state` (`idle\|setting_up\|running\|error\|looping`) and `workflow_status` (`backlog…done`). `closeTask` sets `runtime_state='idle'` (`server/task-engine/cleanup.ts:39`) |
| `CONTRIBUTING.md` | same stale lifecycle block; "Each **agent** runs in a tmux window" | same status fix; the per-task tmux unit is a **worker** (matches the agents/workers rename already documented in `CLAUDE.md`) |
| `CONTRIBUTING.md` | `packages/` listed 4 workspaces | also ships the 4 prebuilt `tmux-{darwin,linux}-{arm64,x64}` binaries |

### Checked, no drift

- `ONBOARDING.md` "Where things live" — all 11 rows verified against `server/octomux-paths.ts`, `server/db.ts`, `server/octomux-root.ts`, `cli/src/commands/init.ts`.
- `README.md` CLI reference table — every row matches a `register*(program)` call at the bottom of `cli/src/index.ts`.
- `CONTRIBUTING.md` architecture tree, build/test/lint script text, `CLAUDE.md` loops + schedules sections.