### PR TITLE
docs: fix doc drift 2026-08-11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,10 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
 
 - `server/` — Express backend (API, terminal streaming, task lifecycle, DB)
   - `api.ts` — mounts the routers from `routes/` onto the Express app
-  - `routes/` — one router per surface (tasks, task-agents, task-workflow, diffs, reviews,
-    review-runs, comments, chats, loops, skills, schedules, settings, orchestrator, …)
+  - `routes/` — one router per surface (tasks, task-agents, task-workflow, diffs, comments,
+    chats, loops, skills, schedules, kinds, settings, orchestrator, …). Workflow-owned
+    routers (`loops`, plus `reviews` and `pr-extracts` under `server/workflows/*/routes.ts`)
+    are mounted via each workflow's `apiRouter`, not imported by `api.ts` directly.
   - `app.ts` — extracted `createApp()` for testability
   - `task-engine/` — worktree + tmux + harness lifecycle. `cleanup.ts` holds `closeTask` /
     `deleteTask`; also `launch.ts`, `git.ts`, `sessions.ts`, `terminals.ts`, `reconcile.ts`,
@@ -49,6 +51,11 @@ root with `OCTOMUX_DATA_DIR` (the Electron app sets this to an app-private path)
   - `hook-base-url.ts` — `hookBaseUrl()` returns `http://127.0.0.1:<port>` for harness callbacks.
   - `schedules/cron.ts` — `isCronDue()`, the 5-field cron evaluator (`croner`, UTC) behind
     scheduled runs. Rows live in the `schedules` table; `poller/schedule-cron.ts` fires them.
+  - `orchestrator/` — the conductor: command gate/schemas, MCP server, approval timeouts.
+  - `gateway/` — chat-DM front end onto the conductor (Telegram + Slack), default-deny
+    owner allowlist, opt-in per channel. Setup and security model in `server/gateway/README.md`.
+  - `integrations/` — provider registry + credential store (`jira`, `linear`,
+    `slack-gateway`, `telegram-gateway`); env vars win over DB-stored values.
 - `src/` — React SPA (pages, components, lib/api.ts)
   - `workflows/` — front-end workflow-UI registry mirroring `server/workflows/`.
     `registerWorkflowUI(kind, { navLabel, icon, ListView, DetailView })` (`loops/register.tsx`)
@@ -169,8 +176,9 @@ no resolution chain, no per-kind DB table, and editing a preset never touches ex
 `poller/execute-schedule-run.ts`, which threads model/timeout into the workflow's `RunContext`.
 Session-vertical prompts interpolate `{{configKey}}` placeholders generically
 (`server/prompt-interpolate.ts`, single-pass). Managed from `/schedules` and Settings → Kinds
-in the UI; `server/routes/schedules.ts` (`GET/POST /api/schedules`, `PATCH /api/schedules/:id`,
-`POST /api/schedules/:id/run`, `GET /api/schedules/:id/export`, `POST /api/schedules/import`)
+in the UI; `server/routes/schedules.ts` (`GET/POST /api/schedules`, `PATCH`/`DELETE /api/schedules/:id`,
+`POST /api/schedules/:id/run`, `GET /api/schedules/:id/runs`,
+`GET /api/schedules/:id/export`, `POST /api/schedules/import`, `GET /api/schedules/kinds`)
 and `server/routes/kinds.ts` (`GET /api/kinds`, `PUT`/`DELETE /api/kinds/:kind`, home tier only).
 
 ## Skills and agent roles
@@ -180,6 +188,11 @@ agents via `--plugin-dir`. **Single source — there is no repo or home tier.** 
 revisions had `<repo>/.octomux/{skills,agents}` and `~/.octomux/agents`; nothing ever
 delivered them (`syncAgents()` is a no-op in both harnesses), so they were listed over
 REST and invisible to every running agent. They are gone; don't reintroduce them.
+
+One narrow exception survives: `octomux add-agent --skeleton <name>` reads
+`<worktree>/.octomux/agents/<name>.md` and prepends it to the prompt
+(`task-engine/lifecycle/add-agent.ts`). That is a per-worktree file read at launch, not a
+discovery tier — nothing lists or serves it.
 
 Users' own skills/subagents live in Claude Code's native `~/.claude/skills/`,
 `~/.claude/agents/`, and `<repo>/.claude/` — the harness reads those directly and octomux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ server/           Express backend (API, terminal streaming, task lifecycle, DB)
   workflows/      workflow kinds (loops, reviewer, doc-drift, …) + kind presets
   schedules/      cron.ts — isCronDue(), the 5-field cron evaluator behind schedules
   poller/         background pollers (PR detection, merged-PR close, hooks, schedules)
+  orchestrator/   the conductor — command gate/schemas, MCP server, approvals
+  gateway/        Telegram + Slack chat front end onto the conductor (see its README.md)
+  integrations/   provider registry + credential store (jira, linear, *-gateway)
   db.ts           SQLite singleton with getDb() / setDb() / initDb()
   db/             schema.ts + forward-only migrations.ts
   types.ts        re-exports @octomux/types + review-orchestrator types
@@ -37,6 +40,8 @@ cli/              CLI tool for task management
 packages/         bun workspaces: types, diff-engine, api-client, test-fixtures
 plugin/           bundled Claude Code plugin (skills/, agents/) — the only tier agents see
 kinds/            built-in schedule-kind presets (*.json), read by server/workflows/presets.ts
+workflows/        Claude Code workflow scripts (review-deep.js) — `octomux init` copies these
+                  to ~/.claude/workflows/, since plugins cannot ship them
 electron/         macOS desktop shell
 e2e/              Playwright E2E tests
 ```

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -101,18 +101,19 @@ Draft first if you want to edit title, prompt, and branch before agents start �
 
 ## 7. Where things live
 
-| Path                          | Purpose                                                 |
-| ----------------------------- | ------------------------------------------------------- |
-| `~/.octomux/settings.json`    | Defaults (editor, Jira, harness flags, default harness) |
-| `~/.octomux/data/tasks.db`    | Task state (production)                                 |
-| `./data/tasks.db`             | Task state (development)                                |
-| `~/.octomux/logs/`            | Server + hook logs                                      |
-| `~/.octomux/hooks/<event>.d/` | Lifecycle hooks                                         |
-| `~/.octomux/kinds/`           | Your own schedule-kind presets (Settings → Kinds)       |
-| `~/.claude/skills/`           | Your own Claude Code skills (read by the harness)       |
-| `~/.claude/workflows/`        | Review workflow scripts installed by `octomux init`     |
-| `<repo>/.worktrees/<task-id>` | Per-task git worktree                                   |
-| `<worktree>/.octomux-hooks/`  | Cursor hook bridge (Cursor tasks)                       |
+| Path                               | Purpose                                                 |
+| ---------------------------------- | ------------------------------------------------------- |
+| `~/.octomux/settings.json`         | Defaults (editor, Jira, harness flags, default harness) |
+| `~/.octomux/data/tasks.db`         | Task state (production)                                 |
+| `./data/tasks.db`                  | Task state (development)                                |
+| `~/.octomux/logs/`                 | Server + hook logs                                      |
+| `~/.octomux/hooks/<event>.d/`      | Lifecycle hooks (global)                                |
+| `<repo>/.octomux/hooks/<event>.d/` | Lifecycle hooks (repo-local; run after the global ones) |
+| `~/.octomux/kinds/`                | Your own schedule-kind presets (Settings → Kinds)       |
+| `~/.claude/skills/`                | Your own Claude Code skills (read by the harness)       |
+| `~/.claude/workflows/`             | Review workflow scripts installed by `octomux init`     |
+| `<repo>/.worktrees/<task-id>`      | Per-task git worktree                                   |
+| `<worktree>/.octomux-hooks/`       | Cursor hook bridge (Cursor tasks)                       |
 
 Set `OCTOMUX_DATA_DIR` to move the `~/.octomux` root elsewhere — the desktop app does this so it never shares the CLI's data directory.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ octomux is a bet on what that surface should look like: not a chat box bolted on
 | Command                              | Description                                                          |
 | ------------------------------------ | -------------------------------------------------------------------- |
 | `octomux start`                      | Dashboard at `:7777` (add `--bind 0.0.0.0` for remote)               |
-| `octomux init`                       | Defaults wizard (Jira/Linear, base branch, harness prefs)            |
+| `octomux init`                       | Defaults wizard (Jira URL/project, base branch) + workflow scripts   |
 | `octomux create-task`                | New task (`--harness`, `--model`, `--mode`, `--fork-from`)           |
 | `octomux list-tasks` / `get-task`    | Inspect tasks                                                        |
 | `octomux close-task` / `delete-task` | Stop or fully remove                                                 |


### PR DESCRIPTION
## Root cause this run

`main` and `next` have diverged. **#253** (`docs: merge doc-drift fixes for gateway/orchestrator, repo-local hooks, routes map`) landed on `main` only, and `next` has 3 commits `main` doesn't have. So the drift #253 fixed is **live again on `next`** — which is what every doc-drift branch is cut from.

This PR backports those fixes to `next`. Every claim was re-verified against the code on `next` first, not cherry-picked blind.

## Drift fixed

| Doc | Drift | Verified against |
|---|---|---|
| `CLAUDE.md` | `routes/` map listed `reviews` and `review-runs` routers that don't exist there — review REST is `server/workflows/reviewer/routes.ts` and `pr-extracts` is `server/workflows/pr-extract/routes.ts`, both mounted via each workflow's `apiRouter`, not imported by `api.ts`. `kinds` was missing. | `server/api.ts:39-63`, `server/routes/`, `server/workflows/*/routes.ts` |
| `CLAUDE.md` | `server/orchestrator/`, `server/gateway/`, `server/integrations/` were undocumented — all three are wired and shipping (`startGatewayIfConfigured` at `server/index.ts:44`). | `server/orchestrator/`, `server/gateway/README.md`, `server/integrations/registry.ts` |
| `CLAUDE.md` | `/api/schedules` endpoint list omitted `DELETE /api/schedules/:id`, `GET /api/schedules/:id/runs`, `GET /api/schedules/kinds`. | `server/routes/schedules.ts:153-330` |
| `CLAUDE.md` | "no repo tier" claim had no exception noted, but `add-agent --skeleton` still reads `<worktree>/.octomux/agents/<name>.md`. | `server/task-engine/lifecycle/add-agent.ts:39` |
| `CONTRIBUTING.md` | Architecture tree missing `orchestrator/`, `gateway/`, `integrations/`, and the root `workflows/`. | `ls server/`, `workflows/review-deep.js`, `cli/src/commands/init.ts:83-96` |
| `ONBOARDING.md` | "Where things live" documented only global `~/.octomux/hooks/<event>.d/`; repo-local `<repo>/.octomux/hooks/<event>.d/` also runs, after the global ones. | `server/hook-dispatcher.ts:87-92` |
| `README.md` | CLI table said `octomux init` = "Jira/Linear, base branch, harness prefs". It takes `--jira-url` / `--jira-project` / `--base-branch` only (no Linear, no harness) and installs the workflow scripts. | `cli/src/commands/init.ts:83-135` |

## Deliberately not touched

Three doc-drift PRs are open against `next` at once; these lines are already claimed and a fourth opinion would just conflict:

- **REST endpoint count** — #253 says `~130`, #257 says `~145`, #258 says `~140`. I re-derived it: **135** unique `(method, /api path)` registrations across `server/**/*.ts` excluding tests. Whichever of those PRs merges should use 135.
- **WebSocket channel count**, **SQLite schema list**, **hook-script paths** in README "Built to extend" — #257 / #258.
- **`.claude-plugin/marketplace.json` slug** (`ShreyPaharia/octomux`) in CLAUDE.md — #257.
- **Task-lifecycle statuses** (`runtime_state` / `workflow_status`) and the `packages/` line — #258.

## Also checked, no drift

README CLI table commands and flags vs `cli/src/index.ts` registrations (`--harness`, `--fork-from`, `--mode`, `--model`, `--notify-agent`, `--n`, `--verify`); `task-engine/` file list; `packages/*`; `kinds/*.json` (six non-`custom` kinds); loop UI routes `/loops` + `/w/loops/:id`; `server/db/`, `server/poller/`, `server/workflows/` trees; `~/.octomux/data/remote-token`; `OCTOMUX_DATA_DIR`, `OCTOMUX_BIND`, `OCTOMUX_REMOTE_TOKEN`, `OCTOMUX_GITHUB_LOGIN`; `<worktree>/.octomux-hooks/`; Node `>=20`; `bun run build` / `typecheck` script text.