### PR TITLE
fix(ws): heartbeat terminated every client on its first tick

### DIFF
--- a/server/ws-heartbeat.test.ts
+++ b/server/ws-heartbeat.test.ts
@@ -16,6 +16,16 @@ class FakeWss extends EventEmitter {
     this.emit('connection', ws);
     return ws;
   }
+
+  /**
+   * How production actually connects: `wss.handleUpgrade(req, socket, head, cb)`
+   * adds the socket to `clients` and calls `cb` — it never emits 'connection'.
+   */
+  upgrade(): FakeWs {
+    const ws = new FakeWs();
+    this.clients.add(ws);
+    return ws;
+  }
 }
 
 describe('installHeartbeat', () => {
@@ -53,6 +63,25 @@ describe('installHeartbeat', () => {
     vi.advanceTimersByTime(1000); // missed pong detected
     expect(ws.terminate).toHaveBeenCalledTimes(1);
     expect(ws.ping).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps noServer clients alive even though they never emit connection', () => {
+    const ws = wss.upgrade();
+    vi.advanceTimersByTime(1000); // adopted + pinged, not terminated
+    expect(ws.terminate).not.toHaveBeenCalled();
+    expect(ws.ping).toHaveBeenCalledTimes(1);
+
+    (ws as unknown as WebSocket).emit('pong'); // pong listener must be attached
+    vi.advanceTimersByTime(1000);
+    expect(ws.terminate).not.toHaveBeenCalled();
+    expect(ws.ping).toHaveBeenCalledTimes(2);
+  });
+
+  it('still terminates a noServer client that misses a pong', () => {
+    const ws = wss.upgrade();
+    vi.advanceTimersByTime(1000); // adopted, ping sent
+    vi.advanceTimersByTime(1000); // no pong came back
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
   });
 
   it('stops pinging after the server closes', () => {

--- a/server/ws-heartbeat.ts
+++ b/server/ws-heartbeat.ts
@@ -18,12 +18,22 @@ export function installHeartbeat(
   intervalMs: number = HEARTBEAT_INTERVAL_MS,
 ): void {
   const alive = new WeakSet<WebSocket>();
-  wss.on('connection', (ws) => {
+  const tracked = new WeakSet<WebSocket>();
+
+  // Adopt clients off `wss.clients` rather than off a 'connection' listener: in
+  // noServer mode `ws` never emits 'connection' — the handleUpgrade callback
+  // takes its place — so every socket would look unanswered and get terminated
+  // on the first tick. Adopting here covers every upgrade site by construction.
+  const track = (ws: WebSocket): void => {
+    if (tracked.has(ws)) return;
+    tracked.add(ws);
     alive.add(ws);
     ws.on('pong', () => alive.add(ws));
-  });
+  };
+
   const timer = setInterval(() => {
     for (const ws of wss.clients) {
+      track(ws);
       if (!alive.has(ws)) {
         ws.terminate();
         continue;


### PR DESCRIPTION
## The bug

`installHeartbeat` (added in #255 to *keep* idle sockets alive) marked sockets alive from a `wss.on('connection')` listener:

```ts
wss.on('connection', (ws) => { alive.add(ws); ws.on('pong', () => alive.add(ws)); });
setInterval(() => { for (const ws of wss.clients) { if (!alive.has(ws)) ws.terminate(); ... } }, 30_000);
```

All four upgrade sites run `ws` in **noServer** mode — `wss.handleUpgrade(req, socket, head, cb)` never emits `'connection'`, the callback takes its place. So `wss.clients` held the socket, `alive` never did, and no `'pong'` listener was ever attached. Every client was `terminate()`d on the next 30s tick.

Affects `/ws/events` (dashboard), terminals, and orchestrator chat — all three install the heartbeat.

## Evidence from a live server

```
kill #1  lived= 5.07s   gap=n/a
kill #2  lived=29.79s   gap=30.00s
kill #3  lived=29.80s   gap=30.00s
```

- Exactly 30.00s apart and phase-locked — one shared interval, not per-socket.
- Staggered sockets aged 5.8s / 12.8s / 19.8s / 26.8s all died in the same instant.
- Close code `1006`, no close frame — `terminate()`, not `close()`.
- The pre-#255 build survived 80s idle; a standalone repro of the same wiring survived 75s.

## The fix

Adopt clients off `wss.clients` on each tick rather than off a `'connection'` listener, so every upgrade site is covered by construction instead of by remembering to re-emit the event.

## Verification

- New tests fail on the old implementation, pass on the new (`2 failed | 4 passed` → `6 passed`). The existing tests were green throughout because `FakeWss.connect()` emitted `'connection'` itself — the exact call production never makes; added an `upgrade()` helper that models the real path.
- Full suite: **367 files, 4304 tests passed**.
- End-to-end, patched server vs an unpatched one on the same machine:
  ```
   0.0s LIVE     OPEN        0.0s PATCHED OPEN
   2.5s LIVE     CLOSE 1006  2.6s PATCHED <-server ping
                           129.1s PATCHED <-server ping   (never closed)
  ```
  The first tick is the proof: old code calls `terminate()` there, patched code calls `ping()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)