### PR TITLE
fix(gate): stop gating task.close; scale task.delete to what it actually does

### DIFF
--- a/packages/capabilities/src/capabilities/task.ts
+++ b/packages/capabilities/src/capabilities/task.ts
@@ -187,7 +187,12 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
       'so it can be resumed.',
     // No http/cli projection — server/registry/capabilities/task.ts module doc point 1.
     mcp: 'close_task',
-    tier: 'always-ask',
+    // Reversible, and the routine end of every task's life — the closed session
+    // stays resumable and the worktree/branch survive, which is exactly what
+    // the summary above promises. Gating it made agents block on a human for
+    // the single most common write they perform, buying no safety: there is
+    // nothing to undo. Deliberately 'auto'.
+    tier: 'auto',
     callers: ['human', 'agent'],
     input: closeTaskInputSchema,
   },
@@ -201,7 +206,14 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
     cli: 'task delete',
     cliAliases: ['delete-task'],
     mcp: 'delete_task',
-    tier: 'always-ask',
+    // Two different operations behind one name. The default soft-delete only
+    // stamps deleted_at and is undone by the restore route, so it rates 'ask' —
+    // one prompt, and promotable to 'auto' with "always allow" if you never
+    // want to see it again. `purge: true` is the irreversible one, so tierFor
+    // raises it to 'always-ask', which no permission rule can promote.
+    tier: 'ask',
+    tierFor: (input) =>
+      (input as { purge?: boolean } | null)?.purge === true ? 'always-ask' : 'ask',
     callers: ['ui', 'human', 'agent'],
     input: taskDeleteInputSchema,
   },

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -129,6 +129,22 @@ export interface CapabilityMeta<TInput = unknown> {
   /** Gate tier applied when `caller === 'agent'`. */
   tier: PolicyTier;
 
+  /**
+   * Raises the tier for a specific invocation, when how dangerous the call is
+   * depends on its INPUT rather than on the capability.
+   *
+   * `task.delete` is the motivating case: by default it soft-deletes (a
+   * `deleted_at` stamp, undone by the restore route), but `purge: true` kills
+   * the tmux session, removes the worktree, deletes the branch and drops the
+   * rows. One static tier cannot describe both — pick `ask` and a stored
+   * permission rule can silently promote an irreversible purge to `auto`; pick
+   * `always-ask` and every routine delete blocks a human.
+   *
+   * Resolved per call, and may only ever RAISE the tier — see `resolveTier`.
+   * A capability cannot use this to gate itself less than it declares.
+   */
+  tierFor?: (input: unknown) => PolicyTier;
+
   /** Caller classes permitted to invoke this at all. */
   callers: CallerClass[];
 

--- a/server/orchestrator/mcp/server.test.ts
+++ b/server/orchestrator/mcp/server.test.ts
@@ -104,10 +104,12 @@ describe('createOctomuxMcpServer — tool registration', () => {
     // is nothing for orchestratorWriteEnabled() to protect.
     expect(tools).toContain('list_tasks');
     expect(tools).toContain('get_task');
+    // close_task is 'auto' too: it is reversible (the session stays resumable,
+    // worktree and branch survive) and it is the routine end of a task's life.
+    expect(tools).toContain('close_task');
     // Everything above 'auto' still requires orchestratorWriteEnabled().
     expect(tools).not.toContain('create_task');
     expect(tools).not.toContain('set_task_status');
-    expect(tools).not.toContain('close_task');
     expect(tools).not.toContain('delete_task');
   });
 
@@ -147,10 +149,14 @@ describe('createOctomuxMcpServer — tool registration', () => {
     expect(tools).toContain('report_complete');
     expect(tools).toContain('list_tasks');
     expect(tools).toContain('get_task');
+    // A worker gets close_task because it is 'auto'. That is not a widening of
+    // what a worker can DO — every worker already has Bash and the review
+    // prompts literally instruct it to run `octomux close-task <id>`. This is
+    // the same power by a second route, not a new one.
+    expect(tools).toContain('close_task');
     expect(tools).not.toContain('create_task');
     expect(tools).not.toContain('send_message');
     expect(tools).not.toContain('set_task_status');
-    expect(tools).not.toContain('close_task');
     expect(tools).not.toContain('delete_task');
   });
 
@@ -214,7 +220,7 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
     vi.unstubAllGlobals();
   });
 
-  it('close_task (always-ask) hits onGatedInvoke instead of running immediately', async () => {
+  it('delete_task (ask) hits onGatedInvoke instead of running immediately', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockRejectedValue(new Error('ECONNREFUSED (no server listening in this test)')),
@@ -225,7 +231,7 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
     const priv = server as unknown as {
       _registeredTools: Record<string, { handler: (input: unknown, extra: unknown) => unknown }>;
     };
-    const tool = priv._registeredTools['close_task'];
+    const tool = priv._registeredTools['delete_task'];
     expect(tool).toBeDefined();
 
     const result = (await tool.handler({ task_id: 'task-x' }, {})) as {
@@ -233,7 +239,35 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
       isError?: boolean;
     };
 
+    // Card creation fails (no server listening), so the gate denies. The point
+    // is that it never reached the handler — a fail-open gate would have
+    // returned a delete result or a "task not found" error instead.
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/could not create an approval card/);
+  });
+
+  it('close_task (auto) runs immediately — no approval card, no gate', async () => {
+    // The counterpart to the test above, and the reason close was moved off
+    // always-ask: an auto capability must reach its handler with no human in
+    // the loop. Reaching runCloseTask (and failing on a nonexistent task) is
+    // proof the gate was not consulted; a gated call would have failed on
+    // card creation first, exactly as delete_task does above.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('ECONNREFUSED (no server listening in this test)')),
+    );
+
+    const { createOctomuxMcpServer } = await import('./server.js');
+    const server = createOctomuxMcpServer();
+    const priv = server as unknown as {
+      _registeredTools: Record<string, { handler: (input: unknown, extra: unknown) => unknown }>;
+    };
+    const result = (await priv._registeredTools['close_task'].handler(
+      { task_id: 'task-x' },
+      {},
+    )) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.content[0].text).not.toMatch(/could not create an approval card/);
+    expect(result.content[0].text).toMatch(/task-x/);
   });
 });

--- a/server/registry/capabilities/task.test.ts
+++ b/server/registry/capabilities/task.test.ts
@@ -81,7 +81,7 @@ describe('registerTaskCapabilities', () => {
     ['task.create', 'post', '/api/tasks', 'task create', 'create_task', 'ask'],
     ['task.start', 'post', '/api/tasks/:id/start', 'task start', undefined, 'ask'],
     ['task.move', 'post', '/api/tasks/:id/move', 'task move', 'set_task_status', 'ask'],
-    ['task.delete', 'delete', '/api/tasks/:id', 'task delete', 'delete_task', 'always-ask'],
+    ['task.delete', 'delete', '/api/tasks/:id', 'task delete', 'delete_task', 'ask'],
   ] as const)('%s has the expected http/cli/mcp/tier shape', (id, method, path, cli, mcp, tier) => {
     const cap = getCapability(id)!;
     expect(cap.http?.method).toBe(method);
@@ -114,7 +114,23 @@ describe('registerTaskCapabilities', () => {
     expect(cap.cli).toBeUndefined();
     expect(cap.cliAliases).toBeUndefined();
     expect(cap.mcp).toBe('close_task');
-    expect(cap.tier).toBe('always-ask');
+    // 'auto', not 'always-ask': closing preserves the worktree and branch and
+    // the session stays resumable, so there is nothing for a human to protect
+    // against — and it is the most common write an agent makes.
+    expect(cap.tier).toBe('auto');
+  });
+
+  it('task.delete raises itself to always-ask when purge is set', () => {
+    // Soft-delete is reversible via the restore route, so it sits at 'ask' and
+    // can be promoted to 'auto' with "always allow". purge:true is the
+    // irreversible one — worktree removed, branch deleted, rows dropped — and
+    // must never be reachable through a stored permission rule.
+    const cap = getCapability('task.delete')!;
+    expect(cap.tier).toBe('ask');
+    expect(cap.tierFor).toBeDefined();
+    expect(cap.tierFor!({ task_id: 't1' })).toBe('ask');
+    expect(cap.tierFor!({ task_id: 't1', purge: false })).toBe('ask');
+    expect(cap.tierFor!({ task_id: 't1', purge: true })).toBe('always-ask');
   });
 
   it.each([

--- a/server/registry/index.test.ts
+++ b/server/registry/index.test.ts
@@ -4,6 +4,7 @@ import {
   defineCapability,
   exemptRoute,
   authorize,
+  resolveTier,
   resolveCaller,
   findUndeclaredRoutes,
   listMcpCapabilities,
@@ -131,5 +132,51 @@ describe('findUndeclaredRoutes', () => {
         { method: 'get', path: '/api/browse' },
       ]),
     ).toEqual([{ method: 'get', path: '/api/browse' }]);
+  });
+});
+
+describe('resolveTier', () => {
+  it('returns the declared tier when the capability has no tierFor', () => {
+    expect(resolveTier(cap({ tier: 'ask' }), 'ask', {})).toBe('ask');
+  });
+
+  it('RAISES the tier when this input is more dangerous than the default', () => {
+    // task.delete's real shape: soft-delete is 'ask', purge is irreversible.
+    const c = cap({
+      tier: 'ask',
+      tierFor: (input) =>
+        (input as { purge?: boolean } | null)?.purge === true ? 'always-ask' : 'ask',
+    });
+    expect(resolveTier(c, 'ask', { purge: true })).toBe('always-ask');
+    expect(resolveTier(c, 'ask', { purge: false })).toBe('ask');
+    expect(resolveTier(c, 'ask', {})).toBe('ask');
+  });
+
+  it('NEVER lowers the tier, even when tierFor asks it to', () => {
+    // The guarantee the gate rests on: a capability cannot opt itself out of
+    // the tier it declares. If this ever passes 'auto' through, an always-ask
+    // capability could gate itself away at will and the declared tier would
+    // stop meaning anything.
+    const sneaky = cap({ tier: 'always-ask', tierFor: () => 'auto' });
+    expect(resolveTier(sneaky, 'always-ask', {})).toBe('always-ask');
+
+    const alsoSneaky = cap({ tier: 'ask', tierFor: () => 'auto' });
+    expect(resolveTier(alsoSneaky, 'ask', {})).toBe('ask');
+  });
+
+  it('raises even from auto — so callers collapsed to auto must not be gated through this path', () => {
+    // Raise-only is unconditional: it does NOT special-case an 'auto' that
+    // came from authorize() collapsing a ui/human caller. That is safe only
+    // because resolveTier is reached from exactly one place — the MCP
+    // projection, whose caller is always 'agent'. The HTTP projection ignores
+    // tier entirely, which is why a human closing a task from the dashboard
+    // has never been gated.
+    //
+    // If tier ever starts gating an HTTP path, this line becomes a bug: a
+    // human would be re-gated by tierFor after authorize() had already
+    // exempted them. Assert the real behaviour so that change fails loudly
+    // here rather than surprising someone in the UI.
+    const c = cap({ tier: 'ask', tierFor: () => 'always-ask' });
+    expect(resolveTier(c, 'auto', { purge: true })).toBe('always-ask');
   });
 });

--- a/server/registry/index.ts
+++ b/server/registry/index.ts
@@ -100,6 +100,26 @@ export type Decision = { allowed: true; tier: PolicyTier } | { allowed: false; r
  * theatre. Agents get the declared tier; `auto` runs, anything else needs a
  * human decision from the caller's transport.
  */
+/** Tier ordering, least to most restrictive. `resolveTier` never moves left. */
+const TIER_RANK: Record<PolicyTier, number> = { auto: 0, ask: 1, 'always-ask': 2 };
+
+/**
+ * The tier for one specific invocation: the capability's declared tier, raised
+ * if `tierFor` says this particular input is more dangerous than the default.
+ *
+ * RAISE-ONLY, deliberately. If `tierFor` could also lower the tier, a
+ * capability could quietly opt itself out of the gate it declares, and the
+ * declared tier would stop being the guarantee the registry's whole gating
+ * story rests on. `Math.max` over the rank enforces that structurally rather
+ * than by convention, so a `tierFor` that returns 'auto' for an 'always-ask'
+ * capability is simply ignored instead of being trusted.
+ */
+export function resolveTier(cap: Capability, declared: PolicyTier, input: unknown): PolicyTier {
+  if (!cap.tierFor) return declared;
+  const requested = cap.tierFor(input);
+  return TIER_RANK[requested] > TIER_RANK[declared] ? requested : declared;
+}
+
 export function authorize(cap: Capability, caller: CallerClass): Decision {
   if (!cap.callers.includes(caller)) {
     return { allowed: false, reason: `${cap.id} is not available to ${caller} callers` };

--- a/server/registry/projections/mcp.ts
+++ b/server/registry/projections/mcp.ts
@@ -23,7 +23,7 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { childLogger } from '../../logger.js';
-import { listMcpCapabilities, authorize } from '../index.js';
+import { listMcpCapabilities, authorize, resolveTier } from '../index.js';
 import type { Capability, CallerClass, CapabilityContext, PolicyTier } from '../types.js';
 
 const logger = childLogger('registry/projections/mcp');
@@ -126,8 +126,13 @@ function registerOne(
       try {
         const ctx: CapabilityContext = { caller: opts.caller };
         let result: unknown;
-        if (tier !== 'auto' && opts.onGatedInvoke) {
-          const gated = await opts.onGatedInvoke(cap, tier, input);
+        // Registration-time tier, raised if THIS input is more dangerous than
+        // the capability's default (task.delete with purge:true). Resolved
+        // here, per call, because `tier` above was fixed when the tool was
+        // registered and cannot see the arguments.
+        const invocationTier = resolveTier(cap, tier, input);
+        if (invocationTier !== 'auto' && opts.onGatedInvoke) {
+          const gated = await opts.onGatedInvoke(cap, invocationTier, input);
           // undefined → proceed to the real handler; anything else IS the
           // result (ask_human's answer) and short-circuits cap.handler — see
           // the onGatedInvoke doc above.


### PR DESCRIPTION
Closing and deleting tasks was blocked behind human approval. This makes both usable again without giving up the safety that actually matters.

## `close_task`: always-ask → auto

Closing **preserves the worktree and branch, and the session stays resumable** — the capability's own summary says so. There is nothing to protect against, and it is the single most common write an agent makes. Gating it blocked a person on every close and bought no safety.

## `delete_task`: two operations behind one name

| Call | Effect | Reversible? |
|---|---|---|
| `delete_task` | stamps `deleted_at` | yes — restore route |
| `delete_task purge:true` | kills tmux, removes worktree, deletes branch, drops rows | **no** |

One static tier can't describe both. `ask` lets a stored permission rule silently promote an irreversible purge to `auto`; `always-ask` blocks every routine delete. That mismatch is the real bug.

So tier is now resolvable **per invocation** — an optional `tierFor(input)` alongside the declared tier. Delete sits at `ask` (promotable with "always allow") and raises itself to `always-ask` when `purge` is set, which no rule can promote.

## `tierFor` may only ever RAISE

Enforced structurally by rank comparison, not by convention. If it could lower, a capability could opt itself out of the tier it declares and the declared tier would stop being the guarantee the entire gating story rests on.

## Mutation-tested

- making `resolveTier` trust `tierFor` blindly → fails the never-lowers test
- dropping purge's escalation → fails the delete-shape test

## Deliberate consequence

`close_task` is `auto`, and the worker tier filter registers all auto tools, so **workers now get `close_task` over MCP**. Not new power — workers have Bash and the review prompts already instruct them to run `octomux close-task <id>`. Same capability, second route.

**Also worth knowing:** server tests resolve `@octomux/capabilities` through `dist`, so editing package source without a `tsc -b` silently exercises stale code — a real regression can look green. That nearly gave me a false negative here.

3205 server/cli/packages + 1444 src pass. `tsc -b` and `cd cli && tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)