### PR TITLE
feat(tasks): promote depends_on out of the orchestrator island

### DIFF
--- a/packages/capabilities/src/capabilities/task.ts
+++ b/packages/capabilities/src/capabilities/task.ts
@@ -96,6 +96,15 @@ export const taskCreateInputSchema = createTaskInputSchema.extend({
   agent: z.string().optional().nullable().describe('Agent persona name'),
   harness_id: z.string().optional().describe('Harness id (default: claude-code)'),
   workflow_status: workflowStatusEnum.optional().describe('Initial workflow_status override'),
+  depends_on: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      'Id of another task this one depends on. Rejected if that task does not exist. ' +
+        "Unless draft:true, the task still gets created but won't auto-start until the " +
+        "dependency's workflow_status reaches 'done'.",
+    ),
 });
 
 // ─── task.start ───────────────────────────────────────────────────────────────
@@ -110,6 +119,16 @@ export const taskMoveInputSchema = z.object({
   id: z.string().describe('The octomux task id'),
   workflow_status: workflowStatusEnum.describe('Target workflow_status'),
   note: z.string().optional().describe('Note (required when moving to human_review or planned)'),
+  depends_on: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Set (or, with null, clear) the id of another task this one depends on. Rejected on a ' +
+        "self-reference, a cycle, or a nonexistent target. Moving to 'in_progress' while the " +
+        "dependency hasn't reached 'done' skips the auto-start — the task becomes eligible " +
+        'once the dependency finishes.',
+    ),
 });
 
 // ─── task.delete ──────────────────────────────────────────────────────────────
@@ -150,7 +169,8 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
   },
   {
     id: 'task.create',
-    summary: 'Create a task (and start it immediately unless draft:true).',
+    summary:
+      'Create a task (and start it immediately unless draft:true or depends_on is set and unmet).',
     // 201 matches routes/tasks.ts:253 — see HttpProjection.status.
     http: { method: 'post', path: '/api/tasks', status: 201 },
     cli: 'task create',

--- a/packages/test-fixtures/src/index.ts
+++ b/packages/test-fixtures/src/index.ts
@@ -73,6 +73,7 @@ const TASK_FIXTURE_BASE = {
   agent: null,
   model: null,
   notify_task_id: null,
+  depends_on: null,
   error: null,
   current_summary: null,
   current_summary_updated_at: null,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -145,6 +145,8 @@ export interface Task {
   notify_task_id: string | null;
   /** Set when this task was created by a cron schedule run. */
   schedule_id?: string | null;
+  /** Another task's id this one depends on — must reach 'done' before this task auto-starts. Null = no dependency. */
+  depends_on: string | null;
   harness_id: string;
   error: string | null;
   /** Summary text set by agent or user. */

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -1250,6 +1250,32 @@ export function runMigrations(instance: Database.Database): void {
   const loopGroupsCols = columnsOf(instance, 'loop_groups');
   addColumn(instance, 'loop_groups', 'run_id', 'run_id TEXT REFERENCES runs(id)', loopGroupsCols);
   instance.exec(`CREATE INDEX IF NOT EXISTS idx_loop_groups_run ON loop_groups(run_id);`);
+
+  // ── Task dependency primitive (2026-08-14, agents/task-depends-on) ─────────
+  // Promotes `depends_on` off `managed_tasks` (orchestrator-only) onto plain
+  // `tasks`, so any task can depend on any other task, not just ones inside a
+  // conductor conversation. One dependency per task (not the JSON array
+  // `managed_tasks.depends_on` uses for its DAG scheduler — that table is
+  // untouched by this migration and keeps working as-is).
+  //
+  // ON DELETE SET NULL (mirrors review_of_task_id above) so hard-deleting a
+  // dependency unblocks its dependent instead of orphaning the FK.
+  // Cycle safety (self-reference, 2-cycles, longer cycles) is NOT expressible
+  // as a DDL constraint here — SQLite has no CHECK that can walk a
+  // self-referencing chain — so it's enforced at the application layer
+  // (repositories/tasks.ts:validateDependsOn) on every write.
+  const taskColsForDependsOn = columnsOf(instance, 'tasks');
+  addColumn(
+    instance,
+    'tasks',
+    'depends_on',
+    'depends_on TEXT REFERENCES tasks(id) ON DELETE SET NULL',
+    taskColsForDependsOn,
+  );
+  instance.exec(
+    `CREATE INDEX IF NOT EXISTS idx_tasks_depends_on
+       ON tasks(depends_on) WHERE depends_on IS NOT NULL`,
+  );
 }
 
 /**

--- a/server/poller/merged-pr.ts
+++ b/server/poller/merged-pr.ts
@@ -4,6 +4,7 @@ import { broadcast } from '../events.js';
 import { fireHook } from '../hook-dispatcher.js';
 import { childLogger } from '../logger.js';
 import { closeTask } from '../task-engine/index.js';
+import { unblockDependents } from '../services/task-service.js';
 import {
   listRunningTasksWithPr,
   addTaskUpdate,
@@ -63,6 +64,7 @@ export async function checkMergedPRs(): Promise<void> {
         const prevWorkflow = task.workflow_status;
         await closeTask(task);
         setWorkflowStatusDone(task.id);
+        unblockDependents(task.id);
         addTaskUpdate({
           task_id: task.id,
           kind: 'transition',

--- a/server/registry/capabilities/task.test.ts
+++ b/server/registry/capabilities/task.test.ts
@@ -310,6 +310,41 @@ describe('task.create', () => {
       /title and description are required/,
     );
   });
+
+  it('accepts depends_on, storing it and skipping startTask while the dependency is unmet', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'in_progress' }); // not done yet
+    const cap = getCapability('task.create')!;
+    const result = (await cap.handler(
+      {
+        title: 'T',
+        description: 'D',
+        repo_path: '/tmp/repo',
+        run_mode: 'none',
+        depends_on: 'dep',
+      },
+      ctx,
+    )) as Record<string, unknown>;
+
+    expect(result.depends_on).toBe('dep');
+    expect(result.runtime_state).toBe('idle');
+    expect(startTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects create with a nonexistent depends_on task', async () => {
+    const cap = getCapability('task.create')!;
+    await expect(
+      cap.handler(
+        {
+          title: 'T',
+          description: 'D',
+          repo_path: '/tmp/repo',
+          run_mode: 'none',
+          depends_on: 'ghost',
+        },
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/);
+  });
 });
 
 describe('task.start', () => {
@@ -328,6 +363,22 @@ describe('task.start', () => {
     insertTestTask({ id: 't1', runtime_state: 'running' });
     const cap = getCapability('task.start')!;
     await expect(cap.handler({ id: 't1' }, ctx)).rejects.toThrow('Only draft tasks can be started');
+  });
+
+  it('rejects starting a draft task whose depends_on has not reached done', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'in_progress' });
+    insertTestTask({ id: 't1', runtime_state: 'idle', depends_on: 'dep' });
+    const cap = getCapability('task.start')!;
+    await expect(cap.handler({ id: 't1' }, ctx)).rejects.toThrow(/waiting on depends_on/);
+    expect(startTask).not.toHaveBeenCalled();
+  });
+
+  it('starts a draft task once its depends_on has reached done', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'done' });
+    insertTestTask({ id: 't1', runtime_state: 'idle', depends_on: 'dep' });
+    const cap = getCapability('task.start')!;
+    await cap.handler({ id: 't1' }, ctx);
+    expect(startTask).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -362,6 +413,78 @@ describe('task.move', () => {
     await cap.handler({ id: 't1', workflow_status: 'in_progress' }, ctx);
     expect(resumeTask).toHaveBeenCalledTimes(1);
     expect(startTask).not.toHaveBeenCalled();
+  });
+
+  // ─── depends_on: cycle safety + enforcement ────────────────────────────────
+
+  it('rejects setting depends_on to itself', async () => {
+    insertTestTask({ id: 't1', workflow_status: 'in_progress' });
+    const cap = getCapability('task.move')!;
+    await expect(
+      cap.handler({ id: 't1', workflow_status: 'in_progress', depends_on: 't1' }, ctx),
+    ).rejects.toThrow(/cannot depend on itself/);
+  });
+
+  it('rejects a depends_on cycle (t2 already depends on t1)', async () => {
+    insertTestTask({ id: 't1', workflow_status: 'in_progress' });
+    insertTestTask({ id: 't2', workflow_status: 'in_progress' });
+    const cap = getCapability('task.move')!;
+
+    await cap.handler({ id: 't2', workflow_status: 'in_progress', depends_on: 't1' }, ctx);
+
+    await expect(
+      cap.handler({ id: 't1', workflow_status: 'in_progress', depends_on: 't2' }, ctx),
+    ).rejects.toThrow(/cycle/);
+  });
+
+  it('rejects setting depends_on to a nonexistent task', async () => {
+    insertTestTask({ id: 't1', workflow_status: 'in_progress' });
+    const cap = getCapability('task.move')!;
+    await expect(
+      cap.handler({ id: 't1', workflow_status: 'in_progress', depends_on: 'ghost' }, ctx),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('does NOT auto-start a task moved to in_progress while its depends_on is unmet', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'in_progress' }); // not done
+    insertTestTask({
+      id: 't1',
+      workflow_status: 'backlog',
+      runtime_state: 'idle',
+      depends_on: 'dep',
+    });
+    const cap = getCapability('task.move')!;
+    await cap.handler({ id: 't1', workflow_status: 'in_progress' }, ctx);
+    expect(startTask).not.toHaveBeenCalled();
+    expect(resumeTask).not.toHaveBeenCalled();
+  });
+
+  it('auto-starts a task moved to in_progress once its depends_on has reached done', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'done' });
+    insertTestTask({
+      id: 't1',
+      workflow_status: 'backlog',
+      runtime_state: 'idle',
+      depends_on: 'dep',
+      worktree: null,
+    });
+    const cap = getCapability('task.move')!;
+    await cap.handler({ id: 't1', workflow_status: 'in_progress' }, ctx);
+    expect(startTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('unblocks a waiting dependent when its dependency moves to done', async () => {
+    insertTestTask({ id: 'dep', workflow_status: 'in_progress' });
+    insertTestTask({
+      id: 'blocked',
+      workflow_status: 'in_progress',
+      runtime_state: 'idle',
+      depends_on: 'dep',
+    });
+    const cap = getCapability('task.move')!;
+    await cap.handler({ id: 'dep', workflow_status: 'done' }, ctx);
+    // 'blocked' carries the default fixture's worktree, so it resumes rather than starts fresh.
+    expect(resumeTask).toHaveBeenCalledWith(expect.objectContaining({ id: 'blocked' }));
   });
 });
 

--- a/server/registry/capabilities/task.ts
+++ b/server/registry/capabilities/task.ts
@@ -130,6 +130,9 @@ import {
   listTasks,
   setRuntimeState,
   setWorkflowStatus,
+  setDependsOn,
+  validateDependsOn,
+  isDependencyUnmet,
   addTaskUpdate,
   listAgentsByTasks,
   listPendingPromptsByTasks,
@@ -141,7 +144,7 @@ import {
 import { getManagedTask } from '../../repositories/orchestrator.js';
 import { getArtifactSummary } from '../../artifact.js';
 import type { PermissionPromptRow } from '../../repositories/permission-prompts.js';
-import { createTask } from '../../services/task-service.js';
+import { createTask, unblockDependents } from '../../services/task-service.js';
 import { badRequest, conflict, notFound } from '../../services/errors.js';
 import {
   fetchTaskWithRelations,
@@ -412,6 +415,7 @@ async function createTaskHandler(input: z.infer<typeof taskCreateInputSchema>) {
     model: input.model ?? null,
     notify_task_id: input.notify_task ?? null,
     is_draft: isDraft,
+    depends_on: input.depends_on ?? null,
   });
 }
 
@@ -426,6 +430,9 @@ async function startTaskHandler(input: z.infer<typeof taskStartInputSchema>) {
 
   if (task.runtime_state !== 'idle') {
     throw badRequest('Only draft tasks can be started');
+  }
+  if (isDependencyUnmet(task.depends_on)) {
+    throw badRequest(`cannot start: waiting on depends_on task ${task.depends_on} to reach 'done'`);
   }
 
   setRuntimeState(task.id, 'setting_up');
@@ -459,6 +466,18 @@ async function moveTaskHandler(input: z.infer<typeof taskMoveInputSchema>) {
     throw badRequest(`note is required when moving to ${input.workflow_status}`);
   }
 
+  // Set/clear depends_on before evaluating auto-start, so a depends_on passed
+  // in the SAME call already gates this move's own in_progress transition.
+  let effectiveDependsOn = task.depends_on;
+  if (input.depends_on !== undefined) {
+    if (input.depends_on !== null) {
+      const err = validateDependsOn(task.id, input.depends_on);
+      if (err) throw badRequest(err);
+    }
+    setDependsOn(task.id, input.depends_on);
+    effectiveDependsOn = input.depends_on;
+  }
+
   // Close eagerly on every move to done — idle agents still hold a live claude
   // process (+MCP sidecars); reopening resumes via harness_session_id.
   if (input.workflow_status === 'done' && task.workflow_status !== 'done') {
@@ -476,10 +495,19 @@ async function moveTaskHandler(input: z.infer<typeof taskMoveInputSchema>) {
     body: input.note ?? null,
   });
 
+  // A task becomes eligible to start once its dependency reaches 'done' —
+  // the minimum useful semantics for depends_on (any earlier attempt to
+  // start it was skipped, leaving it idle+in_progress; see
+  // listDependentsAwaitingStart).
+  if (input.workflow_status === 'done' && prevStatus !== 'done') {
+    unblockDependents(task.id);
+  }
+
   let autoStart: 'start' | 'resume' | null = null;
   if (
     input.workflow_status === 'in_progress' &&
-    (task.runtime_state === 'idle' || task.runtime_state === 'error')
+    (task.runtime_state === 'idle' || task.runtime_state === 'error') &&
+    !isDependencyUnmet(effectiveDependsOn)
   ) {
     autoStart = task.worktree ? 'resume' : 'start';
   }

--- a/server/repositories/tasks.test.ts
+++ b/server/repositories/tasks.test.ts
@@ -25,6 +25,10 @@ import {
   unlinkWorktree,
   markTaskRunning,
   countTasks,
+  setDependsOn,
+  validateDependsOn,
+  isDependencyUnmet,
+  listDependentsAwaitingStart,
 } from './tasks.js';
 import { inTransaction } from './tx.js';
 
@@ -567,6 +571,113 @@ describe('inTransaction', () => {
       const before = countTasks();
       insertTask({ title: 'New', description: 'D' });
       expect(countTasks()).toBe(before + 1);
+    });
+  });
+
+  // ─── depends_on primitive (agents/task-depends-on) ─────────────────────────
+
+  describe('depends_on', () => {
+    it('insertTask stores and getTask reads back depends_on', () => {
+      const a = insertTask({ title: 'A', description: 'D' });
+      const b = insertTask({ title: 'B', description: 'D', depends_on: a });
+      expect(getTask(b)?.depends_on).toBe(a);
+    });
+
+    it('setDependsOn writes and clears the link', () => {
+      const a = insertTask({ title: 'A', description: 'D' });
+      const b = insertTask({ title: 'B', description: 'D' });
+      setDependsOn(b, a);
+      expect(getTask(b)?.depends_on).toBe(a);
+      setDependsOn(b, null);
+      expect(getTask(b)?.depends_on).toBeNull();
+    });
+
+    describe('validateDependsOn — cycle safety', () => {
+      it('rejects a nonexistent target task', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        expect(validateDependsOn(a, 'does-not-exist')).toMatch(/not found/);
+      });
+
+      it('rejects self-dependency', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        expect(validateDependsOn(a, a)).toMatch(/cannot depend on itself/);
+      });
+
+      it('rejects a 2-cycle: A already depends on B, so B -> A is refused', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        const b = insertTask({ title: 'B', description: 'D' });
+        expect(validateDependsOn(a, b)).toBeNull();
+        setDependsOn(a, b); // A -> B
+        expect(validateDependsOn(b, a)).toMatch(/cycle/); // B -> A would close the loop
+      });
+
+      it('rejects a 3-cycle: A -> B -> C exists, so C -> A is refused', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        const b = insertTask({ title: 'B', description: 'D' });
+        const c = insertTask({ title: 'C', description: 'D' });
+        setDependsOn(a, b); // A -> B
+        setDependsOn(b, c); // B -> C
+        expect(validateDependsOn(c, a)).toMatch(/cycle/); // C -> A would close the loop
+      });
+
+      it('allows a valid non-cyclic chain', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        const b = insertTask({ title: 'B', description: 'D' });
+        expect(validateDependsOn(a, b)).toBeNull();
+      });
+
+      it('taskId=null (create-time) only checks existence, never a cycle', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        expect(validateDependsOn(null, a)).toBeNull();
+        expect(validateDependsOn(null, 'nope')).toMatch(/not found/);
+      });
+    });
+
+    describe('isDependencyUnmet', () => {
+      it('is false when depends_on is null', () => {
+        expect(isDependencyUnmet(null)).toBe(false);
+      });
+
+      it('is true while the dependency has not reached done', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        setWorkflowStatus(a, 'in_progress');
+        expect(isDependencyUnmet(a)).toBe(true);
+      });
+
+      it('is false once the dependency reaches done', () => {
+        const a = insertTask({ title: 'A', description: 'D' });
+        setWorkflowStatus(a, 'done');
+        expect(isDependencyUnmet(a)).toBe(false);
+      });
+
+      it('treats a dependency task that no longer exists as still unmet (safe default)', () => {
+        expect(isDependencyUnmet('ghost-task')).toBe(true);
+      });
+    });
+
+    describe('listDependentsAwaitingStart', () => {
+      it('finds idle+in_progress tasks blocked on the given dependency', () => {
+        const dep = insertTask({ title: 'Dep', description: 'D' });
+        const blocked = insertTask({ title: 'Blocked', description: 'D', depends_on: dep });
+        setWorkflowStatus(blocked, 'in_progress'); // runtime_state stays 'idle' (default)
+        expect(listDependentsAwaitingStart(dep).map((t) => t.id)).toEqual([blocked]);
+      });
+
+      it('excludes a dependent that is already running', () => {
+        const dep = insertTask({ title: 'Dep', description: 'D' });
+        const running = insertTask({ title: 'Running', description: 'D', depends_on: dep });
+        setWorkflowStatus(running, 'in_progress');
+        setRuntimeState(running, 'running');
+        expect(listDependentsAwaitingStart(dep)).toEqual([]);
+      });
+
+      it('excludes tasks that depend on a different task', () => {
+        const dep = insertTask({ title: 'Dep', description: 'D' });
+        const otherDep = insertTask({ title: 'OtherDep', description: 'D' });
+        const blocked = insertTask({ title: 'Blocked', description: 'D', depends_on: otherDep });
+        setWorkflowStatus(blocked, 'in_progress');
+        expect(listDependentsAwaitingStart(dep)).toEqual([]);
+      });
     });
   });
 });

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -317,6 +317,8 @@ export interface InsertTaskInput {
   review_of_task_id?: string | null;
   /** Set on scheduled runs — links back to the `schedules` row that fired them. */
   schedule_id?: string | null;
+  /** Another task's id this one depends on. Caller must have run validateDependsOn first. */
+  depends_on?: string | null;
 }
 
 /** Insert a new task row. Returns the generated id. */
@@ -325,8 +327,8 @@ export function insertTask(input: InsertTaskInput): string {
   getDb()
     .prepare(
       `INSERT INTO tasks
-         (id, title, description, runtime_state, workflow_status, initial_prompt, worktree_id, agent, harness_id, model, notify_task_id, source, pr_url, pr_number, pr_head_sha, review_of_task_id, schedule_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, title, description, runtime_state, workflow_status, initial_prompt, worktree_id, agent, harness_id, model, notify_task_id, source, pr_url, pr_number, pr_head_sha, review_of_task_id, schedule_id, depends_on)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
@@ -346,9 +348,83 @@ export function insertTask(input: InsertTaskInput): string {
       input.pr_head_sha ?? null,
       input.review_of_task_id ?? null,
       input.schedule_id ?? null,
+      input.depends_on ?? null,
     );
   logger.info({ task_id: id, operation: 'insertTask' }, 'task inserted');
   return id;
+}
+
+/** Set (or clear, with null) the depends_on link. Caller must have run validateDependsOn first. */
+export function setDependsOn(id: string, dependsOn: string | null): void {
+  getDb()
+    .prepare(`UPDATE tasks SET depends_on = ?, updated_at = datetime('now') WHERE id = ?`)
+    .run(dependsOn, id);
+  logger.info({ task_id: id, depends_on: dependsOn, operation: 'setDependsOn' }, 'depends_on set');
+}
+
+/**
+ * Validate that `dependsOn` is safe to store as `taskId`'s depends_on.
+ *
+ * Checks (in order): the target task exists; it isn't `taskId` itself
+ * (self-dependency); and it doesn't transitively depend back on `taskId`
+ * (a longer cycle). Since a task has at most ONE depends_on, the graph is a
+ * forest of chains, so cycle detection is a single forward walk from
+ * `dependsOn` — bounded by a visited set so pre-existing corrupt data can't
+ * spin the walk forever.
+ *
+ * Pure validation, no throwing (repositories don't shape HTTP errors) — returns
+ * an error message on failure, or null when the edge is safe to write.
+ *
+ * `taskId` is null when validating for a not-yet-inserted task (task.create):
+ * a brand-new id can never already appear in a depends_on chain, so only
+ * existence is checked.
+ */
+export function validateDependsOn(taskId: string | null, dependsOn: string): string | null {
+  const target = getTask(dependsOn);
+  if (!target) return `depends_on task not found: ${dependsOn}`;
+  if (taskId === null) return null;
+  if (taskId === dependsOn) return 'a task cannot depend on itself';
+
+  const visited = new Set<string>([taskId]);
+  let current: string | null = dependsOn;
+  while (current) {
+    if (visited.has(current)) return 'depends_on would create a dependency cycle';
+    visited.add(current);
+    const row = getDb().prepare(`SELECT depends_on FROM tasks WHERE id = ?`).get(current) as
+      | { depends_on: string | null }
+      | undefined;
+    current = row?.depends_on ?? null;
+  }
+  return null;
+}
+
+/**
+ * True when `dependsOn` points at a task that has not reached
+ * workflow_status 'done' (or points at a task that no longer exists — treated
+ * as still-blocked, the safe default). False for null (no dependency).
+ */
+export function isDependencyUnmet(dependsOn: string | null): boolean {
+  if (!dependsOn) return false;
+  const dep = getDb().prepare(`SELECT workflow_status FROM tasks WHERE id = ?`).get(dependsOn) as
+    | { workflow_status: string }
+    | undefined;
+  return !dep || dep.workflow_status !== 'done';
+}
+
+/**
+ * Tasks that named `dependencyTaskId` as their depends_on and are sitting
+ * idle at workflow_status='in_progress' — the shape a task is left in when
+ * its own start was skipped because this dependency wasn't done yet (see
+ * task-service.ts:createTask and task.move's autoStart gate). Used to
+ * auto-start/resume them once the dependency completes.
+ */
+export function listDependentsAwaitingStart(dependencyTaskId: string): Task[] {
+  return getDb()
+    .prepare(
+      `${SELECT_TASK_SQL} WHERE t.depends_on = ? AND t.runtime_state = 'idle'
+                            AND t.workflow_status = 'in_progress' AND t.deleted_at IS NULL`,
+    )
+    .all(dependencyTaskId) as Task[];
 }
 
 /**

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -12,6 +12,7 @@ import {
   restoreTask as restoreTaskRepo,
   touchLastViewed,
   touchAllLastViewed,
+  isDependencyUnmet,
 } from '../repositories/index.js';
 
 import { badRequest, conflict } from '../services/errors.js';
@@ -89,6 +90,11 @@ router.patch('/api/tasks/:id', async (req: Request, res: Response) => {
     // Resume task
     if (task.runtime_state !== 'idle' && task.runtime_state !== 'error') {
       throw badRequest('Can only resume tasks in closed or error state');
+    }
+    if (isDependencyUnmet(task.depends_on)) {
+      throw badRequest(
+        `cannot resume: waiting on depends_on task ${task.depends_on} to reach 'done'`,
+      );
     }
     if (task.run_mode === 'new' || task.run_mode === 'existing' || task.run_mode === 'scratch') {
       if (!task.worktree || !fs.existsSync(task.worktree)) {

--- a/server/services/task-service.test.ts
+++ b/server/services/task-service.test.ts
@@ -15,8 +15,10 @@ import { getDb } from '../db.js';
 // ─── Mock side-effecting deps (mirror orchestrator/exec.test.ts) ────────────
 
 const mockStartTask = vi.fn().mockResolvedValue(undefined);
+const mockResumeTask = vi.fn().mockResolvedValue(undefined);
 vi.mock('../task-engine/index.js', () => ({
   startTask: vi.fn((...args: unknown[]) => mockStartTask(...args)),
+  resumeTask: vi.fn((...args: unknown[]) => mockResumeTask(...args)),
 }));
 
 const mockBroadcast = vi.fn();
@@ -33,8 +35,9 @@ vi.mock('nanoid', () => ({
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
-import { createTask, type CreateTaskServiceInput } from './task-service.js';
+import { createTask, unblockDependents, type CreateTaskServiceInput } from './task-service.js';
 import { ServiceError } from './errors.js';
+import { insertTask, setWorkflowStatus } from '../repositories/tasks.js';
 
 let seq = 0;
 function uniqueId(): string {
@@ -134,5 +137,99 @@ describe('task-service.createTask', () => {
     expect(caught).toBeInstanceOf(ServiceError);
     expect((caught as ServiceError).status).toBe(409);
     expect((caught as ServiceError).message).toMatch(/UNIQUE constraint/);
+  });
+
+  // ─── depends_on (agents/task-depends-on) ─────────────────────────────────
+
+  it('rejects a nonexistent depends_on task with ServiceError(400), and never fires startTask', async () => {
+    let caught: unknown;
+    try {
+      await createTask(baseInput({ depends_on: 'does-not-exist' }));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ServiceError);
+    expect((caught as ServiceError).status).toBe(400);
+    expect(mockStartTask).not.toHaveBeenCalled();
+  });
+
+  it('does NOT kick startTask when depends_on has not reached done, and stores runtime_state idle', async () => {
+    const depId = insertTask({ title: 'Dependency', description: 'D' }); // defaults to workflow_status 'backlog'
+
+    const task = await createTask(
+      baseInput({
+        is_draft: false,
+        workflow_status: 'in_progress',
+        runtime_state: 'setting_up',
+        depends_on: depId,
+      }),
+    );
+
+    expect(mockStartTask).not.toHaveBeenCalled();
+    expect(task.runtime_state).toBe('idle');
+    expect(task.workflow_status).toBe('in_progress');
+    expect(task.depends_on).toBe(depId);
+  });
+
+  it('kicks startTask when depends_on has already reached done', async () => {
+    const depId = insertTask({ title: 'Dependency', description: 'D' });
+    setWorkflowStatus(depId, 'done');
+
+    const task = await createTask(baseInput({ is_draft: false, depends_on: depId }));
+
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(task.depends_on).toBe(depId);
+  });
+});
+
+describe('task-service.unblockDependents', () => {
+  beforeEach(() => {
+    createTestDb();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts a blocked dependent that has no worktree yet', () => {
+    const dep = insertTask({ title: 'Dep', description: 'D' });
+    const blocked = insertTask({ title: 'Blocked', description: 'D', depends_on: dep });
+    setWorkflowStatus(blocked, 'in_progress'); // runtime_state stays 'idle' (default)
+
+    unblockDependents(dep);
+
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    expect(mockStartTask).toHaveBeenCalledWith(expect.objectContaining({ id: blocked }));
+    expect(mockResumeTask).not.toHaveBeenCalled();
+  });
+
+  it('resumes (not starts) a blocked dependent that already has a worktree', () => {
+    const dep = insertTask({ title: 'Dep', description: 'D' });
+    const wtId = 'wt-resume-1';
+    getDb()
+      .prepare(
+        `INSERT INTO worktrees (id, path, mode, status) VALUES (?, '/tmp/existing-wt', 'new', 'in_use')`,
+      )
+      .run(wtId);
+    const blocked = insertTask({
+      title: 'Blocked',
+      description: 'D',
+      depends_on: dep,
+      worktree_id: wtId,
+    });
+    setWorkflowStatus(blocked, 'in_progress');
+
+    unblockDependents(dep);
+
+    expect(mockResumeTask).toHaveBeenCalledTimes(1);
+    expect(mockStartTask).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no dependent is waiting on this task', () => {
+    const dep = insertTask({ title: 'Dep', description: 'D' });
+    unblockDependents(dep);
+    expect(mockStartTask).not.toHaveBeenCalled();
+    expect(mockResumeTask).not.toHaveBeenCalled();
   });
 });

--- a/server/services/task-service.ts
+++ b/server/services/task-service.ts
@@ -11,9 +11,13 @@ import {
   insertTask,
   getTask,
   inTransaction,
+  validateDependsOn,
+  isDependencyUnmet,
+  listDependentsAwaitingStart,
+  setRuntimeState,
 } from '../repositories/index.js';
 import { upsertManagedTask } from '../repositories/orchestrator.js';
-import { startTask } from '../task-engine/index.js';
+import { startTask, resumeTask } from '../task-engine/index.js';
 import { broadcast } from '../events.js';
 import { childLogger } from '../logger.js';
 import { ServiceError } from './errors.js';
@@ -65,6 +69,13 @@ export interface CreateTaskServiceInput {
   notify_task_id: string | null;
   /** When true the task is a draft — startTask is NOT fired. */
   is_draft: boolean;
+  /**
+   * Another task's id this one depends on. When set and that task hasn't
+   * reached workflow_status 'done' yet, startTask is NOT fired (mirrors
+   * is_draft's effect) and the row is inserted with runtime_state='idle'
+   * regardless of what the caller passed — see the depends_on gate below.
+   */
+  depends_on?: string | null;
 
   /** When set, upsert a managed_tasks row inside the transaction. */
   managed?: {
@@ -82,9 +93,11 @@ export interface CreateTaskResult {
 
 /**
  * Mint IDs, wrap worktree + task insert in a single transaction, read back the
- * Task, broadcast task:created, and (unless draft) fire-and-forget startTask.
+ * Task, broadcast task:created, and (unless draft, or blocked on an unmet
+ * depends_on) fire-and-forget startTask.
  *
  * Maps UNIQUE-constraint errors → ServiceError(msg, 409).
+ * Maps an invalid depends_on (nonexistent task) → ServiceError(msg, 400).
  */
 export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
   const id = nanoid(12);
@@ -92,6 +105,19 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
 
   const storedPrompt =
     input.resolved_prompt !== undefined ? input.resolved_prompt : input.initial_prompt;
+
+  // A brand-new id can never already appear in a depends_on chain, so only
+  // existence needs checking here (taskId=null) — the cycle walk is for
+  // task.move re-pointing an EXISTING task's depends_on.
+  if (input.depends_on) {
+    const err = validateDependsOn(null, input.depends_on);
+    if (err) throw new ServiceError(err, 400);
+  }
+  // A task waiting on an unmet dependency never gets startTask fired — same
+  // effect as draft, but the row still carries its intended workflow_status
+  // (e.g. 'in_progress') so listDependentsAwaitingStart can find and start it
+  // once the dependency reaches 'done' (see unblockDependents below).
+  const dependencyUnmet = isDependencyUnmet(input.depends_on ?? null);
 
   try {
     inTransaction(() => {
@@ -120,7 +146,7 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
         id,
         title: input.resolved_title,
         description: input.resolved_description,
-        runtime_state: input.runtime_state,
+        runtime_state: dependencyUnmet ? 'idle' : input.runtime_state,
         workflow_status: input.workflow_status,
         initial_prompt: storedPrompt ?? null,
         worktree_id: worktreeId,
@@ -128,6 +154,7 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
         harness_id: input.harness_id,
         model: input.model,
         notify_task_id: input.notify_task_id,
+        depends_on: input.depends_on ?? null,
       });
 
       if (input.managed) {
@@ -152,7 +179,7 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
 
   broadcast({ type: 'task:created', payload: { taskId: id } });
 
-  if (!input.is_draft) {
+  if (!input.is_draft && !dependencyUnmet) {
     // Fire-and-forget: startTask runs in background, broadcasts task:updated when done.
     startTask(created)
       .then(() => {
@@ -165,4 +192,31 @@ export async function createTask(input: CreateTaskServiceInput): Promise<Task> {
   }
 
   return created;
+}
+
+// ─── unblockDependents ──────────────────────────────────────────────────────
+
+/**
+ * Auto-start/resume every task that was waiting on `dependencyTaskId` to
+ * finish (see listDependentsAwaitingStart). Call this wherever a task's
+ * workflow_status transitions to 'done' — the minimum useful semantics for
+ * the depends_on primitive: a blocked task becomes eligible once its
+ * dependency is done. Fire-and-forget per task, mirroring createTask's own
+ * startTask call site above.
+ */
+export function unblockDependents(dependencyTaskId: string): void {
+  for (const task of listDependentsAwaitingStart(dependencyTaskId)) {
+    setRuntimeState(task.id, 'setting_up', null);
+    broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+    const run = task.worktree ? resumeTask(task) : startTask(task);
+    run
+      .then(() => broadcast({ type: 'task:updated', payload: { taskId: task.id } }))
+      .catch((err: unknown) => {
+        logger.error(
+          { task_id: task.id, operation: 'unblockDependents', err },
+          'unblockDependents: start failed',
+        );
+        broadcast({ type: 'task:updated', payload: { taskId: task.id } });
+      });
+  }
 }

--- a/server/task-select.ts
+++ b/server/task-select.ts
@@ -12,7 +12,7 @@ export const SELECT_TASK_SQL = `
          t.pr_url, t.pr_number, t.pr_head_sha, t.user_window_index,
          t.initial_prompt, t.last_viewed_at, t.deleted_at, t.source, t.worktree_id,
          t.harness_id, t.agent, t.model, t.notify_task_id, t.error,
-         t.schedule_id,
+         t.schedule_id, t.depends_on,
          t.created_at, t.updated_at,
          w.path AS worktree,
          w.repo_path AS repo_path,

--- a/server/test-helpers.ts
+++ b/server/test-helpers.ts
@@ -73,8 +73,8 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
   const workflowStatus = (task as any).workflow_status ?? 'backlog';
 
   db.prepare(
-    `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, tmux_session, pr_url, pr_number, pr_head_sha, user_window_index, initial_prompt, last_viewed_at, source, worktree_id, error, notify_task_id, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO tasks (id, title, description, runtime_state, workflow_status, tmux_session, pr_url, pr_number, pr_head_sha, user_window_index, initial_prompt, last_viewed_at, source, worktree_id, error, notify_task_id, depends_on, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     task.id,
     task.title,
@@ -92,6 +92,7 @@ export function insertTask(db: Database.Database, overrides: Partial<Task> = {})
     wtId,
     task.error,
     (task as any).notify_task_id ?? null,
+    (task as any).depends_on ?? null,
     task.created_at,
     task.updated_at,
   );


### PR DESCRIPTION
Task dependencies existed only as `managed_tasks.depends_on`, reachable only through a conductor conversation. Ordinary tasks had no dependency concept, so DAG-shaped work was conductor-only. This is the primitive behind DAG workflows.

Adds nullable `tasks.depends_on` (FK, `ON DELETE SET NULL`) + partial index, via the existing additive `addColumn` pattern. Nothing dropped.

## Cycle safety is the point, not the column

One dependency per task makes the graph a forest of chains, so validation is a forward walk from the target looking for the writer, bounded by a visited set — the bound defends against pre-existing corrupt rows, not just correctness. `create` checks existence only (a fresh id can't be in a chain); `move` does the full self-reference + cycle check.

## Enforcement implemented, not deferred

A task whose dependency hasn't reached `done` never gets `startTask`/`resumeTask` fired, and sits at `runtime_state='idle'` so `unblockDependents` finds it later. Gated at all four start/resume entry points; unblocking wired at both places a task reaches `done` (`task.move`, merged-PR poller).

## Mutation-tested

| Mutation | Tests failed |
|---|---|
| `validateDependsOn` accepts everything | 8 |
| `isDependencyUnmet` always false | 6 |

Both reverted.

## Deliberately not done

`managed_tasks.depends_on` is left alone — it's a JSON array (orchestrator DAG) against this column's single edge. Converging them is a separate pass, and the orchestrator fold is about to revisit it.

**Known gap:** any future path setting `workflow_status='done'` outside `task.move` and the merged-PR poller would silently fail to unblock dependents. Only those two exist today.

3236 server/cli/packages + 1444 src pass. `tsc -b` and `cd cli && tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)