### PR TITLE
feat(centaur): a worker can ask its owner, and only that

### DIFF
--- a/packages/capabilities/src/capabilities/ask.ts
+++ b/packages/capabilities/src/capabilities/ask.ts
@@ -5,16 +5,31 @@
  * plain types — no server internals, no handler.
  *
  * `human.ask` (MCP tool `ask_human`) lets an agent block on a free-text answer
- * from a human, rather than only being gated when it tries to WRITE something.
- * It reuses the exact same card + poll machinery as the write-capability gate
- * (`server/orchestrator/mcp/gate.ts`'s `onGatedInvoke`) — `always-ask` tier
- * means every call creates a card and waits; there is no "auto" mode for
- * asking a human a question, so a permission rule can never silence it (see
- * `packages/capabilities/src/capabilities/task.ts`'s `task.close`/`task.delete`
- * for the same tier used on destructive writes).
+ * from its session's owner, rather than only being gated when it tries to
+ * WRITE something. It reuses the exact same card + poll machinery as the
+ * write-capability gate (`server/orchestrator/mcp/gate.ts`'s
+ * `onGatedInvoke`) — `always-ask` tier means every call creates a card and
+ * waits; there is no "auto" mode for asking a question, so a permission rule
+ * can never silence it (see `packages/capabilities/src/capabilities/task.ts`'s
+ * `task.close`/`task.delete` for the same tier used on destructive writes).
  *
- * `agent`-only: a human/UI caller typing at a terminal or clicking in the
- * dashboard has no reason to "ask a human" — they already are one.
+ * "Session's owner", not "a human", deliberately: for the conductor that IS a
+ * human at the dashboard, but for a worker the question routes to the
+ * conductor supervising it — `managed_tasks` (task → conversation) is the
+ * routing table, not a workaround for finding a person (see
+ * `server/hooks.ts`'s `/gate-card` doc). The worker doesn't need to know who
+ * or what is on the other end, only that it blocks until an answer comes
+ * back — which today is still always a human, since resolving a card is only
+ * wired up from the dashboard (no conductor-side MCP answer tool exists yet;
+ * that's a separate capability for a later change, not a redesign of this
+ * one).
+ *
+ * `agent`/`worker`-only: a human/UI caller typing at a terminal or clicking in
+ * the dashboard has no reason to invoke this — they already are the person
+ * being asked. Workers (task sessions, as distinct from the orchestrator
+ * conductor) are included because this is precisely the primitive a worker
+ * needs when it is stuck on a design question mid-task — see CallerClass's
+ * doc in ../types.ts.
  *
  * No `http`/`cli` projection: this tool only makes sense inside an agent's own
  * turn, blocking on an answer before it can proceed — there is no synchronous
@@ -27,19 +42,20 @@ import { z } from 'zod';
 import type { CapabilityMeta } from '../types.js';
 
 export const askHumanInputSchema = z.object({
-  question: z.string().describe('The question to ask the human operator'),
+  question: z.string().describe("The question to ask your session's owner"),
 });
 
 export const HUMAN_CAPABILITY_META: CapabilityMeta[] = [
   {
     id: 'human.ask',
     summary:
-      'Ask the human operator a question and block until they answer. Use when you are ' +
-      'genuinely stuck or need a decision only a human can make — not for routine writes ' +
-      '(those already gate on approval via their own tier).',
+      "Ask a question and block until your session's owner answers — the human operator " +
+      'you report to directly, or (for a worker task) the conductor supervising this task. ' +
+      'Use when you are genuinely stuck or need a decision you cannot make yourself — not ' +
+      'for routine writes (those already gate on approval via their own tier).',
     mcp: 'ask_human',
     tier: 'always-ask',
-    callers: ['agent'],
+    callers: ['agent', 'worker'],
     input: askHumanInputSchema,
   },
 ];

--- a/packages/capabilities/src/capabilities/task.ts
+++ b/packages/capabilities/src/capabilities/task.ts
@@ -151,7 +151,10 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
     cliAliases: ['list-tasks'],
     mcp: 'list_tasks',
     tier: 'auto',
-    callers: ['ui', 'human', 'agent'],
+    // 'worker' included: a task worker's MCP session has always had list_tasks
+    // unconditionally (server/orchestrator/mcp/server.ts's module doc) — auto
+    // tier, no blast radius. See CallerClass's doc for the worker/agent split.
+    callers: ['ui', 'human', 'agent', 'worker'],
     input: taskListInputSchema,
   },
   {
@@ -164,7 +167,8 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
     cliAliases: ['get-task'],
     mcp: 'get_task',
     tier: 'auto',
-    callers: ['ui', 'human', 'agent'],
+    // 'worker' included — same reasoning as task.list above.
+    callers: ['ui', 'human', 'agent', 'worker'],
     input: taskGetInputSchema,
   },
   {
@@ -213,7 +217,10 @@ export const TASK_CAPABILITY_META: CapabilityMeta[] = [
     // the single most common write they perform, buying no safety: there is
     // nothing to undo. Deliberately 'auto'.
     tier: 'auto',
-    callers: ['human', 'agent'],
+    // 'worker' included — a worker has always been able to close its own task
+    // this way (server/orchestrator/mcp/server.test.ts's "not a widening of
+    // what a worker can DO" comment); preserved under the new caller class.
+    callers: ['human', 'agent', 'worker'],
     input: closeTaskInputSchema,
   },
   {

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -34,7 +34,20 @@ export type CallerClass =
   /** A human at a terminal running `octomux ...`. Trusted. */
   | 'human'
   /** An autonomous agent, via MCP or CLI. Subject to the gate tier. */
-  | 'agent';
+  | 'agent'
+  /**
+   * A task worker's Claude Code session (as opposed to the orchestrator
+   * conductor, which is `'agent'`). Both are autonomous and both are subject
+   * to the gate tier — `authorize()` treats `'worker'` exactly like `'agent'`
+   * for tier resolution — but a worker's REACH is narrower: it is the
+   * `callers` list on each capability, not the tier, that keeps a worker off
+   * `task.create`/`task.delete`/`task.move` while still letting it read
+   * (`task.list`/`task.get`), close its own task (`task.close`), and block on
+   * a human (`human.ask`). Introduced so a worker can reach `ask_human`
+   * without widening what a worker can destroy — see
+   * spec/surface-consolidation-and-centaur.md's centaur section.
+   */
+  | 'worker';
 
 /** Gate classification. Mirrors `orchestrator/policy.ts` tiers. */
 export type PolicyTier =

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -18,6 +18,7 @@ import {
   upsertManagedTask,
   eventsSince,
   createConversation,
+  getCard,
 } from './repositories/orchestrator.js';
 import { advancePhaseForLabel } from './hooks.js';
 import { getArtifactSummary } from './artifact.js';
@@ -1118,4 +1119,130 @@ describe('POST /api/hooks/phase-complete with SHR-160 LABEL semantics', () => {
       expect(payload.phase).toBe(label);
     },
   );
+});
+
+// ─── POST /api/hooks/gate-card ────────────────────────────────────────────
+//
+// Part B of the worker-ask-human change: a worker's MCP subprocess never has
+// OCTOMUX_CONVERSATION_ID (only the conductor does — see
+// orchestrator/mcp/write.ts's module doc), so it sends task_id instead and
+// this route must resolve the OWNING conversation via `managed_tasks`
+// (findConversationForTask) rather than requiring the caller to know its own
+// conversation. This is routing (a worker's question goes to the conductor
+// supervising it), not a lookup for which human to interrupt — see the
+// route's own doc comment in hooks.ts. The conductor's existing
+// conversation_id-direct path must keep working unchanged.
+describe('POST /api/hooks/gate-card', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    insertTask(db, { id: 'task-gc', runtime_state: 'running', workflow_status: 'in_progress' });
+    insertAgent(db, {
+      id: 'agent-gc',
+      task_id: 'task-gc',
+      harness_session_id: 'sess-gc',
+      hook_token: 'tok-gc',
+    } as any);
+  });
+
+  it('conductor path: conversation_id given directly still creates a card', async () => {
+    const convId = createConversation({ title: 'conductor-conv' });
+
+    const res = await request(app)
+      .post(`/api/hooks/gate-card?token=tok-gc&conversation_id=${convId}`)
+      .send({
+        capability_id: 'task.close',
+        tier: 'always-ask',
+        kind: 'action',
+        command: 'close_task',
+        args: { task_id: 'task-gc' },
+      })
+      .expect(200);
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.result.card_id).toBeTruthy();
+    expect(getCard(res.body.result.card_id)!.conversation_id).toBe(convId);
+  });
+
+  it('worker path: task_id alone resolves the conversation via managed_tasks (orchestrator-managed task)', async () => {
+    const convId = createConversation({ title: 'worker-owning-conv' });
+    upsertManagedTask({ conversation_id: convId, task_id: 'task-gc' });
+
+    const res = await request(app)
+      .post('/api/hooks/gate-card?token=tok-gc&task_id=task-gc')
+      .send({
+        capability_id: 'human.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_human',
+        question: 'which approach?',
+      })
+      .expect(200);
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.result.card_id).toBeTruthy();
+    // The resolved conversation is the one managed_tasks points at, not one
+    // the worker had to know or supply.
+    expect(getCard(res.body.result.card_id)!.conversation_id).toBe(convId);
+  });
+
+  it('plain standalone task (no managed_tasks row): fails CLOSED with a clear, distinct error — never a hang, never a silent card-less 200', async () => {
+    // task-gc exists but has no managed_tasks row — not orchestrator-managed.
+    const res = await request(app)
+      .post('/api/hooks/gate-card?token=tok-gc&task_id=task-gc')
+      .send({
+        capability_id: 'human.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_human',
+        question: 'which approach?',
+      })
+      .expect(200); // hook endpoints report failure IN the body, not via HTTP status
+
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/no owner for this session/);
+    expect(res.body.result).toBeUndefined();
+  });
+
+  it('neither conversation_id nor task_id: fails CLOSED with a clear error', async () => {
+    const res = await request(app)
+      .post('/api/hooks/gate-card?token=tok-gc')
+      .send({
+        capability_id: 'human.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_human',
+        question: 'which approach?',
+      })
+      .expect(200);
+
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBeTruthy();
+    expect(res.body.result).toBeUndefined();
+  });
+
+  it('returns 401 when hook_token is missing or unrecognized', async () => {
+    await request(app)
+      .post('/api/hooks/gate-card?task_id=task-gc')
+      .send({
+        capability_id: 'human.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_human',
+      })
+      .expect(401);
+
+    await request(app)
+      .post('/api/hooks/gate-card?token=bad-token&task_id=task-gc')
+      .send({
+        capability_id: 'human.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_human',
+      })
+      .expect(401);
+  });
 });

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -16,7 +16,7 @@ import {
 } from './repositories/orchestrator.js';
 import { handlePreToolUse } from './orchestrator/gate.js';
 import { pushToConversation } from './orchestrator/stream.js';
-import { createCard } from './repositories/orchestrator.js';
+import { createCard, findConversationForTask } from './repositories/orchestrator.js';
 import {
   runOrchestratorAction,
   ORCHESTRATOR_ACTIONS,
@@ -717,19 +717,45 @@ router.post('/orchestrator-action', requireHookToken, (req: Request, res: Respon
 });
 
 // POST /api/hooks/gate-card
-// The conductor's MCP subprocess RPCs here to create a pending action_cards
-// row for a gated (ask/always-ask) CAPABILITY call and push it to the
-// conversation's WS clients — server/orchestrator/mcp/gate.ts's
+// The conductor's (or a worker's) MCP subprocess RPCs here to create a pending
+// action_cards row for a gated (ask/always-ask) CAPABILITY call and push it to
+// the OWNING conversation's WS clients — server/orchestrator/mcp/gate.ts's
 // `onGatedInvoke`. Mirrors /orchestrator-action's RPC shape but creates a
-// card instead of running an action; the human's later decision is handled
+// card instead of running an action; the owner's later decision is handled
 // by the existing card_decision WS path → gate.ts's executeCard, same as
 // every other action_cards row. Card creation must happen here (not in the
 // subprocess) because pushToConversation needs the main process's live
 // WebSocket client registry — see write.ts's callGateCard doc.
-// Query: ?token=<conductor hook_token>&conversation_id=<conv_id>
+// Query: ?token=<hook_token>&conversation_id=<conv_id>&task_id=<task_id>
 // Body:  { capability_id, tier, kind, command, args?, question? }
+//
+// conversation_id resolution: the conductor sends conversation_id directly
+// (it always has OCTOMUX_CONVERSATION_ID) — that IS its owner. A worker
+// session never has that env var (write.ts's module doc) but sends task_id
+// instead — resolved here via `managed_tasks` (findConversationForTask)
+// rather than threading a new env var into every worker session.
+// `managed_tasks` (task → conversation) is not a lookup for "which human do
+// we bother" — it IS the routing: a worker's owner is the conductor
+// supervising it, and the card lands in that conductor's conversation by
+// design, exactly like a conductor-originated card would. (Today that still
+// resolves to a human via the dashboard either way — there is no
+// conductor-side MCP tool to answer a card yet, a separate capability for a
+// later change.) This only resolves for an ORCHESTRATOR-MANAGED task (it has
+// a `managed_tasks` row by construction, i.e. it HAS an owner). A plain
+// standalone task has no owning conversation at all — `action_cards.
+// conversation_id` is `NOT NULL REFERENCES orchestrator_conversations(id)`,
+// so there is nowhere to put the row even if we wanted to. FAIL CLOSED:
+// respond with a clear, distinct error rather than creating an orphaned card
+// or hanging. (In practice this worker MCP server is only ever wired up for
+// orchestrator-managed tasks — see task-engine/launch.ts's
+// `applyOrchestratorMcpConfig` — so a resolvable task_id is expected on every
+// real call; this guard is what turns a future wiring change or a stray
+// manual call into a clear error instead of a silent gap or a hang.)
 router.post('/gate-card', requireHookToken, (req: Request, res: Response) => {
-  const conversationId = ((req.query.conversation_id ?? '') as string) || undefined;
+  const queryConversationId = ((req.query.conversation_id ?? '') as string) || undefined;
+  const taskId = ((req.query.task_id ?? '') as string) || undefined;
+  const conversationId =
+    queryConversationId ?? (taskId ? findConversationForTask(taskId) : null) ?? undefined;
   const { capability_id, tier, kind, command, args, question } = req.body as {
     capability_id?: string;
     tier?: 'ask' | 'always-ask';
@@ -740,7 +766,12 @@ router.post('/gate-card', requireHookToken, (req: Request, res: Response) => {
   };
 
   if (!conversationId) {
-    res.status(200).json({ ok: false, error: 'conversation_id is required to create a gate card' });
+    res.status(200).json({
+      ok: false,
+      error: taskId
+        ? `no owner for this session — task '${taskId}' is not orchestrator-managed (no conversation to route the card to)`
+        : 'conversation_id (or a resolvable task_id) is required to create a gate card',
+    });
     return;
   }
   if (!capability_id || !tier || !kind || !command) {

--- a/server/orchestrator/mcp/gate.test.ts
+++ b/server/orchestrator/mcp/gate.test.ts
@@ -119,7 +119,7 @@ describe('onGatedInvoke', () => {
     });
 
     await expect(onGatedInvoke(makeCap(), 'always-ask', {})).rejects.toThrow(
-      /rejected by the human/,
+      /rejected by the session's owner/,
     );
   });
 
@@ -133,7 +133,7 @@ describe('onGatedInvoke', () => {
     );
 
     // The distinguishing property under test: this failure mode must never
-    // read like a human decision — assert on the SAME rejection, not a re-run.
+    // read like the owner's decision — assert on the SAME rejection, not a re-run.
     mockCallGateCard.mockRejectedValueOnce(new Error('ECONNREFUSED'));
     await onGatedInvoke(makeCap(), 'always-ask', {}).catch((err: Error) => {
       expect(err.message).not.toMatch(/rejected by the human/);

--- a/server/orchestrator/mcp/gate.ts
+++ b/server/orchestrator/mcp/gate.ts
@@ -238,7 +238,7 @@ export async function onGatedInvoke(
     cardId = created.card_id;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // DISTINCT from rejection/timeout below: the human was never even asked.
+    // DISTINCT from rejection/timeout below: the owner was never even asked.
     throw new Error(`gate: could not create an approval card for '${cap.id}' — ${message}`);
   }
 
@@ -248,11 +248,11 @@ export async function onGatedInvoke(
 
   if (outcome.kind === 'timeout') {
     throw new Error(
-      `gate: '${cap.id}' timed out waiting for a human decision (card ${cardId}) — denied`,
+      `gate: '${cap.id}' timed out waiting for a decision from the session's owner (card ${cardId}) — denied`,
     );
   }
   if (outcome.kind === 'rejected') {
-    throw new Error(`gate: '${cap.id}' was rejected by the human (card ${cardId})`);
+    throw new Error(`gate: '${cap.id}' was rejected by the session's owner (card ${cardId})`);
   }
 
   // approved

--- a/server/orchestrator/mcp/server.test.ts
+++ b/server/orchestrator/mcp/server.test.ts
@@ -144,8 +144,8 @@ describe('createOctomuxMcpServer — tool registration', () => {
     const server = createOctomuxMcpServer();
     const tools = getRegisteredToolNames(server);
     // Worker mode: report_complete plus the 'auto'-tier reads, and nothing
-    // that mutates. The tier filter in server.ts is what draws this line —
-    // see the rationale at that call site.
+    // that mutates. The caller-class 'worker' + each capability's `callers`
+    // list is what draws this line now — see the rationale at that call site.
     expect(tools).toContain('report_complete');
     expect(tools).toContain('list_tasks');
     expect(tools).toContain('get_task');
@@ -154,6 +154,11 @@ describe('createOctomuxMcpServer — tool registration', () => {
     // prompts literally instruct it to run `octomux close-task <id>`. This is
     // the same power by a second route, not a new one.
     expect(tools).toContain('close_task');
+    // NEW: a worker can now block on a human via ask_human (always-ask tier,
+    // but included in human.ask's `callers` — see packages/capabilities/src/
+    // capabilities/ask.ts). This is the capability this test file exists to
+    // guard the boundary of.
+    expect(tools).toContain('ask_human');
     expect(tools).not.toContain('create_task');
     expect(tools).not.toContain('send_message');
     expect(tools).not.toContain('set_task_status');
@@ -269,5 +274,79 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
 
     expect(result.content[0].text).not.toMatch(/could not create an approval card/);
     expect(result.content[0].text).toMatch(/task-x/);
+  });
+});
+
+// ─── Worker can ask_human but cannot create/delete/move a task ──────────────
+//
+// The property the whole change exists to prove: a worker session (caller
+// class 'worker', not 'agent') gets ask_human — including the SAME
+// onGatedInvoke blocking behaviour the conductor's write tools get — while
+// still being denied create_task/delete_task/set_task_status outright. Denied
+// means "never registered as a tool at all" (registerCapabilityTools skips
+// unauthorized capabilities — see projections/mcp.ts's module doc), which
+// this asserts directly by checking the tool is undefined, not merely absent
+// from a name list (belt-and-suspenders against the earlier list-based checks
+// being weakened independently of this one).
+describe('createOctomuxMcpServer — worker ask_human vs. destructive tools', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv['OCTOMUX_TASK_ID'] = process.env.OCTOMUX_TASK_ID;
+    savedEnv['OCTOMUX_ACTION_TOKEN'] = process.env.OCTOMUX_ACTION_TOKEN;
+    savedEnv['OCTOMUX_ACTION_BASE_URL'] = process.env.OCTOMUX_ACTION_BASE_URL;
+    savedEnv['OCTOMUX_CONVERSATION_ID'] = process.env.OCTOMUX_CONVERSATION_ID;
+    savedEnv['OCTOMUX_CAPABILITY_GATE_ENABLED'] = process.env.OCTOMUX_CAPABILITY_GATE_ENABLED;
+
+    process.env.OCTOMUX_TASK_ID = 'task-worker-ask';
+    process.env.OCTOMUX_ACTION_TOKEN = 'tok-worker';
+    process.env.OCTOMUX_ACTION_BASE_URL = 'http://127.0.0.1:7777';
+    delete process.env.OCTOMUX_CONVERSATION_ID; // workers never have this
+    delete process.env.OCTOMUX_CAPABILITY_GATE_ENABLED;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('a worker session gets ask_human, and it hits onGatedInvoke (blocks) instead of the no-op handler', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('ECONNREFUSED (no server listening in this test)')),
+    );
+
+    const { createOctomuxMcpServer } = await import('./server.js');
+    const server = createOctomuxMcpServer();
+    const priv = server as unknown as {
+      _registeredTools: Record<string, { handler: (input: unknown, extra: unknown) => unknown }>;
+    };
+    const tool = priv._registeredTools['ask_human'];
+    expect(tool).toBeDefined();
+
+    const result = (await tool.handler({ question: 'which approach?' }, {})) as {
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+
+    // Card creation is attempted (proving the gate ran, not the no-op
+    // registry/capabilities/human.ts handler, which would have returned
+    // {answer: null, note: '...gating is disabled...'} instead of an isError).
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/could not create an approval card/);
+  });
+
+  it('a worker session never gets create_task, delete_task, or set_task_status as tools at all', async () => {
+    const { createOctomuxMcpServer } = await import('./server.js');
+    const server = createOctomuxMcpServer();
+    const priv = server as unknown as { _registeredTools: Record<string, unknown> };
+
+    expect(priv._registeredTools['create_task']).toBeUndefined();
+    expect(priv._registeredTools['delete_task']).toBeUndefined();
+    expect(priv._registeredTools['set_task_status']).toBeUndefined();
   });
 });

--- a/server/orchestrator/mcp/server.ts
+++ b/server/orchestrator/mcp/server.ts
@@ -281,33 +281,30 @@ export function createOctomuxMcpServer(): McpServer {
   );
 
   // ── Capability-registry tools (list_tasks/get_task/create_task/set_task_status/
-  //    close_task/delete_task) ────────────────────────────────────────────────
-  // Only registered for an orchestrator-started (conductor) session — same gate
-  // as the write tools below, and deliberately NOT for worker sessions.
+  //    close_task/delete_task/ask_human) ─────────────────────────────────────
+  // Registered for BOTH an orchestrator-started (conductor) session and a
+  // worker session, but under different caller classes — that is what keeps a
+  // worker off task.create/task.move/task.delete while still letting it reach
+  // ask_human (the whole point of this call site's rework).
   //
-  // Caller class: 'agent'. Both the conductor and a worker are autonomous
-  // Claude Code sessions, not a human at a terminal or the dashboard — exactly
-  // CallerClass's 'agent' definition (server/registry/types.ts). Every task.*
-  // capability lists 'agent' in its `callers`, so this is the only class that
-  // makes sense here.
+  // Caller class: 'agent' for the conductor, 'worker' for a task session.
+  // OCTOMUX_TASK_ID is the same signal orchestratorWriteEnabled() /
+  // workerReportEnabled() already use to tell them apart (write.ts's module
+  // doc). See CallerClass's doc (packages/capabilities/src/types.ts) for why
+  // the split exists: both are autonomous — `authorize()` gates 'worker'
+  // exactly like 'agent' — but they have different REACH, and `callers` on
+  // each capability (not a tool-name allowlist) is what encodes that reach.
+  // task.list/task.get/task.close/human.ask list 'worker'; task.create/
+  // task.start/task.move/task.delete do not, so `authorize()` denies those to
+  // a worker outright — not registered at all, never registered-then-rejected.
   //
-  // Tier split: the conductor gets every task.* capability; a worker gets only
-  // the 'auto' tier — task.list/get. That preserves both boundaries at once.
-  // Workers have never had create_task/close_task/delete_task (the write loop
-  // below already excluded them) and still don't, because those capabilities
-  // are 'ask'/'always-ask'. But workers DO keep the lean list_tasks/get_task
-  // read tools they have always had unconditionally, which an all-or-nothing
-  // gate on orchestratorWriteEnabled() would have taken away.
-  //
-  // Filtering on tier rather than on a tool-name allowlist means a new
-  // capability lands on the correct side of this boundary by virtue of the
-  // tier its author already had to choose — there is no second list to keep
-  // in sync, and forgetting to update one cannot silently widen a worker's
-  // reach.
-  //
-  // ONE call, not two: registering the 'auto' tier unconditionally and then
-  // the rest for the conductor would register the auto tools twice for the
-  // conductor, and the MCP SDK rejects a duplicate tool name.
+  // No `tiers` filter for the worker branch: `callers` already does the
+  // restricting, and a tier filter would exclude human.ask (always-ask) right
+  // alongside the destructive tools it exists to keep out — for a worker, tier
+  // and "who may even attempt this" are now orthogonal questions. The
+  // conductor branch keeps its tier filter unchanged: a bare MCP session with
+  // no env at all (not a worker, and orchestratorWriteEnabled() false) still
+  // only gets the 'auto' tier.
   //
   // `onGatedInvoke: onGatedInvoke` is what makes task.create/start/move (ask)
   // and task.close/delete (always-ask) actually block on a human instead of
@@ -315,9 +312,12 @@ export function createOctomuxMcpServer(): McpServer {
   // docblock) — see server/orchestrator/mcp/gate.ts's module doc for the
   // fail-closed contract. `human.ask` (ask_human) is gated the same way; its
   // handler never runs for real (onGatedInvoke short-circuits with the human's
-  // answer) unless the kill switch is off.
-  registerCapabilityMcpTools(server, 'agent', {
-    tiers: orchestratorWriteEnabled() ? undefined : ['auto'],
+  // answer) unless the kill switch is off. This is also what makes a worker's
+  // ask_human call actually BLOCK rather than fall through to the no-op
+  // handler in registry/capabilities/human.ts.
+  const isWorkerSession = Boolean(process.env.OCTOMUX_TASK_ID);
+  registerCapabilityMcpTools(server, isWorkerSession ? 'worker' : 'agent', {
+    tiers: isWorkerSession || orchestratorWriteEnabled() ? undefined : ['auto'],
     onGatedInvoke,
   });
 

--- a/server/orchestrator/mcp/write.ts
+++ b/server/orchestrator/mcp/write.ts
@@ -51,11 +51,20 @@ export function actionIdempotencyKey(action: string, input: Record<string, unkno
     .digest('hex');
 }
 
-function actionConfig(): { baseUrl?: string; token?: string; conversationId?: string } {
+function actionConfig(): {
+  baseUrl?: string;
+  token?: string;
+  conversationId?: string;
+  taskId?: string;
+} {
   return {
     baseUrl: process.env.OCTOMUX_ACTION_BASE_URL,
     token: process.env.OCTOMUX_ACTION_TOKEN,
     conversationId: process.env.OCTOMUX_CONVERSATION_ID,
+    // Set for a worker session (OCTOMUX_TASK_ID), never for the conductor.
+    // callGateCard sends it so the server can resolve conversation_id via
+    // managed_tasks when OCTOMUX_CONVERSATION_ID isn't set — see its doc.
+    taskId: process.env.OCTOMUX_TASK_ID,
   };
 }
 
@@ -147,22 +156,39 @@ export interface CreateGateCardInput {
  * mode makes that safe and cheap) rather than RPCing again.
  *
  * Throws on any failure (missing config, network error, non-ok response) —
- * the caller (`onGatedInvoke`) must treat that as a DISTINCT denial from a
- * human rejecting or a timeout: the human was never even asked.
+ * the caller (`onGatedInvoke`) must treat that as a DISTINCT denial from the
+ * owner rejecting or a timeout: the owner was never even asked.
+ *
+ * conversation_id resolution: the conductor always has OCTOMUX_CONVERSATION_ID
+ * set and that wins when present. A worker session never has it (write.ts's
+ * module doc) but does have OCTOMUX_TASK_ID, so this sends task_id instead and
+ * lets the server resolve the OWNING conversation via `managed_tasks`
+ * (server/hooks.ts's `/gate-card` — `findConversationForTask`). This is not a
+ * fallback for locating a person — `managed_tasks` (task → conversation) IS
+ * the routing table: a worker's question is addressed to the conductor
+ * supervising it, and a human is however far up that chain the conductor
+ * escalates to. That only resolves for an ORCHESTRATOR-MANAGED worker (it has
+ * a `managed_tasks` row by definition — see the module doc on
+ * `applyOrchestratorMcpConfig`, which is also why a worker with no
+ * `managed_tasks` row never gets this MCP server wired up in the first place:
+ * there is no case today where a worker reaches this call with neither id
+ * resolvable). If somehow neither is available this throws locally rather
+ * than round-tripping for a guaranteed failure.
  */
 export async function callGateCard(input: CreateGateCardInput): Promise<{ card_id: string }> {
-  const { baseUrl, token, conversationId } = actionConfig();
+  const { baseUrl, token, conversationId, taskId } = actionConfig();
   if (!baseUrl || !token) {
     throw new Error('orchestrator write tools are not configured (missing base url / token)');
   }
-  if (!conversationId) {
-    throw new Error('no conversation configured — cannot create a gate approval card');
+  if (!conversationId && !taskId) {
+    throw new Error('no conversation or task configured — no owner to route this question to');
   }
 
   const url =
     `${baseUrl}/api/hooks/gate-card` +
     `?token=${encodeURIComponent(token)}` +
-    `&conversation_id=${encodeURIComponent(conversationId)}`;
+    (conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : '') +
+    (taskId ? `&task_id=${encodeURIComponent(taskId)}` : '');
 
   logger.debug(
     { capability_id: input.capabilityId, tier: input.tier, kind: input.kind },

--- a/server/registry/capabilities/human.ts
+++ b/server/registry/capabilities/human.ts
@@ -14,8 +14,9 @@
  * path. It only runs when the capability gate's kill switch
  * (`OCTOMUX_CAPABILITY_GATE_ENABLED=false`) is off, in which case
  * `onGatedInvoke` returns `undefined` (bypass) and this handler is reached
- * directly — at that point there is no human to ask, so it answers honestly
- * rather than hanging or throwing.
+ * directly — at that point gating is off entirely, so there is no one to
+ * route the question to, and it answers honestly rather than hanging or
+ * throwing.
  */
 
 import { HUMAN_CAPABILITY_META, askHumanInputSchema } from '@octomux/capabilities';
@@ -34,8 +35,8 @@ async function askHumanHandler(_input: z.infer<typeof askHumanInputSchema>) {
   return {
     answer: null,
     note:
-      'human-in-the-loop gating is disabled (OCTOMUX_CAPABILITY_GATE_ENABLED=false) — ' +
-      'no human was asked',
+      'capability gating is disabled (OCTOMUX_CAPABILITY_GATE_ENABLED=false) — ' +
+      'no one was asked',
   };
 }
 

--- a/server/registry/index.test.ts
+++ b/server/registry/index.test.ts
@@ -70,8 +70,13 @@ describe('authorize', () => {
     ['agent', 'always-ask', 'always-ask'],
     ['ui', 'always-ask', 'auto'],
     ['human', 'ask', 'auto'],
+    // 'worker' is gated exactly like 'agent' — both are autonomous. What
+    // narrows a worker's reach is `callers` (denying it the capability
+    // outright), never a softer tier — see the next test.
+    ['worker', 'auto', 'auto'],
+    ['worker', 'always-ask', 'always-ask'],
   ])('caller %s on a %s capability resolves to tier %s', (caller, tier, expected) => {
-    const result = authorize(cap({ tier }), caller);
+    const result = authorize(cap({ tier, callers: ['ui', 'human', 'agent', 'worker'] }), caller);
     expect(result).toEqual({ allowed: true, tier: expected });
   });
 
@@ -81,6 +86,15 @@ describe('authorize', () => {
       allowed: false,
       reason: 'task.create is not available to agent callers',
     });
+  });
+
+  it('denies a worker a capability whose callers omit "worker" (e.g. task.create) even though agents may call it', () => {
+    const destructive = cap({ tier: 'ask', callers: ['ui', 'human', 'agent'] });
+    expect(authorize(destructive, 'worker')).toEqual({
+      allowed: false,
+      reason: 'task.create is not available to worker callers',
+    });
+    expect(authorize(destructive, 'agent')).toEqual({ allowed: true, tier: 'ask' });
   });
 });
 

--- a/server/registry/index.ts
+++ b/server/registry/index.ts
@@ -124,7 +124,12 @@ export function authorize(cap: Capability, caller: CallerClass): Decision {
   if (!cap.callers.includes(caller)) {
     return { allowed: false, reason: `${cap.id} is not available to ${caller} callers` };
   }
-  return { allowed: true, tier: caller === 'agent' ? cap.tier : 'auto' };
+  // 'worker' is gated exactly like 'agent' — both are autonomous Claude Code
+  // sessions with no standing human intent behind the call. What keeps a
+  // worker off task.create/task.delete/task.move is `cap.callers` (they don't
+  // list 'worker'), not the tier collapsing here — see CallerClass's doc.
+  const isAutonomous = caller === 'agent' || caller === 'worker';
+  return { allowed: true, tier: isAutonomous ? cap.tier : 'auto' };
 }
 
 /**

--- a/server/registry/projections/mcp.test.ts
+++ b/server/registry/projections/mcp.test.ts
@@ -58,6 +58,15 @@ describe('registerCapabilityTools', () => {
     ['caller is in the callers list', ['ui', 'human', 'agent'], 'agent', true],
     ['caller is missing from the callers list', ['ui', 'human'], 'agent', false],
     ['ui excluded from an agent-only capability', ['agent'], 'ui', false],
+    // 'worker' (task sessions) is its own class, distinct from 'agent' (the
+    // conductor) — a capability must opt a worker in explicitly.
+    ['worker included on human.ask-shaped capability', ['agent', 'worker'], 'worker', true],
+    [
+      'worker excluded from an agent-only capability (e.g. task.create)',
+      ['ui', 'human', 'agent'],
+      'worker',
+      false,
+    ],
   ])('%s → registered=%s', (_label, callers, caller, expected) => {
     defineCapability(cap({ callers }));
     const server = newServer();


### PR DESCRIPTION
A worker couldn't call `ask_human`. `orchestratorWriteEnabled()` is false whenever `OCTOMUX_TASK_ID` is set, so workers were registered with `tiers: ['auto']` — and `ask_human` is `always-ask`. The worker is the actor that finishes planning, so the agent most likely to need a checkpoint had no way to raise one.

## Caller class, not a wider tier

Widening the tier filter would also have handed workers `delete_task`. So `CallerClass` gains `'worker'`:

| Capability | worker? |
|---|---|
| `human.ask` | ✅ |
| `task.list` / `task.get` / `task.close` | ✅ (not a widening — see below) |
| `task.create` / `start` / `move` / `delete` | ❌ denied by `authorize()`, never registered |

A worker never sees a tool it can't use. `task.list/get/close` gained `worker` because a worker session has **always** had those three; switching its caller class without this would have silently removed them.

## Routing, not channel-finding

A worker's question goes to its **owning conductor**. `managed_tasks` resolves task → conversation server-side in `/api/hooks/gate-card`, so no new env var is threaded into worker sessions. The human is the top of that chain, not the first stop.

A conductor-side tool to *answer* a worker's question is deliberately **not** in this pass.

## The no-owner case is structurally impossible, not merely handled

`launch.ts` only writes a worker's MCP config when the task is orchestrator-managed — so a task with no conversation never sees `ask_human` at all. The fail-closed guard in `gate-card` is kept anyway as defence against a future wiring change: a distinct error, never a hang, never an orphaned card. **No `action_cards` schema change.**

## Mutation-tested

Adding `'worker'` to `task.delete`'s callers fails 2 tests.

**Known, pre-existing:** resume/hop/respawn paths never call `applyOrchestratorMcpConfig`, so a *resumed* task may lose MCP wiring entirely. Out of scope here, worth its own fix.

3227 pass (baseline 3215 + 12 new), `src` 1444 unchanged. `tsc -b` and `cd cli && tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)