### PR TITLE
feat(orchestrator): re-fire guard that does not depend on phase

### DIFF
--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -16,7 +16,12 @@ import {
 } from './repositories/orchestrator.js';
 import { handlePreToolUse } from './orchestrator/gate.js';
 import { pushToConversation } from './orchestrator/stream.js';
-import { createCard, findConversationForTask } from './repositories/orchestrator.js';
+import {
+  createCard,
+  findConversationForTask,
+  hasCardForTask,
+  hasPhaseCompleteEvent,
+} from './repositories/orchestrator.js';
 import {
   runOrchestratorAction,
   ORCHESTRATOR_ACTIONS,
@@ -363,6 +368,48 @@ router.post(
 );
 
 /**
+ * Re-fire guard for the marker-file backstop, keyed on ARTIFACT / CARD / EVENT
+ * EXISTENCE rather than on `managed_tasks.phase`.
+ *
+ * Today `maybeSignalPhaseComplete` only reaches the marker check once
+ * `managed.phase` already matches the expected stage, so this guard is
+ * belt-and-braces — it changes no behaviour on its own. It exists so a LATER
+ * change can delete the `phase` column: `spec.md` and `plan.json` are never
+ * deleted, so once the phase gate is gone the backstop would otherwise
+ * re-detect them (and re-relay) on every subsequent Stop hook for the rest of
+ * the task's life. `implement` needs no such guard — `advancePhaseForLabel`
+ * deletes the `.octomux/implement-done` sentinel on the call that fires it,
+ * so `fs.existsSync` is self-guarding without any extra state.
+ *
+ *   'spec' → already relayed once a `task:phase_complete` event with
+ *            phase='spec' has already been durably recorded for this task.
+ *            NOTE: an earlier draft of this guard checked "does plan.json
+ *            exist" instead (the NEXT artifact), reasoning that the spec
+ *            relay's whole job is prompting the worker to write it. That has
+ *            a real false positive: a worker can write spec.md AND plan.json
+ *            in the very same turn, before the relay has ever run once — the
+ *            existing test 'speccing + BOTH spec.md and plan.json present →
+ *            only spec fires' covers exactly this. The events log has no
+ *            such gap: an event only exists once advancePhaseForLabel has
+ *            actually fired for this label, so it can't false-positive on a
+ *            worker being fast. See hasPhaseCompleteEvent's doc for cost.
+ *   'plan' → already relayed once an `approve-plan` card exists for this
+ *            task, in ANY status — a resolved (approved/rejected/executed)
+ *            card still proves the card was already minted once; only a
+ *            missing card means "never relayed". See hasCardForTask's doc
+ *            for how the lookup is scoped (action_cards has no task_id
+ *            column).
+ */
+export function hasAlreadyRelayed(taskId: string, label: 'spec' | 'plan'): boolean {
+  if (label === 'spec') {
+    return hasPhaseCompleteEvent(taskId, 'spec');
+  }
+  const convId = findConversationForTask(taskId);
+  if (!convId) return false;
+  return hasCardForTask(convId, taskId, 'approve-plan');
+}
+
+/**
  * Backstop: detect phase completion from marker files on the Stop hook.
  *
  * When the worker uses the explicit report_complete MCP tool, advancePhaseForLabel
@@ -377,6 +424,23 @@ router.post(
  * NOTE: managed_tasks.phase COLUMN values ('speccing'/'planning'/...) are
  * DISTINCT from the broadcast payload.phase LABEL ('spec'/'plan'/'implement').
  * The supervisor switches on the LABEL.
+ *
+ * NOT-YET-SAFE TO DELETE THE PHASE GATES. `hasAlreadyRelayed` (added below)
+ * removes one of the two jobs the `managed.phase === ...` checks do — it stops
+ * a relay firing TWICE. But those checks do a second job that nothing has
+ * replaced yet: they SELECT which branch applies. Every branch here ends in an
+ * unconditional `return`, so with the gates naively removed the spec branch
+ * matches first on every Stop hook (spec.md is never deleted), returns, and the
+ * plan branch is never reached — the plan relay would never fire at all.
+ *
+ * Verified by mutation: replacing both gates with `if (true)` makes the
+ * "third, later Stop hook" test in server/orchestrator/refire-guard.test.ts
+ * fail with ZERO approve-plan cards rather than two.
+ *
+ * So deleting the gates also requires restructuring this function so each
+ * label's artifact check and `hasAlreadyRelayed` guard are evaluated
+ * independently, instead of the first matching branch returning for all of
+ * them. That restructure is deliberately NOT in this change.
  */
 function maybeSignalPhaseComplete(taskId: string): void {
   const managed = getManagedTask(taskId);
@@ -390,6 +454,18 @@ function maybeSignalPhaseComplete(taskId: string): void {
     const specPath = path.join(worktree, 'spec.md');
     if (!fs.existsSync(specPath)) return;
 
+    // Redundant with the `phase === 'speccing'` gate today. It stops a REPEAT
+    // spec relay once that gate is gone, but see the NOT-YET-SAFE note on
+    // maybeSignalPhaseComplete: on its own it is not sufficient to delete the
+    // gates, because this branch still `return`s unconditionally.
+    if (hasAlreadyRelayed(taskId, 'spec')) {
+      logger.debug(
+        { task_id: taskId, operation: 'spec_complete_already_relayed' },
+        'Stop hook backstop: spec already relayed — skipping',
+      );
+      return;
+    }
+
     logger.info(
       { task_id: taskId, operation: 'spec_complete_detected' },
       'Stop hook backstop: spec.md present for managed speccing task — advancing via advancePhaseForLabel',
@@ -401,6 +477,17 @@ function maybeSignalPhaseComplete(taskId: string): void {
   if (managed.phase === 'planning') {
     const planPath = path.join(worktree, 'plan.json');
     if (!fs.existsSync(planPath)) return;
+
+    // Redundant with the `phase === 'planning'` gate today; stops a REPEAT
+    // plan relay once that gate is gone. Same caveat as the spec branch — the
+    // unconditional `return`s must go too. See maybeSignalPhaseComplete's doc.
+    if (hasAlreadyRelayed(taskId, 'plan')) {
+      logger.debug(
+        { task_id: taskId, operation: 'plan_complete_already_relayed' },
+        'Stop hook backstop: plan already relayed (approve-plan card exists) — skipping',
+      );
+      return;
+    }
 
     logger.info(
       { task_id: taskId, operation: 'plan_complete_detected' },

--- a/server/orchestrator/refire-guard.test.ts
+++ b/server/orchestrator/refire-guard.test.ts
@@ -1,0 +1,360 @@
+/**
+ * server/orchestrator/refire-guard.test.ts
+ *
+ * Tests for the artifact/card-existence re-fire guard (hasAlreadyRelayed,
+ * server/hooks.ts) that stands in for `managed_tasks.phase` in the Stop-hook
+ * backstop (maybeSignalPhaseComplete). `spec.md` and `plan.json` are never
+ * deleted, so once a later change removes the `phase` gate, the backstop
+ * would otherwise re-detect them — and re-relay — on every subsequent Stop
+ * hook for the rest of the task's life:
+ *   - spec  → re-injects the "write plan.json" instruction into a live
+ *             session mid-work (via the supervisor's runSendMessage).
+ *   - plan  → mints a duplicate `approve-plan` card with no dedup key.
+ *
+ * These tests exercise the real HTTP hook endpoints (POST /stop and POST
+ * /phase-complete) against a real app + DB, with the supervisor wired up
+ * exactly as server/index.ts wires it (subscribeServerEvents →
+ * supervisor.processEvent) so the full relay (runSendMessage / createCard)
+ * is observable — not just the phase column advancing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createTestDb, insertTask, insertAgent } from '../test-helpers.js';
+import { createApp } from '../app.js';
+import { subscribeServerEvents, type ServerEvent } from '../events.js';
+import { createSupervisor, type Supervisor } from './supervisor.js';
+import {
+  createConversation,
+  upsertManagedTask,
+  getManagedTask,
+  eventsSince,
+  listPendingCards,
+  createCard,
+  resolveCard,
+  appendEvent,
+} from '../repositories/orchestrator.js';
+import { hasAlreadyRelayed } from '../hooks.js';
+
+// Capture runSendMessage calls from the supervisor's spec-relay branch.
+const mockRunSendMessage = vi.fn().mockResolvedValue(undefined);
+vi.mock('./exec.js', () => ({
+  runSendMessage: vi.fn((...args: unknown[]) => mockRunSendMessage(...args)),
+  runCreateTask: vi.fn().mockResolvedValue({ task_id: 'mock', title: 'mock' }),
+  runAddAgent: vi.fn().mockResolvedValue({ agent_id: 'mock', window_index: 1 }),
+  runSetStatus: vi.fn().mockResolvedValue(undefined),
+  runCloseTask: vi.fn().mockResolvedValue(undefined),
+  runResumeTask: vi.fn().mockResolvedValue(undefined),
+  runDeleteTask: vi.fn().mockResolvedValue(undefined),
+  validatePlanJson: vi.fn().mockReturnValue({ valid: true }),
+  PLAN_SCHEMA_VERSION: '1.0.0',
+  PLAN_KIND: 'plan',
+  WORKFLOW_KIND: 'workflow',
+  buildWorkflowTemplate: vi.fn().mockReturnValue('workflow template'),
+}));
+
+// Mock stream.ts so pushToConversation doesn't need a live ws client.
+vi.mock('./stream.js', () => ({
+  pushToConversation: vi.fn(),
+  dispatchUserTurn: vi.fn().mockResolvedValue(undefined),
+  persistAndPush: vi.fn(),
+}));
+
+describe('re-fire guard (hasAlreadyRelayed) — spec/plan relay does not double-fire', () => {
+  let db: Database.Database;
+  let app: ReturnType<typeof createApp>;
+  let worktreeDir: string;
+  let supervisor: Supervisor;
+  let unsubscribe: () => void;
+  // Every broadcast synchronously kicks off supervisor.processEvent (via the
+  // subscribeServerEvents listener below); collect the promises so tests can
+  // await full relay completion before asserting.
+  let pending: Promise<void>[];
+
+  beforeEach(() => {
+    db = createTestDb();
+    app = createApp();
+    worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-refire-'));
+    mockRunSendMessage.mockClear();
+
+    // Wire the supervisor exactly as server/index.ts does, so the real relay
+    // (runSendMessage / createCard) fires off the real broadcast() calls
+    // inside advancePhaseForLabel.
+    supervisor = createSupervisor();
+    pending = [];
+    unsubscribe = subscribeServerEvents((event: ServerEvent, seq: number | undefined) => {
+      if (seq === undefined) return;
+      const taskId = (event.payload as { taskId?: string }).taskId;
+      if (!taskId) return;
+      pending.push(
+        supervisor.processEvent({
+          seq,
+          task_id: taskId,
+          type: event.type,
+          payload: JSON.stringify(event.payload),
+        }),
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all(pending);
+    unsubscribe();
+    supervisor.stop();
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
+  });
+
+  /** Flush the supervisor's async relay work queued by the last request. */
+  async function flush(): Promise<void> {
+    await Promise.all(pending);
+    pending = [];
+  }
+
+  function setup(taskId: string, phase: string, sessionId: string, hookToken: string): string {
+    insertTask(db, {
+      id: taskId,
+      runtime_state: 'running',
+      workflow_status: 'in_progress',
+      worktree: worktreeDir,
+    });
+    insertAgent(db, {
+      id: `agent-${taskId}`,
+      task_id: taskId,
+      harness_session_id: sessionId,
+      hook_token: hookToken,
+    } as any);
+    const convId = createConversation({ title: `conv-${taskId}` });
+    upsertManagedTask({ conversation_id: convId, task_id: taskId, phase });
+    return convId;
+  }
+
+  it('1. explicit report_complete(spec) then a same-task Stop hook with spec.md present → exactly ONE runSendMessage call and ONE task:phase_complete(spec) broadcast', async () => {
+    const taskId = 'task-spec-explicit';
+    const convId = setup(taskId, 'speccing', 'sess-1', 'tok-1');
+    fs.writeFileSync(path.join(worktreeDir, 'spec.md'), '# Spec');
+
+    // Explicit MCP report_complete('spec') → POST /phase-complete
+    await request(app)
+      .post(`/api/hooks/phase-complete?token=tok-1`)
+      .send({ task_id: taskId, phase: 'spec', artifacts: ['spec.md'] })
+      .expect(200);
+    await flush();
+
+    // Same-task Stop hook backstop fires afterwards — phase already advanced
+    // to 'planning', spec.md still present on disk (never deleted).
+    await request(app)
+      .post('/api/hooks/stop?token=tok-1')
+      .send({ session_id: 'sess-1' })
+      .expect(200);
+    await flush();
+
+    expect(mockRunSendMessage).toHaveBeenCalledTimes(1);
+    const specEvents = eventsSince(0).filter((e) => {
+      if (e.type !== 'task:phase_complete') return false;
+      return (JSON.parse(e.payload) as { phase?: string }).phase === 'spec';
+    });
+    expect(specEvents).toHaveLength(1);
+    expect(getManagedTask(taskId)!.phase).toBe('planning');
+    void convId;
+  });
+
+  it('2. explicit report_complete(plan) then a same-task Stop hook with plan.json present → exactly ONE approve-plan card minted', async () => {
+    const taskId = 'task-plan-explicit';
+    const convId = setup(taskId, 'planning', 'sess-2', 'tok-2');
+    fs.writeFileSync(path.join(worktreeDir, 'plan.json'), '{"schema_version":"1.0.0"}');
+
+    await request(app)
+      .post(`/api/hooks/phase-complete?token=tok-2`)
+      .send({ task_id: taskId, phase: 'plan', artifacts: ['plan.json'] })
+      .expect(200);
+    await flush();
+
+    await request(app)
+      .post('/api/hooks/stop?token=tok-2')
+      .send({ session_id: 'sess-2' })
+      .expect(200);
+    await flush();
+
+    const cards = listPendingCards(convId).filter((c) => c.tool_name === 'approve-plan');
+    expect(cards).toHaveLength(1);
+    expect(getManagedTask(taskId)!.phase).toBe('awaiting_approval');
+  });
+
+  it('3. a THIRD, later Stop hook (during implementation) does not re-fire the spec or plan relay', async () => {
+    const taskId = 'task-third-stop';
+    setup(taskId, 'speccing', 'sess-3', 'tok-3');
+    fs.writeFileSync(path.join(worktreeDir, 'spec.md'), '# Spec');
+
+    // Turn 1: spec relays (spec.md present, phase speccing → planning).
+    await request(app)
+      .post('/api/hooks/stop?token=tok-3')
+      .send({ session_id: 'sess-3' })
+      .expect(200);
+    await flush();
+    expect(mockRunSendMessage).toHaveBeenCalledTimes(1);
+
+    // Turn 2: plan relays (worker wrote plan.json, phase planning → awaiting_approval).
+    fs.writeFileSync(path.join(worktreeDir, 'plan.json'), '{"schema_version":"1.0.0"}');
+    await request(app)
+      .post('/api/hooks/stop?token=tok-3')
+      .send({ session_id: 'sess-3' })
+      .expect(200);
+    await flush();
+
+    const convId = getManagedTask(taskId)!.conversation_id;
+    expect(listPendingCards(convId).filter((c) => c.tool_name === 'approve-plan')).toHaveLength(1);
+
+    // Advance to implementing by hand (approval + implement kickoff aren't
+    // this test's concern) — spec.md and plan.json remain on disk throughout.
+    upsertManagedTask({ conversation_id: convId, task_id: taskId, phase: 'implementing' });
+
+    // Turn 3, well after spec/plan relayed: neither marker was deleted, so
+    // without the guard this Stop hook would re-detect both and re-relay.
+    await request(app)
+      .post('/api/hooks/stop?token=tok-3')
+      .send({ session_id: 'sess-3' })
+      .expect(200);
+    await flush();
+
+    expect(mockRunSendMessage).toHaveBeenCalledTimes(1); // still just the one from turn 1
+    expect(listPendingCards(convId).filter((c) => c.tool_name === 'approve-plan')).toHaveLength(1);
+    const specEvents = eventsSince(0).filter((e) => {
+      if (e.type !== 'task:phase_complete') return false;
+      return (JSON.parse(e.payload) as { phase?: string }).phase === 'spec';
+    });
+    const planEvents = eventsSince(0).filter((e) => {
+      if (e.type !== 'task:phase_complete') return false;
+      return (JSON.parse(e.payload) as { phase?: string }).phase === 'plan';
+    });
+    expect(specEvents).toHaveLength(1);
+    expect(planEvents).toHaveLength(1);
+  });
+});
+
+// ─── hasAlreadyRelayed — the guard in isolation, independent of any phase gate ──
+//
+// The tests above still pass today purely because maybeSignalPhaseComplete's
+// `managed.phase === 'speccing'/'planning'` checks skip the marker check
+// entirely once phase has moved on — the guard is never even reached. That
+// proves nothing about the guard itself. These tests call hasAlreadyRelayed
+// directly, with no phase gate in the picture at all, so they demonstrate the
+// predicate carries the weight on its own — exactly the shape it will be
+// relied on for once managed_tasks.phase is deleted.
+describe('hasAlreadyRelayed — guard predicate in isolation (no phase gate involved)', () => {
+  let db: Database.Database;
+  let worktreeDir: string;
+
+  beforeEach(() => {
+    db = createTestDb();
+    worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-refire-unit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
+  });
+
+  it("label 'spec': false until a spec phase_complete event exists, true after", () => {
+    // Deliberately NOT keyed on plan.json's existence. Between the spec relay
+    // and the worker actually writing plan.json there is a window — often many
+    // turns — where the file is absent. A file-existence guard reports "not yet
+    // relayed" for that whole window, which is precisely when the backstop
+    // fires, so it would re-relay exactly when it must not. The durable event
+    // row is written the instant the relay happens and never removed.
+    const taskId = 'task-guard-spec';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+
+    expect(hasAlreadyRelayed(taskId, 'spec')).toBe(false);
+
+    // plan.json appearing is NOT what makes the guard true.
+    fs.writeFileSync(path.join(worktreeDir, 'plan.json'), '{}');
+    expect(hasAlreadyRelayed(taskId, 'spec')).toBe(false);
+
+    appendEvent({
+      task_id: taskId,
+      type: 'task:phase_complete',
+      payload: JSON.stringify({ phase: 'spec' }),
+    });
+    expect(hasAlreadyRelayed(taskId, 'spec')).toBe(true);
+  });
+
+  it("label 'spec': a phase_complete event for a DIFFERENT label does not count", () => {
+    const taskId = 'task-guard-spec-other-label';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+
+    appendEvent({
+      task_id: taskId,
+      type: 'task:phase_complete',
+      payload: JSON.stringify({ phase: 'implement' }),
+    });
+    expect(hasAlreadyRelayed(taskId, 'spec')).toBe(false);
+  });
+
+  it("label 'plan': false with no approve-plan card, true once a PENDING card exists", () => {
+    const taskId = 'task-guard-plan-pending';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+    const convId = createConversation({ title: 'conv-guard-plan' });
+    upsertManagedTask({ conversation_id: convId, task_id: taskId, phase: 'awaiting_approval' });
+
+    expect(hasAlreadyRelayed(taskId, 'plan')).toBe(false);
+
+    createCard({
+      conversation_id: convId,
+      tool_use_id: 'relay-guard-1',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: taskId, plan_path: 'plan.json' }),
+    });
+    expect(hasAlreadyRelayed(taskId, 'plan')).toBe(true);
+  });
+
+  it("label 'plan': stays true after the card is RESOLVED (approved) — a decided card still proves the relay happened", () => {
+    const taskId = 'task-guard-plan-resolved';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+    const convId = createConversation({ title: 'conv-guard-plan-resolved' });
+    upsertManagedTask({ conversation_id: convId, task_id: taskId, phase: 'implementing' });
+
+    const cardId = createCard({
+      conversation_id: convId,
+      tool_use_id: 'relay-guard-2',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: taskId, plan_path: 'plan.json' }),
+    });
+    resolveCard(cardId, 'approved', null);
+
+    expect(hasAlreadyRelayed(taskId, 'plan')).toBe(true);
+  });
+
+  it("label 'plan': a card for a DIFFERENT task in the same conversation does not count", () => {
+    const taskId = 'task-guard-plan-scoped-a';
+    const otherTaskId = 'task-guard-plan-scoped-b';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+    insertTask(db, { id: otherTaskId, worktree: worktreeDir });
+    const convId = createConversation({ title: 'conv-guard-plan-scoped' });
+    upsertManagedTask({ conversation_id: convId, task_id: taskId, phase: 'planning' });
+    upsertManagedTask({
+      conversation_id: convId,
+      task_id: otherTaskId,
+      phase: 'awaiting_approval',
+    });
+
+    createCard({
+      conversation_id: convId,
+      tool_use_id: 'relay-guard-3',
+      tool_name: 'approve-plan',
+      input: JSON.stringify({ task_id: otherTaskId, plan_path: 'plan.json' }),
+    });
+
+    expect(hasAlreadyRelayed(taskId, 'plan')).toBe(false);
+    expect(hasAlreadyRelayed(otherTaskId, 'plan')).toBe(true);
+  });
+
+  it("label 'plan': false when the task has no owning conversation (unmanaged)", () => {
+    const taskId = 'task-guard-plan-unmanaged';
+    insertTask(db, { id: taskId, worktree: worktreeDir });
+    // No managed_tasks row → findConversationForTask returns null.
+    expect(hasAlreadyRelayed(taskId, 'plan')).toBe(false);
+  });
+});

--- a/server/repositories/orchestrator.ts
+++ b/server/repositories/orchestrator.ts
@@ -317,6 +317,34 @@ export function resolveCard(
     .run(status, result, id);
 }
 
+/**
+ * Check whether a card already exists for a given (task, tool_name) pair, in
+ * ANY status — a resolved card (approved/rejected/executed) still proves the
+ * relay already fired once, which is exactly what a re-fire guard needs.
+ *
+ * `action_cards` has no `task_id` column (a card belongs to a conversation,
+ * not a task directly), so this scopes by `conversation_id` (indexed, cheap)
+ * + `tool_name` (not indexed, but conversation-scoped) first, then parses each
+ * row's `input` JSON to match `task_id` exactly — a conversation can own
+ * several managed tasks, so conversation_id + tool_name alone isn't selective
+ * enough. Cost: one scan + JSON.parse per card this conversation has ever
+ * created with this tool_name — bounded by "number of managed tasks this
+ * conductor has ever relayed a plan for", i.e. small in practice.
+ */
+export function hasCardForTask(conversationId: string, taskId: string, toolName: string): boolean {
+  const rows = getDb()
+    .prepare(`SELECT input FROM action_cards WHERE conversation_id = ? AND tool_name = ?`)
+    .all(conversationId, toolName) as Array<{ input: string }>;
+  return rows.some((row) => {
+    try {
+      const parsed = JSON.parse(row.input) as { task_id?: unknown };
+      return parsed.task_id === taskId;
+    } catch {
+      return false;
+    }
+  });
+}
+
 // ─── managed_tasks ────────────────────────────────────────────────────────────
 
 export interface UpsertManagedTaskInput {
@@ -435,6 +463,32 @@ export function eventsSince(sinceSeq: number): StoredEvent[] {
   return getDb()
     .prepare(`SELECT * FROM events WHERE seq > ? ORDER BY seq ASC`)
     .all(sinceSeq) as StoredEvent[];
+}
+
+/**
+ * Check whether a `task:phase_complete` event carrying this phase LABEL
+ * (payload.phase — 'spec'/'plan'/'implement', not a managed_tasks.phase
+ * column value) has already been durably recorded for this task.
+ *
+ * Unlike `managed_tasks.phase` — a mutable "current stage" column that a
+ * later change may delete — `events` is an append-only log: once
+ * `advancePhaseForLabel` broadcasts a label, the row is permanent. So "an
+ * event for this label exists" is exact, durable proof the relay already ran
+ * once, independent of whatever the task's current stage says. Scoped by the
+ * `idx_events_task_id` index, so this is a small per-task scan, not a
+ * table scan.
+ */
+export function hasPhaseCompleteEvent(taskId: string, label: string): boolean {
+  const rows = getDb()
+    .prepare(`SELECT payload FROM events WHERE task_id = ? AND type = 'task:phase_complete'`)
+    .all(taskId) as Array<{ payload: string }>;
+  return rows.some((row) => {
+    try {
+      return (JSON.parse(row.payload) as { phase?: unknown }).phase === label;
+    } catch {
+      return false;
+    }
+  });
 }
 
 // ─── orchestrator_action_results (idempotency cache, SHR-163) ──────────────────


### PR DESCRIPTION
Groundwork for deleting `managed_tasks.phase`. Adds `hasAlreadyRelayed`, wired **alongside** the existing phase gates, so this changes no behaviour on its own.

## The bug it prevents

`spec.md` and `plan.json` are never deleted, so the Stop-hook backstop's phase checks are the only thing stopping it re-detecting them on every later Stop hook:

| Label | If it re-fires |
|---|---|
| `spec` | re-injects "write plan.json" into a live session mid-work |
| `plan` | mints a duplicate `approve-plan` card, no dedup key — a human can click it much later and re-trigger implementation |
| `implement` | safe already; its marker file is deleted on first success |

The guard keys on durable facts, not a stage enum: a spec `phase_complete` event row, or an existing `approve-plan` card for the task (any status — a resolved card still proves the relay happened).

**Deliberately not keyed on `plan.json` existing.** Between the spec relay and the worker writing `plan.json` there's a long window where the file is absent — exactly when the backstop fires. A file-existence guard would report "not yet relayed" precisely when it must not.

## Honest limit, found by mutation

This is **necessary but not sufficient** to delete the phase gates, and the code now says so.

Those gates do a second job nothing has replaced: they *select which branch applies*. Every branch ends in an unconditional `return`, so with the gates naively removed the spec branch matches first on every Stop hook and the plan branch is never reached. Simulating that makes the third-Stop-hook test fail with **zero** approve-plan cards rather than two — the plan relay would never fire at all.

The deletion step must also restructure `maybeSignalPhaseComplete` so each label is evaluated independently. Two comments claiming this guard "carries the weight alone" were wrong and are corrected.

3236 pass, `src` 1444 unchanged. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)