### PR TITLE
feat(centaur): ask_owner — route a question to the session's owner

### DIFF
--- a/packages/capabilities/src/capabilities/ask.ts
+++ b/packages/capabilities/src/capabilities/ask.ts
@@ -1,10 +1,10 @@
 /**
  * packages/capabilities/src/capabilities/ask.ts
  *
- * METADATA for the `human` noun's single capability: `human.ask`. Pure zod +
+ * METADATA for the `owner` noun's single capability: `owner.ask`. Pure zod +
  * plain types — no server internals, no handler.
  *
- * `human.ask` (MCP tool `ask_human`) lets an agent block on a free-text answer
+ * `owner.ask` (MCP tool `ask_owner`) lets an agent block on a free-text answer
  * from its session's owner, rather than only being gated when it tries to
  * WRITE something. It reuses the exact same card + poll machinery as the
  * write-capability gate (`server/orchestrator/mcp/gate.ts`'s
@@ -19,10 +19,9 @@
  * routing table, not a workaround for finding a person (see
  * `server/hooks.ts`'s `/gate-card` doc). The worker doesn't need to know who
  * or what is on the other end, only that it blocks until an answer comes
- * back — which today is still always a human, since resolving a card is only
- * wired up from the dashboard (no conductor-side MCP answer tool exists yet;
- * that's a separate capability for a later change, not a redesign of this
- * one).
+ * back. When a session has no owner at all (a standalone, non-orchestrator-
+ * managed task), the question is routed to a human via the global-monitor
+ * conversation instead — see `server/hooks.ts`'s `resolveGateCardConversationId`.
  *
  * `agent`/`worker`-only: a human/UI caller typing at a terminal or clicking in
  * the dashboard has no reason to invoke this — they already are the person
@@ -41,21 +40,21 @@
 import { z } from 'zod';
 import type { CapabilityMeta } from '../types.js';
 
-export const askHumanInputSchema = z.object({
+export const askOwnerInputSchema = z.object({
   question: z.string().describe("The question to ask your session's owner"),
 });
 
-export const HUMAN_CAPABILITY_META: CapabilityMeta[] = [
+export const OWNER_CAPABILITY_META: CapabilityMeta[] = [
   {
-    id: 'human.ask',
+    id: 'owner.ask',
     summary:
       "Ask a question and block until your session's owner answers — the human operator " +
       'you report to directly, or (for a worker task) the conductor supervising this task. ' +
       'Use when you are genuinely stuck or need a decision you cannot make yourself — not ' +
       'for routine writes (those already gate on approval via their own tier).',
-    mcp: 'ask_human',
+    mcp: 'ask_owner',
     tier: 'always-ask',
     callers: ['agent', 'worker'],
-    input: askHumanInputSchema,
+    input: askOwnerInputSchema,
   },
 ];

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -43,7 +43,7 @@ export type CallerClass =
    * `callers` list on each capability, not the tier, that keeps a worker off
    * `task.create`/`task.delete`/`task.move` while still letting it read
    * (`task.list`/`task.get`), close its own task (`task.close`), and block on
-   * a human (`human.ask`). Introduced so a worker can reach `ask_human`
+   * a human (`owner.ask`). Introduced so a worker can reach `ask_owner`
    * without widening what a worker can destroy — see
    * spec/surface-consolidation-and-centaur.md's centaur section.
    */

--- a/server/hooks.test.ts
+++ b/server/hooks.test.ts
@@ -19,8 +19,10 @@ import {
   eventsSince,
   createConversation,
   getCard,
+  listAllPendingCards,
+  setGlobalMonitor,
 } from './repositories/orchestrator.js';
-import { advancePhaseForLabel } from './hooks.js';
+import { advancePhaseForLabel, resolveGateCardConversationId } from './hooks.js';
 import { getArtifactSummary } from './artifact.js';
 
 describe('Hook endpoints', () => {
@@ -1123,7 +1125,7 @@ describe('POST /api/hooks/phase-complete with SHR-160 LABEL semantics', () => {
 
 // ─── POST /api/hooks/gate-card ────────────────────────────────────────────
 //
-// Part B of the worker-ask-human change: a worker's MCP subprocess never has
+// Part B of the worker-ask-owner change: a worker's MCP subprocess never has
 // OCTOMUX_CONVERSATION_ID (only the conductor does — see
 // orchestrator/mcp/write.ts's module doc), so it sends task_id instead and
 // this route must resolve the OWNING conversation via `managed_tasks`
@@ -1132,6 +1134,11 @@ describe('POST /api/hooks/phase-complete with SHR-160 LABEL semantics', () => {
 // supervising it), not a lookup for which human to interrupt — see the
 // route's own doc comment in hooks.ts. The conductor's existing
 // conversation_id-direct path must keep working unchanged.
+//
+// The routing table (resolveGateCardConversationId's three-branch order) is
+// the deliverable below: owner wins when one exists; the global-monitor
+// conversation is the fallback ONLY when there is no owner; and with neither,
+// the request fails closed instead of hanging or creating an orphaned card.
 describe('POST /api/hooks/gate-card', () => {
   let db: Database.Database;
   let app: ReturnType<typeof createApp>;
@@ -1167,17 +1174,24 @@ describe('POST /api/hooks/gate-card', () => {
     expect(getCard(res.body.result.card_id)!.conversation_id).toBe(convId);
   });
 
-  it('worker path: task_id alone resolves the conversation via managed_tasks (orchestrator-managed task)', async () => {
+  // ── Routing branch 1: OWNER wins ──────────────────────────────────────────
+
+  it('worker with a conductor: task_id resolves the OWNING conversation via managed_tasks (not the global monitor)', async () => {
     const convId = createConversation({ title: 'worker-owning-conv' });
     upsertManagedTask({ conversation_id: convId, task_id: 'task-gc' });
+    // A global monitor is ALSO configured, to prove owner takes precedence —
+    // if resolution ever preferred the monitor, or the owner lookup broke and
+    // fell through, this card would land there instead.
+    const monitorConvId = createConversation({ title: 'global-monitor-conv' });
+    setGlobalMonitor(monitorConvId);
 
     const res = await request(app)
       .post('/api/hooks/gate-card?token=tok-gc&task_id=task-gc')
       .send({
-        capability_id: 'human.ask',
+        capability_id: 'owner.ask',
         tier: 'always-ask',
         kind: 'question',
-        command: 'ask_human',
+        command: 'ask_owner',
         question: 'which approach?',
       })
       .expect(200);
@@ -1185,36 +1199,67 @@ describe('POST /api/hooks/gate-card', () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.result.card_id).toBeTruthy();
     // The resolved conversation is the one managed_tasks points at, not one
-    // the worker had to know or supply.
+    // the worker had to know or supply, and NOT the global monitor.
     expect(getCard(res.body.result.card_id)!.conversation_id).toBe(convId);
+    expect(getCard(res.body.result.card_id)!.conversation_id).not.toBe(monitorConvId);
   });
 
-  it('plain standalone task (no managed_tasks row): fails CLOSED with a clear, distinct error — never a hang, never a silent card-less 200', async () => {
-    // task-gc exists but has no managed_tasks row — not orchestrator-managed.
+  // ── Routing branch 2: no owner → the global monitor ───────────────────────
+
+  it('no owner + global monitor configured: card lands in the GLOBAL MONITOR conversation', async () => {
+    // task-gc exists but has no managed_tasks row — not orchestrator-managed,
+    // i.e. no owner.
+    const monitorConvId = createConversation({ title: 'global-monitor-conv' });
+    setGlobalMonitor(monitorConvId);
+
     const res = await request(app)
       .post('/api/hooks/gate-card?token=tok-gc&task_id=task-gc')
       .send({
-        capability_id: 'human.ask',
+        capability_id: 'owner.ask',
         tier: 'always-ask',
         kind: 'question',
-        command: 'ask_human',
+        command: 'ask_owner',
+        question: 'which approach?',
+      })
+      .expect(200);
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.result.card_id).toBeTruthy();
+    expect(getCard(res.body.result.card_id)!.conversation_id).toBe(monitorConvId);
+  });
+
+  // ── Routing branch 3: no owner, no monitor → fail closed ──────────────────
+
+  it('plain standalone task (no managed_tasks row) and no global monitor: fails CLOSED with a distinct error — never a hang, never an orphaned card', async () => {
+    // task-gc exists but has no managed_tasks row (no owner), and this test
+    // never calls setGlobalMonitor (no fallback human either).
+    const res = await request(app)
+      .post('/api/hooks/gate-card?token=tok-gc&task_id=task-gc')
+      .send({
+        capability_id: 'owner.ask',
+        tier: 'always-ask',
+        kind: 'question',
+        command: 'ask_owner',
         question: 'which approach?',
       })
       .expect(200); // hook endpoints report failure IN the body, not via HTTP status
 
     expect(res.body.ok).toBe(false);
     expect(res.body.error).toMatch(/no owner for this session/);
+    expect(res.body.error).toMatch(/no.*global-monitor/);
     expect(res.body.result).toBeUndefined();
+    // Never an orphaned card: nothing was written to action_cards.
+    expect(listAllPendingCards()).toEqual([]);
   });
 
-  it('neither conversation_id nor task_id: fails CLOSED with a clear error', async () => {
+  it('neither conversation_id nor task_id, no global monitor: fails CLOSED with a distinct error', async () => {
     const res = await request(app)
       .post('/api/hooks/gate-card?token=tok-gc')
       .send({
-        capability_id: 'human.ask',
+        capability_id: 'owner.ask',
         tier: 'always-ask',
         kind: 'question',
-        command: 'ask_human',
+        command: 'ask_owner',
         question: 'which approach?',
       })
       .expect(200);
@@ -1222,26 +1267,59 @@ describe('POST /api/hooks/gate-card', () => {
     expect(res.body.ok).toBe(false);
     expect(res.body.error).toBeTruthy();
     expect(res.body.result).toBeUndefined();
+    expect(listAllPendingCards()).toEqual([]);
+  });
+
+  // ── resolveGateCardConversationId directly (unit-level, no HTTP) ──────────
+
+  describe('resolveGateCardConversationId', () => {
+    it('owner beats a configured global monitor', () => {
+      // task-gc is inserted by this describe block's beforeEach — managed_tasks
+      // has a FK on task_id, so the owner lookup needs a real task row.
+      const convId = createConversation({ title: 'owner-conv' });
+      upsertManagedTask({ conversation_id: convId, task_id: 'task-gc' });
+      setGlobalMonitor(createConversation({ title: 'monitor-conv' }));
+
+      const result = resolveGateCardConversationId(undefined, 'task-gc');
+
+      expect(result).toEqual({ conversationId: convId });
+    });
+
+    it('falls back to the global monitor when there is no owner', () => {
+      const monitorConvId = createConversation({ title: 'monitor-conv' });
+      setGlobalMonitor(monitorConvId);
+
+      const result = resolveGateCardConversationId(undefined, 'task-unowned');
+
+      expect(result).toEqual({ conversationId: monitorConvId });
+    });
+
+    it('fails closed with a distinct error when there is neither an owner nor a global monitor', () => {
+      const result = resolveGateCardConversationId(undefined, 'task-unowned');
+
+      expect('error' in result).toBe(true);
+      expect((result as { error: string }).error).toMatch(/no owner for this session/);
+    });
   });
 
   it('returns 401 when hook_token is missing or unrecognized', async () => {
     await request(app)
       .post('/api/hooks/gate-card?task_id=task-gc')
       .send({
-        capability_id: 'human.ask',
+        capability_id: 'owner.ask',
         tier: 'always-ask',
         kind: 'question',
-        command: 'ask_human',
+        command: 'ask_owner',
       })
       .expect(401);
 
     await request(app)
       .post('/api/hooks/gate-card?token=bad-token&task_id=task-gc')
       .send({
-        capability_id: 'human.ask',
+        capability_id: 'owner.ask',
         tier: 'always-ask',
         kind: 'question',
-        command: 'ask_human',
+        command: 'ask_owner',
       })
       .expect(401);
   });

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -19,6 +19,7 @@ import { pushToConversation } from './orchestrator/stream.js';
 import {
   createCard,
   findConversationForTask,
+  getGlobalMonitorConversation,
   hasCardForTask,
   hasPhaseCompleteEvent,
 } from './repositories/orchestrator.js';
@@ -803,6 +804,55 @@ router.post('/orchestrator-action', requireHookToken, (req: Request, res: Respon
     });
 });
 
+/**
+ * Resolve which conversation a `/gate-card` request's question or approval
+ * lands in. The ONE place this decision is made — the route handler below is
+ * the only caller — so "where does this go" can never be answered
+ * differently in two places later.
+ *
+ * Resolution order:
+ *   1. OWNER. The conductor sends `conversation_id` directly (it always has
+ *      OCTOMUX_CONVERSATION_ID) — that IS its owner, no lookup needed. A
+ *      worker session never has that env var (write.ts's module doc) but
+ *      sends `task_id` instead, resolved via `managed_tasks`
+ *      (findConversationForTask): a worker's owner is the conductor
+ *      supervising it, and the card lands in that conductor's conversation by
+ *      design, exactly like a conductor-originated card would.
+ *   2. NO owner (a plain, non-orchestrator-managed task, or no identifying
+ *      param at all) → route to a human via the global-monitor conversation
+ *      (getGlobalMonitorConversation, §6/SHR-136 — the same conversation the
+ *      supervisor already falls back to for unowned task events, see
+ *      orchestrator/supervisor.ts's processEvent).
+ *   3. no owner AND no global-monitor configured → FAIL CLOSED with a
+ *      distinct, readable error rather than creating an orphaned card or
+ *      hanging. `action_cards.conversation_id` is `NOT NULL REFERENCES
+ *      orchestrator_conversations(id)`, so there is nowhere to put the row
+ *      even if we wanted to.
+ */
+export function resolveGateCardConversationId(
+  queryConversationId: string | undefined,
+  taskId: string | undefined,
+): { conversationId: string } | { error: string } {
+  const owner = queryConversationId ?? (taskId ? findConversationForTask(taskId) : null);
+  if (owner) return { conversationId: owner };
+
+  const monitor = getGlobalMonitorConversation();
+  if (monitor) return { conversationId: monitor };
+
+  if (taskId) {
+    return {
+      error:
+        `no owner for this session — task '${taskId}' is not orchestrator-managed, and no ` +
+        'global-monitor conversation is configured to route this question to a human',
+    };
+  }
+  return {
+    error:
+      'no owner for this session — no conversation_id or resolvable task_id was given, and no ' +
+      'global-monitor conversation is configured to route this question to a human',
+  };
+}
+
 // POST /api/hooks/gate-card
 // The conductor's (or a worker's) MCP subprocess RPCs here to create a pending
 // action_cards row for a gated (ask/always-ask) CAPABILITY call and push it to
@@ -816,33 +866,17 @@ router.post('/orchestrator-action', requireHookToken, (req: Request, res: Respon
 // Query: ?token=<hook_token>&conversation_id=<conv_id>&task_id=<task_id>
 // Body:  { capability_id, tier, kind, command, args?, question? }
 //
-// conversation_id resolution: the conductor sends conversation_id directly
-// (it always has OCTOMUX_CONVERSATION_ID) — that IS its owner. A worker
-// session never has that env var (write.ts's module doc) but sends task_id
-// instead — resolved here via `managed_tasks` (findConversationForTask)
-// rather than threading a new env var into every worker session.
-// `managed_tasks` (task → conversation) is not a lookup for "which human do
-// we bother" — it IS the routing: a worker's owner is the conductor
-// supervising it, and the card lands in that conductor's conversation by
-// design, exactly like a conductor-originated card would. (Today that still
-// resolves to a human via the dashboard either way — there is no
-// conductor-side MCP tool to answer a card yet, a separate capability for a
-// later change.) This only resolves for an ORCHESTRATOR-MANAGED task (it has
-// a `managed_tasks` row by construction, i.e. it HAS an owner). A plain
-// standalone task has no owning conversation at all — `action_cards.
-// conversation_id` is `NOT NULL REFERENCES orchestrator_conversations(id)`,
-// so there is nowhere to put the row even if we wanted to. FAIL CLOSED:
-// respond with a clear, distinct error rather than creating an orphaned card
-// or hanging. (In practice this worker MCP server is only ever wired up for
+// conversation_id resolution is `resolveGateCardConversationId` above — see
+// its doc for the full owner → global-monitor → fail-closed order. (In
+// practice this worker MCP server is only ever wired up for
 // orchestrator-managed tasks — see task-engine/launch.ts's
 // `applyOrchestratorMcpConfig` — so a resolvable task_id is expected on every
-// real call; this guard is what turns a future wiring change or a stray
-// manual call into a clear error instead of a silent gap or a hang.)
+// real worker call; the fail-closed branch is what turns a future wiring
+// change or a stray manual call into a clear error instead of a silent gap
+// or a hang.)
 router.post('/gate-card', requireHookToken, (req: Request, res: Response) => {
   const queryConversationId = ((req.query.conversation_id ?? '') as string) || undefined;
   const taskId = ((req.query.task_id ?? '') as string) || undefined;
-  const conversationId =
-    queryConversationId ?? (taskId ? findConversationForTask(taskId) : null) ?? undefined;
   const { capability_id, tier, kind, command, args, question } = req.body as {
     capability_id?: string;
     tier?: 'ask' | 'always-ask';
@@ -852,15 +886,13 @@ router.post('/gate-card', requireHookToken, (req: Request, res: Response) => {
     question?: string;
   };
 
-  if (!conversationId) {
-    res.status(200).json({
-      ok: false,
-      error: taskId
-        ? `no owner for this session — task '${taskId}' is not orchestrator-managed (no conversation to route the card to)`
-        : 'conversation_id (or a resolvable task_id) is required to create a gate card',
-    });
+  const resolved = resolveGateCardConversationId(queryConversationId, taskId);
+  if ('error' in resolved) {
+    res.status(200).json({ ok: false, error: resolved.error });
     return;
   }
+  const conversationId = resolved.conversationId;
+
   if (!capability_id || !tier || !kind || !command) {
     res
       .status(200)

--- a/server/orchestrator/gate.test.ts
+++ b/server/orchestrator/gate.test.ts
@@ -883,7 +883,7 @@ describe('gate.executeCard — capability-registry gate cards', () => {
 
   it("a question card's answer (approve + respond_text) is persisted on the card result", async () => {
     const cardId = insertCapabilityCard({
-      capabilityId: 'human.ask',
+      capabilityId: 'owner.ask',
       tier: 'always-ask',
       kind: 'question',
       question: 'Which repo?',

--- a/server/orchestrator/gate.ts
+++ b/server/orchestrator/gate.ts
@@ -276,7 +276,7 @@ export async function executeCard(input: ExecuteCardInput): Promise<void> {
   }
 
   // ── Capability-registry gate card: task.close/create/move/... (`ask`/
-  //    `always-ask` tier) or an ask_human question card. Created by
+  //    `always-ask` tier) or an ask_owner question card. Created by
   //    onGatedInvoke (mcp/gate.ts) via POST /api/hooks/gate-card. Unlike the
   //    Bash-gate cards below, NOTHING runs server-side here — the MCP
   //    subprocess itself is blocked in a poll loop waiting for this card's

--- a/server/orchestrator/mcp/gate.test.ts
+++ b/server/orchestrator/mcp/gate.test.ts
@@ -96,13 +96,13 @@ describe('onGatedInvoke', () => {
     expect(result).toBeUndefined();
   });
 
-  it('approve on ask_human short-circuits with the answer — cap.handler never needed', async () => {
+  it('approve on ask_owner short-circuits with the answer — cap.handler never needed', async () => {
     mockCallGateCard.mockImplementation(async () => {
-      const cardId = seedCard('human.ask', 'always-ask', 'question');
+      const cardId = seedCard('owner.ask', 'always-ask', 'question');
       resolveCard(cardId, 'approved', JSON.stringify({ answer: 'do it' }));
       return { card_id: cardId };
     });
-    const askCap = makeCap({ id: 'human.ask', mcp: 'ask_human' });
+    const askCap = makeCap({ id: 'owner.ask', mcp: 'ask_owner' });
 
     const result = await onGatedInvoke(askCap, 'always-ask', { question: 'proceed?' });
 

--- a/server/orchestrator/mcp/gate.ts
+++ b/server/orchestrator/mcp/gate.ts
@@ -17,7 +17,7 @@
  * FAIL CLOSED — the whole point of this module. Three distinct outcomes, and
  * `cap.handler` runs in exactly one of them:
  *   1. card created, human approves  → resolves (undefined, or {answer} for
- *      ask_human) → the caller (registerOne in projections/mcp.ts) proceeds.
+ *      ask_owner) → the caller (registerOne in projections/mcp.ts) proceeds.
  *   2. card created, human rejects, OR the wait times out → THROWS. Rejection
  *      and timeout get distinct messages (never conflated — a caller reading
  *      the error can tell "no" from "nobody answered").
@@ -100,7 +100,7 @@ function isPromoted(capabilityId: string): boolean {
 /**
  * Resolve a task id from a capability's input, if the shape has one
  * (task.start/move use `id`, task.close uses `task_id`; task.create and
- * human.ask have neither). Best-effort only — used purely to flip a worker's
+ * owner.ask have neither). Best-effort only — used purely to flip a worker's
  * hook_activity so the monitor grid shows "blocked on human"; never affects
  * the gate decision.
  */
@@ -219,7 +219,7 @@ export async function onGatedInvoke(
     return undefined;
   }
 
-  const isQuestion = cap.mcp === 'ask_human';
+  const isQuestion = cap.mcp === 'ask_owner';
   const questionText = isQuestion
     ? (input as { question?: string } | undefined)?.question
     : undefined;

--- a/server/orchestrator/mcp/server.test.ts
+++ b/server/orchestrator/mcp/server.test.ts
@@ -154,11 +154,11 @@ describe('createOctomuxMcpServer — tool registration', () => {
     // prompts literally instruct it to run `octomux close-task <id>`. This is
     // the same power by a second route, not a new one.
     expect(tools).toContain('close_task');
-    // NEW: a worker can now block on a human via ask_human (always-ask tier,
-    // but included in human.ask's `callers` — see packages/capabilities/src/
+    // NEW: a worker can now block on a human via ask_owner (always-ask tier,
+    // but included in owner.ask's `callers` — see packages/capabilities/src/
     // capabilities/ask.ts). This is the capability this test file exists to
     // guard the boundary of.
-    expect(tools).toContain('ask_human');
+    expect(tools).toContain('ask_owner');
     expect(tools).not.toContain('create_task');
     expect(tools).not.toContain('send_message');
     expect(tools).not.toContain('set_task_status');
@@ -277,10 +277,10 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
   });
 });
 
-// ─── Worker can ask_human but cannot create/delete/move a task ──────────────
+// ─── Worker can ask_owner but cannot create/delete/move a task ──────────────
 //
 // The property the whole change exists to prove: a worker session (caller
-// class 'worker', not 'agent') gets ask_human — including the SAME
+// class 'worker', not 'agent') gets ask_owner — including the SAME
 // onGatedInvoke blocking behaviour the conductor's write tools get — while
 // still being denied create_task/delete_task/set_task_status outright. Denied
 // means "never registered as a tool at all" (registerCapabilityTools skips
@@ -288,7 +288,7 @@ describe('createOctomuxMcpServer — onGatedInvoke wiring', () => {
 // this asserts directly by checking the tool is undefined, not merely absent
 // from a name list (belt-and-suspenders against the earlier list-based checks
 // being weakened independently of this one).
-describe('createOctomuxMcpServer — worker ask_human vs. destructive tools', () => {
+describe('createOctomuxMcpServer — worker ask_owner vs. destructive tools', () => {
   const savedEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
@@ -314,7 +314,7 @@ describe('createOctomuxMcpServer — worker ask_human vs. destructive tools', ()
     vi.unstubAllGlobals();
   });
 
-  it('a worker session gets ask_human, and it hits onGatedInvoke (blocks) instead of the no-op handler', async () => {
+  it('a worker session gets ask_owner, and it hits onGatedInvoke (blocks) instead of the no-op handler', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockRejectedValue(new Error('ECONNREFUSED (no server listening in this test)')),
@@ -325,7 +325,7 @@ describe('createOctomuxMcpServer — worker ask_human vs. destructive tools', ()
     const priv = server as unknown as {
       _registeredTools: Record<string, { handler: (input: unknown, extra: unknown) => unknown }>;
     };
-    const tool = priv._registeredTools['ask_human'];
+    const tool = priv._registeredTools['ask_owner'];
     expect(tool).toBeDefined();
 
     const result = (await tool.handler({ question: 'which approach?' }, {})) as {
@@ -334,7 +334,7 @@ describe('createOctomuxMcpServer — worker ask_human vs. destructive tools', ()
     };
 
     // Card creation is attempted (proving the gate ran, not the no-op
-    // registry/capabilities/human.ts handler, which would have returned
+    // registry/capabilities/owner.ts handler, which would have returned
     // {answer: null, note: '...gating is disabled...'} instead of an isError).
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/could not create an approval card/);

--- a/server/orchestrator/mcp/server.ts
+++ b/server/orchestrator/mcp/server.ts
@@ -281,11 +281,11 @@ export function createOctomuxMcpServer(): McpServer {
   );
 
   // ── Capability-registry tools (list_tasks/get_task/create_task/set_task_status/
-  //    close_task/delete_task/ask_human) ─────────────────────────────────────
+  //    close_task/delete_task/ask_owner) ─────────────────────────────────────
   // Registered for BOTH an orchestrator-started (conductor) session and a
   // worker session, but under different caller classes — that is what keeps a
   // worker off task.create/task.move/task.delete while still letting it reach
-  // ask_human (the whole point of this call site's rework).
+  // ask_owner (the whole point of this call site's rework).
   //
   // Caller class: 'agent' for the conductor, 'worker' for a task session.
   // OCTOMUX_TASK_ID is the same signal orchestratorWriteEnabled() /
@@ -294,12 +294,12 @@ export function createOctomuxMcpServer(): McpServer {
   // the split exists: both are autonomous — `authorize()` gates 'worker'
   // exactly like 'agent' — but they have different REACH, and `callers` on
   // each capability (not a tool-name allowlist) is what encodes that reach.
-  // task.list/task.get/task.close/human.ask list 'worker'; task.create/
+  // task.list/task.get/task.close/owner.ask list 'worker'; task.create/
   // task.start/task.move/task.delete do not, so `authorize()` denies those to
   // a worker outright — not registered at all, never registered-then-rejected.
   //
   // No `tiers` filter for the worker branch: `callers` already does the
-  // restricting, and a tier filter would exclude human.ask (always-ask) right
+  // restricting, and a tier filter would exclude owner.ask (always-ask) right
   // alongside the destructive tools it exists to keep out — for a worker, tier
   // and "who may even attempt this" are now orthogonal questions. The
   // conductor branch keeps its tier filter unchanged: a bare MCP session with
@@ -310,11 +310,11 @@ export function createOctomuxMcpServer(): McpServer {
   // and task.close/delete (always-ask) actually block on a human instead of
   // running immediately like the old COMMANDS write loop did (see actions.ts's
   // docblock) — see server/orchestrator/mcp/gate.ts's module doc for the
-  // fail-closed contract. `human.ask` (ask_human) is gated the same way; its
+  // fail-closed contract. `owner.ask` (ask_owner) is gated the same way; its
   // handler never runs for real (onGatedInvoke short-circuits with the human's
   // answer) unless the kill switch is off. This is also what makes a worker's
-  // ask_human call actually BLOCK rather than fall through to the no-op
-  // handler in registry/capabilities/human.ts.
+  // ask_owner call actually BLOCK rather than fall through to the no-op
+  // handler in registry/capabilities/owner.ts.
   const isWorkerSession = Boolean(process.env.OCTOMUX_TASK_ID);
   registerCapabilityMcpTools(server, isWorkerSession ? 'worker' : 'agent', {
     tiers: isWorkerSession || orchestratorWriteEnabled() ? undefined : ['auto'],

--- a/server/orchestrator/mcp/write.ts
+++ b/server/orchestrator/mcp/write.ts
@@ -132,7 +132,7 @@ export async function callOrchestratorAction(
 // ─── Gate card RPC (capability registry ask/always-ask gate) ────────────────
 
 export interface CreateGateCardInput {
-  /** Capability id, e.g. 'task.close' or 'human.ask'. */
+  /** Capability id, e.g. 'task.close' or 'owner.ask'. */
   capabilityId: string;
   tier: 'ask' | 'always-ask';
   /** 'action' → approve/reject an implied write. 'question' → free-text answer. */

--- a/server/orchestrator/stream.ts
+++ b/server/orchestrator/stream.ts
@@ -69,9 +69,9 @@ export interface WsCardEvent {
    * the "always allow" toggle for `always-ask` cards.
    */
   tier?: 'ask' | 'always-ask';
-  /** 'action' (default) → approve/reject an implied write. 'question' → free-text answer (ask_human). */
+  /** 'action' (default) → approve/reject an implied write. 'question' → free-text answer (ask_owner). */
   kind?: 'action' | 'question';
-  /** The question text, present only when kind === 'question'. */
+  /** The question text, present only when kind === 'question' (ask_owner). */
   question?: string;
 }
 

--- a/server/registry/capabilities/owner.ts
+++ b/server/registry/capabilities/owner.ts
@@ -1,12 +1,12 @@
 /**
- * server/registry/capabilities/human.ts
+ * server/registry/capabilities/owner.ts
  *
- * Handler for `human.ask` (MCP tool `ask_human`). Pairs
- * `HUMAN_CAPABILITY_META` (packages/capabilities/src/capabilities/ask.ts)
+ * Handler for `owner.ask` (MCP tool `ask_owner`). Pairs
+ * `OWNER_CAPABILITY_META` (packages/capabilities/src/capabilities/ask.ts)
  * with its server-only handler, mirroring `registerTaskCapabilities` /
  * `registerLearningCapabilities`.
  *
- * `human.ask` is `always-ask` tier, so on every real call
+ * `owner.ask` is `always-ask` tier, so on every real call
  * `registerCapabilityTools` (server/registry/projections/mcp.ts) runs
  * `onGatedInvoke` (server/orchestrator/mcp/gate.ts) BEFORE this handler —
  * and `onGatedInvoke` resolves with `{ answer }` for this capability, which
@@ -19,18 +19,18 @@
  * throwing.
  */
 
-import { HUMAN_CAPABILITY_META, askHumanInputSchema } from '@octomux/capabilities';
+import { OWNER_CAPABILITY_META, askOwnerInputSchema } from '@octomux/capabilities';
 import type { CapabilityMeta } from '@octomux/capabilities';
 import { z } from 'zod';
 import { defineCapability } from '../index.js';
 
 function findMeta<TInput>(id: string, _schema: z.ZodType<TInput>): CapabilityMeta<TInput> {
-  const meta = HUMAN_CAPABILITY_META.find((m) => m.id === id);
+  const meta = OWNER_CAPABILITY_META.find((m) => m.id === id);
   if (!meta) throw new Error(`registry: missing capability metadata for '${id}'`);
   return meta as CapabilityMeta<TInput>;
 }
 
-async function askHumanHandler(_input: z.infer<typeof askHumanInputSchema>) {
+async function askOwnerHandler(_input: z.infer<typeof askOwnerInputSchema>) {
   // Reached only when the capability gate kill switch is off — see module doc.
   return {
     answer: null,
@@ -40,9 +40,9 @@ async function askHumanHandler(_input: z.infer<typeof askHumanInputSchema>) {
   };
 }
 
-export function registerHumanCapabilities(): void {
+export function registerOwnerCapabilities(): void {
   defineCapability({
-    ...findMeta('human.ask', askHumanInputSchema),
-    handler: askHumanHandler,
+    ...findMeta('owner.ask', askOwnerInputSchema),
+    handler: askOwnerHandler,
   });
 }

--- a/server/registry/mount.ts
+++ b/server/registry/mount.ts
@@ -24,7 +24,7 @@ import { registerCapabilityCommands } from '@octomux/capabilities';
 import { registerTaskCapabilities } from './capabilities/task.js';
 import { registerLearningCapabilities } from './capabilities/learning.js';
 import { registerRunCapabilities } from './capabilities/run.js';
-import { registerHumanCapabilities } from './capabilities/human.js';
+import { registerOwnerCapabilities } from './capabilities/owner.js';
 import { registerRouteExemptions } from './exemptions.js';
 
 const logger = childLogger('registry/mount');
@@ -52,7 +52,7 @@ export function installCapabilities(): void {
   registerTaskCapabilities();
   registerLearningCapabilities();
   registerRunCapabilities();
-  registerHumanCapabilities();
+  registerOwnerCapabilities();
   registerRouteExemptions();
 
   logger.debug(

--- a/server/registry/projections/mcp.test.ts
+++ b/server/registry/projections/mcp.test.ts
@@ -60,7 +60,7 @@ describe('registerCapabilityTools', () => {
     ['ui excluded from an agent-only capability', ['agent'], 'ui', false],
     // 'worker' (task sessions) is its own class, distinct from 'agent' (the
     // conductor) — a capability must opt a worker in explicitly.
-    ['worker included on human.ask-shaped capability', ['agent', 'worker'], 'worker', true],
+    ['worker included on owner.ask-shaped capability', ['agent', 'worker'], 'worker', true],
     [
       'worker excluded from an agent-only capability (e.g. task.create)',
       ['ui', 'human', 'agent'],

--- a/server/registry/projections/mcp.ts
+++ b/server/registry/projections/mcp.ts
@@ -50,7 +50,7 @@ export interface RegisterCapabilityToolsOptions {
    *                        write-approval case — task.close et al. — where
    *                        the human's job was only to say yes).
    *  - resolves any other value → that value IS the tool result; `cap.handler`
-   *                        is never called (the `ask_human` case — the
+   *                        is never called (the `ask_owner` case — the
    *                        human's ANSWER is the result, not a side effect
    *                        `cap.handler` would separately produce).
    */
@@ -134,7 +134,7 @@ function registerOne(
         if (invocationTier !== 'auto' && opts.onGatedInvoke) {
           const gated = await opts.onGatedInvoke(cap, invocationTier, input);
           // undefined → proceed to the real handler; anything else IS the
-          // result (ask_human's answer) and short-circuits cap.handler — see
+          // result (ask_owner's answer) and short-circuits cap.handler — see
           // the onGatedInvoke doc above.
           result = gated !== undefined ? gated : await cap.handler(input, ctx);
         } else {

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -42,7 +42,7 @@ export interface OctomuxSettings {
   /**
    * KILL SWITCH for the capability registry's ask/always-ask gate
    * (server/orchestrator/mcp/gate.ts). When false, every `ask`/`always-ask`
-   * MCP capability call (task.create/start/move/close/delete, ask_human) runs
+   * MCP capability call (task.create/start/move/close/delete, ask_owner) runs
    * immediately with no card and no human decision — same as before this gate
    * existed. Overridden by OCTOMUX_CAPABILITY_GATE_ENABLED. Default true
    * (gating ON) when absent.

--- a/src/components/orchestrator/QuestionCard.test.tsx
+++ b/src/components/orchestrator/QuestionCard.test.tsx
@@ -1,7 +1,7 @@
 /**
  * src/components/orchestrator/QuestionCard.test.tsx
  *
- * Tests for QuestionCard — the `ask_human` question-shaped card:
+ * Tests for QuestionCard — the `ask_owner` question-shaped card:
  *  - Renders the question text.
  *  - Submitting an answer sends { decision:'approve', text: <answer> }
  *    (forwarded by OrchestratorPage as respond_text — see its handleCardDecision).

--- a/src/components/orchestrator/QuestionCard.tsx
+++ b/src/components/orchestrator/QuestionCard.tsx
@@ -1,7 +1,7 @@
 /**
  * src/components/orchestrator/QuestionCard.tsx
  *
- * Question-shaped card for the `ask_human` capability — the agent is blocked
+ * Question-shaped card for the `ask_owner` capability — the agent is blocked
  * on a free-text ANSWER, not approve/reject of an implied write. Sibling to
  * ActionCard (src/components/orchestrator/ActionCard.tsx), not a variant of
  * it: no arg fields, no "always allow" toggle (always-ask is never

--- a/src/components/orchestrator/types.ts
+++ b/src/components/orchestrator/types.ts
@@ -53,7 +53,7 @@ export interface ToolCallItem {
 }
 
 /**
- * A question card for the `ask_human` capability — the agent is blocked
+ * A question card for the `ask_owner` capability — the agent is blocked
  * waiting for a free-text answer, not a write to approve/reject. Rendered by
  * QuestionCard; sibling to ActionCard rather than a variant of it (no arg
  * fields, no always-allow toggle — always-ask is never promotable).

--- a/src/lib/orchestrator-api.ts
+++ b/src/lib/orchestrator-api.ts
@@ -67,7 +67,7 @@ export type WsIncomingEvent =
       args: Record<string, unknown>;
       /** Gate tier — drives the alwaysAsk badge / hides "always allow". */
       tier?: 'ask' | 'always-ask';
-      /** 'action' (default) → approve/reject. 'question' → free-text answer (ask_human). */
+      /** 'action' (default) → approve/reject. 'question' → free-text answer (ask_owner). */
       kind?: 'action' | 'question';
       /** The question text, present only when kind === 'question'. */
       question?: string;

--- a/src/pages/OrchestratorPage.test.tsx
+++ b/src/pages/OrchestratorPage.test.tsx
@@ -327,7 +327,7 @@ describe('OrchestratorPage', () => {
     expect(screen.getByText('First message')).toBeInTheDocument();
   });
 
-  // ── Capability-gate cards (task.close/create/... + ask_human) ────────────
+  // ── Capability-gate cards (task.close/create/... + ask_owner) ────────────
 
   it('renders a question card for a kind:"question" card event and forwards the answer as respond_text', async () => {
     renderWithRouter(<OrchestratorPage />, { route: '/orchestrator' });
@@ -341,7 +341,7 @@ describe('OrchestratorPage', () => {
       lastWs?.simulateMessage({
         type: 'card',
         id: 'card-q-1',
-        command: 'ask_human',
+        command: 'ask_owner',
         args: {},
         tier: 'always-ask',
         kind: 'question',


### PR DESCRIPTION
Renames `ask_human` → `ask_owner` (capability `human.ask` → `owner.ask`) and makes the routing match the name. No back-compat alias — the tool is a day old and nothing external depends on it.

## Why the rename matters

The old name lied to the model. A worker's question doesn't go to a person, it goes to the **conductor supervising it**; the human is the top of that chain, not the first stop. An agent told the tool is `ask_human` phrases its question for a person — wrong audience.

## One resolution function, one call site

So "where does this go" can't acquire a second answer later:

| Order | Destination |
|---|---|
| 1 | **owner** — the conductor, via `managed_tasks` for a worker, or the `conversation_id` a conductor supplies for itself |
| 2 | **global-monitor conversation** — the same row the supervisor already falls back to for unowned task events, so this is precedent, not a new concept |
| 3 | **fail closed** — distinct error, no card, no hang |

No `action_cards` schema change: `conversation_id` stays `NOT NULL`, and the global-monitor conversation is a real row that satisfies it.

## Both branches mutation-tested independently

| Mutation | Result |
|---|---|
| owner lookup disabled | 3 owner-path tests fail; monitor fallback still passes |
| monitor fallback disabled | 2 monitor tests fail; owner tests still pass |

The routing genuinely branches — neither path is covering for the other.

**Known:** `spec/surface-consolidation-and-centaur.md` still says `ask_human` in three places. Left as the historical design document it is.

3246 pass (baseline 3236 + 10 routing tests), `src` 1444 unchanged. `tsc -b` and `cd cli && tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)