### PR TITLE
fix(poller): nudge auto-review agents stalled by mid-stream API errors

### DIFF
--- a/server/poller/index.ts
+++ b/server/poller/index.ts
@@ -11,6 +11,7 @@ import {
   SCHEDULE_INTERVAL,
   TRIAGE_PR_COMMENTS_INTERVAL,
   QUIESCENCE_INTERVAL,
+  REVIEW_STALL_INTERVAL,
 } from './intervals.js';
 import { pollMergedPRs } from './merged-pr.js';
 import { pollPRsAndReviewers } from './pr-and-reviewers.js';
@@ -20,6 +21,7 @@ import { pollStatuses } from './status.js';
 import { pollTriagePrComments } from './triage-pr-comments.js';
 import { pollWalkthroughHandoffs } from './walkthrough-handoff.js';
 import { pollQuiescence } from './quiescence.js';
+import { pollReviewStalls } from './review-stall.js';
 
 const logger = childLogger('poller');
 
@@ -37,6 +39,7 @@ export function startPolling(): void {
     createPoller(pollWalkthroughHandoffs, HANDOFF_INTERVAL),
     createPoller(pollSchedules, SCHEDULE_INTERVAL),
     createPoller(pollTriagePrComments, TRIAGE_PR_COMMENTS_INTERVAL),
+    createPoller(pollReviewStalls, REVIEW_STALL_INTERVAL),
     createPoller(async () => {
       try {
         const { sweepExpiredApprovalCards } = await import('../orchestrator/approval-timeout.js');
@@ -76,3 +79,4 @@ export { pollSchedules } from './schedule-cron.js';
 export { checkTriagePrComments, pollTriagePrComments } from './triage-pr-comments.js';
 export { repoNameWithOwner, parseNameWithOwner } from './github-repo.js';
 export { pollQuiescence } from './quiescence.js';
+export { pollReviewStalls } from './review-stall.js';

--- a/server/poller/intervals.ts
+++ b/server/poller/intervals.ts
@@ -12,3 +12,9 @@ export const APPROVAL_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;
 export const SCHEDULE_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;
 /** Feed prod-log-triage PR review comments into the loop playbook. */
 export const TRIAGE_PR_COMMENTS_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;
+/** Nudge auto-review agents whose turn died mid-stream (no Stop hook fires). */
+export const REVIEW_STALL_INTERVAL = process.env.NODE_ENV === 'test' ? 0 : 60000;
+// 15 min: must exceed the longest observed tool-free synthesis turn (~13 min);
+// the pane in-flight check is the real guard, this just bounds sweep frequency.
+export const REVIEW_STALL_AFTER_MS = 15 * 60 * 1000;
+export const REVIEW_STALL_MAX_NUDGES = 3;

--- a/server/poller/review-stall.test.ts
+++ b/server/poller/review-stall.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from '../bun-test.js';
+import type Database from '../sqlite.js';
+
+const execTmuxMock = vi.fn();
+vi.mock('../tmux-bin.js', () => ({
+  execTmux: execTmuxMock,
+}));
+
+const { createTestDb, insertTask, insertAgent, insertPermissionPrompt } = await import(
+  '../test-helpers.js'
+);
+const { pollReviewStalls } = await import('./review-stall.js');
+
+function setWorkerActivity(db: Database, agentId: string, activity: string, updatedAtExpr: string) {
+  db.prepare(
+    `UPDATE workers SET hook_activity = ?, hook_activity_updated_at = ${updatedAtExpr} WHERE id = ?`,
+  ).run(activity, agentId);
+}
+
+function insertStalledReviewTask(db: Database, id: string, overrides: Record<string, unknown> = {}) {
+  insertTask(db, {
+    id,
+    runtime_state: 'running',
+    workflow_status: 'in_progress',
+    tmux_session: `octomux-agent-${id}`,
+    source: 'auto_review',
+    ...overrides,
+  } as never);
+  insertAgent(db, {
+    id: `agent-${id}`,
+    task_id: id,
+    status: 'running',
+    hook_token: `tok-${id}`,
+  } as never);
+  // Stale 'active' — the mid-stream-death shape (Stop hook never fired).
+  setWorkerActivity(db, `agent-${id}`, 'active', `datetime('now', '-1200 seconds')`);
+}
+
+function insertStallNudgeNote(db: Database, taskId: string, n: number, createdAtExpr: string) {
+  for (let i = 0; i < n; i++) {
+    db.prepare(
+      `INSERT INTO task_updates (id, task_id, kind, body, created_at)
+       VALUES (?, ?, 'note', 'auto: stall nudge', ${createdAtExpr})`,
+    ).run(`nudge-${taskId}-${i}`, taskId);
+  }
+}
+
+function countStallNudges(db: Database, taskId: string): number {
+  return (
+    db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM task_updates
+          WHERE task_id = ? AND kind = 'note' AND body = 'auto: stall nudge'`,
+      )
+      .get(taskId) as { n: number }
+  ).n;
+}
+
+function sendKeysCalls(): string[][] {
+  return execTmuxMock.mock.calls
+    .map((c: unknown[]) => c[0] as string[])
+    .filter((args) => args[0] === 'send-keys');
+}
+
+describe('pollReviewStalls', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    execTmuxMock.mockReset();
+    // Default pane: idle prompt, no in-flight marker.
+    execTmuxMock.mockResolvedValue({ stdout: '❯\n⏵⏵ bypass permissions on', stderr: '' });
+  });
+
+  it('nudges a stale-active auto-review task and records the note', async () => {
+    insertStalledReviewTask(db, 'task-s1');
+
+    await pollReviewStalls();
+
+    const sends = sendKeysCalls();
+    expect(sends.length).toBe(2); // message + Enter
+    expect(sends[0]).toContain('-l');
+    expect(String(sends[0].at(-1))).toContain('close-task task-s1');
+    expect(countStallNudges(db, 'task-s1')).toBe(1);
+  });
+
+  it('skips when the pane shows an in-flight turn (esc to interrupt)', async () => {
+    insertStalledReviewTask(db, 'task-s2');
+    execTmuxMock.mockResolvedValue({
+      stdout: '✽ Booping… (25m 3s)\nesc to interrupt',
+      stderr: '',
+    });
+
+    await pollReviewStalls();
+
+    expect(sendKeysCalls().length).toBe(0);
+    expect(countStallNudges(db, 'task-s2')).toBe(0);
+  });
+
+  it('nudges anyway when pane capture fails (fail open)', async () => {
+    insertStalledReviewTask(db, 'task-s3');
+    execTmuxMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'capture-pane') return Promise.reject(new Error('no such pane'));
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+
+    await pollReviewStalls();
+
+    expect(sendKeysCalls().length).toBe(2);
+    expect(countStallNudges(db, 'task-s3')).toBe(1);
+  });
+
+  const skipped = [
+    {
+      name: 'non-review task',
+      setup: (db: Database) => insertStalledReviewTask(db, 'task-x', { source: null }),
+      taskId: 'task-x',
+    },
+    {
+      name: 'recent hook activity',
+      setup: (db: Database) => {
+        insertStalledReviewTask(db, 'task-x');
+        setWorkerActivity(db, 'agent-task-x', 'active', `datetime('now', '-60 seconds')`);
+      },
+      taskId: 'task-x',
+    },
+    {
+      name: 'nudge cap reached',
+      setup: (db: Database) => {
+        insertStalledReviewTask(db, 'task-x');
+        insertStallNudgeNote(db, 'task-x', 3, `datetime('now', '-7200 seconds')`);
+      },
+      taskId: 'task-x',
+    },
+    {
+      name: 'nudged within the stall window',
+      setup: (db: Database) => {
+        insertStalledReviewTask(db, 'task-x');
+        insertStallNudgeNote(db, 'task-x', 1, `datetime('now', '-120 seconds')`);
+      },
+      taskId: 'task-x',
+    },
+    {
+      name: 'pending permission prompt',
+      setup: (db: Database) => {
+        insertStalledReviewTask(db, 'task-x');
+        insertPermissionPrompt(db, {
+          id: 'pp-x',
+          task_id: 'task-x',
+          agent_id: 'agent-task-x',
+          session_id: 'sess-x',
+          status: 'pending',
+        });
+      },
+      taskId: 'task-x',
+    },
+    {
+      name: 'task not running',
+      setup: (db: Database) => insertStalledReviewTask(db, 'task-x', { runtime_state: 'idle' }),
+      taskId: 'task-x',
+    },
+  ];
+
+  it.each(skipped)('does not nudge: $name', async ({ setup }) => {
+    setup(db);
+
+    await pollReviewStalls();
+
+    expect(sendKeysCalls().length).toBe(0);
+  });
+
+  it('stops nudging after the cap across sweeps', async () => {
+    insertStalledReviewTask(db, 'task-cap');
+    // Simulate three past nudges older than the stall window.
+    insertStallNudgeNote(db, 'task-cap', 3, `datetime('now', '-3600 seconds')`);
+
+    await pollReviewStalls();
+
+    expect(sendKeysCalls().length).toBe(0);
+    expect(countStallNudges(db, 'task-cap')).toBe(3);
+  });
+});

--- a/server/poller/review-stall.ts
+++ b/server/poller/review-stall.ts
@@ -1,0 +1,70 @@
+import { childLogger } from '../logger.js';
+import { execTmux } from '../tmux-bin.js';
+import { sendMessageToAgent } from '../tmux-input.js';
+import { countPendingByTask } from '../repositories/permission-prompts.js';
+import { findFirstActiveAgent } from '../repositories/workers.js';
+import { addTaskUpdate, listStalledAutoReviewTasks } from '../repositories/tasks.js';
+import { REVIEW_STALL_AFTER_MS, REVIEW_STALL_MAX_NUDGES } from './intervals.js';
+
+const logger = childLogger('poller/review-stall');
+
+/** Claude Code's TUI shows this in the status bar only while a turn is in flight. */
+const IN_FLIGHT_MARKER = 'esc to interrupt';
+
+function stallNudge(taskId: string): string {
+  return (
+    'Automated stall check: no agent activity detected for a while — your last turn may have ' +
+    'died on a dropped API stream. Continue the review flow from where you left off. If the ' +
+    `review is already complete, close this task with \`octomux close-task ${taskId}\`.`
+  );
+}
+
+/**
+ * Nudge auto-review agents whose turn died mid-stream. The Claude CLI abandons
+ * a turn on a stream error WITHOUT firing the Stop hook, so the worker sits
+ * 'active' with a stale hook_activity_updated_at while the TUI waits at an
+ * idle prompt — invisible to the quiescence sweep, and the review never
+ * finishes. Detect that shape and type a continue prompt into the session.
+ *
+ * A long tool-free turn (artifact synthesis) leaves the same stale-active DB
+ * shape, so the pane is checked for the in-flight marker before nudging;
+ * capture failure nudges anyway (a queued message in a live TUI is harmless —
+ * it just becomes the next user message). Bounded by REVIEW_STALL_MAX_NUDGES
+ * per task, recorded as task_updates notes.
+ */
+export async function pollReviewStalls(): Promise<void> {
+  for (const task of listStalledAutoReviewTasks(REVIEW_STALL_AFTER_MS, REVIEW_STALL_MAX_NUDGES)) {
+    if (countPendingByTask(task.id) > 0) continue;
+
+    const agent = findFirstActiveAgent(task.id);
+    if (!agent) continue;
+
+    try {
+      const { stdout } = await execTmux([
+        'capture-pane',
+        '-p',
+        '-t',
+        `${task.tmux_session}:${agent.window_index}`,
+      ]);
+      if (stdout.includes(IN_FLIGHT_MARKER)) continue;
+    } catch {
+      // Pane capture failed — fall through and nudge; send failure is handled below.
+    }
+
+    try {
+      await sendMessageToAgent(task.tmux_session, agent.window_index, stallNudge(task.id));
+    } catch (err) {
+      logger.warn(
+        { task_id: task.id, agent_id: agent.id, err: (err as Error).message },
+        'stall nudge failed (session may be gone)',
+      );
+      continue;
+    }
+
+    addTaskUpdate({ task_id: task.id, kind: 'note', body: 'auto: stall nudge' });
+    logger.warn(
+      { task_id: task.id, agent_id: agent.id, operation: 'review_stall_nudge' },
+      'nudged stalled review agent',
+    );
+  }
+}

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -962,6 +962,50 @@ export function listTasksAwaitingQuiescence(debounceMs: number): Array<{ id: str
 }
 
 /**
+ * Auto-review tasks whose agent looks stalled: still running, but no hook
+ * activity for stallMs. A turn that dies on a dropped API stream never fires
+ * the Stop hook, so hook_activity stays 'active' with a stale timestamp —
+ * unlike quiescence, this deliberately does NOT require hook_activity='idle'.
+ *
+ * Nudge bookkeeping lives in task_updates (kind='note', body='auto: stall
+ * nudge'): tasks already nudged maxNudges times, or nudged within the last
+ * stallMs, are excluded so the sweep can't spam a dead session.
+ */
+export function listStalledAutoReviewTasks(
+  stallMs: number,
+  maxNudges: number,
+): Array<{ id: string; tmux_session: string }> {
+  const cutoff = `-${Math.ceil(stallMs / 1000)}`;
+  return getDb()
+    .prepare(
+      `SELECT t.id, t.tmux_session
+         FROM tasks t
+        WHERE t.source = 'auto_review'
+          AND t.runtime_state = 'running'
+          AND t.deleted_at IS NULL
+          AND t.tmux_session IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM workers w WHERE w.task_id = t.id AND w.status != 'stopped'
+          )
+          AND (
+            SELECT MAX(w.hook_activity_updated_at)
+              FROM workers w
+             WHERE w.task_id = t.id AND w.status != 'stopped'
+          ) <= datetime('now', ? || ' seconds')
+          AND (
+            SELECT COUNT(*) FROM task_updates u
+             WHERE u.task_id = t.id AND u.kind = 'note' AND u.body = 'auto: stall nudge'
+          ) < ?
+          AND NOT EXISTS (
+            SELECT 1 FROM task_updates u
+             WHERE u.task_id = t.id AND u.kind = 'note' AND u.body = 'auto: stall nudge'
+               AND u.created_at > datetime('now', ? || ' seconds')
+          )`,
+    )
+    .all(cutoff, maxNudges, cutoff) as Array<{ id: string; tmux_session: string }>;
+}
+
+/**
  * Tasks that need the user's attention right now: pending permission prompts,
  * or errored tasks whose error hasn't been viewed. Used by the inbox.
  */


### PR DESCRIPTION
## What

Adds a `review-stall` poller sweep (60s) that detects auto-review tasks whose agent turn died on a dropped API stream and types a continue prompt back into the tmux session.

- New `server/poller/review-stall.ts` + `listStalledAutoReviewTasks()` repo query
- Detection shape: `auto_review` task still `running`, all hook activity stale ≥ 15 min, no pending permission prompt — deliberately does **not** require `hook_activity = 'idle'`, because a mid-stream death never fires the Stop hook and leaves the worker stale-`active`
- Pane guard: skips when the captured tmux pane shows `esc to interrupt` (an in-flight tool-free synthesis turn leaves the same stale-active DB shape); capture failure fails open
- Nudge tells the agent to continue or `octomux close-task` if already done — self-terminating either way; capped at 3 nudges per task, debounced by the stall window, recorded as `task_updates` notes (no schema change)

## Why

Observed twice in prod (bedrock PR #1410 review, 2026-08-19): the Claude CLI hit "API Error: Response stalled mid-stream" while building the review artifact and abandoned the turn. The task sat `running` with an idle prompt for 1h20m — invisible to the quiescence sweep (which requires `hook_activity = 'idle'`) — and the review artifact + Slack summary were never delivered until a manual nudge.

## Testing

- `bun test server/poller/review-stall.test.ts` — 10 new tests: nudge + note bookkeeping, in-flight pane skip, fail-open on capture error, and the skip matrix (non-review task, recent activity, nudge cap, nudge debounce, pending prompt, not running)
- `bun test server/poller/ server/repositories/` — 363 pass
- Lint clean; the 2 pre-existing typecheck errors in `server/plugins/loader.ts` are untouched
- Detection shape validated against the live incident: the stalled task's worker showed stale-`active`, and quiescence never fired for it