### PR TITLE
feat(poller): trigger re-review when review is re-requested without a push

### DIFF
--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -1249,6 +1249,19 @@ export function runMigrations(instance: Database): void {
     `CREATE INDEX IF NOT EXISTS idx_tasks_depends_on
        ON tasks(depends_on) WHERE depends_on IS NOT NULL`,
   );
+
+  // ── Re-review trigger tracking (2026-08-19) ────────────────────────────────
+  // Latest GitHub REVIEW_REQUESTED_EVENT timestamp seen for the owner on this
+  // PR, so the reviewer poller can fire a re-review when review is re-requested
+  // without a push (head SHA unchanged).
+  const taskColsForReReview = columnsOf(instance, 'tasks');
+  addColumn(
+    instance,
+    'tasks',
+    'pr_review_requested_at',
+    'pr_review_requested_at TEXT',
+    taskColsForReReview,
+  );
 }
 
 /**

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     pr_url                       TEXT,
     pr_number                    INTEGER,
     pr_head_sha                  TEXT,
+    pr_review_requested_at       TEXT,
     user_window_index            INTEGER,
     initial_prompt               TEXT,
     last_viewed_at               TEXT,

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -1139,7 +1139,7 @@ describe('pollReviewerRequests', () => {
     const [task, opts] = vi.mocked(resumeTask).mock.calls[0] as [Task, { prompt?: string }];
     expect(task.id).toBe('closed-review');
     expect(opts.prompt).toContain('/review-artifact');
-    expect(opts.prompt).toContain('sha-new');
+    expect(opts.prompt).toContain('Head advanced to sha-new');
     expect(opts.prompt).toContain('octomux close-task closed-review');
     // Prompt refresh must not happen — the resumed conversation gets the nudge.
     expect(getTask(db, 'closed-review')!.pr_head_sha).toBe('sha-new');
@@ -1183,7 +1183,7 @@ describe('pollReviewerRequests', () => {
     const [task, opts] = vi.mocked(resumeTask).mock.calls[0] as [Task, { prompt?: string }];
     expect(task.id).toBe('closed-review');
     expect(opts.prompt).toContain('/review-artifact');
-    expect(opts.prompt).toContain('re-requested');
+    expect(opts.prompt).toContain('Head unchanged');
     const row = db
       .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'closed-review'`)
       .get() as { pr_review_requested_at: string };
@@ -1219,6 +1219,82 @@ describe('pollReviewerRequests', () => {
     await pollReviewerRequests();
 
     expect(vi.mocked(resumeTask)).not.toHaveBeenCalled();
+    const row = db
+      .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'closed-review'`)
+      .get() as { pr_review_requested_at: string };
+    expect(row.pr_review_requested_at).toBe('2026-08-19T12:00:00Z');
+  });
+
+  it('nudges a running review when review is re-requested without a push', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, {
+      id: 'running-review',
+      repo_path: REPO,
+      runtime_state: 'running',
+      tmux_session: 'octomux-agent-running-review',
+      pr_number: 42,
+      pr_head_sha: 'sha-aaa',
+      source: 'auto_review',
+    });
+    db.prepare(
+      `UPDATE tasks SET pr_review_requested_at = '2026-08-19T10:00:00Z' WHERE id = 'running-review'`,
+    ).run();
+    insertAgent(db, {
+      id: 'agent-a',
+      task_id: 'running-review',
+      window_index: 0,
+      status: 'running',
+    });
+    mockPrList([
+      makePR({
+        headRefOid: 'sha-aaa',
+        reviewRequestEvents: [{ login: OWNER, createdAt: '2026-08-19T12:00:00Z' }],
+      }),
+    ]);
+
+    await pollReviewerRequests();
+
+    expect(vi.mocked(sendMessageToAgent)).toHaveBeenCalledOnce();
+    const message = vi.mocked(sendMessageToAgent).mock.calls[0][2] as string;
+    expect(message).toContain('Head unchanged');
+    expect(message).toContain('/review-artifact');
+    const row = db
+      .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'running-review'`)
+      .get() as { pr_review_requested_at: string };
+    expect(row.pr_review_requested_at).toBe('2026-08-19T12:00:00Z');
+  });
+
+  it('does not retrigger on a review-request event older than the baseline', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, {
+      id: 'closed-review',
+      repo_path: REPO,
+      runtime_state: 'idle',
+      tmux_session: 'octomux-agent-closed-review',
+      pr_number: 42,
+      pr_head_sha: 'sha-aaa',
+      source: 'auto_review',
+    });
+    db.prepare(
+      `UPDATE tasks SET pr_review_requested_at = '2026-08-19T12:00:00Z' WHERE id = 'closed-review'`,
+    ).run();
+    insertAgent(db, {
+      id: 'agent-a',
+      task_id: 'closed-review',
+      window_index: 0,
+      status: 'stopped',
+    });
+    mockPrList([
+      makePR({
+        headRefOid: 'sha-aaa',
+        reviewRequestEvents: [{ login: OWNER, createdAt: '2026-08-19T10:00:00Z' }],
+      }),
+    ]);
+
+    await pollReviewerRequests();
+
+    expect(vi.mocked(resumeTask)).not.toHaveBeenCalled();
+    // Baseline must not be rewritten backward.
     const row = db
       .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'closed-review'`)
       .get() as { pr_review_requested_at: string };

--- a/server/poller.test.ts
+++ b/server/poller.test.ts
@@ -851,6 +851,14 @@ describe('pollReviewerRequests', () => {
           requestedReviewer: { __typename: 'User', login: rr.login },
         })),
       },
+      timelineItems: {
+        nodes: (
+          (pr.reviewRequestEvents as Array<{ login: string; createdAt: string }> | undefined) ?? []
+        ).map((ev) => ({
+          createdAt: ev.createdAt,
+          requestedReviewer: { login: ev.login },
+        })),
+      },
     }));
     const graphqlBody = JSON.stringify({ data: { search: { nodes: searchNodes } } });
 
@@ -1139,6 +1147,114 @@ describe('pollReviewerRequests', () => {
       type: 'task:updated',
       payload: { taskId: 'closed-review' },
     });
+  });
+
+  it('resumes a closed review session when review is re-requested without a push', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, {
+      id: 'closed-review',
+      repo_path: REPO,
+      runtime_state: 'idle',
+      tmux_session: 'octomux-agent-closed-review',
+      pr_number: 42,
+      pr_head_sha: 'sha-aaa',
+      source: 'auto_review',
+    });
+    db.prepare(
+      `UPDATE tasks SET pr_review_requested_at = '2026-08-19T10:00:00Z' WHERE id = 'closed-review'`,
+    ).run();
+    insertAgent(db, {
+      id: 'agent-a',
+      task_id: 'closed-review',
+      window_index: 0,
+      status: 'stopped',
+    });
+    // Same head SHA, but a newer REVIEW_REQUESTED_EVENT for the owner.
+    mockPrList([
+      makePR({
+        headRefOid: 'sha-aaa',
+        reviewRequestEvents: [{ login: OWNER, createdAt: '2026-08-19T12:00:00Z' }],
+      }),
+    ]);
+
+    await pollReviewerRequests();
+
+    expect(vi.mocked(resumeTask)).toHaveBeenCalledOnce();
+    const [task, opts] = vi.mocked(resumeTask).mock.calls[0] as [Task, { prompt?: string }];
+    expect(task.id).toBe('closed-review');
+    expect(opts.prompt).toContain('/review-artifact');
+    expect(opts.prompt).toContain('re-requested');
+    const row = db
+      .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'closed-review'`)
+      .get() as { pr_review_requested_at: string };
+    expect(row.pr_review_requested_at).toBe('2026-08-19T12:00:00Z');
+  });
+
+  it('backfills the re-request baseline without resuming when none was recorded', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, {
+      id: 'closed-review',
+      repo_path: REPO,
+      runtime_state: 'idle',
+      tmux_session: 'octomux-agent-closed-review',
+      pr_number: 42,
+      pr_head_sha: 'sha-aaa',
+      source: 'auto_review',
+    });
+    insertAgent(db, {
+      id: 'agent-a',
+      task_id: 'closed-review',
+      window_index: 0,
+      status: 'stopped',
+    });
+    // Pre-migration row: pr_review_requested_at is NULL, so an event can't be
+    // told apart from the original request — record it, don't trigger.
+    mockPrList([
+      makePR({
+        headRefOid: 'sha-aaa',
+        reviewRequestEvents: [{ login: OWNER, createdAt: '2026-08-19T12:00:00Z' }],
+      }),
+    ]);
+
+    await pollReviewerRequests();
+
+    expect(vi.mocked(resumeTask)).not.toHaveBeenCalled();
+    const row = db
+      .prepare(`SELECT pr_review_requested_at FROM tasks WHERE id = 'closed-review'`)
+      .get() as { pr_review_requested_at: string };
+    expect(row.pr_review_requested_at).toBe('2026-08-19T12:00:00Z');
+  });
+
+  it('ignores re-request events for other reviewers', async () => {
+    insertTask(db, { id: 'seed', repo_path: REPO });
+    insertTask(db, {
+      id: 'closed-review',
+      repo_path: REPO,
+      runtime_state: 'idle',
+      tmux_session: 'octomux-agent-closed-review',
+      pr_number: 42,
+      pr_head_sha: 'sha-aaa',
+      source: 'auto_review',
+    });
+    db.prepare(
+      `UPDATE tasks SET pr_review_requested_at = '2026-08-19T10:00:00Z' WHERE id = 'closed-review'`,
+    ).run();
+    insertAgent(db, {
+      id: 'agent-a',
+      task_id: 'closed-review',
+      window_index: 0,
+      status: 'stopped',
+    });
+    mockPrList([
+      makePR({
+        headRefOid: 'sha-aaa',
+        reviewRequestEvents: [{ login: 'someone-else', createdAt: '2026-08-19T12:00:00Z' }],
+      }),
+    ]);
+
+    await pollReviewerRequests();
+
+    expect(vi.mocked(resumeTask)).not.toHaveBeenCalled();
   });
 
   it('does not resume a closed review session when head SHA is unchanged', async () => {

--- a/server/poller/reviewer-requests.ts
+++ b/server/poller/reviewer-requests.ts
@@ -92,7 +92,7 @@ const REVIEW_REQUESTED_GRAPHQL_QUERY = `query {
             }
           }
         }
-        timelineItems(last: 10, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+        timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT]) {
           nodes {
             ... on ReviewRequestedEvent {
               createdAt
@@ -163,7 +163,11 @@ function isOwnerStillRequested(pr: OpenReviewPR, ownerLogin: string): boolean {
   );
 }
 
-/** Latest review-request timestamp for the owner (ISO strings compare lexicographically). */
+/**
+ * Latest review-request timestamp for the owner (ISO strings compare
+ * lexicographically). Direct user requests only — team re-requests carry no
+ * `login` and are dropped, matching isOwnerStillRequested's scope.
+ */
 function latestReviewRequestAt(pr: OpenReviewPR, ownerLogin: string): string | null {
   let latest: string | null = null;
   for (const ev of pr.reviewRequestEvents) {
@@ -267,6 +271,8 @@ async function upsertReviewTask(
       return { action: 'skipped' };
     }
 
+    // Written only after the trigger actually lands — a failed nudge/resume
+    // must leave the baseline behind so the next poll cycle retries.
     const markTriggered = () => {
       setPrHeadSha(existing.id, pr.headRefOid);
       if (requestedAt) setPrReviewRequestedAt(existing.id, requestedAt);
@@ -278,7 +284,7 @@ async function upsertReviewTask(
         // (harness session id) and hand it the re-review prompt.
         const task = getTask(existing.id) as Task | undefined;
         if (!task) return { action: 'skipped' };
-        await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
+        if (headChanged) await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
         await resumeTask(task, { prompt: buildReReviewNudge(pr, existing.id, headChanged) });
         markTriggered();
         return { action: 'resumed', taskId: existing.id };
@@ -301,7 +307,7 @@ async function upsertReviewTask(
     if (existing.runtime_state === 'running' || existing.runtime_state === 'setting_up') {
       if (!existing.tmux_session) return { action: 'skipped' };
 
-      await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
+      if (headChanged) await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
       const delivered = await nudgeAgentForReReview(
         existing.id,
         existing.tmux_session,

--- a/server/poller/reviewer-requests.ts
+++ b/server/poller/reviewer-requests.ts
@@ -16,6 +16,7 @@ import {
   hardDeleteTask,
   updateTaskPromptAndSha,
   setPrHeadSha,
+  setPrReviewRequestedAt,
 } from '../repositories/tasks.js';
 import { deleteWorktree } from '../repositories/worktrees.js';
 import { countAgentsForTask, findFirstActiveAgent } from '../repositories/workers.js';
@@ -40,6 +41,8 @@ interface OpenReviewPR {
   headRefName: string;
   baseRefName: string;
   reviewRequests: ReviewRequestEntity[];
+  /** REVIEW_REQUESTED_EVENT timeline entries — powers re-review on re-request. */
+  reviewRequestEvents: Array<{ login: string; createdAt: string }>;
 }
 
 function listTrackedRepos(): string[] {
@@ -61,6 +64,12 @@ interface RawSearchNode {
       requestedReviewer: { __typename?: string; login?: string } | null;
     }>;
   };
+  timelineItems?: {
+    nodes: Array<{
+      createdAt?: string;
+      requestedReviewer?: { login?: string } | null;
+    } | null>;
+  };
 }
 
 const REVIEW_REQUESTED_GRAPHQL_QUERY = `query {
@@ -80,6 +89,14 @@ const REVIEW_REQUESTED_GRAPHQL_QUERY = `query {
             requestedReviewer {
               __typename
               ... on User { login }
+            }
+          }
+        }
+        timelineItems(last: 10, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+          nodes {
+            ... on ReviewRequestedEvent {
+              createdAt
+              requestedReviewer { ... on User { login } }
             }
           }
         }
@@ -114,6 +131,15 @@ async function fetchAllReviewRequestedPRs(): Promise<Map<string, OpenReviewPR[]>
         reviewRequests: (node.reviewRequests?.nodes ?? [])
           .map((rr) => ({ login: rr.requestedReviewer?.login }))
           .filter((rr): rr is { login: string } => typeof rr.login === 'string'),
+        reviewRequestEvents: (node.timelineItems?.nodes ?? [])
+          .map((ev) => ({
+            login: ev?.requestedReviewer?.login,
+            createdAt: ev?.createdAt,
+          }))
+          .filter(
+            (ev): ev is { login: string; createdAt: string } =>
+              typeof ev.login === 'string' && typeof ev.createdAt === 'string',
+          ),
       };
       const key = node.repository.nameWithOwner.toLowerCase();
       const list = byRepo.get(key);
@@ -137,6 +163,16 @@ function isOwnerStillRequested(pr: OpenReviewPR, ownerLogin: string): boolean {
   );
 }
 
+/** Latest review-request timestamp for the owner (ISO strings compare lexicographically). */
+function latestReviewRequestAt(pr: OpenReviewPR, ownerLogin: string): string | null {
+  let latest: string | null = null;
+  for (const ev of pr.reviewRequestEvents) {
+    if (ev.login.toLowerCase() !== ownerLogin.toLowerCase()) continue;
+    if (!latest || ev.createdAt > latest) latest = ev.createdAt;
+  }
+  return latest;
+}
+
 function buildReviewPrompt(pr: OpenReviewPR, requestedAt: string, reviewTaskId: string): string {
   return buildPrReviewPrompt({
     reviewTaskId,
@@ -153,10 +189,14 @@ function buildShaUpdateNote(prompt: string, newSha: string, timestamp: string): 
   return `${prompt}\n\nUpdated: head advanced to ${newSha} at ${timestamp}`;
 }
 
-function buildReReviewNudge(pr: OpenReviewPR, taskId: string): string {
+function buildReReviewNudge(pr: OpenReviewPR, taskId: string, headChanged: boolean): string {
+  const reason = headChanged
+    ? `Head advanced to ${pr.headRefOid}.`
+    : `Head unchanged at ${pr.headRefOid} — review was explicitly re-requested, so run the ` +
+      `re-review anyway (re-verify the open findings; discussion may have moved without a push).`;
   return (
     `Re-review requested for PR #${pr.number} (${pr.url}). ` +
-    `Head advanced to ${pr.headRefOid}. ` +
+    `${reason} ` +
     `Run the /review-artifact re-review flow — redeploy to the same artifact URL with a delta ` +
     `section, send the Slack ping as before, then close this task again with ` +
     `\`octomux close-task ${taskId}\`.`
@@ -167,11 +207,16 @@ async function nudgeAgentForReReview(
   taskId: string,
   tmuxSession: string,
   pr: OpenReviewPR,
+  headChanged: boolean,
 ): Promise<boolean> {
   const agent = findFirstActiveAgent(taskId);
   if (!agent) return false;
   try {
-    await sendMessageToAgent(tmuxSession, agent.window_index, buildReReviewNudge(pr, taskId));
+    await sendMessageToAgent(
+      tmuxSession,
+      agent.window_index,
+      buildReReviewNudge(pr, taskId, headChanged),
+    );
     return true;
   } catch (err) {
     logger.warn(
@@ -198,12 +243,34 @@ async function checkoutNewHead(taskId: string, worktreePath: string | null, head
 async function upsertReviewTask(
   repoPath: string,
   pr: OpenReviewPR,
+  ownerLogin: string,
 ): Promise<{ action: 'created' | 'updated' | 'nudged' | 'resumed' | 'skipped'; taskId?: string }> {
   const existing = findExistingPrTask(repoPath, pr.number);
+  const requestedAt = latestReviewRequestAt(pr, ownerLogin);
 
   if (existing) {
     if (existing.source !== 'auto_review') return { action: 'skipped' };
-    if (existing.pr_head_sha === pr.headRefOid) return { action: 'skipped' };
+
+    const headChanged = existing.pr_head_sha !== pr.headRefOid;
+    // A review-request event newer than the one we last acted on = the author
+    // re-requested review without pushing. Rows from before this column existed
+    // (NULL baseline) can't distinguish old from new requests — backfill the
+    // baseline and only trigger on the next event.
+    const reRequested =
+      requestedAt !== null &&
+      existing.pr_review_requested_at !== null &&
+      requestedAt > existing.pr_review_requested_at;
+    if (!headChanged && !reRequested) {
+      if (requestedAt && !existing.pr_review_requested_at) {
+        setPrReviewRequestedAt(existing.id, requestedAt);
+      }
+      return { action: 'skipped' };
+    }
+
+    const markTriggered = () => {
+      setPrHeadSha(existing.id, pr.headRefOid);
+      if (requestedAt) setPrReviewRequestedAt(existing.id, requestedAt);
+    };
 
     if (existing.runtime_state === 'idle') {
       if (countAgentsForTask(existing.id) > 0) {
@@ -212,28 +279,37 @@ async function upsertReviewTask(
         const task = getTask(existing.id) as Task | undefined;
         if (!task) return { action: 'skipped' };
         await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
-        await resumeTask(task, { prompt: buildReReviewNudge(pr, existing.id) });
-        setPrHeadSha(existing.id, pr.headRefOid);
+        await resumeTask(task, { prompt: buildReReviewNudge(pr, existing.id, headChanged) });
+        markTriggered();
         return { action: 'resumed', taskId: existing.id };
       }
 
       // Never-started draft: refresh the prompt + sha; startTask delivers it.
-      const updatedPrompt = buildShaUpdateNote(
-        existing.initial_prompt ?? buildReviewPrompt(pr, new Date().toISOString(), existing.id),
-        pr.headRefOid,
-        new Date().toISOString(),
-      );
-      updateTaskPromptAndSha(existing.id, pr.headRefOid, updatedPrompt);
-      return { action: 'updated', taskId: existing.id };
+      // A bare re-request needs no prompt churn — the draft hasn't run yet.
+      if (headChanged) {
+        const updatedPrompt = buildShaUpdateNote(
+          existing.initial_prompt ?? buildReviewPrompt(pr, new Date().toISOString(), existing.id),
+          pr.headRefOid,
+          new Date().toISOString(),
+        );
+        updateTaskPromptAndSha(existing.id, pr.headRefOid, updatedPrompt);
+      }
+      if (requestedAt) setPrReviewRequestedAt(existing.id, requestedAt);
+      return headChanged ? { action: 'updated', taskId: existing.id } : { action: 'skipped' };
     }
 
     if (existing.runtime_state === 'running' || existing.runtime_state === 'setting_up') {
       if (!existing.tmux_session) return { action: 'skipped' };
 
       await checkoutNewHead(existing.id, existing.worktree_path, pr.headRefOid);
-      const delivered = await nudgeAgentForReReview(existing.id, existing.tmux_session, pr);
+      const delivered = await nudgeAgentForReReview(
+        existing.id,
+        existing.tmux_session,
+        pr,
+        headChanged,
+      );
       if (!delivered) return { action: 'skipped' };
-      setPrHeadSha(existing.id, pr.headRefOid);
+      markTriggered();
       return { action: 'nudged', taskId: existing.id };
     }
 
@@ -264,6 +340,8 @@ async function upsertReviewTask(
   if (!created || created.source !== 'auto_review') {
     return { action: 'skipped' };
   }
+  // Baseline for re-request detection on later cycles.
+  if (requestedAt) setPrReviewRequestedAt(created.id, requestedAt);
   return { action: 'created', taskId: created.id };
 }
 
@@ -378,7 +456,7 @@ export async function pollReviewerRequests(): Promise<void> {
       if (!isOwnerStillRequested(pr, ownerLogin)) continue;
       activePrNumbers.add(pr.number);
 
-      const result = await upsertReviewTask(repoPath, pr);
+      const result = await upsertReviewTask(repoPath, pr, ownerLogin);
       if (result.action === 'created') {
         logger.info(
           { task_id: result.taskId, pr_number: pr.number, repo_path: repoPath },

--- a/server/repositories/tasks.ts
+++ b/server/repositories/tasks.ts
@@ -507,6 +507,15 @@ export function setPrHeadSha(id: string, prHeadSha: string): void {
     .run(prHeadSha, id);
 }
 
+/** Set pr_review_requested_at (latest review-request event seen for the owner). */
+export function setPrReviewRequestedAt(id: string, requestedAt: string): void {
+  getDb()
+    .prepare(
+      `UPDATE tasks SET pr_review_requested_at = ?, updated_at = datetime('now') WHERE id = ?`,
+    )
+    .run(requestedAt, id);
+}
+
 /** Touch last_viewed_at for a single task. */
 export function touchLastViewed(id: string): void {
   getDb().prepare(`UPDATE tasks SET last_viewed_at = datetime('now') WHERE id = ?`).run(id);
@@ -759,6 +768,7 @@ export function findExistingPrTask(
       runtime_state: string;
       source: string | null;
       pr_head_sha: string | null;
+      pr_review_requested_at: string | null;
       initial_prompt: string | null;
       tmux_session: string | null;
       worktree_path: string | null;
@@ -768,7 +778,9 @@ export function findExistingPrTask(
     .prepare(
       `SELECT t.id AS id, t.runtime_state AS runtime_state,
               t.source AS source,
-              t.pr_head_sha AS pr_head_sha, t.initial_prompt AS initial_prompt,
+              t.pr_head_sha AS pr_head_sha,
+              t.pr_review_requested_at AS pr_review_requested_at,
+              t.initial_prompt AS initial_prompt,
               t.tmux_session AS tmux_session,
               w.path AS worktree_path
          FROM tasks t
@@ -783,6 +795,7 @@ export function findExistingPrTask(
         runtime_state: string;
         source: string | null;
         pr_head_sha: string | null;
+        pr_review_requested_at: string | null;
         initial_prompt: string | null;
         tmux_session: string | null;
         worktree_path: string | null;


### PR DESCRIPTION
## What

The reviewer poller now fires a re-review when review is re-requested on GitHub even if no new commits were pushed. Previously the only trigger was a head-SHA advance, so a bare re-request was silently skipped.

- New `tasks.pr_review_requested_at` column (guarded forward-only migration) records the latest `REVIEW_REQUESTED_EVENT` timestamp seen for the owner.
- The existing review-requested GraphQL search additionally fetches `timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT])` — one query, no extra API calls.
- A newer event than the stored baseline triggers the existing re-review machinery: closed sessions are resumed in the same conversation, running agents get a tmux nudge. The nudge instructs the `/review-artifact` re-review flow (same artifact URL, delta section, Slack ping) and distinguishes "head advanced" from "head unchanged — re-requested".
- Rows predating the column backfill their baseline on first sight instead of firing a spurious re-review; the baseline only advances after a trigger actually lands, so a failed nudge retries next cycle.
- Skips the redundant fetch/checkout when the head didn't move.

## Why

Authors often re-request review after replying to findings or resolving threads without pushing — those re-requests went nowhere. Now they resume the previous review session and update the existing artifact with a delta, keeping one artifact URL per PR across rounds.

## Testing

- `bun test server/poller.test.ts` — 94 pass, including 5 new cases: resume on re-request without push, nudge of a running review, NULL-baseline backfill (no spurious trigger), older-event skip guard (baseline not rewritten backward), other-reviewer events ignored.
- `bun test --parallel` across all review-related suites (431 pass); full `test:server` failures match base (pre-existing).
- Validated the `timelineItems` GraphQL shape against live GitHub via `gh api graphql`.
- `bun run lint` clean (0 errors); typecheck errors on base (plugins/loader) are pre-existing and untouched.