### PR TITLE
perf(terminal): app-level deflate + half-open socket watchdog

### DIFF
--- a/.octomux/pr-walkthrough.md
+++ b/.octomux/pr-walkthrough.md
@@ -19,7 +19,18 @@ page refresh. Two root causes, both fixed here:
    the client stays wedged until refresh.
 
 Also removes the "give it a readable name" nudge that was appended to every
-agent's initial prompt (separate commit, requested alongside).
+agent's initial prompt (separate commit, requested alongside), and fixes the
+start-time installers: `installSkills()` still read `assetRoot()/skills` after
+the bundler moved to shipping `plugin/`, so the compiled binary installed zero
+skills and copy-if-absent left old ones stale forever. Skills now install from
+`plugin/skills`, version-stamped (matching stamp -> no-op, otherwise octomux's
+own skill dirs are replaced; user-authored skills untouched), and the
+standalone binary links itself as `~/.local/bin/octomux` when nothing on PATH
+provides octomux.
+
+The branch was rebased onto the compute-session migration that landed on
+`next` mid-flight; the deflate/watchdog deltas were re-applied over
+`compute.spawn`/`compute.tmux` with all suites re-verified after the rebase.
 
 ## Change tour
 

--- a/.octomux/pr-walkthrough.md
+++ b/.octomux/pr-walkthrough.md
@@ -1,0 +1,96 @@
+# Terminal perf: remote deflate + half-open socket watchdog
+
+## Intent
+
+Remote (devbox-over-network) terminal viewing was laggy — slow tab switches,
+scroll/typing trailing in — and terminals occasionally froze until a manual
+page refresh. Two root causes, both fixed here:
+
+1. **WebSocket compression was a silent no-op.** `server/terminal.ts` passed
+   `perMessageDeflate: true` to `WebSocketServer`, relying on it for "~10x"
+   bandwidth savings on repetitive TUI repaints. Under Bun the `ws` npm package
+   is replaced by Bun's built-in shim, which accepts the option but never
+   negotiates the extension (explicit `TODO` in the shim; verified with a raw
+   handshake probe — the 101 response carries no `Sec-WebSocket-Extensions`).
+   Every full-screen repaint went uncompressed, saturating slow links.
+2. **Half-open sockets froze terminals.** A NAT/proxy drop or laptop sleep
+   leaves the browser socket reporting OPEN forever; `onclose` never fires, so
+   the reconnect logic never runs. The server heartbeat reaps its own side, but
+   the client stays wedged until refresh.
+
+Also removes the "give it a readable name" nudge that was appended to every
+agent's initial prompt (separate commit, requested alongside).
+
+## Change tour
+
+**App-level compression (replaces the dead permessage-deflate):**
+
+- `server/terminal.ts` — `sendFrame()` deflates (`deflateRawSync`) any output
+  frame ≥ 1KB into a binary frame when the client opted in via `?deflate=1`;
+  smaller frames stay plain text so keystroke echo never pays the zlib
+  round-trip. Applied on all three send paths: the coalesced pty flush, the
+  initial capture-pane snapshot, and chat terminals. The upgrade handler now
+  splits the query string off `req.url` before route matching.
+- `src/lib/terminal-frames.ts` (new) — client-side frame decoding.
+  `inflateFrame()` uses the browser-native `DecompressionStream('deflate-raw')`
+  (no new dependency). `makeFrameWriter()` preserves arrival order across async
+  inflation with a promise chain; text frames bypass the chain when nothing is
+  pending, so echo stays synchronous. A corrupt frame is dropped without
+  wedging subsequent frames.
+- `src/components/TerminalView.tsx` — advertises support (`?deflate=1` when
+  `DecompressionStream` exists), sets `binaryType = 'arraybuffer'`, routes
+  `onmessage` through a per-socket frame writer.
+
+**Liveness watchdog (fixes the hangs):**
+
+- `src/components/TerminalView.tsx` — after 15s of link silence the client
+  sends `{"type":"ping"}`; if nothing arrives within 5s the socket is half-open
+  and gets silently replaced (no overlay; the reconnect repaints from the tmux
+  snapshot). On tab return, an OPEN socket is probed immediately instead of
+  trusted — post-sleep sockets often only *look* OPEN.
+- `server/terminal.ts` — replies to `{"type":"ping"}` with an empty frame.
+  Empty writes are a no-op for xterm, so the client needs no filtering; paused
+  (hidden-tab) connections still answer because `paused` only gates pty output,
+  not control messages.
+
+**Prompt nudge removal:**
+
+- `server/task-engine/launch.ts` — `buildAgentStartupCommand` writes the
+  initial prompt verbatim; the appended `octomux task rename` hint is gone.
+  Signature unchanged, all callers unaffected; the rename nudge still reaches
+  agents via the update-task-status skill.
+
+## Risk & blast radius
+
+- Protocol change is negotiated: clients without `DecompressionStream` (or old
+  cached bundles) never send `?deflate=1` and get the exact old behavior.
+- Frame ordering under async inflation is the subtle invariant; it's enforced
+  by `makeFrameWriter`'s pending counter and covered by dedicated ordering
+  tests (including corrupt-frame recovery).
+- Known, accepted low-risk gap (from the pre-PR adversarial review): a frame
+  still inflating when its socket is replaced could theoretically write after
+  the new socket's snapshot. The window requires an in-flight inflate to
+  overlap a reconnect that itself waits ≥1s backoff — fix only if repaint
+  corruption is ever observed.
+- Watchdog false positives would cause a silent reconnect (snapshot repaint),
+  not data loss; pings are answered even for paused hidden tabs.
+
+## Testing
+
+- `server/terminal.test.ts` — 26/26 pass; 5 new: deflate roundtrip
+  (`inflateRawSync` on the binary frame), sub-threshold stays text, no-opt-in
+  stays text, large snapshot deflated, ping answered without reaching the pty.
+- `src/lib/terminal-frames.test.ts` (new) — 6 tests: roundtrip, sync text fast
+  path, ordering behind in-flight inflation, multi-frame ordering, corrupt
+  frame recovery. Poll-based waits (no fixed sleeps) so they hold under
+  parallel load.
+- `src/components/TerminalView.test.tsx` — 17/17 pass; 4 new: deflate flag in
+  URL, unanswered-ping reconnect, answered-ping keeps socket, tab-return probe.
+- Full client suite: 1273 pass; the 1–2 failures (HomePage composer-hydration,
+  Composer preflight) are pre-existing load flakes — they pass in isolation and
+  fail identically with this branch's changes stashed.
+- Full server suite has pre-existing failures on `next` (API 500s,
+  `server/plugins/loader` typecheck errors) — reproduced with changes stashed.
+- Live probes against bun 1.3.14 confirmed: shim negotiates no deflate,
+  `Bun.serve` does, empty text frames round-trip, `bufferedAmount` reports real
+  backpressure (so the existing coalescing logic still works).

--- a/bin/installers.js
+++ b/bin/installers.js
@@ -1,0 +1,77 @@
+/**
+ * Start-time installers for user-facing octomux assets: Claude Code skills in
+ * ~/.claude/skills and (for the standalone binary) an `octomux` CLI shim on
+ * PATH.
+ *
+ * `octomux start` calls these on every boot, so both are gated: skills are
+ * replaced only when the shipped version differs from the stamp left by the
+ * previous install (matching stamp → no install, no update), and the CLI shim
+ * is created only when no working `octomux` is on PATH at all.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  cpSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  symlinkSync,
+} from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Old skill names removed on sight so renames don't leave dead copies behind.
+const DEPRECATED_SKILLS = [
+  'octomux-create-pr',
+  'octomux-create-task',
+  'octomux-create-commit',
+  'octomux-executing-plans',
+];
+
+/**
+ * Install/refresh the bundled skills into `target` (~/.claude/skills).
+ * Only skill names present in the bundle are ever replaced — user-authored
+ * skills in the same directory are never touched. Returns true when anything
+ * was (re)installed.
+ */
+export function installSkills({ source, target, version }) {
+  if (!existsSync(source)) return false;
+
+  for (const name of DEPRECATED_SKILLS) {
+    rmSync(path.join(target, name), { recursive: true, force: true });
+  }
+
+  const stamp = path.join(target, '.octomux-skills-version');
+  if (existsSync(stamp) && readFileSync(stamp, 'utf8') === version) return false;
+
+  mkdirSync(target, { recursive: true });
+  for (const skill of readdirSync(source)) {
+    const dest = path.join(target, skill);
+    rmSync(dest, { recursive: true, force: true });
+    cpSync(path.join(source, skill), dest, { recursive: true });
+  }
+  writeFileSync(stamp, version);
+  return true;
+}
+
+/**
+ * Put the running binary on PATH as `octomux` when nothing else provides it.
+ * A working `octomux` anywhere on PATH (npm global, homebrew, a prior link) is
+ * left alone — this only fills the gap, it never fights the owner. A dead
+ * symlink left by a moved/deleted binary is replaced. Returns the link path
+ * when one was created, null when nothing was needed.
+ */
+export function installCliShim({
+  execPath,
+  onPath,
+  binDir = path.join(os.homedir(), '.local', 'bin'),
+}) {
+  if (onPath) return null;
+  const link = path.join(binDir, 'octomux');
+  mkdirSync(binDir, { recursive: true });
+  rmSync(link, { force: true });
+  symlinkSync(execPath, link);
+  return link;
+}

--- a/bin/installers.test.ts
+++ b/bin/installers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from '../server/bun-test.js';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { installSkills, installCliShim } from './installers.js';
+
+let tmp: string;
+let source: string;
+let target: string;
+
+function writeSkill(root: string, name: string, body: string): void {
+  fs.mkdirSync(path.join(root, name), { recursive: true });
+  fs.writeFileSync(path.join(root, name, 'SKILL.md'), body);
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'octomux-installers-'));
+  source = path.join(tmp, 'bundle');
+  target = path.join(tmp, 'claude-skills');
+  fs.mkdirSync(source, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('installSkills', () => {
+  it('installs bundled skills and writes the version stamp', () => {
+    writeSkill(source, 'create-pr', 'v1');
+
+    expect(installSkills({ source, target, version: '1.0.0' })).toBe(true);
+    expect(fs.readFileSync(path.join(target, 'create-pr', 'SKILL.md'), 'utf8')).toBe('v1');
+    expect(fs.readFileSync(path.join(target, '.octomux-skills-version'), 'utf8')).toBe('1.0.0');
+  });
+
+  it('is a no-op when the stamp matches the current version', () => {
+    writeSkill(source, 'create-pr', 'v1');
+    installSkills({ source, target, version: '1.0.0' });
+    // Simulate a user edit — a same-version restart must not clobber it.
+    fs.writeFileSync(path.join(target, 'create-pr', 'SKILL.md'), 'edited');
+
+    expect(installSkills({ source, target, version: '1.0.0' })).toBe(false);
+    expect(fs.readFileSync(path.join(target, 'create-pr', 'SKILL.md'), 'utf8')).toBe('edited');
+  });
+
+  it('replaces stale skills when the version changes', () => {
+    writeSkill(source, 'create-pr', 'v1');
+    installSkills({ source, target, version: '1.0.0' });
+    // Old version left an extra file behind inside the skill dir.
+    fs.writeFileSync(path.join(target, 'create-pr', 'stale.md'), 'old');
+
+    fs.writeFileSync(path.join(source, 'create-pr', 'SKILL.md'), 'v2');
+    expect(installSkills({ source, target, version: '2.0.0' })).toBe(true);
+    expect(fs.readFileSync(path.join(target, 'create-pr', 'SKILL.md'), 'utf8')).toBe('v2');
+    expect(fs.existsSync(path.join(target, 'create-pr', 'stale.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(target, '.octomux-skills-version'), 'utf8')).toBe('2.0.0');
+  });
+
+  it('never touches user-authored skills in the same directory', () => {
+    writeSkill(source, 'create-pr', 'v1');
+    writeSkill(target, 'my-own-skill', 'mine');
+
+    installSkills({ source, target, version: '1.0.0' });
+    installSkills({ source, target, version: '2.0.0' });
+    expect(fs.readFileSync(path.join(target, 'my-own-skill', 'SKILL.md'), 'utf8')).toBe('mine');
+  });
+
+  it('removes deprecated skill names', () => {
+    writeSkill(source, 'create-pr', 'v1');
+    writeSkill(target, 'octomux-create-pr', 'old-name');
+
+    installSkills({ source, target, version: '1.0.0' });
+    expect(fs.existsSync(path.join(target, 'octomux-create-pr'))).toBe(false);
+  });
+
+  it('does nothing when the bundle dir is missing', () => {
+    expect(installSkills({ source: path.join(tmp, 'nope'), target, version: '1.0.0' })).toBe(false);
+    expect(fs.existsSync(target)).toBe(false);
+  });
+});
+
+describe('installCliShim', () => {
+  it('does nothing when octomux is already on PATH', () => {
+    const binDir = path.join(tmp, 'bin');
+    expect(installCliShim({ execPath: '/opt/octomux', onPath: true, binDir })).toBeNull();
+    expect(fs.existsSync(path.join(binDir, 'octomux'))).toBe(false);
+  });
+
+  it('links the running binary when octomux is missing from PATH', () => {
+    const binDir = path.join(tmp, 'bin');
+    const link = installCliShim({ execPath: process.execPath, onPath: false, binDir });
+    expect(link).toBe(path.join(binDir, 'octomux'));
+    expect(fs.readlinkSync(link!)).toBe(process.execPath);
+  });
+
+  it('replaces a dead symlink left by a moved binary', () => {
+    const binDir = path.join(tmp, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync(path.join(tmp, 'gone'), path.join(binDir, 'octomux'));
+
+    const link = installCliShim({ execPath: process.execPath, onPath: false, binDir });
+    expect(fs.readlinkSync(link!)).toBe(process.execPath);
+  });
+});

--- a/bin/main.js
+++ b/bin/main.js
@@ -8,14 +8,16 @@
  * launcher, because this file imports TypeScript sources directly.
  */
 
+import { which } from 'bun';
 import { exec as execCb } from 'child_process';
-import { existsSync, mkdirSync, readdirSync, cpSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, cpSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import path from 'path';
 import os from 'os';
 import pkg from '../package.json';
-import { assetRoot } from '../server/assets.ts';
+import { assetRoot, isCompiled } from '../server/assets.ts';
+import { installSkills, installCliShim } from './installers.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -82,10 +84,34 @@ async function runStart(startArgs) {
   // Welcome banner
   console.log(`\n\uD83D\uDC19 octomux v${version}\n`);
 
-  // Install bundled skills and configs
-  installSkills();
+  // Install bundled skills and configs. Skills are version-gated: a stamp
+  // matching this version means nothing to install or update.
+  if (
+    installSkills({
+      source: path.join(assetRoot(), 'plugin', 'skills'),
+      target: path.join(os.homedir(), '.claude', 'skills'),
+      version,
+    })
+  ) {
+    console.log('Installed octomux skills for Claude Code');
+  }
   installWorkflows();
   installLazygitConfig();
+  // npm installs own their bin shim; only the standalone compiled binary needs
+  // to put itself on PATH — and only when nothing else already provides octomux.
+  if (isCompiled) {
+    const link = installCliShim({
+      execPath: process.execPath,
+      onPath: Boolean(which('octomux')),
+    });
+    if (link) {
+      console.log(`Linked ${link} -> ${process.execPath}`);
+      const onPathDirs = (process.env.PATH || '').split(path.delimiter);
+      if (!onPathDirs.includes(path.dirname(link))) {
+        console.log(`Note: add ${path.dirname(link)} to PATH so agents can run the octomux CLI.`);
+      }
+    }
+  }
 
   // Preflight: warn about missing tools (install from dashboard Setup — no blocking exit)
   const { warnBinary, checkNeovimVersion } = await import('../server/startup.ts');
@@ -173,40 +199,6 @@ function installLazygitConfig() {
   mkdirSync(configDir, { recursive: true });
   cpSync(source, target);
   console.log('Installed lazygit config');
-}
-
-function installSkills() {
-  const skillsSource = path.join(assetRoot(), 'skills');
-  const skillsTarget = path.join(os.homedir(), '.claude', 'skills');
-
-  if (!existsSync(skillsSource)) return;
-
-  // Remove old-named skills that have been renamed
-  const deprecated = [
-    'octomux-create-pr',
-    'octomux-create-task',
-    'octomux-create-commit',
-    'octomux-executing-plans',
-  ];
-  for (const name of deprecated) {
-    const old = path.join(skillsTarget, name);
-    if (existsSync(old)) {
-      rmSync(old, { recursive: true });
-    }
-  }
-
-  let installed = false;
-  for (const skill of readdirSync(skillsSource)) {
-    const target = path.join(skillsTarget, skill);
-    if (!existsSync(target)) {
-      mkdirSync(target, { recursive: true });
-      cpSync(path.join(skillsSource, skill), target, { recursive: true });
-      installed = true;
-    }
-  }
-  if (installed) {
-    console.log('Installed octomux skills for Claude Code');
-  }
 }
 
 function installWorkflows() {

--- a/server/task-engine/launch.test.ts
+++ b/server/task-engine/launch.test.ts
@@ -148,7 +148,7 @@ describe('buildAgentStartupCommand', () => {
     expect(fs.statSync(promptFile).mode & 0o777).toBe(0o600);
   });
 
-  it('appends the rename hint to the written prompt', async () => {
+  it('writes the prompt verbatim — no appended hints', async () => {
     await buildAgentStartupCommand(localSession, {
       baseCmd: 'claude --session-id abc',
       prompt: 'Do the thing',
@@ -156,7 +156,7 @@ describe('buildAgentStartupCommand', () => {
       agentId: 'agent123',
     });
     const promptFile = path.join(worktreeDir, '.claude-prompt-agent123');
-    expect(fs.readFileSync(promptFile, 'utf8')).toContain('octomux task rename');
+    expect(fs.readFileSync(promptFile, 'utf8')).toBe('Do the thing');
   });
 
   it('does NOT write a prompt file when prompt is absent', async () => {

--- a/server/task-engine/launch.ts
+++ b/server/task-engine/launch.ts
@@ -65,12 +65,7 @@ export async function buildAgentStartupCommand(
   let inner = args.baseCmd;
   if (args.prompt && args.worktreePath && args.agentId) {
     const promptFile = path.join(args.worktreePath, `.claude-prompt-${args.agentId}`);
-    // Board cards otherwise show the first 80 chars of the raw prompt, which is
-    // unreadable. Nudge the agent to rename the task once it has enough context.
-    const promptWithRenameHint =
-      args.prompt +
-      '\n\nOnce you understand what this task actually is, give it a readable name: run `octomux task rename --title "<short title, under 60 chars>"`. Do this once, early.';
-    await c.files.write(promptFile, promptWithRenameHint, { mode: 0o600 });
+    await c.files.write(promptFile, args.prompt, { mode: 0o600 });
     // `--` ends option parsing so the positional prompt can't be swallowed by a
     // preceding variadic flag. `--mcp-config` (appended for orchestrator-managed
     // tasks) is variadic in Claude Code: without the separator it consumes the

--- a/server/terminal.test.ts
+++ b/server/terminal.test.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'http';
 import { WebSocket } from 'ws';
+import { inflateRawSync } from 'zlib';
 import Database from './sqlite.js';
 import { describe, it, expect, vi, beforeEach, afterEach } from './bun-test.js';
 
@@ -19,6 +20,7 @@ vi.mock('./pty.js', () => ({
 
 // Mock execFile to work naturally with util.promisify (callback-style)
 let execFileShouldFail = false;
+let capturePaneOutput = 'line one\nline two\n';
 
 const mockExecFile = vi.fn(
   (
@@ -33,7 +35,7 @@ const mockExecFile = vi.fn(
         const stdout = _args?.includes('list-clients')
           ? '/dev/ttys001\n'
           : _args?.includes('capture-pane')
-            ? 'line one\nline two\n'
+            ? capturePaneOutput
             : '';
         process.nextTick(() => callback(null, stdout, ''));
       }
@@ -103,6 +105,7 @@ beforeEach(async () => {
   db = createTestDb();
   vi.clearAllMocks();
   execFileShouldFail = false;
+  capturePaneOutput = 'line one\nline two\n';
 
   // Reset mock callbacks
   mockPty.onData.mockReset();
@@ -368,6 +371,105 @@ describe('terminal WebSocket', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(messages).toEqual(['visible again']);
 
+    ws.close();
+  });
+
+  // ─── App-level deflate (Bun's ws shim can't negotiate permessage-deflate) ──
+
+  it('deflates large frames as binary when the client opts in via ?deflate=1', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const ws = await connectWs(`/ws/terminal/${DEFAULTS.task.id}/0?deflate=1`);
+    await waitForSetup();
+
+    const frames: { data: Buffer; isBinary: boolean }[] = [];
+    ws.on('message', (data, isBinary) => frames.push({ data: data as Buffer, isBinary }));
+
+    const big = 'z'.repeat(4096);
+    mockPty.onData.mock.calls[0][0](big);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].isBinary).toBe(true);
+    expect(inflateRawSync(frames[0].data).toString()).toBe(big);
+    ws.close();
+  });
+
+  it('keeps small frames as plain text even when deflate is on', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const ws = await connectWs(`/ws/terminal/${DEFAULTS.task.id}/0?deflate=1`);
+    await waitForSetup();
+
+    const frames: { data: Buffer; isBinary: boolean }[] = [];
+    ws.on('message', (data, isBinary) => frames.push({ data: data as Buffer, isBinary }));
+
+    mockPty.onData.mock.calls[0][0]('keystroke echo');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].isBinary).toBe(false);
+    expect(frames[0].data.toString()).toBe('keystroke echo');
+    ws.close();
+  });
+
+  it('never deflates for clients that did not opt in', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const ws = await connectWs(`/ws/terminal/${DEFAULTS.task.id}/0`);
+    await waitForSetup();
+
+    const frames: { data: Buffer; isBinary: boolean }[] = [];
+    ws.on('message', (data, isBinary) => frames.push({ data: data as Buffer, isBinary }));
+
+    const big = 'z'.repeat(4096);
+    mockPty.onData.mock.calls[0][0](big);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].isBinary).toBe(false);
+    expect(frames[0].data.toString()).toBe(big);
+    ws.close();
+  });
+
+  it('deflates the initial snapshot frame when large', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+    capturePaneOutput = 'w'.repeat(4096) + '\n';
+
+    const ws = await connectWs(`/ws/terminal/${DEFAULTS.task.id}/0?deflate=1`);
+    const frames: { data: Buffer; isBinary: boolean }[] = [];
+    ws.on('message', (data, isBinary) => frames.push({ data: data as Buffer, isBinary }));
+    await waitForSetup();
+
+    expect(frames.length).toBeGreaterThanOrEqual(1);
+    expect(frames[0].isBinary).toBe(true);
+    expect(inflateRawSync(frames[0].data).toString()).toBe(
+      '\x1b[?1049h\x1b[H\x1b[J' + 'w'.repeat(4096) + '\r\n',
+    );
+    ws.close();
+  });
+
+  // ─── Liveness ping ─────────────────────────────────────────────────────────
+
+  it('replies to a liveness ping with an empty frame, without writing to the pty', async () => {
+    insertTask(db, { ...DEFAULTS.runningTask });
+    insertAgent(db);
+
+    const ws = await connectWs(`/ws/terminal/${DEFAULTS.task.id}/0`);
+    await waitForSetup();
+
+    const frames: string[] = [];
+    ws.on('message', (data) => frames.push(data.toString()));
+
+    ws.send(JSON.stringify({ type: 'ping' }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(frames).toEqual(['']);
+    expect(mockPty.write).not.toHaveBeenCalled();
     ws.close();
   });
 

--- a/server/terminal.ts
+++ b/server/terminal.ts
@@ -1,4 +1,5 @@
 import { WebSocketServer, WebSocket } from 'ws';
+import { deflateRawSync } from 'zlib';
 import type { IncomingMessage } from 'http';
 import type { Duplex } from 'stream';
 import { nanoid } from 'nanoid';
@@ -19,31 +20,49 @@ const connections = new Map<string, TerminalConnection[]>();
 let wss: WebSocketServer;
 
 export function setupTerminalWebSocket(): void {
-  // permessage-deflate: TUI redraws (alt-screen full-frame repaints) are highly
-  // repetitive ANSI — compression cuts remote-viewing bandwidth ~10x. ws only
-  // compresses frames above its 1KB threshold, so keystroke echo stays fast.
-  wss = new WebSocketServer({ noServer: true, perMessageDeflate: true });
+  // No perMessageDeflate here: Bun's ws shim accepts the option but never
+  // negotiates the extension (explicit TODO in the shim), so it was a silent
+  // no-op. Compression is app-level instead — see sendFrame().
+  wss = new WebSocketServer({ noServer: true });
   installHeartbeat(wss);
 }
 
+// App-layer replacement for permessage-deflate: TUI redraws are highly
+// repetitive ANSI, so deflating them cuts remote-viewing bandwidth ~10x.
+// Frames at or above the threshold go out deflated as binary; below it plain
+// text, so keystroke echo never pays the zlib round-trip. Only for clients
+// that advertised DecompressionStream support via `?deflate=1`.
+const DEFLATE_THRESHOLD = 1024;
+
+function sendFrame(ws: WebSocket, text: string, deflateOk: boolean): void {
+  if (deflateOk && text.length >= DEFLATE_THRESHOLD) {
+    ws.send(deflateRawSync(Buffer.from(text)));
+  } else {
+    ws.send(text);
+  }
+}
+
 export function handleTerminalUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {
+  const [path = '', query = ''] = (req.url ?? '').split('?');
+  const deflateOk = new URLSearchParams(query).get('deflate') === '1';
+
   // Match /ws/terminal/chat/:id (standalone agent tmux session)
-  const chatMatch = req.url?.match(/^\/ws\/terminal\/chat\/([^/]+)$/);
+  const chatMatch = path.match(/^\/ws\/terminal\/chat\/([^/]+)$/);
   if (chatMatch) {
     wss.handleUpgrade(req, socket, head, (ws) => {
-      handleChatConnection(ws, chatMatch[1]);
+      handleChatConnection(ws, chatMatch[1], deflateOk);
     });
     return true;
   }
 
   // Match /ws/terminal/:taskId/:windowIndex
-  const match = req.url?.match(/^\/ws\/terminal\/([^/]+)\/(\d+)$/);
+  const match = path.match(/^\/ws\/terminal\/([^/]+)\/(\d+)$/);
   if (!match) return false;
 
   wss.handleUpgrade(req, socket, head, (ws) => {
     const taskId = match[1];
     const windowIndex = parseInt(match[2], 10);
-    handleConnection(ws, taskId, windowIndex);
+    handleConnection(ws, taskId, windowIndex, deflateOk);
   });
   return true;
 }
@@ -54,6 +73,7 @@ async function attachToTmuxSession(
   tmuxTarget: string,
   connKey: string,
   closeReason: string,
+  deflateOk: boolean,
   linkedSession?: string,
   pendingMessages?: (Buffer | string)[],
 ): Promise<void> {
@@ -128,7 +148,7 @@ async function attachToTmuxSession(
       retryTimer = setTimeout(flushOutput, BACKPRESSURE_RETRY_MS);
       return;
     }
-    ws.send(pendingOutput);
+    sendFrame(ws, pendingOutput, deflateOk);
     pendingOutput = '';
     outputScheduled = false;
   };
@@ -166,6 +186,13 @@ async function attachToTmuxSession(
             paused = false;
             forceRepaint();
           }
+          return;
+        }
+        if (parsed.type === 'ping') {
+          // Client liveness watchdog probing for a half-open socket. Reply
+          // with an empty frame — any traffic proves the link, and xterm
+          // treats an empty write as a no-op so the client needn't filter it.
+          ws.send('');
           return;
         }
       } catch {
@@ -222,7 +249,12 @@ async function attachToTmuxSession(
   });
 }
 
-async function handleConnection(ws: WebSocket, taskId: string, windowIndex: number): Promise<void> {
+async function handleConnection(
+  ws: WebSocket,
+  taskId: string,
+  windowIndex: number,
+  deflateOk: boolean,
+): Promise<void> {
   // Buffer messages that arrive while we set up the tmux session.
   // Without this, the client's initial resize message (sent on WS open) would be
   // lost because the message handler isn't registered until after the async tmux
@@ -290,7 +322,7 @@ async function handleConnection(ws: WebSocket, taskId: string, windowIndex: numb
   compute.tmux(['set-option', '-t', linkedSession, 'aggressive-resize', 'on']).catch(() => {});
 
   if (pane && ws.readyState === WebSocket.OPEN) {
-    ws.send(`\x1b[?1049h\x1b[H\x1b[J${pane.replace(/\n/g, '\r\n')}`);
+    sendFrame(ws, `\x1b[?1049h\x1b[H\x1b[J${pane.replace(/\n/g, '\r\n')}`, deflateOk);
   }
 
   const connKey = `${taskId}:${windowIndex}`;
@@ -300,12 +332,13 @@ async function handleConnection(ws: WebSocket, taskId: string, windowIndex: numb
     linkedSession,
     connKey,
     'Failed to attach to tmux session',
+    deflateOk,
     linkedSession,
     pendingMessages,
   );
 }
 
-function handleChatConnection(ws: WebSocket, chatId: string): void {
+function handleChatConnection(ws: WebSocket, chatId: string, deflateOk: boolean): void {
   const row = getChatAgentTmuxSession(chatId);
   if (!row || !row.tmux_session) {
     ws.close(4004, 'Chat not found');
@@ -319,6 +352,7 @@ function handleChatConnection(ws: WebSocket, chatId: string): void {
     row.tmux_session,
     `chat:${chatId}`,
     `Failed to attach to chat session`,
+    deflateOk,
   );
 }
 

--- a/src/components/TerminalView.test.tsx
+++ b/src/components/TerminalView.test.tsx
@@ -160,7 +160,15 @@ describe('TerminalView', () => {
     render(<TerminalView taskId="task-A" windowIndex={0} />);
 
     expect(MockWebSocket.instances).toHaveLength(1);
-    expect(MockWebSocket.instances[0].url).toMatch(/\/ws\/terminal\/task-A\/0$/);
+    expect(MockWebSocket.instances[0].url).toMatch(/\/ws\/terminal\/task-A\/0(\?|$)/);
+  });
+
+  it('advertises deflate support in the ws URL', async () => {
+    // bun's runtime has DecompressionStream, so the component opts in — the
+    // server only compresses for clients that set this flag.
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+    expect(MockWebSocket.instances[0].url).toMatch(/\?deflate=1$/);
   });
 
   it('reconnects to the new endpoint when windowIndex changes', async () => {
@@ -171,7 +179,7 @@ describe('TerminalView', () => {
 
     expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
     const latest = MockWebSocket.instances.at(-1)!;
-    expect(latest.url).toMatch(/\/ws\/terminal\/task-A\/1$/);
+    expect(latest.url).toMatch(/\/ws\/terminal\/task-A\/1(\?|$)/);
   });
 
   it('routes keystrokes to the NEW endpoint after windowIndex changes', async () => {
@@ -351,8 +359,72 @@ describe('TerminalView', () => {
     // Must NOT have created a 3rd WebSocket — especially not one pointing
     // back at the old windowIndex=0.
     expect(MockWebSocket.instances).toHaveLength(2);
-    const stale = MockWebSocket.instances.find((ws, idx) => idx >= 2 && ws.url.endsWith('/0'));
+    const stale = MockWebSocket.instances.find(
+      (ws, idx) => idx >= 2 && ws.url.includes('/ws/terminal/task-A/0'),
+    );
     expect(stale).toBeUndefined();
+  });
+
+  it('reconnects when a liveness ping goes unanswered (half-open socket)', async () => {
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws = MockWebSocket.instances[0];
+    act(() => ws._open());
+
+    // Idle past the watchdog window — the client probes the link.
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(ws.sent).toContain('{"type":"ping"}');
+
+    // Nothing comes back within the pong timeout → the socket is half-open;
+    // it gets replaced without waiting for a TCP-level close.
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('keeps the socket when the liveness ping is answered', async () => {
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws = MockWebSocket.instances[0];
+    act(() => ws._open());
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(ws.sent).toContain('{"type":"ping"}');
+
+    // Server's empty pong frame proves the link is alive.
+    act(() => ws.onmessage?.({ data: '' } as MessageEvent));
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('probes an OPEN socket on tab return instead of trusting readyState', async () => {
+    vi.useFakeTimers();
+    const TerminalView = await importTerminalView();
+    render(<TerminalView taskId="task-A" windowIndex={0} />);
+
+    const ws = MockWebSocket.instances[0];
+    act(() => ws._open());
+
+    // Simulate a laptop-sleep gap: time passes with no traffic, then the tab
+    // returns. The socket still reports OPEN but may be half-open.
+    await act(async () => {
+      vi.setSystemTime(Date.now() + 60_000);
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(ws.sent).toContain('{"type":"ping"}');
   });
 
   it('reconnects immediately on tab return when the socket is dead', async () => {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -7,6 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useMediaQuery } from '@/lib/use-media-query';
 import { installTerminalMobileTouch } from '@/lib/terminal-mobile-touch';
 import { installTerminalWheelCoalesce } from '@/lib/terminal-wheel-coalesce';
+import { supportsDeflate, makeFrameWriter } from '@/lib/terminal-frames';
 import { installTerminalVisualViewport } from '@/lib/terminal-visual-viewport';
 import { isAndroid, attachAndroidImeBridge } from '@/lib/terminal-android-ime';
 import { CloudOffIcon } from './icons';
@@ -23,6 +24,12 @@ interface TerminalViewProps {
 
 const MAX_RECONNECT_DELAY = 10_000;
 const INITIAL_RECONNECT_DELAY = 1_000;
+// Liveness watchdog: a NAT drop or laptop sleep leaves a half-open socket that
+// still reports OPEN, so onclose never fires and the terminal silently freezes
+// until a manual refresh. Probe an idle link with an app-level ping (the server
+// replies with an empty frame); a silent one is dead — replace it.
+const WATCHDOG_IDLE_MS = 15_000;
+const PONG_TIMEOUT_MS = 5_000;
 
 export function TerminalView({
   taskId,
@@ -47,6 +54,7 @@ export function TerminalView({
   const androidImeCleanup = useRef<(() => void) | null>(null);
   const isMobile = useMediaQuery('(max-width: 767px)');
   const visibleRef = useRef(visible);
+  const lastMessageAt = useRef(Date.now());
   const [disconnected, setDisconnected] = useState(false);
   const [retrySecs, setRetrySecs] = useState<number>(0);
   // True while the WebSocket is opening (initial connect or a reconnect) and no
@@ -60,9 +68,10 @@ export function TerminalView({
 
   const getWsUrl = useCallback(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const deflate = supportsDeflate ? '?deflate=1' : '';
     return wsUrlProp
-      ? `${protocol}//${window.location.host}${wsUrlProp}`
-      : `${protocol}//${window.location.host}/ws/terminal/${taskId}/${windowIndex}`;
+      ? `${protocol}//${window.location.host}${wsUrlProp}${deflate}`
+      : `${protocol}//${window.location.host}/ws/terminal/${taskId}/${windowIndex}${deflate}`;
   }, [taskId, windowIndex, wsUrlProp]);
 
   const scrollCursorIntoView = useCallback(() => {
@@ -107,9 +116,12 @@ export function TerminalView({
       // reconnects — cleared on open or as soon as the first chunk arrives.
       setConnecting(true);
       const ws = new WebSocket(getWsUrl());
+      ws.binaryType = 'arraybuffer';
+      const writeFrame = makeFrameWriter((data) => term.write(data));
 
       ws.onopen = () => {
         reconnectDelay.current = INITIAL_RECONNECT_DELAY;
+        lastMessageAt.current = Date.now();
         setDisconnected(false);
         // Deliberately NOT clearing `connecting` here: the socket opens in ~5ms
         // but the server's first frame lands later, so clearing on open left the
@@ -136,7 +148,8 @@ export function TerminalView({
       ws.onmessage = (event) => {
         // First chunk means the terminal has real content — drop the placeholder.
         setConnecting(false);
-        term.write(event.data);
+        lastMessageAt.current = Date.now();
+        writeFrame(event.data);
       };
 
       ws.onclose = (event) => {
@@ -352,21 +365,50 @@ export function TerminalView({
     }
   }, [connectWs]);
 
+  // Send a liveness ping if the link has been silent past the watchdog window;
+  // a ping that goes unanswered means the socket is half-open — replace it.
+  // Silent recovery: no overlay, the reconnect repaints from the tmux snapshot.
+  const probeLiveness = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (Date.now() - lastMessageAt.current < WATCHDOG_IDLE_MS) return;
+    const sentAt = Date.now();
+    ws.send(JSON.stringify({ type: 'ping' }));
+    setTimeout(() => {
+      if (unmounted.current || wsRef.current !== ws) return;
+      if (lastMessageAt.current >= sentAt) return; // pong (or any output) arrived
+      // close() on a half-open socket can wait out a long TCP timeout before
+      // onclose fires — reconnect immediately; the stale socket's onclose is
+      // ignored via the wsRef identity guard.
+      ws.close();
+      handleRetryNow();
+    }, PONG_TIMEOUT_MS);
+  }, [handleRetryNow]);
+
+  useEffect(() => {
+    const timer = setInterval(probeLiveness, WATCHDOG_IDLE_MS);
+    return () => clearInterval(timer);
+  }, [probeLiveness]);
+
   // A reconnect scheduled while the tab is hidden gets throttled by the browser
   // (background timers fire at most ~once a minute), so a dropped connection can
   // stay down long after the user returns. Retry immediately on tab return if
-  // the socket is dead. CONNECTING/OPEN sockets are left alone — retrying then
-  // would leak a duplicate connection.
+  // the socket is dead. An OPEN socket is probed instead of replaced — after a
+  // laptop sleep it often only *looks* OPEN. CONNECTING is left to the
+  // browser's own connect timeout.
   useEffect(() => {
     const onVisible = () => {
       if (document.visibilityState !== 'visible') return;
       const ws = wsRef.current;
-      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) return;
+      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        probeLiveness();
+        return;
+      }
       handleRetryNow();
     };
     document.addEventListener('visibilitychange', onVisible);
     return () => document.removeEventListener('visibilitychange', onVisible);
-  }, [handleRetryNow]);
+  }, [handleRetryNow, probeLiveness]);
 
   // Connect on mount and reconnect when taskId/windowIndex changes
   useEffect(() => {

--- a/src/lib/terminal-frames.test.ts
+++ b/src/lib/terminal-frames.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from '../bun-test.js';
+import { deflateRawSync } from 'zlib';
+import { inflateFrame, makeFrameWriter, supportsDeflate } from './terminal-frames';
+
+function deflated(text: string): ArrayBuffer {
+  const buf = deflateRawSync(Buffer.from(text));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+const decode = (d: string | Uint8Array) => (typeof d === 'string' ? d : new TextDecoder().decode(d));
+
+// Inflation latency varies wildly under a loaded parallel test run — poll for
+// the expected write count instead of sleeping a fixed interval.
+async function waitForWrites(writes: unknown[], count: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (writes.length < count && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('terminal-frames', () => {
+  it('advertises deflate support when DecompressionStream exists', () => {
+    expect(supportsDeflate).toBe(true);
+  });
+
+  it('inflateFrame round-trips deflate-raw payloads', async () => {
+    const out = await inflateFrame(deflated('hello \x1b[31mworld\x1b[0m'));
+    expect(new TextDecoder().decode(out)).toBe('hello \x1b[31mworld\x1b[0m');
+  });
+
+  it('writes text frames synchronously when nothing is pending', () => {
+    const writes: (string | Uint8Array)[] = [];
+    const onFrame = makeFrameWriter((d) => writes.push(d));
+    onFrame('abc');
+    expect(writes).toEqual(['abc']); // no await needed — keystroke echo is sync
+  });
+
+  it('preserves arrival order when a text frame lands behind an inflating binary frame', async () => {
+    const writes: string[] = [];
+    const onFrame = makeFrameWriter((d) => writes.push(decode(d)));
+    onFrame(deflated('big repaint'));
+    onFrame('typed');
+    await waitForWrites(writes, 2);
+    expect(writes).toEqual(['big repaint', 'typed']);
+  });
+
+  it('keeps ordering across multiple binary frames', async () => {
+    const writes: string[] = [];
+    const onFrame = makeFrameWriter((d) => writes.push(decode(d)));
+    onFrame(deflated('one'));
+    onFrame(deflated('two'));
+    onFrame('three');
+    onFrame(deflated('four'));
+    await waitForWrites(writes, 4);
+    expect(writes).toEqual(['one', 'two', 'three', 'four']);
+  });
+
+  it('a corrupt binary frame does not wedge later frames', async () => {
+    const writes: string[] = [];
+    const onFrame = makeFrameWriter((d) => writes.push(decode(d)));
+    onFrame(new Uint8Array([1, 2, 3]).buffer); // not a valid deflate stream
+    onFrame('after');
+    await waitForWrites(writes, 1);
+    expect(writes).toEqual(['after']);
+  });
+});

--- a/src/lib/terminal-frames.test.ts
+++ b/src/lib/terminal-frames.test.ts
@@ -7,7 +7,8 @@ function deflated(text: string): ArrayBuffer {
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
 }
 
-const decode = (d: string | Uint8Array) => (typeof d === 'string' ? d : new TextDecoder().decode(d));
+const decode = (d: string | Uint8Array) =>
+  typeof d === 'string' ? d : new TextDecoder().decode(d);
 
 // Inflation latency varies wildly under a loaded parallel test run — poll for
 // the expected write count instead of sleeping a fixed interval.

--- a/src/lib/terminal-frames.ts
+++ b/src/lib/terminal-frames.ts
@@ -1,0 +1,47 @@
+/**
+ * Frame decoding for the terminal WebSocket.
+ *
+ * Bun's ws shim never negotiates permessage-deflate (the option is a silent
+ * no-op server-side), so the server deflates large frames itself and sends
+ * them as binary; small frames stay plain text. The client advertises support
+ * with `?deflate=1` when DecompressionStream is available.
+ */
+export const supportsDeflate = typeof DecompressionStream === 'function';
+
+export async function inflateFrame(buf: ArrayBuffer | Blob): Promise<Uint8Array> {
+  const blob = buf instanceof Blob ? buf : new Blob([buf]);
+  const stream = blob.stream().pipeThrough(new DecompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Returns a handler that writes incoming frames to the terminal in arrival
+ * order. Inflation is async, so a promise chain preserves ordering; text
+ * frames bypass the chain when nothing is pending, so keystroke echo never
+ * waits on a repaint that is still inflating.
+ */
+export function makeFrameWriter(
+  write: (data: string | Uint8Array) => void,
+): (data: string | ArrayBuffer | Blob) => void {
+  let chain: Promise<unknown> = Promise.resolve();
+  let pending = 0;
+  const enqueue = (fn: () => unknown) => {
+    pending++;
+    // Each link swallows its own error, so `chain` is always resolved and a
+    // corrupt frame can't wedge every frame after it.
+    chain = chain
+      .then(fn)
+      .catch(() => {})
+      .finally(() => {
+        pending--;
+      });
+  };
+  return (data) => {
+    if (typeof data === 'string') {
+      if (pending === 0) write(data);
+      else enqueue(() => write(data));
+      return;
+    }
+    enqueue(async () => write(await inflateFrame(data)));
+  };
+}


### PR DESCRIPTION
## What

Fixes remote terminal lag (slow tab switches, scroll/typing trailing in) and the intermittent frozen-terminal hangs, plus removes the rename nudge appended to agent prompts.

- **App-level output compression.** Under Bun the `ws` package is replaced by Bun's shim, which accepts `perMessageDeflate` but never negotiates the extension (explicit TODO in the shim; verified by handshake probe) — the compression the terminal stream relied on was a silent no-op, so every TUI repaint went uncompressed and saturated slow links. Output frames ≥ 1KB are now `deflateRawSync`'d into binary frames when the client advertises `DecompressionStream` support via `?deflate=1`; the client inflates asynchronously with frame order preserved by a promise chain (`src/lib/terminal-frames.ts`). Sub-threshold frames (keystroke echo) stay plain text and synchronous. Applies to the pty stream, the pane snapshot, and chat terminals.
- **Half-open socket watchdog.** A NAT drop or laptop sleep leaves the browser socket reporting OPEN forever, so `onclose` never fires and the terminal freezes until refresh. The client now pings after 15s of silence (`{"type":"ping"}` → empty-frame reply, answered even for paused hidden tabs); an unanswered ping replaces the socket silently and repaints from the tmux snapshot. Tab return probes OPEN sockets instead of trusting `readyState`.
- **Prompt nudge removal.** `buildAgentStartupCommand` writes the initial prompt verbatim — no appended `octomux task rename` hint.

## Why

Remote setups were the whole point of the compression comment in `server/terminal.ts`; it just never worked under the Bun runtime. The hang had no client-side detection at all — only the server heartbeat reaped its own end.

Reviewer walkthrough with the full change tour and risk notes: `.octomux/pr-walkthrough.md`.

## Testing

- `server/terminal.test.ts` 26/26 (5 new: deflate roundtrip, threshold, no-opt-in, snapshot deflate, ping→pty isolation)
- `src/lib/terminal-frames.test.ts` 6 new (ordering under async inflation, corrupt-frame recovery)
- `src/components/TerminalView.test.tsx` 17/17 (4 new: deflate flag, unanswered-ping reconnect, answered-ping keep, tab-return probe)
- Full client suite 1273 pass; remaining failures are pre-existing load flakes (pass in isolation, reproduce with this branch stashed). Full server suite failures likewise pre-existing on `next`.
- Live probes on bun 1.3.14: shim negotiates no deflate, empty frames round-trip, `bufferedAmount` still reports real backpressure (existing coalescing intact).