### PR TITLE
fix(binary): resolve all runtime assets via assetRoot in the compiled binary

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -34,6 +34,15 @@ if (command === 'start') {
   await runStart(args.slice(1));
 } else if (command === 'review') {
   await runReview(args.slice(1));
+} else if (command === '__submit-result-mcp') {
+  // Hidden: stdio MCP subprocess spawned by the compiled binary itself
+  // (submitResultServerInvocation in server/agent-session/mcp/config.ts).
+  const { main } = await import('../server/agent-session/mcp/submit-result-server.ts');
+  await main();
+} else if (command === '__octomux-mcp') {
+  // Hidden: stdio MCP subprocess (mcpServerInvocation in server/orchestrator/runner.ts).
+  const { main } = await import('../server/orchestrator/mcp/server.ts');
+  await main();
 } else {
   // Delegate to CLI (commander-based) for all other commands
   await import('../cli/src/index.ts');

--- a/cli/src/commands/hooks-install.ts
+++ b/cli/src/commands/hooks-install.ts
@@ -1,24 +1,15 @@
 import { Command } from 'commander';
-import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import chalk from 'chalk';
+import { assetRoot } from '../../../server/assets.js';
 import { success, errorMessage } from '../format.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
+// assetRoot(), not import.meta.url: inside the compiled binary the templates
+// only exist in the extracted runtime dir.
 function resolveTemplateDir(): string {
-  const candidates = [
-    path.resolve(__dirname, '..', '..', '..', '..', 'templates', 'hooks'),
-    path.resolve(__dirname, '..', '..', '..', 'templates', 'hooks'),
-    path.resolve(__dirname, '..', '..', 'templates', 'hooks'),
-    path.resolve(__dirname, '..', 'templates', 'hooks'),
-  ];
-  for (const c of candidates) {
-    if (fs.existsSync(c)) return c;
-  }
-  return candidates[0];
+  return path.join(assetRoot(), 'templates', 'hooks');
 }
 
 interface TemplateManifest {

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import readline from 'readline';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { fileURLToPath } from 'url';
+import { assetRoot } from '../../../server/assets.js';
 import { errorMessage, success } from '../format.js';
 
 interface InitOptions {
@@ -63,20 +63,14 @@ function normalizeProjectKey(raw: string): string {
 }
 
 /**
- * Locate the packaged `workflows/` dir by walking up from this module, mirroring
- * `bundledOctomuxPluginDir()` in the server. Returns null when not found (e.g. a
- * partial install) so init never hard-fails on an optional asset.
+ * Locate the packaged `workflows/` dir via assetRoot() — in the compiled binary
+ * it only exists in the extracted runtime dir, never next to import.meta.url.
+ * Returns null when not found (e.g. a partial install) so init never hard-fails
+ * on an optional asset.
  */
 function bundledWorkflowsDir(): string | null {
-  let dir = path.dirname(fileURLToPath(import.meta.url));
-  for (let i = 0; i < 6; i++) {
-    const candidate = path.join(dir, 'workflows');
-    if (fs.existsSync(path.join(candidate, 'review-deep.js'))) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return null;
+  const candidate = path.join(assetRoot(), 'workflows');
+  return fs.existsSync(path.join(candidate, 'review-deep.js')) ? candidate : null;
 }
 
 /**

--- a/scripts/bundle-assets.mjs
+++ b/scripts/bundle-assets.mjs
@@ -22,7 +22,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 // plugin/skills and plugin/agents, and builtInSkillsDir() resolves
 // `<assetRoot()>/plugin/skills`. Naming the leaf dirs here silently bundled
 // neither — the compiled binary shipped zero skills until this was fixed.
-const TREES = ['plugin', 'kinds', 'templates', 'workflows', 'dist'];
+const TREES = ['plugin', 'kinds', 'templates', 'workflows', 'dist', '.config'];
+// Single runtime-needed files outside the trees: the cursor harness copies the
+// hook bridge into each workspace (resolveBridgeSource in harnesses/cursor.ts).
+const FILES = ['bin/octomux-hook-bridge.js'];
 const OUT = path.join(root, 'server', 'assets.generated.json');
 
 function walk(dir, base, out) {
@@ -50,6 +53,18 @@ for (const tree of TREES) {
     bytes += buf.length;
   }
   console.log(`  ${tree}: ${files.length} files`);
+}
+
+for (const rel of FILES) {
+  const abs = path.join(root, rel);
+  if (!existsSync(abs)) {
+    console.warn(`⚠  skipping missing asset file: ${rel}`);
+    continue;
+  }
+  const buf = readFileSync(abs);
+  bundle[rel] = buf.toString('base64');
+  bytes += buf.length;
+  console.log(`  ${rel}`);
 }
 
 writeFileSync(OUT, JSON.stringify(bundle));

--- a/server/agent-session/mcp/config.ts
+++ b/server/agent-session/mcp/config.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import path from 'path';
 import fs from 'fs';
+import { isCompiled } from '../../assets.js';
 
 // ─── Invocation resolver ─────────────────────────────────────────────────────
 
@@ -27,6 +28,12 @@ import fs from 'fs';
  * Returns null if neither candidate exists.
  */
 export function submitResultServerInvocation(): { command: string; args: string[] } | null {
+  // Compiled binary: no dist-server on disk and no tsx — the binary dispatches
+  // its own `__submit-result-mcp` argv to main() (see bin/main.js).
+  if (isCompiled) {
+    return { command: process.execPath, args: ['__submit-result-mcp'] };
+  }
+
   const here = fileURLToPath(import.meta.url);
   const dir = path.dirname(here);
 

--- a/server/agent-session/mcp/submit-result-server.ts
+++ b/server/agent-session/mcp/submit-result-server.ts
@@ -152,7 +152,9 @@ function isMainModule(): boolean {
   }
 }
 
-async function main(): Promise<void> {
+// Exported so the compiled binary can dispatch here via its
+// `__submit-result-mcp` argv (isMainModule() never matches inside $bunfs).
+export async function main(): Promise<void> {
   // Resolve schema — prefer inline JSON, fall back to a file path
   const schemaInline = process.env.OCTOMUX_SUBMIT_RESULT_SCHEMA;
   const schemaPath = process.env.OCTOMUX_SUBMIT_RESULT_SCHEMA_PATH;

--- a/server/harnesses/cursor.ts
+++ b/server/harnesses/cursor.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { assetRoot } from '../assets.js';
 import type { Harness, HarnessLaunchOpts, HarnessResumeOpts } from './types.js';
 import { validateAgentName, validateFlagString } from './types.js';
 import {
@@ -66,22 +66,14 @@ function hooksJsonObject(bridgeDest: string) {
 }
 
 /**
- * Locate the bridge script. The source layout is `<root>/bin/octomux-hook-bridge.js`
- * but `import.meta.url` differs between dev (`<root>/server/harnesses/cursor.ts`
- * under tsx) and bundled production (`<root>/dist-server/harnesses-*.js`). Walk up
- * from the running module looking for the bin/ sibling.
+ * Locate the bridge script at `<assetRoot()>/bin/octomux-hook-bridge.js` — the
+ * compiled binary only has it in the extracted runtime dir, never next to
+ * `import.meta.url` ($bunfs).
  */
 function resolveBridgeSource(): string {
-  const startDir = path.dirname(fileURLToPath(import.meta.url));
-  let dir = startDir;
-  for (let i = 0; i < 6; i++) {
-    const candidate = path.join(dir, 'bin', 'octomux-hook-bridge.js');
-    if (fs.existsSync(candidate)) return candidate;
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  throw new Error(`Cannot locate bin/octomux-hook-bridge.js from ${startDir} (walked up 6 levels)`);
+  const candidate = path.join(assetRoot(), 'bin', 'octomux-hook-bridge.js');
+  if (fs.existsSync(candidate)) return candidate;
+  throw new Error(`Cannot locate octomux-hook-bridge.js at ${candidate}`);
 }
 
 export const cursorHarness: Harness = {

--- a/server/orchestrator/mcp/server.ts
+++ b/server/orchestrator/mcp/server.ts
@@ -441,9 +441,11 @@ function registerWorkerTools(server: McpServer): void {
 
 /**
  * Main entrypoint: create the server and connect to stdio transport.
- * Only runs when invoked directly (not when imported as a module).
+ * Only runs when invoked directly (not when imported as a module). Exported so
+ * the compiled binary can dispatch here via its `__octomux-mcp` argv
+ * (isMainModule() never matches inside $bunfs).
  */
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   logger.info({ operation: 'startup' }, 'octomux MCP server starting (stdio)');
 
   const server = createOctomuxMcpServer();

--- a/server/orchestrator/runner.ts
+++ b/server/orchestrator/runner.ts
@@ -31,6 +31,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
+import { isCompiled } from '../assets.js';
 import { execTmux } from '../tmux-bin.js';
 import { hookBaseUrl } from '../hook-base-url.js';
 import { octomuxRoot } from '../octomux-root.js';
@@ -209,6 +210,12 @@ function writeOrchestratorsettings(convId: string): string {
  * the worker mcp-config.json (SHR-160 — do NOT duplicate the logic there).
  */
 export function mcpServerInvocation(): { command: string; args: string[] } | null {
+  // Compiled binary: no dist-server on disk and no tsx — the binary dispatches
+  // its own `__octomux-mcp` argv to the server's main() (see bin/main.js).
+  if (isCompiled) {
+    return { command: process.execPath, args: ['__octomux-mcp'] };
+  }
+
   const here = fileURLToPath(import.meta.url);
   const dir = path.dirname(here);
 

--- a/server/setup-status.ts
+++ b/server/setup-status.ts
@@ -1,15 +1,12 @@
-import path from 'path';
 import { execFile as execFileCb, execFileSync } from 'child_process';
 import { promisify } from 'util';
-import { fileURLToPath } from 'url';
+import { assetRoot } from './assets.js';
 import { probeBinary, brewInstall, hasBrew } from './binary-check.js';
 import type { BinaryDep } from './startup.js';
 import { getSettings, type OctomuxSettings, type EditorChoice } from './settings.js';
 import { ensureGithubLogin } from './github-login.js';
 import { syncLazyVimPlugins } from './startup.js';
 const execFile = promisify(execFileCb);
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export type SetupItemStatus = 'ok' | 'missing' | 'outdated' | 'unconfigured' | 'optional_missing';
 
@@ -100,10 +97,6 @@ const EDITOR_DEPS: Record<EditorChoice, BinaryDep & { displayName: string }> = {
     installUrl: 'https://code.visualstudio.com/',
   },
 };
-
-function packageRoot(): string {
-  return path.resolve(__dirname, '..');
-}
 
 /**
  * Pick an install action for a missing binary dep: prefer Homebrew on macOS, then a
@@ -305,7 +298,9 @@ export async function runSetupInstall(id: string): Promise<{ ok: boolean; messag
   }
 
   if (id === 'lazyvim-sync') {
-    syncLazyVimPlugins(packageRoot());
+    // assetRoot(), not __dirname: in the compiled binary the .config tree only
+    // exists in the extracted runtime dir (and /$bunfs is read-only anyway).
+    syncLazyVimPlugins(assetRoot());
     return { ok: true, message: 'LazyVim plugin sync finished (or was already up to date)' };
   }
 


### PR DESCRIPTION
Ships the compiled-binary asset fixes to main for the next release.

Everything resolved relative to `import.meta.url` points into the read-only `/$bunfs` inside the `bun build --compile` binary, where none of the shipped assets exist on disk. This broke, for every npm/standalone-binary user:

- **bundled octomux plugin** (`bundledOctomuxPluginDir`) — threw `Cannot locate bundled octomux plugin` at agent launch (the reported bug)
- **submit-result MCP server** — resolver returned null, every agent launched without the `submit_result` tool
- **orchestrator MCP server** — conductor/workers launched without octomux read tools
- **cursor hook bridge** — cursor task launch threw; bridge is now bundled as an asset file
- **`octomux init` workflows install** — silent no-op, `/octomux:review-deep` couldn't run
- **`octomux hooks-install`** — templates always "not found"
- **LazyVim sync** — pointed at unwritable `/$bunfs`; `.config` is now a bundled asset tree

All asset lookups now go through `assetRoot()` (extracted runtime dir when compiled), and the binary dispatches hidden `__submit-result-mcp` / `__octomux-mcp` argv to run the MCP stdio servers from itself.

Verified against a real compiled build with isolated `$HOME`: runtime extraction ships `bin/`, `.config/`, and the plugin manifest; `octomux init` installs `review-deep.js`; both MCP dispatches answer a real `initialize` handshake over stdio.